### PR TITLE
bugfix: Fix QML scope — newElement and Element.* in model components

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -404,6 +404,7 @@ MuseScore {
 
     BatchEngine {
         id: batchEngine
+        pluginRef: chordLibrary
         curScore: chordLibrary.curScore
         tempDiagramFile: tempDiagramFile
         clipboardXmlPath: Qt.resolvedUrl("paste-clipboard.xml")
@@ -1201,6 +1202,7 @@ MuseScore {
 
     InsertionEngine {
         id: insertionEngine
+        pluginRef: chordLibrary
         curScore: chordLibrary.curScore
         tempDiagramFile: tempDiagramFile
         audioFile: audioFile
@@ -1579,6 +1581,7 @@ MuseScore {
 
     InlineTools {
         id: inlineTools
+        pluginRef: chordLibrary
         curScore: chordLibrary.curScore
         voicingsData: chordLibrary.voicingsData
         filterContext: chordLibrary.filterContext

--- a/plugin/model/BatchEngine.qml
+++ b/plugin/model/BatchEngine.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import MuseScore 3.0
 import "ChordSelector.js" as ChordSelector
 import "MelodyEngine.js" as MelodyEngine
 import "Transposer.js" as Transposer
@@ -19,6 +20,9 @@ Item {
     id: batchEngine
 
     // === External dependencies (wired from parent) ===
+
+    // MuseScore plugin root — needed for newElement() and Element.* constants
+    property var pluginRef: null
 
     // MuseScore API — parent passes these; null when no score is open
     property var curScore: null
@@ -578,7 +582,7 @@ Item {
         cursor.prev()
         if (cursor.element && cursor.element.type === Element.CHORD) {
             for (var i = 1; i < pitches.length; i++) {
-                var note = newElement(Element.NOTE)
+                var note = pluginRef.newElement(Element.NOTE)
                 note.pitch = pitches[i]
                 note.tpc1 = DiagramEngine.pitchToTpc(pitches[i])
                 note.tpc2 = note.tpc1

--- a/plugin/model/InlineTools.qml
+++ b/plugin/model/InlineTools.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import MuseScore 3.0
 import "ChordSelector.js" as ChordSelector
 import "MelodyEngine.js" as MelodyEngine
 import "Transposer.js" as Transposer
@@ -15,6 +16,7 @@ Item {
     id: inlineTools
 
     // === External dependencies ===
+    property var pluginRef: null  // MuseScore plugin root for newElement()
     property var curScore: null
     property var voicingsData: []
     property string filterContext: ""
@@ -313,7 +315,7 @@ Item {
                 }
 
                 if (cursor.segment) {
-                    var staffText = newElement(Element.STAFF_TEXT)
+                    var staffText = pluginRef.newElement(Element.STAFF_TEXT)
                     staffText.text = pos.fingering
                     cursor.add(staffText)
                     added++

--- a/plugin/model/InsertionEngine.qml
+++ b/plugin/model/InsertionEngine.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import MuseScore 3.0
 import "Transposer.js" as Transposer
 
 // InsertionEngine.qml — Diagram insertion and voicing playback.
@@ -15,6 +16,7 @@ Item {
     id: insertionEngine
 
     // === External dependencies ===
+    property var pluginRef: null  // MuseScore plugin root for newElement()
     property var curScore: null
     property var tempDiagramFile: null    // FileIO for paste-clipboard.xml
     property var audioFile: null          // FileIO for MIDI playback
@@ -93,7 +95,7 @@ Item {
 
         curScore.startCmd()
 
-        var fd = newElement(Element.FRET_DIAGRAM)
+        var fd = pluginRef.newElement(Element.FRET_DIAGRAM)
         fd.fretStrings = voicing.strings || 6
         fd.fretFrets = voicing.visible_frets || 4
         fd.fretOffset = voicing.fret_number + offset - 1
@@ -129,7 +131,7 @@ Item {
     function hasSetDotApi() {
         if (_hasSetDot !== null) return _hasSetDot
         try {
-            var fd = newElement(Element.FRET_DIAGRAM)
+            var fd = pluginRef.newElement(Element.FRET_DIAGRAM)
             _hasSetDot = (typeof fd.setDot === "function")
             if (_hasSetDot)
                 console.log("setDot() API detected — using direct insertion")
@@ -152,7 +154,7 @@ Item {
         try {
             curScore.startCmd()
 
-            var fd = newElement(Element.FRET_DIAGRAM)
+            var fd = pluginRef.newElement(Element.FRET_DIAGRAM)
             fd.fretStrings = numStrings
             fd.fretFrets = voicing.visible_frets || 4
             fd.fretOffset = voicing.fret_number + offset - 1


### PR DESCRIPTION
Root cause of blank plugin window. 90/90 tests pass.