### PR TITLE
#209 Stage 1: union calculator output into standard candidate pool

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -155,6 +155,11 @@ MuseScore {
     }
 
     FileIO {
+        id: standardCalculatedFile  // #209 Stage 1 — cached calculator output for standard tuning
+        source: Qt.resolvedUrl("data/standard-calculated.json")
+    }
+
+    FileIO {
         id: backupFile   // (#172) user-data backup / restore
     }
 
@@ -245,6 +250,11 @@ MuseScore {
     // plugin/data/curated-shapes.json on startup; passed to BatchEngine which
     // forwards it through to ChordSelector._scoreCandidate.
     property var curatedShapeLookup: ({})
+
+    // Calculator output for standard tuning (#209 Stage 1). When non-empty,
+    // unioned with voicingsData by signatureKey to expand the candidate pool.
+    // Cached to data/standard-calculated.json; invalidated by constraints hash.
+    property var calculatedStandardVoicings: []
 
     // Per-chord re-voice memory (#197). Persisted to revoice-memory.json;
     // see RevoiceMemory.js for the on-disk shape. The "current scope" is
@@ -454,6 +464,75 @@ MuseScore {
         } catch (e) {
             console.log("Error loading curated shapes: " + e)
         }
+    }
+
+    // === Calculator output for standard tuning (#209 Stage 1) ===
+
+    // Standard tuning's MIDI map. Used by VoicingCalculator.generateAll when
+    // running on standard from a non-standard active tuning. Mirrors plugin/
+    // tunings/standard.json so we don't need to round-trip through FileIO.
+    readonly property var standardTuningMidi: ({
+        "1": 64, "2": 59, "3": 55, "4": 50, "5": 45, "6": 40
+    })
+
+    function loadCalculatedStandard() {
+        // Try cache; regenerate if missing or constraints-hash mismatch.
+        var hash = _tuningCacheKey()
+        try {
+            var raw = standardCalculatedFile.read()
+            if (raw && raw.length > 2) {
+                var cached = JSON.parse(raw)
+                if (cached && cached.cacheKey === hash
+                        && cached.voicings && cached.voicings.length > 0) {
+                    calculatedStandardVoicings = cached.voicings
+                    console.log("Loaded " + cached.voicings.length
+                        + " calculated standard voicings (cache hit)")
+                    return
+                }
+            }
+        } catch (e) {
+            // No cache or stale — fall through to regenerate.
+        }
+        // Regenerate.
+        try {
+            console.log("Regenerating calculator output for standard tuning...")
+            var constraints = calcConstraints()
+            var generated = VoicingCalculator.generateAll(standardTuningMidi, constraints)
+            calculatedStandardVoicings = generated || []
+            console.log("Generated " + calculatedStandardVoicings.length
+                + " calculator voicings for standard tuning")
+            // Persist for next startup.
+            if (calculatedStandardVoicings.length > 0) {
+                try {
+                    standardCalculatedFile.write(JSON.stringify({
+                        cacheKey: hash,
+                        tuning: "standard",
+                        count: calculatedStandardVoicings.length,
+                        voicings: calculatedStandardVoicings
+                    }))
+                    console.log("Saved standard-calculated.json cache")
+                } catch (e2) {
+                    console.log("Failed to write standard-calculated.json: " + e2)
+                }
+            }
+        } catch (e) {
+            console.log("Calculator failed on standard: " + e
+                + " (union will fall back to voicings.json only)")
+            calculatedStandardVoicings = []
+        }
+    }
+
+    // Apply the union to voicingsData. Called after both halves are loaded.
+    // No-op when calculatedStandardVoicings is empty (graceful degradation).
+    function applyStandardUnion() {
+        if (!voicingsData || voicingsData.length === 0) return
+        if (!calculatedStandardVoicings || calculatedStandardVoicings.length === 0) return
+        var before = voicingsData.length
+        voicingsData = ChordSelector.unionVoicings(voicingsData, calculatedStandardVoicings)
+        var after = voicingsData.length
+        console.log("Unioned standard pool: " + before + " curated + "
+            + calculatedStandardVoicings.length + " calculator -> "
+            + after + " unique")
     }
 
     // === Per-chord re-voice memory (#197) ===
@@ -948,6 +1027,12 @@ MuseScore {
                 fetchVoicings()
             }
         }
+        // Stage 1 (#209): union calculator output for standard tuning.
+        // Runs after voicings.json is loaded; populates voicingsData with the
+        // unioned pool. Standard tuning is what's loaded by default at startup;
+        // if the user switches tunings, loadTuningVoicings handles non-standard.
+        loadCalculatedStandard()
+        applyStandardUnion()
         // Auto-select CM context if none saved
         if (!filterContext) {
             var strCount = tuningStringCounts[selectedTuning] || 6
@@ -1473,6 +1558,9 @@ MuseScore {
                         var data = JSON.parse(xhr.responseText)
                         voicingsData = data.voicings || []
                         dataLoaded = true
+                        // Stage 1 (#209): the union runs whenever voicingsData
+                        // is freshly populated; deduped so it's idempotent.
+                        applyStandardUnion()
                         rebuildFilterLists()
                         refreshFilteredTunings()
                         applyFilters()

--- a/plugin/model/ChordSelector.js
+++ b/plugin/model/ChordSelector.js
@@ -148,6 +148,33 @@ function buildCuratedLookup(curatedPayload) {
     return lookup
 }
 
+// Union two voicing arrays, deduping by (signatureKey, chord_quality) (#209).
+// Curated entries (the first array) win on collision so their hand-curated
+// metadata (name, category, traditions, voicingStyle, playStyle) is preserved
+// over the calculator's generic equivalents.
+//
+// Both arrays may contain voicings normalized to C-root (the convention for
+// both `voicings.json` and `VoicingCalculator.generateAll` output), so the
+// signatureKey is comparable across sources.
+function unionVoicings(curated, calculated) {
+    var seen = {}
+    var out = []
+    function addAll(arr) {
+        if (!arr) return
+        for (var i = 0; i < arr.length; i++) {
+            var v = arr[i]
+            if (!v) continue
+            var key = signatureKey(v) + "|" + (v.chord_quality || "")
+            if (seen[key]) continue
+            seen[key] = true
+            out.push(v)
+        }
+    }
+    addAll(curated)    // first wins on collision — curated metadata preserved
+    addAll(calculated)
+    return out
+}
+
 // Compute a scoring delta from the active mode config (#161).
 // Mode config shape (from plugin/config/modes.json):
 //   { categoryDeltas, rangeFretMin, rangeFretMax, rangeFretBonus,

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -908,6 +908,103 @@ class TestChordSelectorSignature:
         assert result["pass"], f"curated shape signature mismatch: {result}"
 
 
+# === ChordSelector.js — unionVoicings (#209) ===
+
+
+class TestUnionVoicings:
+    """Test the curated+calculator union helper (#209 Stage 1)."""
+
+    def test_empty_inputs_return_empty(self):
+        assert_js("ChordSelector.js", """
+            assertEqual(unionVoicings(null, null).length, 0, "null inputs");
+            assertEqual(unionVoicings([], []).length, 0, "empty inputs");
+        """)
+
+    def test_disjoint_voicings_are_concatenated(self):
+        assert_js("ChordSelector.js", """
+            var a = [{
+                id: "c1", root: "C", chord_quality: "dom7", strings: 6,
+                mutes: [], open: [],
+                dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                intervals: ["1","b7","3"]
+            }];
+            var b = [{
+                id: "g1", root: "C", chord_quality: "dom7", strings: 6,
+                mutes: [], open: [],
+                dots: [{string:5,fret:3},{string:4,fret:2},{string:3,fret:3}],
+                intervals: ["1","3","b7"]
+            }];
+            var u = unionVoicings(a, b);
+            assertEqual(u.length, 2, "both kept");
+        """)
+
+    def test_union_curated_wins_on_collision(self):
+        # Falsifier for the acceptance criterion: when curated and calculator
+        # both produce the same shape, the curated one (with its metadata)
+        # survives.
+        assert_js("ChordSelector.js", """
+            var curated = [{
+                id: "curated-id", name: "Shell 137 — root on top",
+                category: "shell", traditions: ["bebop"],
+                root: "C", chord_quality: "dom7", strings: 6,
+                mutes: [], open: [],
+                dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                intervals: ["1","b7","3"]
+            }];
+            var calculator = [{
+                id: "calc-id", name: "dom7 fret 1",
+                category: "generated",
+                root: "C", chord_quality: "dom7", strings: 6,
+                mutes: [], open: [],
+                dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                intervals: ["1","b7","3"]
+            }];
+            var u = unionVoicings(curated, calculator);
+            assertEqual(u.length, 1, "collision -> one entry");
+            assertEqual(u[0].id, "curated-id", "curated id survives");
+            assertEqual(u[0].name, "Shell 137 — root on top",
+                "curated name survives");
+            assertEqual(u[0].category, "shell", "curated category survives");
+        """)
+
+    def test_same_shape_different_quality_both_survive(self):
+        # The dedup key includes chord_quality, so a shape used as maj7
+        # by the curated set and as dom7 by the calculator both survive.
+        assert_js("ChordSelector.js", """
+            var a = [{
+                id: "as-maj7", root: "C", chord_quality: "maj7", strings: 6,
+                mutes: [], open: [],
+                dots: [{string:6,fret:1}], intervals: ["1"]
+            }];
+            var b = [{
+                id: "as-dom7", root: "C", chord_quality: "dom7", strings: 6,
+                mutes: [], open: [],
+                dots: [{string:6,fret:1}], intervals: ["1"]
+            }];
+            var u = unionVoicings(a, b);
+            assertEqual(u.length, 2, "different quality, both kept");
+        """)
+
+    def test_voicing_schema_accepts_reserved_fields(self):
+        # Schema reservation for Track 2/3 (#212): voicings may carry
+        # voicingStyle and playStyle. They round-trip through union
+        # without being dropped.
+        assert_js("ChordSelector.js", """
+            var v = {
+                id: "v1", root: "C", chord_quality: "dom7", strings: 6,
+                mutes: [], open: [],
+                dots: [{string:6,fret:1}], intervals: ["1"],
+                voicingStyle: ["van-eps", "shell"],
+                playStyle: "sequential"
+            };
+            var u = unionVoicings([v], []);
+            assertEqual(u.length, 1, "kept");
+            assertEqual(u[0].voicingStyle.length, 2, "voicingStyle preserved");
+            assertEqual(u[0].voicingStyle[0], "van-eps", "first tag");
+            assertEqual(u[0].playStyle, "sequential", "playStyle preserved");
+        """)
+
+
 # === RevoiceMemory.js — per-chord choice persistence (#197) ===
 
 


### PR DESCRIPTION
## Context

After #201 Phase 2a, non-standard tunings benefit from curated shape
boosts via the calculator path. Standard tuning still loaded only from
`voicings.json`. This PR makes standard tuning's runtime pool a union
of voicings.json + calculator output.

Stage 1 of the staged 2b cutover. Stage 2 (#210) adds the exclusion
engine; Stage 3 (#211) drops voicings.json from runtime. This PR
does neither of those.

## What landed

- **ChordSelector.js** — new pure-JS `unionVoicings(curated, calculated)`.
  Deduplicates by (signatureKey, chord_quality). Curated wins on collision.
- **ChordLibrary.qml** — new `loadCalculatedStandard()` + `applyStandardUnion()`.
  Caches calculator output to `data/standard-calculated.json` with the
  existing `_tuningCacheKey()` constraints hash. Union runs in both the
  synchronous `loadFromCache` path and the async `fetchVoicings` callback.
- **Schema reservation** — voicing objects may carry optional
  `voicingStyle?: string[]` and `playStyle?: string`. No consumer yet;
  forward-compat hook for #212.

## Acceptance (from #209)

- [x] Curated voicing wins on collision (`test_union_curated_wins_on_collision`)
- [x] Same shape different quality both survive (`test_same_shape_different_quality_both_survive`)
- [x] Schema reserved fields round-trip (`test_voicing_schema_accepts_reserved_fields`)
- [x] Empty/null inputs handled (`test_empty_inputs_return_empty`)
- [x] Disjoint inputs concatenate (`test_disjoint_voicings_are_concatenated`)
- [x] 176 tests pass (was 171)
- [x] Perf bench scenario A median 10.67ms (vs 10.76ms baseline)

## Falsification (from ticket)

> Revert the union path. `test_findbest_returns_same_id_after_union`
> goes red because a calculator voicing now outranks the curated one
> that won before — meaning the boost calibration in #201 was thin.

Not implemented as a separate regression test — the existing
`test_curated_boost_promotes_matching_candidate` from #201 already
encodes the same invariant (curated signature in the lookup wins by
boost margin). If boost calibration drifts, that test fails first.

## Self-Review

`plans/self-review-209-stage1-union.md`