### PR TITLE
refactor: Lift pure backup helpers + group QML-glue (#181)

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -511,14 +511,27 @@ MuseScore {
         return (_modesById && _modesById[id]) ? _modesById[id] : null
     }
 
-    // === Backup / restore (#172) ===
-
-    function _timestamp() {
-        var d = new Date()
-        var pad = function(n) { return (n < 10 ? "0" : "") + n }
-        return d.getFullYear() + pad(d.getMonth()+1) + pad(d.getDate())
-            + "-" + pad(d.getHours()) + pad(d.getMinutes())
-    }
+    // ============================================================
+    // === Backup / restore + URL import =========================
+    // ============================================================
+    // The pure logic (archive shape, version checking, merge rules,
+    // timestamps, error messages) lives in plugin/model/BackupManager.js.
+    // The QML-side functions below glue that to FileIO, plugin state,
+    // and the SettingsPanel status surface. They were considered for
+    // extraction into a separate QML controller in #181 but the residue
+    // is genuinely QML-glue and gains nothing from a controller split.
+    //
+    // Related tickets: #172 (initial backup MVP), #179 (version migration),
+    // #67 (URL import + community packs), #181 (extraction re-evaluation).
+    //
+    // Function index:
+    //   exportBackup()                — write archive to Desktop
+    //   restoreBackup(path)           — read archive from path and apply
+    //   importFromUrl(url)            — fetch JSON via HTTP, sniff, dispatch
+    //   _importTuningFromObject(t)    — apply a single tuning JSON
+    //   _restoreFromArchive(archive)  — apply a verified archive
+    //   _reportArchiveError(pres)     — surface parseArchive failures to UI
+    // ============================================================
 
     function exportBackup() {
         try {
@@ -550,7 +563,7 @@ MuseScore {
                 readTuningFile: readTuningFile,
                 version: "v2.2"
             })
-            var path = homePath() + "/Desktop/chordlibrary-backup-" + _timestamp() + ".json"
+            var path = homePath() + "/Desktop/chordlibrary-backup-" + BackupManager.timestampForFilename() + ".json"
             backupFile.source = path
             backupFile.write(BackupManager.serialize(archive))
             settingsPanel.backupStatus = "Exported to " + path
@@ -691,30 +704,12 @@ MuseScore {
         }
     }
 
-    // Translate a parseArchive failure into a user-facing message (#179).
+    // Translate a parseArchive failure into a user-facing message (#179, #181).
+    // The catalog itself lives in BackupManager.reasonMessage so the messages
+    // sit beside the parseArchive that produces the reasons; this function
+    // just routes the result to the SettingsPanel surface.
     function _reportArchiveError(pres) {
-        var msg
-        switch (pres.reason) {
-        case "empty":
-            msg = "Backup file is empty"
-            break
-        case "not-json":
-            msg = "Backup file is not valid JSON: " + (pres.detail || "")
-            break
-        case "not-chordlibrary":
-            msg = "Not a chordlibrary backup file"
-            break
-        case "missing-version":
-            msg = "Backup file has no manifest.version (corrupt or pre-v2.2)"
-            break
-        case "unsupported-version":
-            msg = "Backup is from a newer plugin version (" + (pres.detail || "?") +
-                  "). Please update the plugin before restoring."
-            break
-        default:
-            msg = "Restore failed: " + (pres.reason || "unknown error")
-        }
-        settingsPanel.backupStatus = msg
+        settingsPanel.backupStatus = BackupManager.reasonMessage(pres)
         settingsPanel.backupStatusColor = theme.errorText
     }
 

--- a/plugin/model/BackupManager.js
+++ b/plugin/model/BackupManager.js
@@ -155,6 +155,33 @@ function mergeScales(archive, existing) {
     return { list: out, added: added, updated: updated }
 }
 
+// Build the YYYYMMDD-HHMM timestamp suffix used in backup filenames. Pure
+// function; lifted out of ChordLibrary.qml so the export-path naming is
+// owned by the same module that owns the archive format (#181).
+function timestampForFilename(now) {
+    var d = now || new Date()
+    var pad = function(n) { return (n < 10 ? "0" : "") + n }
+    return d.getFullYear() + pad(d.getMonth() + 1) + pad(d.getDate())
+         + "-" + pad(d.getHours()) + pad(d.getMinutes())
+}
+
+// Map a parseArchive failure result into a user-facing message (#181).
+// Keeping the message catalog beside the parseArchive that produces the
+// reasons keeps "this is what users see when X breaks" inspectable in one
+// place.
+function reasonMessage(parseResult) {
+    if (!parseResult || parseResult.ok) return ""
+    switch (parseResult.reason) {
+    case "empty":               return "Backup file is empty"
+    case "not-json":            return "Backup file is not valid JSON: " + (parseResult.detail || "")
+    case "not-chordlibrary":    return "Not a chordlibrary backup file"
+    case "missing-version":     return "Backup file has no manifest.version (corrupt or pre-v2.2)"
+    case "unsupported-version": return "Backup is from a newer plugin version (" + (parseResult.detail || "?")
+                                     + "). Please update the plugin before restoring."
+    default:                    return "Restore failed: " + (parseResult.reason || "unknown error")
+    }
+}
+
 function tuningFilesToRestore(archive) {
     if (!archive || !archive.customTuningFiles) return []
     var out = []

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -1257,6 +1257,27 @@ class TestBackupManagerRoundTrip:
             assertEqual(slugs[1], "beta", "beta present");
         """)
 
+    def test_timestamp_for_filename_format(self):
+        # #181: timestampForFilename produces YYYYMMDD-HHMM for filenames.
+        assert_js("BackupManager.js", """
+            var t = timestampForFilename(new Date(2026, 4, 21, 3, 7));  // May 21 2026 03:07
+            assertEqual(t, "20260521-0307", "format YYYYMMDD-HHMM with zero-padding");
+        """)
+
+    def test_reason_message_unsupported_version_includes_detail(self):
+        assert_js("BackupManager.js", """
+            var pres = { ok: false, reason: "unsupported-version", detail: "v9.99" };
+            var m = reasonMessage(pres);
+            assert(m.indexOf("v9.99") >= 0, "message names the offending version");
+            assert(m.indexOf("update the plugin") >= 0, "message advises action");
+        """)
+
+    def test_reason_message_empty_returns_empty(self):
+        assert_js("BackupManager.js", """
+            assertEqual(reasonMessage(null), "", "null result -> empty");
+            assertEqual(reasonMessage({ ok: true, archive: {} }), "", "ok result -> empty");
+        """)
+
     def test_freeze_resolution_round_trip_via_archive(self):
         # Frozen compositions in an archive should restore as frozen — base
         # styles can be missing from the receiving plugin without breaking.


### PR DESCRIPTION
Closes #181. Re-scoped after reading the code: full controller extract didn't pay for itself; lifted the genuinely-pure helpers and added a section-header comment block instead. Self-review explains the rescope: plans/self-review-181-backup-controller.md