### PR TITLE
bugfix: Context filter includes voicings with fewer strings

### DIFF
--- a/plugin/model/ChordSelector.js
+++ b/plugin/model/ChordSelector.js
@@ -140,8 +140,14 @@ function findBestVoicing(voicingsData, targetRoot, quality, opts) {
         var scoreA = 0, scoreB = 0
         if (a.chord_quality === quality) scoreA += 20
         if (b.chord_quality === quality) scoreB += 20
-        if (opts.filterContext && a.context === opts.filterContext) scoreA += 100
-        if (opts.filterContext && b.context === opts.filterContext) scoreB += 100
+        // Context: exact match +100, same-prefix smaller context +50
+        if (opts.filterContext) {
+            var ctxPfx = opts.filterContext.replace(/[0-9]+$/, "")
+            if (a.context === opts.filterContext) scoreA += 100
+            else if ((a.context || "").replace(/[0-9]+$/, "") === ctxPfx) scoreA += 50
+            if (b.context === opts.filterContext) scoreB += 100
+            else if ((b.context || "").replace(/[0-9]+$/, "") === ctxPfx) scoreB += 50
+        }
         if (opts.filterCategory && a.category === opts.filterCategory) scoreA += 50
         if (opts.filterCategory && b.category === opts.filterCategory) scoreB += 50
         if (a.category === "shell") scoreA += 10
@@ -226,8 +232,14 @@ function findAllVoicings(voicingsData, targetRoot, quality, opts) {
         var scoreA = 0, scoreB = 0
         if (a.chord_quality === quality) scoreA += 20
         if (b.chord_quality === quality) scoreB += 20
-        if (opts.filterContext && a.context === opts.filterContext) scoreA += 100
-        if (opts.filterContext && b.context === opts.filterContext) scoreB += 100
+        // Context: exact match +100, same-prefix smaller context +50
+        if (opts.filterContext) {
+            var ctxPfx = opts.filterContext.replace(/[0-9]+$/, "")
+            if (a.context === opts.filterContext) scoreA += 100
+            else if ((a.context || "").replace(/[0-9]+$/, "") === ctxPfx) scoreA += 50
+            if (b.context === opts.filterContext) scoreB += 100
+            else if ((b.context || "").replace(/[0-9]+$/, "") === ctxPfx) scoreB += 50
+        }
         if (opts.filterCategory && a.category === opts.filterCategory) scoreA += 50
         if (opts.filterCategory && b.category === opts.filterCategory) scoreB += 50
         if (a.category === "shell") scoreA += 10

--- a/plugin/model/FilterEngine.js
+++ b/plugin/model/FilterEngine.js
@@ -37,10 +37,30 @@ function applyFilters(voicingsData, opts) {
         if (contextMax < maxStrings) maxStrings = contextMax
     }
 
+    // Context matching: CM7 also includes CM6, CM5, CM4 (a 4-string drop2
+    // is valid on a 7-string guitar). Extract the context type prefix (CM/CV)
+    // and match any context with the same prefix and <= string count.
+    var ctxPrefix = ""
+    var ctxStrings = 0
+    if (opts.filterContext && opts.contextStringCounts) {
+        // Extract prefix: "CM7" → "CM", "CV6" → "CV"
+        ctxPrefix = opts.filterContext.replace(/[0-9]+$/, "")
+        ctxStrings = opts.contextStringCounts[opts.filterContext] || 99
+    }
+
     var result = []
     for (var i = 0; i < voicingsData.length; i++) {
         var v = voicingsData[i]
-        if (opts.filterContext && v.context !== opts.filterContext) continue
+        if (opts.filterContext) {
+            if (ctxPrefix) {
+                // Match same context type with <= string count
+                var vPrefix = (v.context || "").replace(/[0-9]+$/, "")
+                var vStrings = opts.contextStringCounts[v.context] || 99
+                if (vPrefix !== ctxPrefix || vStrings > ctxStrings) continue
+            } else {
+                if (v.context !== opts.filterContext) continue
+            }
+        }
         if (opts.filterCategory && v.category !== opts.filterCategory) continue
         if (opts.filterQuality && v.chord_quality !== opts.filterQuality
             && v.chord_quality !== "quartal") continue


### PR DESCRIPTION
CM7 now shows CM6/CM5/CM4 voicings too. 90/90 tests pass.