### PR TITLE
#196: Voicing comparison tray with FIFO eviction

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -20,6 +20,7 @@ import "model/StyleComposer.js" as StyleComposer
 import "model/DiagramEngine.js" as DiagramEngine
 import "model/IRealParser.js" as IRealParser
 import "model/RevoiceMemory.js" as RevoiceMemory
+import "model/ComparisonTray.js" as ComparisonTray
 
 MuseScore {
     id: chordLibrary
@@ -2512,35 +2513,37 @@ MuseScore {
         statusMsg.color = theme.successText
     }
 
-    // === T-015: Voicing Comparison ===
+    // === Voicing Comparison Tray (#196) ===
 
     property var compareVoicings: []  // up to 3 voicings for side-by-side comparison
     property bool showComparison: false
 
     function addToComparison(voicing) {
-        if (compareVoicings.length >= 3) {
-            statusMsg.text = "Comparison full (max 3) — clear first"
+        if (!voicing) return
+        if (ComparisonTray.contains(compareVoicings, voicing)) {
+            statusMsg.text = "Already in comparison"
             statusMsg.color = theme.textMuted
             return
         }
-        // Check for duplicates
-        for (var i = 0; i < compareVoicings.length; i++) {
-            if (compareVoicings[i].id === voicing.id) {
-                statusMsg.text = "Already in comparison"
-                statusMsg.color = theme.textMuted
-                return
-            }
+        var prev = compareVoicings
+        compareVoicings = ComparisonTray.add(compareVoicings, voicing)
+        showComparison = compareVoicings.length > 0
+        // FIFO eviction hint when at capacity (AC: "visual hint")
+        if (prev.length === 3) {
+            statusMsg.text = "Added to comparison (3/3) — oldest dropped"
+        } else {
+            statusMsg.text = "Added to comparison (" + compareVoicings.length + "/3)"
         }
-        var updated = compareVoicings.slice()
-        updated.push(voicing)
-        compareVoicings = updated
-        showComparison = true
-        statusMsg.text = "Added to comparison (" + compareVoicings.length + "/3)"
         statusMsg.color = theme.successText
     }
 
+    function removeFromComparison(index) {
+        compareVoicings = ComparisonTray.removeAt(compareVoicings, index)
+        showComparison = compareVoicings.length > 0
+    }
+
     function clearComparison() {
-        compareVoicings = []
+        compareVoicings = ComparisonTray.clear()
         showComparison = false
     }
 
@@ -3137,6 +3140,11 @@ MuseScore {
                 batchEngine.applyReharm(newRoot, newQuality)
             }
             onClearSavedChoicesClicked: chordLibrary.clearRevoiceMemoryForCurrentScope()
+            // #196 — comparison tray inside the walkthrough
+            compareVoicings: chordLibrary.compareVoicings
+            suggestFingeringFn: function(v) { return suggestFingering(v) }
+            onRemoveFromComparisonRequested: function(index) { chordLibrary.removeFromComparison(index) }
+            onClearComparisonRequested: chordLibrary.clearComparison()
         }
 
         // === Tab 0: Library (extracted to ui/LibraryPanel.qml, #99) ===
@@ -3258,6 +3266,7 @@ MuseScore {
             onPlayVoicingRequested: function(voicing, mode) { chordLibrary.playVoicing(voicing, mode) }
             onCompareRequested: function(voicing) { chordLibrary.addToComparison(voicing) }
             onClearComparisonRequested: chordLibrary.clearComparison()
+            onRemoveFromComparisonRequested: function(index) { chordLibrary.removeFromComparison(index) }
 
             // --- Save to Library + Library Health (moved from Settings, #144) ---
             homePath: chordLibrary.homePath()

--- a/plugin/model/ComparisonTray.js
+++ b/plugin/model/ComparisonTray.js
@@ -1,0 +1,65 @@
+.pragma library
+
+// ComparisonTray.js — side-by-side voicing comparison state machine (#196).
+//
+// Pure-JS state container for the comparison tray. The tray holds up to
+// `CAPACITY` voicings; adding a (CAPACITY+1)th evicts the oldest (FIFO).
+// Adding a voicing already in the tray is a no-op (re-clicking "Compare"
+// on the same card does not duplicate). The tray identifies voicings by
+// `voicing.id`; voicings without an id are still accepted but compared by
+// reference.
+
+var CAPACITY = 3
+
+function emptyTray() {
+    return []
+}
+
+function _sameVoicing(a, b) {
+    if (!a || !b) return false
+    if (a.id && b.id) return a.id === b.id
+    return a === b
+}
+
+function contains(tray, voicing) {
+    if (!tray || !voicing) return false
+    for (var i = 0; i < tray.length; i++) {
+        if (_sameVoicing(tray[i], voicing)) return true
+    }
+    return false
+}
+
+// Add a voicing to the tray. Returns a NEW array (caller swaps assignment
+// — QML property bindings rely on identity change to fire updates).
+//   - if already present, returns the same array unchanged
+//   - if at capacity, drops the oldest (index 0) and appends
+function add(tray, voicing) {
+    if (!voicing) return tray || []
+    if (contains(tray, voicing)) return tray
+    var next = (tray || []).slice()
+    next.push(voicing)
+    while (next.length > CAPACITY) next.shift()
+    return next
+}
+
+// Remove the voicing at `index`. Returns a NEW array.
+function removeAt(tray, index) {
+    if (!tray || index < 0 || index >= tray.length) return tray || []
+    var next = tray.slice()
+    next.splice(index, 1)
+    return next
+}
+
+// Remove voicing by id (or reference). Returns a NEW array.
+function removeVoicing(tray, voicing) {
+    if (!tray || !voicing) return tray || []
+    for (var i = 0; i < tray.length; i++) {
+        if (_sameVoicing(tray[i], voicing)) return removeAt(tray, i)
+    }
+    return tray
+}
+
+// Empty the tray. Returns a NEW (empty) array.
+function clear() {
+    return []
+}

--- a/plugin/ui/ComparisonTrayPanel.qml
+++ b/plugin/ui/ComparisonTrayPanel.qml
@@ -1,0 +1,102 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+// ComparisonTrayPanel — side-by-side voicing comparison (#196).
+// Renders the current `compareVoicings` array (max 3). Embedded by both
+// LibraryPanel and WalkthroughPanel so the tray is visible in both contexts.
+
+Rectangle {
+    id: trayPanel
+
+    property var compareVoicings: []
+    property var suggestFingeringFn: function(v) { return [] }
+
+    signal removeRequested(int index)
+    signal clearRequested()
+
+    Layout.fillWidth: true
+    Layout.preferredHeight: 100
+    color: theme.consoleBg
+    radius: 4
+    border.color: theme.divider
+    visible: compareVoicings && compareVoicings.length > 0
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.margins: 6
+        spacing: 6
+
+        Repeater {
+            model: trayPanel.compareVoicings.length
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                radius: 4
+                color: theme.cardBackground
+                border.color: theme.cardBorder
+
+                property var cv: trayPanel.compareVoicings[index] || {}
+
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: 4
+                    spacing: 2
+
+                    Label {
+                        text: cv.name || ""
+                        font.pixelSize: 10
+                        font.bold: true
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+                    Label {
+                        text: (cv.intervals || []).join(" ")
+                        font.pixelSize: 9
+                        Layout.fillWidth: true
+                    }
+                    Label {
+                        text: "Fret " + (cv.fret_number || "?") + "  |  " + (cv.notes || []).join(" ")
+                        font.pixelSize: 9
+                        color: theme.textMuted
+                        Layout.fillWidth: true
+                    }
+                    Label {
+                        text: {
+                            var f = trayPanel.suggestFingeringFn(cv)
+                            if (!f || f.length === 0) return ""
+                            var parts = []
+                            for (var i = 0; i < f.length; i++) parts.push("S" + f[i].string + ":" + f[i].finger)
+                            return "Fingering: " + parts.join(" ")
+                        }
+                        font.pixelSize: 8
+                        color: theme.textFaint
+                        Layout.fillWidth: true
+                    }
+                }
+
+                // Per-entry remove button (#196 X-button on tray)
+                Button {
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+                    anchors.margins: 2
+                    text: "×"
+                    font.pixelSize: 11
+                    implicitWidth: 18
+                    implicitHeight: 16
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Remove from comparison"
+                    onClicked: trayPanel.removeRequested(index)
+                }
+            }
+        }
+
+        Button {
+            text: "Clear"
+            font.pixelSize: 9
+            implicitWidth: 40
+            onClicked: trayPanel.clearRequested()
+        }
+    }
+}

--- a/plugin/ui/LibraryPanel.qml
+++ b/plugin/ui/LibraryPanel.qml
@@ -86,6 +86,7 @@ Item {
     signal playVoicingRequested(var voicing, string mode)
     signal compareRequested(var voicing)
     signal clearComparisonRequested()
+    signal removeFromComparisonRequested(int index)
     signal scaleFilterChanged(string scaleName)
     signal profileChanged(string profileId)
     signal modeChanged(string modeId)
@@ -682,78 +683,13 @@ Item {
             }
         }
 
-        // Comparison panel
-        Rectangle {
-            visible: libraryPanel.showComparison
-            Layout.fillWidth: true
-            Layout.preferredHeight: 100
-            color: theme.consoleBg
-            radius: 4
-            border.color: theme.divider
-
-            RowLayout {
-                anchors.fill: parent
-                anchors.margins: 6
-                spacing: 6
-
-                Repeater {
-                    model: libraryPanel.compareVoicings.length
-
-                    Rectangle {
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        radius: 4
-                        color: theme.cardBackground
-                        border.color: theme.cardBorder
-
-                        property var cv: libraryPanel.compareVoicings[index] || {}
-
-                        ColumnLayout {
-                            anchors.fill: parent
-                            anchors.margins: 4
-                            spacing: 2
-
-                            Label {
-                                text: cv.name || ""
-                                font.pixelSize: 10
-                                font.bold: true
-                                elide: Text.ElideRight
-                                Layout.fillWidth: true
-                            }
-                            Label {
-                                text: (cv.intervals || []).join(" ")
-                                font.pixelSize: 9
-                                Layout.fillWidth: true
-                            }
-                            Label {
-                                text: "Fret " + (cv.fret_number || "?") + "  |  " + (cv.notes || []).join(" ")
-                                font.pixelSize: 9
-                                color: theme.textMuted
-                                Layout.fillWidth: true
-                            }
-                            Label {
-                                text: {
-                                    var f = libraryPanel.suggestFingeringFn(cv)
-                                    if (f.length === 0) return ""
-                                    var parts = []
-                                    for (var i = 0; i < f.length; i++) parts.push("S" + f[i].string + ":" + f[i].finger)
-                                    return "Fingering: " + parts.join(" ")
-                                }
-                                font.pixelSize: 8
-                                color: theme.textFaint
-                                Layout.fillWidth: true
-                            }
-                        }
-                    }
-                }
-
-                Button {
-                    text: "Clear"
-                    font.pixelSize: 9
-                    implicitWidth: 40
-                    onClicked: libraryPanel.clearComparisonRequested()
-                }
-            }
+        // Comparison tray (#196) — extracted to shared component so the
+        // same tray renders in both Library tab and Walkthrough.
+        ComparisonTrayPanel {
+            compareVoicings: libraryPanel.compareVoicings
+            suggestFingeringFn: libraryPanel.suggestFingeringFn
+            onRemoveRequested: function(index) { libraryPanel.removeFromComparisonRequested(index) }
+            onClearRequested: libraryPanel.clearComparisonRequested()
         }
 
         // ─────────────────────────────────────────────

--- a/plugin/ui/WalkthroughPanel.qml
+++ b/plugin/ui/WalkthroughPanel.qml
@@ -36,6 +36,12 @@ ColumnLayout {
     property var fingeringFn: function(v) { return "" }  // FingeringEngine.computeFingeringString
     property bool melodyLockDefault: false  // from Library tab's Melody Lock button
 
+    // Voicing comparison tray (#196). Bound from parent. Renders inline at the
+    // top of the walkthrough so the user can keep candidates side-by-side
+    // while stepping through chords.
+    property var compareVoicings: []
+    property var suggestFingeringFn: function(v) { return [] }
+
     // Lock states (readable by parent for bass string selection)
     readonly property bool melodyLocked: typeof melodyLockBtn !== "undefined" && melodyLockBtn ? melodyLockBtn.checked : false
     readonly property bool bassLocked: typeof bassLockBtn !== "undefined" && bassLockBtn ? bassLockBtn.checked : false
@@ -51,6 +57,9 @@ ColumnLayout {
     // Section-based mode (#167)
     signal sectionsChanged(var sections)
     signal clearSavedChoicesClicked()  // #197 — wipe revoice memory for current scope
+    // #196 — tray controls shared with LibraryPanel
+    signal removeFromComparisonRequested(int index)
+    signal clearComparisonRequested()
 
     // Section data + mode list (wired from parent)
     property var scoreSections: []
@@ -81,6 +90,15 @@ ColumnLayout {
         if (batchActive && batchIndex > 0 && batchIndex <= batchChords.length)
             return batchChords[batchIndex - 1]
         return null
+    }
+
+    // Voicing comparison tray (#196) — same component used in LibraryPanel.
+    // Auto-hides when empty.
+    ComparisonTrayPanel {
+        compareVoicings: walkthroughPanel.compareVoicings
+        suggestFingeringFn: walkthroughPanel.suggestFingeringFn
+        onRemoveRequested: function(index) { walkthroughPanel.removeFromComparisonRequested(index) }
+        onClearRequested: walkthroughPanel.clearComparisonRequested()
     }
 
     // Header row with title and nav buttons

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -1001,6 +1001,75 @@ class TestRevoiceMemory:
         """)
 
 
+# === ComparisonTray.js — side-by-side voicing comparison (#196) ===
+
+
+class TestComparisonTray:
+    """Test ComparisonTray.js FIFO + dedup behavior."""
+
+    def test_empty_tray_starts_empty(self):
+        assert_js("ComparisonTray.js", """
+            var t = emptyTray();
+            assertEqual(t.length, 0, "tray empty");
+        """)
+
+    def test_add_appends_voicing(self):
+        assert_js("ComparisonTray.js", """
+            var t = add(emptyTray(), { id: "v1", name: "Shell" });
+            assertEqual(t.length, 1, "one entry");
+            assertEqual(t[0].id, "v1", "by id");
+        """)
+
+    def test_add_skips_duplicates_by_id(self):
+        assert_js("ComparisonTray.js", """
+            var t = emptyTray();
+            t = add(t, { id: "v1" });
+            t = add(t, { id: "v1" });
+            assertEqual(t.length, 1, "duplicate add ignored");
+        """)
+
+    def test_comparison_tray_evicts_oldest_on_fourth(self):
+        # The ticket's named falsifier (#196): adding a 4th voicing must
+        # evict the first. Capacity is 3.
+        assert_js("ComparisonTray.js", """
+            var t = emptyTray();
+            t = add(t, { id: "v1" });
+            t = add(t, { id: "v2" });
+            t = add(t, { id: "v3" });
+            assertEqual(t.length, 3, "at capacity");
+            t = add(t, { id: "v4" });
+            assertEqual(t.length, 3, "still at capacity after 4th add");
+            assertEqual(t[0].id, "v2", "v1 evicted (FIFO)");
+            assertEqual(t[1].id, "v3", "v3 shifted");
+            assertEqual(t[2].id, "v4", "v4 appended");
+        """)
+
+    def test_remove_at_drops_specific_entry(self):
+        assert_js("ComparisonTray.js", """
+            var t = [{ id: "a" }, { id: "b" }, { id: "c" }];
+            t = removeAt(t, 1);
+            assertEqual(t.length, 2, "one removed");
+            assertEqual(t[0].id, "a", "first kept");
+            assertEqual(t[1].id, "c", "third kept");
+        """)
+
+    def test_clear_empties_tray(self):
+        # Falsifier for the Clear AC.
+        assert_js("ComparisonTray.js", """
+            var t = [{ id: "a" }, { id: "b" }, { id: "c" }];
+            t = clear();
+            assertEqual(t.length, 0, "tray cleared");
+        """)
+
+    def test_contains_reports_membership(self):
+        assert_js("ComparisonTray.js", """
+            var v = { id: "v1" };
+            assert(!contains([], v), "empty doesn't contain");
+            assert(contains([v], v), "contains by reference");
+            assert(contains([{ id: "v1" }], v), "contains by id even if different ref");
+        """)
+
+
 # === StyleComposer.js — style composition (#162) ===
 
 


### PR DESCRIPTION
## Context

The Library tab had a previously-stubbed comparison rectangle that wasn't
hooked up to functional state. The Walkthrough had no comparison surface
at all. Both gaps closed here.

## Goal

Working comparison tray, max 3 voicings, FIFO eviction on the 4th add,
visible in both Library and Walkthrough.

## What landed

- **New** `plugin/model/ComparisonTray.js` — pure JS state module. 6 functions.
- **New** `plugin/ui/ComparisonTrayPanel.qml` — shared component used by both
  panels.
- **LibraryPanel.qml** — replaced 60 lines of inline tray markup with the
  shared component.
- **WalkthroughPanel.qml** — embeds the same component at the top.
- **ChordLibrary.qml** — `addToComparison` rewritten to use the module
  (FIFO at cap instead of reject); added `removeFromComparison(index)`.
- **Tests** — 7 new on ComparisonTray.js.

## Acceptance (from #196)

- [x] Card has "Compare" toggle (was pre-existing ⇔ on hover; now functional)
- [x] 4th add evicts oldest (`test_comparison_tray_evicts_oldest_on_fourth`)
- [x] Tray visible in both Library and Walkthrough
- [x] Tests pass + FIFO/Clear coverage (164 → 171)

Bonus: per-entry X button to remove individual slots.

## Falsification (from ticket)

> Revert the tray component. The test
> `test_comparison_tray_evicts_oldest_on_fourth` goes red because adding
> the 4th voicing no longer evicts the first.

Test implemented under that exact name.

## Scope decisions (deferred — not in AC)

- Score-contribution breakdown ("which boosts apply") — needs
  `_scoreCandidate` refactor to return breakdown.
- Fretboard thumbnail in tray entries — needs `VoicingCard` Canvas extraction.
- Click tray entry → paste into score — needs new signal plumbing.

Filed as follow-ups in the self-review note. None block AC.

## Self-Review

`plans/self-review-196-comparison-tray.md`