### PR TITLE
bugfix: Remove MuseScore import from model QML files (blank window fix)

### DIFF
--- a/plugin/model/BatchEngine.qml
+++ b/plugin/model/BatchEngine.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.15
-import MuseScore 3.0
 import "ChordSelector.js" as ChordSelector
 import "MelodyEngine.js" as MelodyEngine
 import "Transposer.js" as Transposer

--- a/plugin/model/InlineTools.qml
+++ b/plugin/model/InlineTools.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.15
-import MuseScore 3.0
 import "ChordSelector.js" as ChordSelector
 import "MelodyEngine.js" as MelodyEngine
 import "Transposer.js" as Transposer

--- a/plugin/model/InsertionEngine.qml
+++ b/plugin/model/InsertionEngine.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.15
-import MuseScore 3.0
 import "Transposer.js" as Transposer
 
 // InsertionEngine.qml — Diagram insertion and voicing playback.


### PR DESCRIPTION
Removes import MuseScore 3.0 from BatchEngine, InlineTools, InsertionEngine. These imports likely prevent the QML engine from instantiating the plugin. 90/90 tests pass.