### PR TITLE
#197: Per-chord re-voice memory across walkthrough sessions

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -19,6 +19,7 @@ import "model/BackupManager.js" as BackupManager
 import "model/StyleComposer.js" as StyleComposer
 import "model/DiagramEngine.js" as DiagramEngine
 import "model/IRealParser.js" as IRealParser
+import "model/RevoiceMemory.js" as RevoiceMemory
 
 MuseScore {
     id: chordLibrary
@@ -148,6 +149,11 @@ MuseScore {
     }
 
     FileIO {
+        id: revoiceMemoryFile  // #197 — per-chord voicing choice persistence
+        source: Qt.resolvedUrl("revoice-memory.json")
+    }
+
+    FileIO {
         id: backupFile   // (#172) user-data backup / restore
     }
 
@@ -238,6 +244,12 @@ MuseScore {
     // plugin/data/curated-shapes.json on startup; passed to BatchEngine which
     // forwards it through to ChordSelector._scoreCandidate.
     property var curatedShapeLookup: ({})
+
+    // Per-chord re-voice memory (#197). Persisted to revoice-memory.json;
+    // see RevoiceMemory.js for the on-disk shape. The "current scope" is
+    // derived from (curScore.path, activeMode, activeStyle, selectedTuning).
+    property var revoiceMemory: ({ version: "v1", scopes: {} })
+    readonly property int revoiceMemoryMaxBytes: 100000  // 100KB cap (AC #4)
     property var standardVoicingsData: []  // backup of the standard library for tuning switches
     property bool usingTuningVoicings: false  // true when tuning-specific voicings are loaded
     // Tab navigation: 0=Library, 1=ScoreTools, 2=Export, 3=Import, 4=Practice, 5=Settings
@@ -441,6 +453,53 @@ MuseScore {
         } catch (e) {
             console.log("Error loading curated shapes: " + e)
         }
+    }
+
+    // === Per-chord re-voice memory (#197) ===
+
+    function loadRevoiceMemory() {
+        try {
+            var raw = revoiceMemoryFile.read()
+            revoiceMemory = RevoiceMemory.parseMemory(raw)
+            console.log("Loaded revoice memory: "
+                + Object.keys(revoiceMemory.scopes).length + " scope(s)")
+        } catch (e) {
+            console.log("No revoice memory; starting fresh")
+            revoiceMemory = { version: "v1", scopes: {} }
+        }
+    }
+
+    function saveRevoiceMemory() {
+        try {
+            RevoiceMemory.pruneToSize(revoiceMemory, revoiceMemoryMaxBytes)
+            revoiceMemoryFile.write(JSON.stringify(revoiceMemory))
+        } catch (e) {
+            console.log("Error saving revoice memory: " + e)
+        }
+    }
+
+    function currentRevoiceScopeKey() {
+        // Score path may be empty for unsaved scores; RevoiceMemory uses
+        // "<no-path>" in that case — saved choices share a scope across all
+        // unsaved scores under the same axes. Acceptable per ticket Assumptions.
+        var scorePath = (curScore && curScore.path) ? curScore.path : ""
+        return RevoiceMemory.buildScopeKey(scorePath, activeMode, _activeProfileId, selectedTuning)
+    }
+
+    function revoiceMemoryGet(chordSymbol) {
+        return RevoiceMemory.getChoice(revoiceMemory, currentRevoiceScopeKey(), chordSymbol)
+    }
+
+    function revoiceMemoryRecord(chordSymbol, voicingId) {
+        RevoiceMemory.recordChoice(revoiceMemory, currentRevoiceScopeKey(), chordSymbol, voicingId)
+        saveRevoiceMemory()
+    }
+
+    function clearRevoiceMemoryForCurrentScope() {
+        RevoiceMemory.clearScope(revoiceMemory, currentRevoiceScopeKey())
+        saveRevoiceMemory()
+        statusMsg.text = "Cleared saved voicing choices for this score"
+        statusMsg.color = theme.successText
     }
 
     function setActiveMode(modeId) {
@@ -810,6 +869,9 @@ MuseScore {
         modeConfig: chordLibrary.currentModeConfig()
         // Curated shape boost (#194 Phase 2a)
         curatedLookup: chordLibrary.curatedShapeLookup
+        // Per-chord re-voice memory (#197)
+        revoiceMemoryGetFn: function(chordSymbol) { return chordLibrary.revoiceMemoryGet(chordSymbol) }
+        revoiceMemoryRecordFn: function(chordSymbol, voicingId) { chordLibrary.revoiceMemoryRecord(chordSymbol, voicingId) }
         // Section-aware mode resolution (#167)
         modeIdResolverFn: function(chordIdx) { return chordLibrary.modeForChord(chordIdx) }
         modeConfigResolverFn: function(chordIdx) { return chordLibrary.modeConfigForChord(chordIdx) }
@@ -876,6 +938,7 @@ MuseScore {
         loadProfiles()
         loadModes()
         loadCuratedShapes()
+        loadRevoiceMemory()
         loadSettings()
         loadTuningStringCount()
         if (!dataLoaded) {
@@ -3073,6 +3136,7 @@ MuseScore {
             onReharmSelected: function(newRoot, newQuality) {
                 batchEngine.applyReharm(newRoot, newQuality)
             }
+            onClearSavedChoicesClicked: chordLibrary.clearRevoiceMemoryForCurrentScope()
         }
 
         // === Tab 0: Library (extracted to ui/LibraryPanel.qml, #99) ===

--- a/plugin/model/BatchEngine.qml
+++ b/plugin/model/BatchEngine.qml
@@ -58,6 +58,12 @@ Item {
     // wires the parsed curated-shapes.json on startup.
     property var curatedLookup: ({})
 
+    // Per-chord re-voice memory (#197). Both null when memory is disabled.
+    // getter: (chordSymbol) -> voicingId-or-null
+    // recorder: (chordSymbol, voicingId) -> void (caller persists)
+    property var revoiceMemoryGetFn: null
+    property var revoiceMemoryRecordFn: null
+
     // === Batch state (managed internally, exposed for WalkthroughPanel) ===
 
     property var batchQueue: []
@@ -203,6 +209,11 @@ Item {
         var item = batchChords[batchIndex - 1]
         if (!item) return
         item.voicing = voicing
+
+        // Persist alt selection for next session (#197).
+        if (revoiceMemoryRecordFn && voicing.id) {
+            revoiceMemoryRecordFn(item.text, voicing.id)
+        }
 
         // Update clipboard
         var xml = generateXmlForVoicing(voicing, item.root)
@@ -371,6 +382,18 @@ Item {
                             // Pass the about-to-be-assigned chord index so section-aware
                             // mode resolution (#167) picks the right mode for each chord.
                             var voicing = findBestVoicing(parsed.root, parsed.quality, melodyMidi, bassMidi, chords.length)
+                            // Per-chord re-voice memory (#197). If the user picked
+                            // a specific voicing for this chord-symbol last time
+                            // under the same (mode, style, tuning), restore it.
+                            if (voicing && revoiceMemoryGetFn) {
+                                var savedId = revoiceMemoryGetFn(text)
+                                if (savedId) {
+                                    var alts = findAllVoicings(parsed.root, parsed.quality, melodyMidi, bassMidi, chords.length)
+                                    for (var sai = 0; sai < alts.length; sai++) {
+                                        if (alts[sai].id === savedId) { voicing = alts[sai]; break }
+                                    }
+                                }
+                            }
                             if (voicing) {
                                 chords.push({
                                     text: text,
@@ -561,6 +584,11 @@ Item {
 
         item._warnings = warnings
         item.voicing = newVoicing
+
+        // Persist the user's choice for next session (#197).
+        if (revoiceMemoryRecordFn && newVoicing.id) {
+            revoiceMemoryRecordFn(item.text, newVoicing.id)
+        }
 
         // Regenerate clipboard XML
         var xml = generateXmlForVoicing(newVoicing, item.root)

--- a/plugin/model/RevoiceMemory.js
+++ b/plugin/model/RevoiceMemory.js
@@ -1,0 +1,105 @@
+.pragma library
+
+// RevoiceMemory.js — Persistent per-chord voicing choices across walkthrough
+// sessions (#197).
+//
+// Memory shape:
+//   {
+//     version: "v1",
+//     scopes: {
+//       "<scopeKey>": {
+//         choices: { "<chordSymbol>": "<voicingId>", ... },
+//         ts: <millisecond epoch — LRU recency for pruning>
+//       },
+//       ...
+//     }
+//   }
+//
+// Scope key: "(scorePath, mode, style, tuning)" joined; ensures that changing
+// any of those axes scopes to a fresh memory (per ticket AC: "Changing the
+// mode/style/tuning resets the saved choices"). When the user comes back with
+// the same axes, prior choices are restored.
+
+function emptyMemory() {
+    return { version: "v1", scopes: {} }
+}
+
+function buildScopeKey(scorePath, mode, style, tuning) {
+    var sp = scorePath || "<no-path>"
+    var m = mode || ""
+    var s = style || ""
+    var t = tuning || ""
+    return sp + "|m:" + m + "|s:" + s + "|t:" + t
+}
+
+function _ensureScope(memory, scopeKey) {
+    if (!memory.scopes) memory.scopes = {}
+    if (!memory.scopes[scopeKey]) memory.scopes[scopeKey] = { choices: {}, ts: 0 }
+    return memory.scopes[scopeKey]
+}
+
+// Record a per-chord choice. Mutates memory in place and returns it.
+function recordChoice(memory, scopeKey, chordSymbol, voicingId, timestamp) {
+    if (!memory) memory = emptyMemory()
+    if (!chordSymbol || !voicingId) return memory
+    var scope = _ensureScope(memory, scopeKey)
+    scope.choices[chordSymbol] = voicingId
+    scope.ts = timestamp || Date.now()
+    return memory
+}
+
+// Retrieve a saved voicing id for (scopeKey, chordSymbol), or null.
+// Updates the scope's recency on hit (so frequently-used scopes survive prune).
+function getChoice(memory, scopeKey, chordSymbol, timestamp) {
+    if (!memory || !memory.scopes) return null
+    var scope = memory.scopes[scopeKey]
+    if (!scope || !scope.choices) return null
+    var id = scope.choices[chordSymbol]
+    if (id) scope.ts = timestamp || Date.now()
+    return id || null
+}
+
+// Remove a single scope (e.g., "Clear saved choices" for the current scope).
+function clearScope(memory, scopeKey) {
+    if (!memory || !memory.scopes) return memory || emptyMemory()
+    delete memory.scopes[scopeKey]
+    return memory
+}
+
+// Remove all scopes (full wipe — for tests, settings reset).
+function clearAll() {
+    return emptyMemory()
+}
+
+// Serialize, then drop oldest scopes (lowest ts) until under maxBytes.
+// Returns the pruned memory. Acceptance #4 requires < 100KB.
+function pruneToSize(memory, maxBytes) {
+    if (!memory || !memory.scopes) return memory || emptyMemory()
+    var serialized = JSON.stringify(memory)
+    if (serialized.length <= maxBytes) return memory
+    // Sort scope keys ascending by ts (oldest first) and drop until under budget.
+    var keys = Object.keys(memory.scopes)
+    keys.sort(function(a, b) {
+        return (memory.scopes[a].ts || 0) - (memory.scopes[b].ts || 0)
+    })
+    while (keys.length > 0 && JSON.stringify(memory).length > maxBytes) {
+        var oldest = keys.shift()
+        delete memory.scopes[oldest]
+    }
+    return memory
+}
+
+// Parse a JSON string into a valid memory object, returning emptyMemory() on
+// failure or schema mismatch (defensive against corrupt settings file).
+function parseMemory(raw) {
+    if (!raw) return emptyMemory()
+    try {
+        var m = JSON.parse(raw)
+        if (!m || typeof m !== "object") return emptyMemory()
+        if (m.version !== "v1") return emptyMemory()
+        if (!m.scopes || typeof m.scopes !== "object") return emptyMemory()
+        return m
+    } catch (e) {
+        return emptyMemory()
+    }
+}

--- a/plugin/ui/WalkthroughPanel.qml
+++ b/plugin/ui/WalkthroughPanel.qml
@@ -50,6 +50,7 @@ ColumnLayout {
     signal bassStringClicked(int bassStr)
     // Section-based mode (#167)
     signal sectionsChanged(var sections)
+    signal clearSavedChoicesClicked()  // #197 — wipe revoice memory for current scope
 
     // Section data + mode list (wired from parent)
     property var scoreSections: []
@@ -1005,6 +1006,15 @@ ColumnLayout {
             ToolTip.visible: hovered
             ToolTip.text: "Re-select voicing with melody, bass note, and/or category override"
             onClicked: emitRevoice()
+        }
+
+        Button {
+            // #197 — wipe per-chord choices for this (score, mode, style, tuning) scope
+            text: "Clear saved"
+            font.pixelSize: 10
+            ToolTip.visible: hovered
+            ToolTip.text: "Forget all per-chord voicing choices saved for this score"
+            onClicked: walkthroughPanel.clearSavedChoicesClicked()
         }
     }
 

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -908,6 +908,99 @@ class TestChordSelectorSignature:
         assert result["pass"], f"curated shape signature mismatch: {result}"
 
 
+# === RevoiceMemory.js — per-chord choice persistence (#197) ===
+
+
+class TestRevoiceMemory:
+    """Test RevoiceMemory.js scope-keyed choice storage."""
+
+    def test_empty_memory_starts_with_no_scopes(self):
+        assert_js("RevoiceMemory.js", """
+            var m = emptyMemory();
+            assertEqual(m.version, "v1", "version stamped");
+            assertEqual(Object.keys(m.scopes).length, 0, "no scopes yet");
+        """)
+
+    def test_record_and_get_round_trip(self):
+        assert_js("RevoiceMemory.js", """
+            var m = emptyMemory();
+            var key = buildScopeKey("/path/to.mscz", "chord-melody", "default", "standard");
+            recordChoice(m, key, "Cm7", "v-shell-137", 1000);
+            assertEqual(getChoice(m, key, "Cm7"), "v-shell-137", "saved choice returned");
+            assertEqual(getChoice(m, key, "F7"), null, "absent symbol returns null");
+        """)
+
+    def test_scope_key_includes_all_axes(self):
+        # Each of (scorePath, mode, style, tuning) must produce a distinct key,
+        # so changing any one isolates a fresh scope.
+        assert_js("RevoiceMemory.js", """
+            var a = buildScopeKey("/a.mscz", "chord-melody", "default", "standard");
+            var b = buildScopeKey("/b.mscz", "chord-melody", "default", "standard");
+            var c = buildScopeKey("/a.mscz", "comping",      "default", "standard");
+            var d = buildScopeKey("/a.mscz", "chord-melody", "bebop",   "standard");
+            var e = buildScopeKey("/a.mscz", "chord-melody", "default", "baritone");
+            assertNotEqual(a, b, "different score = different scope");
+            assertNotEqual(a, c, "different mode = different scope");
+            assertNotEqual(a, d, "different style = different scope");
+            assertNotEqual(a, e, "different tuning = different scope");
+        """)
+
+    def test_changing_mode_does_not_replay_prior_choice(self):
+        # The headline AC: changing mode/style/tuning must reset choices.
+        # Falsifier from the ticket.
+        assert_js("RevoiceMemory.js", """
+            var m = emptyMemory();
+            var cm = buildScopeKey("/a.mscz", "chord-melody", "default", "standard");
+            var cmp = buildScopeKey("/a.mscz", "comping",      "default", "standard");
+            recordChoice(m, cm, "F7", "v-melody-pick", 1000);
+            assertEqual(getChoice(m, cm, "F7"), "v-melody-pick", "saved in chord-melody scope");
+            assertEqual(getChoice(m, cmp, "F7"), null,
+                "switched to comping scope: no replay of chord-melody choice");
+        """)
+
+    def test_clear_scope_removes_just_one_scope(self):
+        assert_js("RevoiceMemory.js", """
+            var m = emptyMemory();
+            var a = buildScopeKey("/a.mscz", "chord-melody", "default", "standard");
+            var b = buildScopeKey("/b.mscz", "chord-melody", "default", "standard");
+            recordChoice(m, a, "C7", "v-a", 1000);
+            recordChoice(m, b, "C7", "v-b", 1000);
+            clearScope(m, a);
+            assertEqual(getChoice(m, a, "C7"), null, "scope a cleared");
+            assertEqual(getChoice(m, b, "C7"), "v-b", "scope b untouched");
+        """)
+
+    def test_prune_drops_oldest_scope_first(self):
+        # Build a memory with enough scopes to exceed a small budget, then
+        # confirm the oldest (by ts) is dropped.
+        assert_js("RevoiceMemory.js", """
+            var m = emptyMemory();
+            for (var i = 0; i < 50; i++) {
+                var key = "/score" + i + ".mscz|m:chord-melody|s:default|t:standard";
+                recordChoice(m, key, "F7", "v-id-" + i, i + 1);
+            }
+            var beforeKeys = Object.keys(m.scopes).length;
+            pruneToSize(m, 500);  // tight budget — most scopes drop
+            var afterKeys = Object.keys(m.scopes).length;
+            assert(afterKeys < beforeKeys, "prune dropped some scopes");
+            // The newest scope (ts=50) must survive.
+            var newestKey = "/score49.mscz|m:chord-melody|s:default|t:standard";
+            assert(m.scopes[newestKey] !== undefined, "newest scope survives");
+            // The oldest (ts=1) must be gone.
+            var oldestKey = "/score0.mscz|m:chord-melody|s:default|t:standard";
+            assert(m.scopes[oldestKey] === undefined, "oldest scope dropped");
+        """)
+
+    def test_parse_memory_handles_corrupt_input(self):
+        assert_js("RevoiceMemory.js", """
+            assertEqual(parseMemory("").version, "v1", "empty string -> empty memory");
+            assertEqual(parseMemory("not json").version, "v1", "invalid json -> empty memory");
+            assertEqual(parseMemory('{"version":"v0"}').version, "v1", "wrong version -> empty");
+            var ok = parseMemory('{"version":"v1","scopes":{"a":{"choices":{"F7":"v1"},"ts":1}}}');
+            assertEqual(ok.scopes.a.choices.F7, "v1", "valid memory parses through");
+        """)
+
+
 # === StyleComposer.js — style composition (#162) ===
 
 


### PR DESCRIPTION
## Context

Today, every re-voice in Walkthrough is forgotten when the walkthrough ends.
Iterative chord-melody work is painful: each session restarts the picks.

## Goal

Persist per-chord voicing choices across walkthrough sessions, keyed on
(scorePath, mode, style, tuning) so changing any axis scopes to a fresh slate.

## What landed

- **New** `plugin/model/RevoiceMemory.js` — pure JS .pragma library. Builds
  scope keys, records/retrieves choices, LRU-prunes to a size cap, defensive
  parse for corrupt/missing files.
- **BatchEngine.qml** — `revoiceMemoryGetFn` / `revoiceMemoryRecordFn`
  callback properties. Lookup runs after the initial `findBestVoicing` in
  `startWalkthrough` (swaps to the saved voicing if it's in the alt list).
  Record runs on `revoiceCurrentStepWith` and `applyAlternativeVoicing`.
- **ChordLibrary.qml** — `revoice-memory.json` FileIO + loader, scope-key
  builder, write-through save, public `clearRevoiceMemoryForCurrentScope()`.
- **WalkthroughPanel.qml** — "Clear saved" button + `clearSavedChoicesClicked`
  signal.
- **Tests** — 7 new on RevoiceMemory.js. The mode-change test is the
  ticket's falsifier verbatim.

## Acceptance (from #197)

- [x] Voice a tune, close walkthrough, reopen → same voicing per chord
- [x] Changing mode/style/tuning resets (scope-key isolation)
- [x] "Clear saved choices" button in Walkthrough panel
- [x] Storage stays under 100KB (LRU prune on every save)
- [x] Existing tests pass + new tests cover key-on-axes (157 → 164)

## Falsification (from ticket)

> Revert. The test `test_revoice_memory_keyed_on_mode_change` goes red
> because changing mode no longer invalidates the cached choice.

Implemented under the name `test_changing_mode_does_not_replay_prior_choice`.

## Self-Review

`plans/self-review-197-revoice-memory.md`