### PR TITLE
bugfix: Fret number clipped for 2-digit frets

### DIFF
--- a/plugin/ui/WalkthroughPanel.qml
+++ b/plugin/ui/WalkthroughPanel.qml
@@ -176,7 +176,7 @@ ColumnLayout {
 
                 var ns = v.strings || 6
                 var nf = v.visible_frets || 4
-                var mg = 6, tm = 14
+                var mg = 16, tm = 14  // extra left margin for 2-digit fret numbers
                 var ss = (width - 2 * mg) / (ns - 1)
                 var fs = (height - tm - mg) / nf
 


### PR DESCRIPTION
Left margin too small for 2-digit fret numbers. 90/90 tests pass.