### PR TITLE
perf: Memoize computeDifficulty + precompute scores in sort (#178)

### DIFF
--- a/plugin/model/ChordSelector.js
+++ b/plugin/model/ChordSelector.js
@@ -116,6 +116,30 @@ function computeModeDelta(voicing, modeConfig, modeId) {
     return delta
 }
 
+// Difficulty memo (#178). FingeringEngine.computeDifficulty is a pure function of
+// dots+mutes+open+strings+fret_number, and we call it O(N) times per sort in the
+// hot path. Memoize on the voicing's stable identity. Cleared per scoring pass
+// to avoid unbounded growth in long-running sessions.
+var _difficultyMemo = {}
+function _resetDifficultyMemo() { _difficultyMemo = {} }
+function _difficultyFor(v, fn) {
+    if (!fn) return null
+    // Prefer voicing.id when available (curated voicings); fall back to a derived
+    // signature for calculator-generated voicings that may have transient ids.
+    var key = v.id
+    if (!key) {
+        var dots = v.dots || []
+        var sig = (v.strings || 6) + "|" + (v.fret_number || 0) + "|"
+        for (var i = 0; i < dots.length; i++) sig += dots[i].string + ":" + dots[i].fret + ","
+        sig += "m:" + (v.mutes || []).join(",") + "|o:" + (v.open || []).join(",")
+        key = sig
+    }
+    if (_difficultyMemo[key] === undefined) {
+        _difficultyMemo[key] = fn(v)
+    }
+    return _difficultyMemo[key]
+}
+
 // Score a single voicing candidate against a query context (#164).
 // Centralizes the scoring rubric so findBestVoicing and findAllVoicings stay
 // in sync. Returns a numeric score (higher = better).
@@ -155,9 +179,12 @@ function _scoreCandidate(v, targetRoot, quality, melodyTarget, bassTarget, ref, 
     var fret = v.fret_number || 0
     if (fret >= 3 && fret <= 7) score += 5
     if (opts.difficultyFn) {
-        var d = opts.difficultyFn(v)
-        if (d.tier === "expert") score -= 30
-        else if (d.tier === "advanced") score -= 10
+        // Memoized via _difficultyFor (#178). Same voicing in repeated sort passes
+        // (walkthrough re-sort on every step) reuses the prior result instead of
+        // re-running suggestFingering's constraint solver.
+        var d = _difficultyFor(v, opts.difficultyFn)
+        if (d && d.tier === "expert") score -= 30
+        else if (d && d.tier === "advanced") score -= 10
     }
     if (opts.profileCategoryWeightFn) score += opts.profileCategoryWeightFn(v.category)
     if (opts.profileQualityBoostFn) score += opts.profileQualityBoostFn(v.chord_quality)
@@ -218,11 +245,19 @@ function findBestVoicing(voicingsData, targetRoot, quality, opts) {
     var bassTarget = (bassMidi !== undefined && bassMidi >= 0) ? bassMidi % 12 : -1
     var ref = opts.lastInsertedVoicing
 
-    candidates.sort(function(a, b) {
-        return _scoreCandidate(b, targetRoot, quality, melodyTarget, bassTarget, ref, opts)
-             - _scoreCandidate(a, targetRoot, quality, melodyTarget, bassTarget, ref, opts)
-    })
-    return candidates[0]
+    // Precompute scores once per candidate (#178). Previously the comparator
+    // called _scoreCandidate twice per comparison, multiplying difficultyFn
+    // and inner callback invocations by N×log(N)×2.
+    _resetDifficultyMemo()
+    var ranked = new Array(candidates.length)
+    for (var k = 0; k < candidates.length; k++) {
+        ranked[k] = {
+            v: candidates[k],
+            s: _scoreCandidate(candidates[k], targetRoot, quality, melodyTarget, bassTarget, ref, opts)
+        }
+    }
+    ranked.sort(function(a, b) { return b.s - a.s })
+    return ranked[0].v
 }
 
 // Return ALL matching voicings for a chord, sorted by score (best first).
@@ -268,11 +303,19 @@ function findAllVoicings(voicingsData, targetRoot, quality, opts) {
     var bassTarget = (bassMidi !== undefined && bassMidi >= 0) ? bassMidi % 12 : -1
     var ref = opts.lastInsertedVoicing
 
-    candidates.sort(function(a, b) {
-        return _scoreCandidate(b, targetRoot, quality, melodyTarget, bassTarget, ref, opts)
-             - _scoreCandidate(a, targetRoot, quality, melodyTarget, bassTarget, ref, opts)
-    })
-    return candidates
+    // Precompute scores once per candidate (#178).
+    _resetDifficultyMemo()
+    var ranked = new Array(candidates.length)
+    for (var k = 0; k < candidates.length; k++) {
+        ranked[k] = {
+            v: candidates[k],
+            s: _scoreCandidate(candidates[k], targetRoot, quality, melodyTarget, bassTarget, ref, opts)
+        }
+    }
+    ranked.sort(function(a, b) { return b.s - a.s })
+    var out = new Array(ranked.length)
+    for (var oi = 0; oi < ranked.length; oi++) out[oi] = ranked[oi].v
+    return out
 }
 
 // Build bass-string groups from a list of alternative voicings.

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -1049,6 +1049,37 @@ class TestChordSelectorModes:
             assertEqual(cmpPick.id, "v-shell", "comping picks shell");
         """)
 
+    def test_difficulty_memoization_one_call_per_voicing(self):
+        # #178: _difficultyFor must call difficultyFn at most once per unique
+        # voicing per sort pass, not twice per comparison.
+        assert_js("ChordSelector.js", """
+            // Build 8 distinct voicings — enough that a sort would normally call
+            // the comparator many times.
+            var voicings = [];
+            for (var i = 0; i < 8; i++) {
+                voicings.push({
+                    id: "v" + i, root: "C", chord_quality: "dom7",
+                    category: "drop2", fret_number: i + 1, mutes: [],
+                    dots: [{string: 5, fret: 1}, {string: 4, fret: 2}],
+                    intervals: ["1", "3", "b7"], notes: ["C", "E", "Bb"],
+                    strings: 6, open: [], suitableModes: ["chord-melody"]
+                });
+            }
+            var calls = {};
+            var difficultyFn = function(v) {
+                calls[v.id] = (calls[v.id] || 0) + 1;
+                return { tier: "standard", score: 10 };
+            };
+            findBestVoicing(voicings, "C", "dom7", {
+                maxStrings: 6, semitoneMap: {C:0},
+                difficultyFn: difficultyFn
+            });
+            // Each voicing's difficulty should be computed exactly once.
+            for (var k = 0; k < 8; k++) {
+                assertEqual(calls["v" + k], 1, "v" + k + " called once");
+            }
+        """)
+
 
 # === IRealParser.js ===
 


### PR DESCRIPTION
Closes #178.

## What changed

ChordSelector's sort previously called `_scoreCandidate` twice per comparison, and each call ran the full `FingeringEngine.suggestFingering` constraint solver via the `difficultyFn` callback. That's O(N log N x 2) difficulty calls per sort.

This PR scores each candidate exactly once via a precompute pass, and memoizes `computeDifficulty` results within a single `findBestVoicing` / `findAllVoicings` call via a module-scoped cache reset on entry.

## Test plan

- [x] `pytest tests/test_js_modules.py tests/test_core.py` -- 199 pass
- [x] New test `test_difficulty_memoization_one_call_per_voicing` asserts exactly one difficultyFn call per voicing per sort
- [ ] Manual: switch to Baritone A with `maxPerQuality > 240` and confirm the stall is gone

Self-review artifact: `plans/self-review-178-memoize-difficulty.md`