### PR TITLE
feat: Curated-shapes.json + signature infrastructure (#194 Phase 1)

### DIFF
--- a/plugin/data/additional-shapes.json
+++ b/plugin/data/additional-shapes.json
@@ -1,0 +1,5 @@
+{
+  "version": "v1",
+  "schemaNote": "shapes the calculator may not regenerate under default constraints \u2014 empty until we measure",
+  "shapes": []
+}

--- a/plugin/data/curated-shapes.json
+++ b/plugin/data/curated-shapes.json
@@ -1,0 +1,16022 @@
+{
+  "version": "v1",
+  "schemaNote": "signature is root-relative; ChordSelector computes the same shape per candidate at runtime",
+  "shapes": [
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "4"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Extended (root on top)",
+      "category": "extended",
+      "chord_quality": "13sus4",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "4",
+        "6",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "5",
+        "7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "sus4",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "5",
+        "1",
+        "4",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "dom9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "b7",
+        "9",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "5",
+        "1",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "dom13",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "4",
+        "b7",
+        "3",
+        "6"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b9"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Altered (6th on top)",
+      "category": "altered",
+      "chord_quality": "13b9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b9",
+        "3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "b9"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "4"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 6 \u2014 Altered (b7 on top)",
+      "category": "altered",
+      "chord_quality": "7b9sus4",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "b9",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b9"
+          ],
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Altered (b9 on top)",
+      "category": "altered",
+      "chord_quality": "7sharp5b9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "3",
+        "#5",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "7sharp5sharp9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b3",
+        "#5",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "13sharp9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b3",
+        "6",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "7b5sharp9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b3",
+        "b5",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b9"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 6 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "7b5b9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b9",
+        "b5",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          4
+        ],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            5,
+            "4"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 6 \u2014 Extended (b7 on top)",
+      "category": "extended",
+      "chord_quality": "9sus4",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "9",
+        "9",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "maj7sharp5",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "7",
+        "3",
+        "#5",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "b3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "dom7sharp9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "b7",
+        "1",
+        "3",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          1,
+          3,
+          6
+        ],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ],
+          [
+            5,
+            "3"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "dom9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "3",
+        "1",
+        "3",
+        "5",
+        "9",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          1,
+          2,
+          3
+        ],
+        "pairs": [
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [],
+        "opens": [
+          2,
+          4
+        ],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            5,
+            "b3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 6 \u2014 Extended (7th on top)",
+      "category": "extended",
+      "chord_quality": "min-maj9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "9",
+        "9",
+        "7",
+        "7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "#9"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "#4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#4",
+        "6",
+        "#9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "aug7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "3",
+        "#5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "#5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7sharp5",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 8
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "#5"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "aug7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "#5",
+        "1",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "#5"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "aug7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "#5",
+        "1"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "#5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "aug7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "1",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "#5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "augMaj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "bb7"
+          ],
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [
+        "caged-a"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "bb7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 14
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "aug7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (#5 on top)",
+      "category": "drop2",
+      "chord_quality": "augMaj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "#5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "aug7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "#5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "augMaj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (7th on top)",
+      "category": "shell",
+      "chord_quality": "aug7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "7"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (7th on top)",
+      "category": "shell",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "7"
+      ],
+      "sourceCount": 6
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "bb7"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "bb7",
+        "b3",
+        "b5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "bb7"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "bb7",
+        "1",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "bb7"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "b5"
+          ]
+        ]
+      },
+      "name": "Fret 4 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b5",
+        "1",
+        "b3",
+        "bb7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "bb7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (b5 on top)",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [
+        "caged-e"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "bb7",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "#9"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "#9",
+        "6"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "bb7"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (bb7 on top)",
+      "category": "shell",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "bb7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "dom13",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "3",
+        "6"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "dim7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "6",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "1",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "bb7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (b5 on top)",
+      "category": "drop3",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "bb7",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "1",
+        "b5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "1",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "3",
+        "b7",
+        "1",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "bb7"
+          ],
+          [
+            3,
+            "b5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "bb7",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "b3"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "dim7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "b3",
+        "6",
+        "1",
+        "b5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "#5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "dom7alt",
+      "traditions": [
+        "caged-a"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (#5 on top)",
+      "category": "drop2",
+      "chord_quality": "dom7alt",
+      "traditions": [
+        "caged-e"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "#5"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "13"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (b7 on top)",
+      "category": "drop2",
+      "chord_quality": "dom13",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "13",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7sharp9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "b3",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "13"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (13th on top)",
+      "category": "shell",
+      "chord_quality": "dom13",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b13"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (b13 on top)",
+      "category": "extended",
+      "chord_quality": "dom7b13",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b13"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (b13 on top)",
+      "category": "extended",
+      "chord_quality": "dom7b13",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "b13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "b9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "dom7b9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b9",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Altered (b9 on top)",
+      "category": "altered",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b9"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Altered (b9 on top)",
+      "category": "altered",
+      "chord_quality": "dom7b9",
+      "traditions": [
+        "laukens-p37"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "5",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "dom9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b9 on top)",
+      "category": "drop2",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b9"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b9",
+        "3",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b9"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 9 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b9"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 6 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "dom7b9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b9"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b9 on top)",
+      "category": "shell",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (b5 on top)",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "#4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#4",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 3
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "b5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "3",
+        "b7",
+        "1",
+        "b5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "#11"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (3rd on top)",
+      "category": "extended",
+      "chord_quality": "dom7sharp11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#11",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            3,
+            "#11"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (3rd on top)",
+      "category": "extended",
+      "chord_quality": "dom7sharp11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "#11",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7sharp9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 6
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "dom9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "5",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "dom9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "dom9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "13"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (13th on top)",
+      "category": "extended",
+      "chord_quality": "maj13",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "13"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (13th on top)",
+      "category": "shell",
+      "chord_quality": "dom13",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "maj69",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "9",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "6"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "6",
+        "3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "6"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "6",
+        "1",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "6"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "6",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "maj6",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "1",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "6",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "1",
+        "3",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "maj6",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          3,
+          4
+        ],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "9"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "sus2",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "9",
+        "5",
+        "1",
+        "5"
+      ],
+      "sourceCount": 3
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          1,
+          3
+        ],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "5",
+        "1",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "#4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7sharp11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#4",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "3"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "3",
+        "7",
+        "1",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "maj9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "7",
+        "9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "#11"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (3rd on top)",
+      "category": "extended",
+      "chord_quality": "maj7sharp11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#11",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "maj9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "5",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "pairs": [
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "maj9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "9",
+        "5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "maj9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "maj9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "maj9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min11",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "1",
+        "4"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "min11",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "b7",
+        "9",
+        "4"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "min6",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "6",
+        "1",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min11",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min11",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "#9"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "#9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "11"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (11th on top)",
+      "category": "extended",
+      "chord_quality": "min11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "b7",
+        "11"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "#9"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (7th on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "#9",
+        "7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "#9"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "#9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "6"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "6",
+        "b3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "6"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "6",
+        "1",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "b3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "6"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "6",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (7th on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "11"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (11th on top)",
+      "category": "extended",
+      "chord_quality": "min11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "11"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "6",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "min6",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b3",
+        "6"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "6"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "6",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b3",
+        "b7",
+        "1",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "b3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "6"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "6",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          3
+        ],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "5",
+        "1",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "maj69",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "maj69",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (5th on top)",
+      "category": "drop3",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [
+        "caged-a"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "#9"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "#9",
+        "b7"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "min9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "5",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          4,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "maj69",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "min9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "b7",
+        "9",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          4
+        ],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Extended",
+      "category": "extended",
+      "chord_quality": "min9",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "9",
+        "b7",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "#9"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "#4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#4",
+        "b7",
+        "#9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "7",
+        "3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b3",
+        "b5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "13"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "4",
+        "b7",
+        "b3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "13"
+          ],
+          [
+            4,
+            "b3"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b3",
+        "13",
+        "9",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "#9"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "min9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#9",
+        "b7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "b5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "b5"
+          ]
+        ]
+      },
+      "name": "Fret 4 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b5",
+        "1",
+        "b3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (b5 on top)",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [
+        "caged-e"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (b5 on top)",
+      "category": "drop3",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          3
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "b5"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b5",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "13"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "4"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "4",
+        "b7",
+        "b3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            4,
+            "13"
+          ],
+          [
+            5,
+            "b3"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b3",
+        "13",
+        "9",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "min9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "b7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "min9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "9"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "9",
+        "5",
+        "1",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "13"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b3",
+        "13",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Quartal (b3 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [
+        "caged-a"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "1"
+          ],
+          [
+            5,
+            "5"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [
+          3,
+          4,
+          5
+        ],
+        "pairs": [
+          [
+            2,
+            "1"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            4,
+            "13"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "13",
+        "9",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "7"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Quartal (b3 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "2"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (2nd on top)",
+      "category": "drop2",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "2"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "2"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "2",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          6
+        ],
+        "opens": [
+          3
+        ],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "sus4",
+      "traditions": [
+        "chords-db"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "5",
+        "1",
+        "4"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (5th on top)",
+      "category": "drop3",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (5th on top)",
+      "category": "drop3",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "2"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (2nd on top)",
+      "category": "drop2",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "2"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (4th on top)",
+      "category": "drop2",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "2"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (2nd on top)",
+      "category": "shell",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "2"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "4",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "2"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "2",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "2"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (2nd on top)",
+      "category": "shell",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "2"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (4th on top)",
+      "category": "drop2",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "13"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b3",
+        "13",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          5,
+          6
+        ],
+        "opens": [
+          3,
+          4
+        ],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "1"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (4th on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [
+        "caged-a",
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (4th on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "b7"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 6,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            6,
+            "4"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Extended (4th on top)",
+      "category": "extended",
+      "chord_quality": "13sus4",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "4",
+        "6",
+        "1",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "b9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            6,
+            "4"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Altered (4th on top)",
+      "category": "altered",
+      "chord_quality": "7b9sus4",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "4",
+        "b7",
+        "b9",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          1
+        ],
+        "pairs": [
+          [
+            2,
+            "b9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "b5"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "7b5b9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "1",
+        "3",
+        "b7",
+        "b9",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          1,
+          6
+        ],
+        "pairs": [
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "7sharp5b9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "3",
+        "#5",
+        "b9",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          1,
+          6
+        ],
+        "pairs": [
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "7sharp5sharp9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b3",
+        "#5",
+        "1",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          1,
+          6
+        ],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "13sharp9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b3",
+        "6",
+        "1",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          1,
+          6
+        ],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "dom7sharp9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b3",
+        "b7",
+        "1",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          1,
+          6
+        ],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "b5"
+          ],
+          [
+            4,
+            "1"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "7b5sharp9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "1",
+        "b5",
+        "b7",
+        "b3",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          1,
+          5,
+          6
+        ],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "13b9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "3",
+        "b7",
+        "b9",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          4
+        ],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            6,
+            "4"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Extended (4th on top)",
+      "category": "extended",
+      "chord_quality": "9sus4",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "9",
+        "b7",
+        "1",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          1,
+          2,
+          6
+        ],
+        "pairs": [
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            5,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Altered (3rd on top)",
+      "category": "altered",
+      "chord_quality": "maj7sharp5",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "7",
+        "3",
+        "#5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [],
+        "opens": [
+          2,
+          4
+        ],
+        "pairs": [
+          [
+            1,
+            "7"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            5,
+            "b3"
+          ],
+          [
+            6,
+            "7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Extended (7th on top)",
+      "category": "extended",
+      "chord_quality": "min-maj9",
+      "traditions": [
+        "laukens-coverage"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "b3",
+        "9",
+        "7",
+        "7",
+        "7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "aug7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "3",
+        "#5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "#5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7sharp5",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 8
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "#5"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "aug7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "#5",
+        "1",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "#5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "augMaj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 14
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "aug7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (#5 on top)",
+      "category": "drop2",
+      "chord_quality": "augMaj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "#5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "aug7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "#5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "augMaj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (7th on top)",
+      "category": "shell",
+      "chord_quality": "aug7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "7"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (7th on top)",
+      "category": "shell",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "7"
+      ],
+      "sourceCount": 6
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "#9"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "#4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#4",
+        "6",
+        "#9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "bb7"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "bb7",
+        "b3",
+        "b5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "bb7"
+          ]
+        ]
+      },
+      "name": "Fret 2 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "bb7",
+        "1",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "bb7"
+          ],
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [
+        "caged-a"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "bb7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "bb7"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "b5"
+          ]
+        ]
+      },
+      "name": "Fret 4 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b5",
+        "1",
+        "b3",
+        "bb7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "bb7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (b5 on top)",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [
+        "caged-e"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "bb7",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "bb7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (b5 on top)",
+      "category": "drop3",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "bb7",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "bb7"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (bb7 on top)",
+      "category": "shell",
+      "chord_quality": "dim7",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "bb7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "#9"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "#9",
+        "6"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "13"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (b7 on top)",
+      "category": "drop2",
+      "chord_quality": "dom13",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "13",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "bb7"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (bb7 on top)",
+      "category": "shell",
+      "chord_quality": "dim7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "bb7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "3",
+        "b7",
+        "1",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "bb7"
+          ],
+          [
+            3,
+            "b5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "dim7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "bb7",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "13"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (13th on top)",
+      "category": "shell",
+      "chord_quality": "dom13",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 6
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "13"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (13th on top)",
+      "category": "shell",
+      "chord_quality": "dom13",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [
+          3
+        ],
+        "pairs": [
+          [
+            4,
+            "3"
+          ],
+          [
+            6,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str bass \u2014 Drop 3",
+      "category": "drop3",
+      "chord_quality": "dom7",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (5th on top)",
+      "category": "drop3",
+      "chord_quality": "dom7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "#5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "dom7alt",
+      "traditions": [
+        "caged-a"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b9"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Altered (b9 on top)",
+      "category": "altered",
+      "chord_quality": "dom7b9",
+      "traditions": [
+        "laukens-p37"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "5",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "#5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (#5 on top)",
+      "category": "drop2",
+      "chord_quality": "dom7alt",
+      "traditions": [
+        "caged-e"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "#5"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b13"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (b13 on top)",
+      "category": "extended",
+      "chord_quality": "dom7b13",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "b13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b9"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b9",
+        "3",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "#4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#4",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 3
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b9"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 9 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "#11"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (3rd on top)",
+      "category": "extended",
+      "chord_quality": "dom7sharp11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#11",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (b5 on top)",
+      "category": "shell",
+      "chord_quality": "dom7alt",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b5"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b13"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (b13 on top)",
+      "category": "extended",
+      "chord_quality": "dom7b13",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b9 on top)",
+      "category": "drop2",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Altered (b9 on top)",
+      "category": "altered",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "#5"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (#5 on top)",
+      "category": "shell",
+      "chord_quality": "dom7sharp5",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "#5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          4,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b9"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (b9 on top)",
+      "category": "shell",
+      "chord_quality": "dom7b9",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b9"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b9 on top)",
+      "category": "shell",
+      "chord_quality": "dom7b9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "dom9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "5",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (b5 on top)",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "b5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "dom7flat5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            3,
+            "#11"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (3rd on top)",
+      "category": "extended",
+      "chord_quality": "dom7sharp11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "#11",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "dom9",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "dom9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "dom9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "6"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "6",
+        "3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "3"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "3",
+        "7",
+        "1",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "6"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "6",
+        "1",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "maj69",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "dom9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "b7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "13"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (13th on top)",
+      "category": "extended",
+      "chord_quality": "maj13",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "6"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "6",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          6
+        ],
+        "opens": [
+          5
+        ],
+        "pairs": [
+          [
+            4,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (3rd on top)",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "maj69",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "6",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "6"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "6",
+        "3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "dom7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          4,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "maj69",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "6",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "#9"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "#9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "7",
+        "3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [
+          3
+        ],
+        "pairs": [
+          [
+            4,
+            "3"
+          ],
+          [
+            6,
+            "7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str bass \u2014 Drop 3",
+      "category": "drop3",
+      "chord_quality": "maj7",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (5th on top)",
+      "category": "drop3",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (3rd on top)",
+      "category": "shell",
+      "chord_quality": "maj7",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "3"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "#4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7sharp11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#4",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "7"
+          ],
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 5 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "3",
+        "7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "#11"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (3rd on top)",
+      "category": "extended",
+      "chord_quality": "maj7sharp11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#11",
+        "7",
+        "3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "maj9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "5",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "maj9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "3",
+        "7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "maj9",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "maj9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "maj9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "3",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "7",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "7"
+          ],
+          [
+            4,
+            "#9"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (7th on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "#9",
+        "7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "7"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (7th on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min-maj7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "11"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Extended (11th on top)",
+      "category": "extended",
+      "chord_quality": "min11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b3",
+        "b7",
+        "11"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "11"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (11th on top)",
+      "category": "extended",
+      "chord_quality": "min11",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "11"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "#9"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (4th on top)",
+      "category": "shell",
+      "chord_quality": "min11",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "#9",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "#9"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "#9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "6"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "6",
+        "b3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 8 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b3",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "6"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "6",
+        "1",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "6"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "b3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "6"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "6",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "6"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "6"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "6",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5
+        ],
+        "opens": [
+          3
+        ],
+        "pairs": [
+          [
+            4,
+            "b3"
+          ],
+          [
+            6,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str bass \u2014 Drop 3",
+      "category": "drop3",
+      "chord_quality": "min7",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "6"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "6",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (5th on top)",
+      "category": "drop3",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [
+        "caged-a"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "#9"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "#9",
+        "b7"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [
+        "caged-a",
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Extended (9th on top)",
+      "category": "extended",
+      "chord_quality": "min9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "5",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "#9"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "#4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#4",
+        "b7",
+        "#9"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Fret 7 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b3",
+        "b5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "#9"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (9th on top)",
+      "category": "drop2",
+      "chord_quality": "min9",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "#9",
+        "b7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "b5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b5",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "b5"
+          ]
+        ]
+      },
+      "name": "Fret 4 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b5",
+        "1",
+        "b3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (b5 on top)",
+      "category": "drop2",
+      "chord_quality": "min7b5",
+      "traditions": [
+        "caged-e"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "min9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "b7",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "b7"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (b3 on top)",
+      "category": "shell",
+      "chord_quality": "min7",
+      "traditions": [
+        "guide-tone"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 4
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b5"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 3 (b5 on top)",
+      "category": "drop3",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "b5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "b5"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "min7b5",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b5",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (9th on top)",
+      "category": "shell",
+      "chord_quality": "min9",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "13"
+          ],
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b3",
+        "13",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [
+          3,
+          4,
+          5
+        ],
+        "pairs": [
+          [
+            2,
+            "1"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ],
+          [
+            6,
+            "5"
+          ],
+          [
+            7,
+            "9"
+          ]
+        ]
+      },
+      "name": "Str 4-5-6-7 \u2014 Quartal (4th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "9",
+        "5",
+        "1",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "b3"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            6,
+            "4"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "Str 4-5-6-7 \u2014 Quartal (b3 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "1"
+          ],
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            4,
+            "13"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "13",
+        "9",
+        "5",
+        "1"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "13"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "4",
+        "b7",
+        "b3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "2"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (2nd on top)",
+      "category": "drop2",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "2"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "1"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "b3"
+          ]
+        ]
+      },
+      "name": "Fret 1 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b3",
+        "b7",
+        "1",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "5"
+          ],
+          [
+            2,
+            "9"
+          ],
+          [
+            3,
+            "13"
+          ],
+          [
+            4,
+            "b3"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b3",
+        "13",
+        "9",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "6",
+        "b3"
+      ],
+      "sourceCount": 1
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Fret 3 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "b3",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [
+          3,
+          4
+        ],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "1"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "9"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "9",
+        "5",
+        "1",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "9"
+          ],
+          [
+            4,
+            "13"
+          ],
+          [
+            5,
+            "b3"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b3",
+        "13",
+        "9",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Quartal (b3 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [
+        "caged-a"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "9"
+          ],
+          [
+            6,
+            "13"
+          ],
+          [
+            7,
+            "b3"
+          ]
+        ]
+      },
+      "name": "Str 4-5-6-7 \u2014 Quartal (5th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b3",
+        "13",
+        "9",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "9"
+          ],
+          [
+            2,
+            "13"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "b7",
+        "b3",
+        "13",
+        "9"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Quartal (b3 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "4",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b7"
+          ],
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "1"
+          ],
+          [
+            4,
+            "5"
+          ]
+        ]
+      },
+      "name": "Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "13"
+          ],
+          [
+            5,
+            "b3"
+          ],
+          [
+            6,
+            "b7"
+          ],
+          [
+            7,
+            "4"
+          ]
+        ]
+      },
+      "name": "Str 4-5-6-7 \u2014 Quartal (13th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "4",
+        "b7",
+        "b3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "13"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "4"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "4",
+        "b7",
+        "b3",
+        "13"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "b7"
+          ],
+          [
+            5,
+            "4"
+          ],
+          [
+            6,
+            "1"
+          ],
+          [
+            7,
+            "5"
+          ]
+        ]
+      },
+      "name": "Str 4-5-6-7 \u2014 Quartal (b7 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "2"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (2nd on top)",
+      "category": "drop2",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "2"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (4th on top)",
+      "category": "drop2",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b3"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "5"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Drop 2 (b3 on top)",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "1"
+          ],
+          [
+            5,
+            "5"
+          ]
+        ]
+      },
+      "name": "Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "category": "quartal",
+      "chord_quality": "quartal",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "5",
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "2"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "2",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "2"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (2nd on top)",
+      "category": "shell",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "2"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "4",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "5"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Drop 2 (5th on top)",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "b7",
+        "b3",
+        "5"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "b3"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "min6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "4"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Drop 2 (4th on top)",
+      "category": "drop2",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            1,
+            "b3"
+          ],
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "5"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "Fret 10 \u2014 Drop 2",
+      "category": "drop2",
+      "chord_quality": "min7",
+      "traditions": [
+        "caged-d"
+      ],
+      "boost": 40,
+      "intervals": [
+        "1",
+        "5",
+        "b7",
+        "b3"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "6"
+          ],
+          [
+            3,
+            "3"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (6th on top)",
+      "category": "shell",
+      "chord_quality": "maj6",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "3",
+        "6"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "2"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "2",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "2"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (2nd on top)",
+      "category": "shell",
+      "chord_quality": "sus2",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "2"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          3,
+          6
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "b7"
+          ],
+          [
+            7,
+            "1"
+          ]
+        ]
+      },
+      "name": "7-str root \u2014 Shell (4th on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [
+        "van-eps"
+      ],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "b7"
+          ],
+          [
+            4,
+            "4"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "4"
+          ],
+          [
+            3,
+            "b7"
+          ],
+          [
+            5,
+            "1"
+          ]
+        ]
+      },
+      "name": "A shape \u2014 Shell (4th on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "b7"
+          ],
+          [
+            6,
+            "1"
+          ]
+        ]
+      },
+      "name": "E shape \u2014 Shell (4th on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "b7",
+        "4"
+      ],
+      "sourceCount": 2
+    },
+    {
+      "signature": {
+        "strings": 7,
+        "mutes": [
+          1,
+          5,
+          6,
+          7
+        ],
+        "opens": [],
+        "pairs": [
+          [
+            2,
+            "b7"
+          ],
+          [
+            3,
+            "4"
+          ],
+          [
+            4,
+            "1"
+          ]
+        ]
+      },
+      "name": "D shape \u2014 Shell (b7 on top)",
+      "category": "shell",
+      "chord_quality": "sus4",
+      "traditions": [],
+      "boost": 60,
+      "intervals": [
+        "1",
+        "4",
+        "b7"
+      ],
+      "sourceCount": 2
+    }
+  ]
+}

--- a/plugin/model/ChordSelector.js
+++ b/plugin/model/ChordSelector.js
@@ -83,6 +83,71 @@ function parseChordSymbol(text) {
     return result
 }
 
+// Compute a voicing's root-relative fingering signature (#194).
+// Matches the shape produced by scripts/derive_curated_shapes.py so the
+// curated-shapes.json lookup at scoring time is symmetric.
+//
+// Returns a string key suitable for object lookup. Format:
+//   "<strings>|m:<sorted-mutes>|o:<sorted-opens>|p:<sorted (string,interval) pairs>"
+//
+// Two voicings with the same root-relative shape produce the same key
+// regardless of which root they're transposed to.
+function signatureKey(voicing) {
+    if (!voicing) return ""
+    var strings = voicing.strings || 6
+    var mutes = (voicing.mutes || []).slice().sort(function(a, b) { return a - b })
+    var opens = (voicing.open || []).slice().sort(function(a, b) { return a - b })
+    var dots = voicing.dots || []
+    var intervals = voicing.intervals || []
+    var pairs = []
+    for (var i = 0; i < dots.length; i++) {
+        if (i >= intervals.length) continue
+        pairs.push([dots[i].string, intervals[i]])
+    }
+    pairs.sort(function(a, b) {
+        if (a[0] !== b[0]) return a[0] - b[0]
+        if (a[1] < b[1]) return -1
+        if (a[1] > b[1]) return 1
+        return 0
+    })
+    var pairStr = ""
+    for (var pi = 0; pi < pairs.length; pi++) {
+        if (pi > 0) pairStr += ","
+        pairStr += pairs[pi][0] + ":" + pairs[pi][1]
+    }
+    return strings + "|m:" + mutes.join(",") + "|o:" + opens.join(",") + "|p:" + pairStr
+}
+
+// Build a lookup map from a curated-shapes.json payload (#194).
+// Returns { signatureKey -> { boost, name, traditions, … } }.
+function buildCuratedLookup(curatedPayload) {
+    var lookup = {}
+    if (!curatedPayload || !curatedPayload.shapes) return lookup
+    for (var i = 0; i < curatedPayload.shapes.length; i++) {
+        var shape = curatedPayload.shapes[i]
+        var sig = shape.signature || {}
+        // Reconstruct the same key format signatureKey() produces.
+        var strings = sig.strings || 6
+        var mutes = (sig.mutes || []).slice().sort(function(a, b) { return a - b })
+        var opens = (sig.opens || []).slice().sort(function(a, b) { return a - b })
+        var pairs = (sig.pairs || []).slice()
+        pairs.sort(function(a, b) {
+            if (a[0] !== b[0]) return a[0] - b[0]
+            if (a[1] < b[1]) return -1
+            if (a[1] > b[1]) return 1
+            return 0
+        })
+        var pairStr = ""
+        for (var pi = 0; pi < pairs.length; pi++) {
+            if (pi > 0) pairStr += ","
+            pairStr += pairs[pi][0] + ":" + pairs[pi][1]
+        }
+        var key = strings + "|m:" + mutes.join(",") + "|o:" + opens.join(",") + "|p:" + pairStr
+        lookup[key] = shape
+    }
+    return lookup
+}
+
 // Compute a scoring delta from the active mode config (#161).
 // Mode config shape (from plugin/config/modes.json):
 //   { categoryDeltas, rangeFretMin, rangeFretMax, rangeFretBonus,

--- a/scripts/derive_curated_shapes.py
+++ b/scripts/derive_curated_shapes.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Derive curated-shapes.json from voicings.json (#194).
+
+The 820 curated voicings in voicings.json collapse to ~167 unique
+root-relative fingering signatures after stripping per-root variants.
+This script computes the signatures and emits two files the plugin
+loads at runtime:
+
+  plugin/data/curated-shapes.json    — signature -> boost metadata
+  plugin/data/additional-shapes.json — entries we want to surface
+                                       but whose signature the
+                                       calculator may not regenerate
+                                       under default constraints
+
+The signature is root-relative: it captures the interval played on
+each string (plus mutes/opens/strings count), not the absolute frets.
+So "C7 shell on strings 6/4/3" and "F7 shell on strings 6/4/3" share
+the same signature.
+
+Calculator output also exposes `intervals` parallel to `notes`, so
+matching at runtime is symmetric: compute the candidate's signature,
+look up in the signature map.
+
+Usage:
+    python scripts/derive_curated_shapes.py
+    python scripts/derive_curated_shapes.py --dry-run
+    python scripts/derive_curated_shapes.py --report
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCE = REPO_ROOT / "plugin" / "data" / "voicings.json"
+DEST_CURATED = REPO_ROOT / "plugin" / "data" / "curated-shapes.json"
+DEST_ADDITIONAL = REPO_ROOT / "plugin" / "data" / "additional-shapes.json"
+
+
+def signature_of(voicing: dict) -> tuple:
+    """Compute a root-relative fingering signature.
+
+    Returns a tuple of:
+      (strings, frozenset(mutes), frozenset(opens), tuple((string, interval), ...))
+    """
+    strings = voicing.get("strings", 6)
+    mutes = frozenset(voicing.get("mutes", []))
+    opens = frozenset(voicing.get("open", []))
+    dots = voicing.get("dots", [])
+    intervals = voicing.get("intervals", [])
+    # dots[i] aligns with intervals[i]
+    pairs = []
+    for i, dot in enumerate(dots):
+        if i >= len(intervals):
+            continue  # malformed data; skip
+        pairs.append((dot["string"], intervals[i]))
+    pairs.sort()
+    return (strings, mutes, opens, tuple(pairs))
+
+
+def signature_to_json(sig: tuple) -> dict:
+    """Serialize a signature tuple as a JSON-friendly dict.
+
+    The runtime side (ChordSelector._signatureKey) builds the same
+    shape and stringifies it; keep the two implementations in sync.
+    """
+    strings, mutes, opens, pairs = sig
+    return {
+        "strings": strings,
+        "mutes": sorted(mutes),
+        "opens": sorted(opens),
+        "pairs": [list(p) for p in pairs],
+    }
+
+
+def boost_for(entries: list[dict]) -> int:
+    """Pick a boost magnitude based on the curated entry's tags.
+
+    Range +40 to +80 per think-v2.4-design.md assumption (above mode
+    +25, below the +500 melody/bass-lock bonus). Higher boost for
+    famous traditions; lower for routine shapes.
+    """
+    tags = set()
+    for e in entries:
+        for t in e.get("tags", []):
+            tags.add(t)
+    # Traditions get strong boost
+    if any(t in tags for t in ("freddie-green", "ted-greene-ninth",
+                                "barry-harris-sixth-diminished")):
+        return 80
+    # Named idiomatic patterns
+    if any(t in tags for t in ("van-eps", "guide-tone", "shell")):
+        return 60
+    # Generic curated entries
+    return 40
+
+
+def primary_entry(entries: list[dict]) -> dict:
+    """Pick the deterministic 'primary' entry from a signature group.
+
+    Tie-breakers: shortest name, then alphabetical id.
+    """
+    return sorted(entries, key=lambda e: (len(e.get("name", "")),
+                                           e.get("id", "")))[0]
+
+
+def aggregate_traditions(entries: list[dict]) -> list[str]:
+    """Union the tradition-shaped tags across a signature group."""
+    tradition_keys = {
+        "freddie-green", "ted-greene", "ted-greene-ninth",
+        "barry-harris-sixth-diminished", "van-eps",
+        "guide-tone", "caged-a", "caged-d", "caged-e",
+        "laukens-coverage", "laukens-p37", "chords-db",
+    }
+    found = set()
+    for e in entries:
+        for t in e.get("tags", []):
+            if t in tradition_keys:
+                found.add(t)
+    return sorted(found)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=SOURCE)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--report", action="store_true",
+                        help="Print signature group sizes and exit")
+    args = parser.parse_args()
+
+    with args.source.open() as f:
+        payload = json.load(f)
+
+    voicings = payload.get("voicings", [])
+    by_signature: dict[tuple, list[dict]] = defaultdict(list)
+
+    for v in voicings:
+        sig = signature_of(v)
+        by_signature[sig].append(v)
+
+    if args.report:
+        sizes = sorted((len(v), sig) for sig, v in by_signature.items())
+        print(f"{len(voicings)} voicings collapse to {len(by_signature)} signatures")
+        print(f"  largest group: {sizes[-1][0]} entries")
+        print(f"  smallest group: {sizes[0][0]} entries")
+        from collections import Counter
+        dist = Counter(len(v) for v in by_signature.values())
+        for size, count in sorted(dist.items()):
+            print(f"  {count} signature(s) with {size} entries each")
+        return 0
+
+    # Build curated shapes — one entry per signature
+    curated = []
+    for sig, entries in sorted(by_signature.items()):
+        primary = primary_entry(entries)
+        traditions = aggregate_traditions(entries)
+        sig_json = signature_to_json(sig)
+        # Use the primary entry's name but strip the leading "C7 — " /
+        # "Cmaj7 — " portion since the shape is root-relative.
+        name = primary.get("name", primary.get("id", "unnamed"))
+        if " — " in name:
+            # "C13b9 — Fret 5 — Altered (6th on top)" -> drop the first segment
+            name = " — ".join(name.split(" — ")[1:])
+        curated.append({
+            "signature": sig_json,
+            "name": name,
+            "category": primary.get("category", ""),
+            "chord_quality": primary.get("chord_quality", ""),
+            "traditions": traditions,
+            "boost": boost_for(entries),
+            "intervals": list(primary.get("intervals", [])),
+            "sourceCount": len(entries),
+        })
+
+    additional: list[dict] = []
+    # For v0 of the migration we don't yet split additional-shapes;
+    # ALL curated shapes go to curated-shapes.json. The split is a
+    # follow-up once we measure calculator regeneration rate against
+    # the curated set (see acceptance criteria for #194).
+
+    print(f"{len(voicings)} curated voicings -> {len(curated)} signature groups")
+    print(f"  boost distribution:")
+    from collections import Counter
+    boost_dist = Counter(c["boost"] for c in curated)
+    for boost, count in sorted(boost_dist.items()):
+        print(f"    {boost}: {count} shapes")
+
+    if args.dry_run:
+        print("Dry run — no files written")
+        return 0
+
+    payload_curated = {
+        "version": "v1",
+        "schemaNote": "signature is root-relative; ChordSelector computes the same shape per candidate at runtime",
+        "shapes": curated,
+    }
+    with DEST_CURATED.open("w") as f:
+        json.dump(payload_curated, f, indent=2)
+        f.write("\n")
+    print(f"Wrote {DEST_CURATED}")
+
+    payload_additional = {
+        "version": "v1",
+        "schemaNote": "shapes the calculator may not regenerate under default constraints — empty until we measure",
+        "shapes": additional,
+    }
+    with DEST_ADDITIONAL.open("w") as f:
+        json.dump(payload_additional, f, indent=2)
+        f.write("\n")
+    print(f"Wrote {DEST_ADDITIONAL}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -742,6 +742,114 @@ class TestDataCacheJS:
         """)
 
 
+# === ChordSelector.js — curated shape signature (#194) ===
+
+
+class TestChordSelectorSignature:
+    """Test the root-relative fingering signature helpers (#194)."""
+
+    def test_signature_key_stable_across_dot_order(self):
+        assert_js("ChordSelector.js", """
+            var v1 = {
+                strings: 6, mutes: [], open: [],
+                dots: [{string:3,fret:2}, {string:4,fret:1}, {string:6,fret:1}],
+                intervals: ["3", "b7", "1"]
+            };
+            var v2 = {
+                strings: 6, mutes: [], open: [],
+                dots: [{string:6,fret:1}, {string:4,fret:1}, {string:3,fret:2}],
+                intervals: ["1", "b7", "3"]
+            };
+            assertEqual(signatureKey(v1), signatureKey(v2),
+                "same shape, different dot order, same key");
+        """)
+
+    def test_signature_key_different_intervals_different_keys(self):
+        assert_js("ChordSelector.js", """
+            var maj7 = {
+                strings: 6, mutes: [], open: [],
+                dots: [{string:6,fret:1}, {string:4,fret:1}, {string:3,fret:2}],
+                intervals: ["1", "b7", "7"]
+            };
+            var dom7 = {
+                strings: 6, mutes: [], open: [],
+                dots: [{string:6,fret:1}, {string:4,fret:1}, {string:3,fret:2}],
+                intervals: ["1", "b7", "3"]
+            };
+            assertNotEqual(signatureKey(maj7), signatureKey(dom7),
+                "different intervals -> different keys");
+        """)
+
+    def test_signature_key_root_relative(self):
+        # Same shape transposed: only the fret_number changes; the intervals
+        # stay the same; the key should match.
+        assert_js("ChordSelector.js", """
+            var c7 = {
+                strings: 6, mutes: [], open: [], fret_number: 8,
+                dots: [{string:6,fret:1}, {string:4,fret:1}, {string:3,fret:2}],
+                intervals: ["1", "b7", "3"]
+            };
+            var f7 = Object.assign({}, c7, { fret_number: 1 });
+            assertEqual(signatureKey(c7), signatureKey(f7),
+                "root-relative: fret_number doesn't affect key");
+        """)
+
+    def test_build_curated_lookup_returns_keyed_map(self):
+        assert_js("ChordSelector.js", """
+            var payload = {
+                shapes: [{
+                    signature: {
+                        strings: 6, mutes: [], opens: [],
+                        pairs: [[3, "3"], [4, "b7"], [6, "1"]]
+                    },
+                    name: "Shell 137",
+                    boost: 60
+                }]
+            };
+            var lookup = buildCuratedLookup(payload);
+            var keys = Object.keys(lookup);
+            assertEqual(keys.length, 1, "one entry");
+            // Construct a matching voicing and verify the lookup finds it
+            var v = {
+                strings: 6, mutes: [], open: [],
+                dots: [{string:6,fret:1}, {string:4,fret:1}, {string:3,fret:2}],
+                intervals: ["1", "b7", "3"]
+            };
+            var key = signatureKey(v);
+            assert(lookup[key] !== undefined, "voicing signature matches curated");
+            assertEqual(lookup[key].boost, 60, "boost retrieved");
+        """)
+
+    def test_curated_shapes_json_matches_runtime_signature(self):
+        # Regression: every entry in curated-shapes.json must produce a key
+        # that runtime signatureKey() would reconstruct for the same shape.
+        # This is the cross-script-and-runtime invariant for #194.
+        import json as _json
+        with open(os.path.join(REPO_ROOT, "plugin", "data", "curated-shapes.json")) as f:
+            data = _json.load(f)
+        first = data["shapes"][0]
+        # Build a voicing from the signature pairs + dummy frets
+        pairs = first["signature"]["pairs"]
+        dots = [{"string": p[0], "fret": 1} for p in pairs]
+        intervals = [p[1] for p in pairs]
+        voicing = {
+            "strings": first["signature"]["strings"],
+            "mutes": first["signature"]["mutes"],
+            "open": first["signature"]["opens"],
+            "dots": dots,
+            "intervals": intervals,
+        }
+        result = run_js(["ChordSelector.js"], f"""
+            var payload = {_json.dumps(data)};
+            var lookup = buildCuratedLookup(payload);
+            var v = {_json.dumps(voicing)};
+            var key = signatureKey(v);
+            _results.push({{ pass: lookup[key] !== undefined, message: "first curated shape lookups via runtime signatureKey" }});
+            if (lookup[key] === undefined) _pass = false;
+        """)
+        assert result["pass"], f"curated shape signature mismatch: {result}"
+
+
 # === StyleComposer.js — style composition (#162) ===
 
 


### PR DESCRIPTION
Closes part of #194 — Phase 1 ships data + signature scaffolding. Phase 2 (apply boost in _scoreCandidate + switch standard tuning to calculator) ships as a separate PR with regression baseline.

Self-review: plans/self-review-194-curated-shapes-data.md