### PR TITLE
feat: Backup archive version migration on restore (#179)

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -579,24 +579,33 @@ MuseScore {
                 settingsPanel.backupStatusColor = theme.errorText
                 return
             }
-            try {
-                var parsed = JSON.parse(xhr.responseText)
-                // Sniff: backup archive has manifest.plugin === "chordlibrary"
-                if (parsed.manifest && parsed.manifest.plugin === "chordlibrary") {
-                    _restoreFromArchive(parsed)
-                    return
+            // Route through BackupManager so version-checking applies to URL
+            // imports the same way it does to file restores (#179).
+            var pres = BackupManager.parseArchive(xhr.responseText)
+            if (pres.ok) {
+                _restoreFromArchive(pres.archive)
+                if (pres.migrated) {
+                    settingsPanel.backupStatus += " (migrated from older archive version)"
                 }
-                // Tuning file: has strings + notes objects with numeric keys
-                if (parsed.strings && parsed.notes && parsed.name) {
-                    _importTuningFromObject(parsed)
-                    return
-                }
-                settingsPanel.backupStatus = "Unrecognised file shape. Expected a tuning or backup-archive JSON."
-                settingsPanel.backupStatusColor = theme.errorText
-            } catch (e) {
-                settingsPanel.backupStatus = "Parse failed: " + String(e)
-                settingsPanel.backupStatusColor = theme.errorText
+                return
             }
+            if (pres.reason === "not-chordlibrary" || pres.reason === "missing-version") {
+                // Could still be a single tuning file. Try sniff path.
+                try {
+                    var parsed = JSON.parse(xhr.responseText)
+                    if (parsed.strings && parsed.notes && parsed.name) {
+                        _importTuningFromObject(parsed)
+                        return
+                    }
+                    settingsPanel.backupStatus = "Unrecognised file shape. Expected a tuning or backup-archive JSON."
+                    settingsPanel.backupStatusColor = theme.errorText
+                } catch (e) {
+                    settingsPanel.backupStatus = "Parse failed: " + String(e)
+                    settingsPanel.backupStatusColor = theme.errorText
+                }
+                return
+            }
+            _reportArchiveError(pres)
         }
         xhr.send()
     }
@@ -667,17 +676,46 @@ MuseScore {
         try {
             backupFile.source = path
             var raw = backupFile.read()
-            var archive = BackupManager.parseArchive(raw)
-            if (!archive) {
-                settingsPanel.backupStatus = "Not a valid chordlibrary backup file"
-                settingsPanel.backupStatusColor = theme.errorText
+            var pres = BackupManager.parseArchive(raw)
+            if (!pres.ok) {
+                _reportArchiveError(pres)
                 return
             }
-            _restoreFromArchive(archive)
+            _restoreFromArchive(pres.archive)
+            if (pres.migrated) {
+                settingsPanel.backupStatus += " (migrated from older archive version)"
+            }
         } catch (e) {
             settingsPanel.backupStatus = "Restore failed: " + String(e)
             settingsPanel.backupStatusColor = theme.errorText
         }
+    }
+
+    // Translate a parseArchive failure into a user-facing message (#179).
+    function _reportArchiveError(pres) {
+        var msg
+        switch (pres.reason) {
+        case "empty":
+            msg = "Backup file is empty"
+            break
+        case "not-json":
+            msg = "Backup file is not valid JSON: " + (pres.detail || "")
+            break
+        case "not-chordlibrary":
+            msg = "Not a chordlibrary backup file"
+            break
+        case "missing-version":
+            msg = "Backup file has no manifest.version (corrupt or pre-v2.2)"
+            break
+        case "unsupported-version":
+            msg = "Backup is from a newer plugin version (" + (pres.detail || "?") +
+                  "). Please update the plugin before restoring."
+            break
+        default:
+            msg = "Restore failed: " + (pres.reason || "unknown error")
+        }
+        settingsPanel.backupStatus = msg
+        settingsPanel.backupStatusColor = theme.errorText
     }
 
     function setProfile(profileId) {

--- a/plugin/model/BackupManager.js
+++ b/plugin/model/BackupManager.js
@@ -15,6 +15,18 @@
 
 .pragma library
 
+// Versions this plugin can read on restore (#179). Append as the archive shape
+// stabilizes across releases. Anything not in this list returns a structured
+// "unsupported-version" error from parseArchive.
+var SUPPORTED_VERSIONS = ["v2.2"]
+var CURRENT_VERSION = "v2.2"
+
+// Migration registry: { fromVersion: function(archive) -> archive }
+// Keyed by the archive's manifest.version. Migrations run in order from the
+// archive's declared version up to CURRENT_VERSION. Empty today because v2.2
+// is the only supported version; declared structure for future use.
+var MIGRATIONS = {}
+
 function buildArchive(opts) {
     // opts: { settings, allStyles, allScales, customTuningSlugs, readTuningFile }
     var custStyles = []
@@ -48,7 +60,7 @@ function buildArchive(opts) {
     return {
         manifest: {
             plugin: "chordlibrary",
-            version: opts.version || "v2.2",
+            version: opts.version || CURRENT_VERSION,
             exportedAt: new Date().toISOString()
         },
         settings: opts.settings || {},
@@ -62,15 +74,46 @@ function serialize(archive) {
     return JSON.stringify(archive, null, 2)
 }
 
+// Parse + version-check an archive. Returns one of:
+//   { ok: true,  archive: <archive>, migrated: <bool> }
+//   { ok: false, reason: "empty" }
+//   { ok: false, reason: "not-json", detail: <string> }
+//   { ok: false, reason: "not-chordlibrary" }
+//   { ok: false, reason: "missing-version" }
+//   { ok: false, reason: "unsupported-version", detail: <version-string> }
+//
+// Callers should switch on `reason` to produce user-facing messages. Future
+// versions add migrations to MIGRATIONS; an older-but-known version chains
+// through the registered migrations until current.
 function parseArchive(rawJson) {
-    if (!rawJson || rawJson.length === 0) return null
+    if (!rawJson || rawJson.length === 0) return { ok: false, reason: "empty" }
+    var a
     try {
-        var a = JSON.parse(rawJson)
-        if (!a.manifest || a.manifest.plugin !== "chordlibrary") return null
-        return a
+        a = JSON.parse(rawJson)
     } catch (e) {
-        return null
+        return { ok: false, reason: "not-json", detail: String(e) }
     }
+    if (!a.manifest || a.manifest.plugin !== "chordlibrary") {
+        return { ok: false, reason: "not-chordlibrary" }
+    }
+    if (!a.manifest.version) {
+        return { ok: false, reason: "missing-version" }
+    }
+    var v = a.manifest.version
+    if (SUPPORTED_VERSIONS.indexOf(v) < 0) {
+        return { ok: false, reason: "unsupported-version", detail: v }
+    }
+    // Run any migrations chained from `v` up to CURRENT_VERSION. v2.2 only
+    // supports its own version today, so this loop is a no-op until we add
+    // entries to MIGRATIONS.
+    var migrated = false
+    var current = v
+    while (current !== CURRENT_VERSION && MIGRATIONS[current]) {
+        a = MIGRATIONS[current](a)
+        current = a.manifest.version
+        migrated = true
+    }
+    return { ok: true, archive: a, migrated: migrated }
 }
 
 // Merge restore helpers — each returns a summary object {added, updated, skipped}

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -1081,6 +1081,62 @@ class TestChordSelectorModes:
         """)
 
 
+# === BackupManager.js — parseArchive (#179) ===
+
+
+class TestBackupManagerParse:
+    """Test BackupManager.parseArchive structured-result behavior."""
+
+    def test_empty_input_returns_empty_reason(self):
+        assert_js("BackupManager.js", """
+            var r = parseArchive("");
+            assertEqual(r.ok, false, "ok=false");
+            assertEqual(r.reason, "empty", "reason=empty");
+        """)
+
+    def test_invalid_json_returns_not_json(self):
+        assert_js("BackupManager.js", """
+            var r = parseArchive("{not valid json");
+            assertEqual(r.ok, false, "ok=false");
+            assertEqual(r.reason, "not-json", "reason=not-json");
+            assert(r.detail !== undefined, "detail set");
+        """)
+
+    def test_non_chordlibrary_manifest_rejected(self):
+        assert_js("BackupManager.js", """
+            var r = parseArchive(JSON.stringify({ manifest: { plugin: "other-tool", version: "v1.0" } }));
+            assertEqual(r.reason, "not-chordlibrary", "reason=not-chordlibrary");
+        """)
+
+    def test_missing_version_rejected(self):
+        assert_js("BackupManager.js", """
+            var r = parseArchive(JSON.stringify({ manifest: { plugin: "chordlibrary" } }));
+            assertEqual(r.reason, "missing-version", "reason=missing-version");
+        """)
+
+    def test_unsupported_version_rejected(self):
+        assert_js("BackupManager.js", """
+            var r = parseArchive(JSON.stringify({
+                manifest: { plugin: "chordlibrary", version: "v9.99" }
+            }));
+            assertEqual(r.ok, false, "ok=false");
+            assertEqual(r.reason, "unsupported-version", "reason=unsupported-version");
+            assertEqual(r.detail, "v9.99", "detail names the version");
+        """)
+
+    def test_current_version_accepted(self):
+        assert_js("BackupManager.js", """
+            var archive = {
+                manifest: { plugin: "chordlibrary", version: "v2.2", exportedAt: "2026-05-21" },
+                settings: {}, customStyles: [], customScales: [], customTuningFiles: {}
+            };
+            var r = parseArchive(JSON.stringify(archive));
+            assertEqual(r.ok, true, "ok=true");
+            assertEqual(r.migrated, false, "current version not migrated");
+            assertEqual(r.archive.manifest.version, "v2.2", "archive returned");
+        """)
+
+
 # === IRealParser.js ===
 
 


### PR DESCRIPTION
Closes #179.

Replaces parseArchive's archive-or-null return with a discriminated-union result so a future v3 archive into a v2.2 plugin surfaces a specific error instead of silent corruption.

Self-review artifact: plans/self-review-179-backup-version-migration.md