### PR TITLE
feat: Active style readout in composition form (#195)

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -16,6 +16,7 @@ import "model/DataCache.js" as DataCache
 import "model/HygieneEngine.js" as HygieneEngine
 import "model/FingeringEngine.js" as FingeringEngine
 import "model/BackupManager.js" as BackupManager
+import "model/StyleComposer.js" as StyleComposer
 import "model/DiagramEngine.js" as DiagramEngine
 import "model/IRealParser.js" as IRealParser
 
@@ -2777,6 +2778,11 @@ MuseScore {
                 // If the dialog wasn't supported, openFileBrowser sets statusMsg and returns.
                 // User can also drop a backup at ~/Desktop/chordlibrary-backup-restore.json
                 // and click Restore again if the dialog didn't appear.
+            }
+            // Active style readout callback (#195) — SettingsPanel uses this
+            // to live-preview what its composition-form draft resolves to.
+            resolveCompositionFn: function(composition, allStyles) {
+                return StyleComposer.resolve(composition, allStyles)
             }
             // Save a new composition to styles.json and reload (#170)
             onCompositionSaveRequested: function(composition) {

--- a/plugin/ui/SettingsPanel.qml
+++ b/plugin/ui/SettingsPanel.qml
@@ -99,6 +99,52 @@ Item {
     property string compositionScaleRule: "union-priority"
     property string compositionResolution: "re-resolve"
 
+    // Composition resolver (#195) — parent passes StyleComposer.resolve as a
+    // callback so the live readout doesn't import the model directly.
+    property var resolveCompositionFn: function(composition, allStyles) { return null }
+
+    // Build a draft composition from the current form state for live preview.
+    function _draftComposition() {
+        var enabled = []
+        var weights = {}
+        var keys = Object.keys(_compositionEnabled)
+        for (var i = 0; i < keys.length; i++) {
+            if (_compositionEnabled[keys[i]]) {
+                enabled.push(keys[i])
+                weights[keys[i]] = _compositionWeights[keys[i]] || 1.0
+            }
+        }
+        return {
+            id: "_draft",
+            name: compositionName,
+            composedFrom: enabled,
+            composition: {
+                numericRule: compositionNumericRule,
+                scaleRule: compositionScaleRule,
+                weights: weights,
+                resolution: compositionResolution
+            },
+            chordScaleOverrides: {},
+            categoryWeights: {},
+            qualityBoosts: {}
+        }
+    }
+
+    // Compact readout: top-N entries by absolute magnitude, formatted "key: ±value".
+    function _topByAbsMagnitude(obj, n) {
+        if (!obj) return []
+        var keys = Object.keys(obj)
+        var pairs = []
+        for (var i = 0; i < keys.length; i++) {
+            pairs.push({ key: keys[i], val: obj[keys[i]] })
+        }
+        pairs.sort(function(a, b) { return Math.abs(b.val) - Math.abs(a.val) })
+        return pairs.slice(0, n).map(function(p) {
+            var sign = p.val > 0 ? "+" : ""
+            return p.key + ": " + sign + p.val
+        })
+    }
+
     // --- Sub-tab state ---
     property int currentSubTab: 0
 
@@ -1492,6 +1538,93 @@ Item {
                                     model: ["re-resolve", "freeze"]
                                     currentIndex: model.indexOf(settingsPanel.compositionResolution)
                                     onActivated: settingsPanel.compositionResolution = currentText
+                                }
+                            }
+
+                            // Resolved-style readout (#195). Shows what the
+                            // current composition draft actually evaluates to,
+                            // so users notice when two styles cancel out.
+                            Rectangle {
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: resolvedReadoutCol.implicitHeight + 12
+                                color: theme.cardBackground
+                                border.color: theme.cardBorder
+                                border.width: 1
+                                radius: 4
+                                ColumnLayout {
+                                    id: resolvedReadoutCol
+                                    anchors.fill: parent
+                                    anchors.margins: 6
+                                    spacing: 3
+
+                                    property var _resolved: settingsPanel.resolveCompositionFn(
+                                        settingsPanel._draftComposition(),
+                                        settingsPanel.profilesData
+                                    )
+
+                                    Label {
+                                        text: "RESOLVED PREVIEW"
+                                        font.pixelSize: 9
+                                        font.bold: true
+                                        color: theme.textMuted
+                                    }
+                                    Label {
+                                        property var cw: resolvedReadoutCol._resolved
+                                            ? resolvedReadoutCol._resolved.categoryWeights : null
+                                        property var top: settingsPanel._topByAbsMagnitude(cw, 5)
+                                        visible: top.length > 0
+                                        text: "category weights: " + top.join(", ")
+                                        font.pixelSize: 9
+                                        font.family: "Menlo, Monaco, monospace"
+                                        wrapMode: Text.WordWrap
+                                        Layout.fillWidth: true
+                                    }
+                                    Label {
+                                        property var qb: resolvedReadoutCol._resolved
+                                            ? resolvedReadoutCol._resolved.qualityBoosts : null
+                                        property var top: settingsPanel._topByAbsMagnitude(qb, 5)
+                                        visible: top.length > 0
+                                        text: "quality boosts: " + top.join(", ")
+                                        font.pixelSize: 9
+                                        font.family: "Menlo, Monaco, monospace"
+                                        wrapMode: Text.WordWrap
+                                        Layout.fillWidth: true
+                                    }
+                                    Label {
+                                        property var cso: resolvedReadoutCol._resolved
+                                            ? resolvedReadoutCol._resolved.chordScaleOverrides : null
+                                        property string summary: {
+                                            if (!cso) return ""
+                                            var keys = Object.keys(cso)
+                                            if (keys.length === 0) return ""
+                                            var parts = []
+                                            for (var i = 0; i < Math.min(keys.length, 5); i++) {
+                                                parts.push(keys[i] + ": " + (cso[keys[i]] || []).join(", "))
+                                            }
+                                            return parts.join("  ·  ")
+                                        }
+                                        visible: summary.length > 0
+                                        text: "scales: " + summary
+                                        font.pixelSize: 9
+                                        font.family: "Menlo, Monaco, monospace"
+                                        wrapMode: Text.WordWrap
+                                        Layout.fillWidth: true
+                                    }
+                                    Label {
+                                        property bool empty: {
+                                            var r = resolvedReadoutCol._resolved
+                                            if (!r) return true
+                                            return Object.keys(r.categoryWeights || {}).length === 0
+                                                && Object.keys(r.qualityBoosts || {}).length === 0
+                                                && Object.keys(r.chordScaleOverrides || {}).length === 0
+                                        }
+                                        visible: empty
+                                        text: "resolved to nothing — select at least 2 styles with non-zero weights"
+                                        font.pixelSize: 9
+                                        font.italic: true
+                                        color: theme.textMuted
+                                        Layout.fillWidth: true
+                                    }
                                 }
                             }
 

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -1042,6 +1042,25 @@ class TestStyleComposer:
             assertEqual(out.categoryWeights.drop2, 10, "manouche skipped");
         """)
 
+    def test_resolved_readout_matches_resolver(self):
+        # #195: the SettingsPanel readout consumes StyleComposer.resolve output
+        # directly. This test verifies a known composition fixture resolves to
+        # the expected category weights so the readout's "top by abs magnitude"
+        # display will surface the right entries.
+        assert_js("StyleComposer.js", self.BASES + """
+            var comp = {
+                id: "c1", composedFrom: ["bebop", "manouche"],
+                composition: { numericRule: "weighted-sum",
+                               weights: { bebop: 1.0, manouche: 1.0 } }
+            };
+            var resolved = resolve(comp, all);
+            // Verify deterministic outputs the readout would render:
+            assertEqual(resolved.categoryWeights.shell, 20, "shell stacks to 20");
+            assertEqual(resolved.categoryWeights.drop2, 0, "drop2 cancels");
+            // The readout sorts by absolute magnitude; shell would surface first.
+            // The drop2 cancellation surfaces via the dedicated 'resolved to nothing' branch only when ALL fields are zero.
+        """)
+
     def test_missing_base_style_skipped(self):
         assert_js("StyleComposer.js", self.BASES + """
             var comp = {


### PR DESCRIPTION
Closes #195 (composition-form scope; Library-tab readout drops out, deferred). Self-review: plans/self-review-195-active-style-readout.md