### PR TITLE
#210 Stage 2: exclusion engine + per-tuning-per-mode tolerances + user overrides

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -21,6 +21,7 @@ import "model/DiagramEngine.js" as DiagramEngine
 import "model/IRealParser.js" as IRealParser
 import "model/RevoiceMemory.js" as RevoiceMemory
 import "model/ComparisonTray.js" as ComparisonTray
+import "model/ExclusionEngine.js" as ExclusionEngine
 
 MuseScore {
     id: chordLibrary
@@ -160,6 +161,11 @@ MuseScore {
     }
 
     FileIO {
+        id: toleranceConfigFile  // #210 Stage 2 — per-tuning-per-mode exclusion thresholds
+        source: Qt.resolvedUrl("config/tuning-mode-tolerances.json")
+    }
+
+    FileIO {
         id: backupFile   // (#172) user-data backup / restore
     }
 
@@ -255,6 +261,14 @@ MuseScore {
     // unioned with voicingsData by signatureKey to expand the candidate pool.
     // Cached to data/standard-calculated.json; invalidated by constraints hash.
     property var calculatedStandardVoicings: []
+
+    // Exclusion engine (#210 Stage 2). The full tolerance map (per-mode +
+    // per-tuning-per-mode overrides), loaded once from config. The per-user
+    // signature override map ("include" / "exclude" decisions) persisted to
+    // settings.json. The exclusion pass is rerun whenever voicingsData,
+    // activeMode, selectedTuning, or userVoicingOverrides change.
+    property var voicingToleranceMap: ({ modes: {}, tunings: {} })
+    property var userVoicingOverrides: ({})  // signatureKey -> "include" | "exclude"
 
     // Per-chord re-voice memory (#197). Persisted to revoice-memory.json;
     // see RevoiceMemory.js for the on-disk shape. The "current scope" is
@@ -535,6 +549,77 @@ MuseScore {
             + after + " unique")
     }
 
+    // === Exclusion engine (#210 Stage 2) ===
+
+    function loadVoicingTolerances() {
+        try {
+            var raw = toleranceConfigFile.read()
+            if (raw && raw.length > 2) {
+                voicingToleranceMap = JSON.parse(raw) || { modes: {}, tunings: {} }
+                console.log("Loaded voicing tolerances: "
+                    + Object.keys(voicingToleranceMap.modes || {}).length + " mode default(s), "
+                    + Object.keys(voicingToleranceMap.tunings || {}).length + " tuning override(s)")
+            }
+        } catch (e) {
+            console.log("Error loading voicing tolerances: " + e)
+            voicingToleranceMap = { modes: {}, tunings: {} }
+        }
+    }
+
+    // Apply the exclusion engine in-place: attach _excludedReason to each
+    // voicing (null when visible, {dimension, message} when hidden).
+    // findBestVoicing/findAllVoicings consult this via BatchEngine.
+    function applyExclusionPass() {
+        if (!voicingsData || voicingsData.length === 0) return
+        var tolerances = ExclusionEngine.resolveTolerances(
+            voicingToleranceMap, selectedTuning, activeMode)
+        var opts = {
+            signatureKeyFn: function(v) { return ChordSelector.signatureKey(v) },
+            difficultyFn: function(v) { return FingeringEngine.computeDifficulty(v) }
+        }
+        var hidden = 0
+        var updated = []
+        for (var i = 0; i < voicingsData.length; i++) {
+            var v = voicingsData[i]
+            // Don't mutate cached objects in place — copy then attach.
+            var clone = {}
+            for (var k in v) clone[k] = v[k]
+            // Cache signature on the clone so UI override actions can
+            // identify the voicing without re-computing.
+            clone._signatureKey = ChordSelector.signatureKey(v)
+            clone._excludedReason = ExclusionEngine.evaluateExclusion(
+                v, tolerances, userVoicingOverrides, opts)
+            if (clone._excludedReason) hidden++
+            updated.push(clone)
+        }
+        voicingsData = updated
+        console.log("Exclusion pass: " + (voicingsData.length - hidden)
+            + " visible, " + hidden + " hidden")
+        // Re-partition for UI surfaces.
+        applyFilters()
+    }
+
+    function setVoicingOverride(signatureKey, decision) {
+        // decision: "include" | "exclude" | null (clear)
+        if (!signatureKey) return
+        var next = {}
+        for (var k in userVoicingOverrides) next[k] = userVoicingOverrides[k]
+        if (decision === null || decision === undefined) {
+            delete next[signatureKey]
+        } else {
+            next[signatureKey] = decision
+        }
+        userVoicingOverrides = next
+        saveSettings()
+        applyExclusionPass()
+    }
+
+    function clearAllVoicingOverrides() {
+        userVoicingOverrides = ({})
+        saveSettings()
+        applyExclusionPass()
+    }
+
     // === Per-chord re-voice memory (#197) ===
 
     function loadRevoiceMemory() {
@@ -590,6 +675,9 @@ MuseScore {
         activeMode = modeId
         console.log("Mode: " + (_modesById[modeId] ? _modesById[modeId].name : modeId))
         saveSettings()
+        // #210 Stage 2: tolerances are mode-specific, so the exclusion pass
+        // must rerun after mode changes.
+        applyExclusionPass()
     }
 
     // Resolve current mode to its config object (or null if not loaded yet).
@@ -1018,6 +1106,7 @@ MuseScore {
         loadProfiles()
         loadModes()
         loadCuratedShapes()
+        loadVoicingTolerances()
         loadRevoiceMemory()
         loadSettings()
         loadTuningStringCount()
@@ -1033,6 +1122,9 @@ MuseScore {
         // if the user switches tunings, loadTuningVoicings handles non-standard.
         loadCalculatedStandard()
         applyStandardUnion()
+        // Stage 2 (#210): apply exclusion engine to the (unioned) pool.
+        // Re-runs on tuning/mode changes via property change handlers below.
+        applyExclusionPass()
         // Auto-select CM context if none saved
         if (!filterContext) {
             var strCount = tuningStringCounts[selectedTuning] || 6
@@ -1134,6 +1226,10 @@ MuseScore {
             if (s.activeMode) setActiveMode(s.activeMode)
             // Restore score sections (#167). Array of {startIdx, mode, name}.
             if (s.scoreSections && Array.isArray(s.scoreSections)) scoreSections = s.scoreSections
+            // #210 Stage 2 — restore user voicing overrides
+            if (s.userVoicingOverrides && typeof s.userVoicingOverrides === "object") {
+                userVoicingOverrides = s.userVoicingOverrides
+            }
             refreshFilteredTunings()
             console.log("Settings loaded: url=" + jsonUrl + ", placement=" + diagramPlacement + ", tuning=" + selectedTuning + ", context=" + filterContext + ", profile=" + (s.activeProfile || "default"))
         } catch (e) {
@@ -1159,6 +1255,7 @@ MuseScore {
             activeProfile: _activeProfileId,
             activeMode: activeMode,
             scoreSections: scoreSections,
+            userVoicingOverrides: userVoicingOverrides,  // #210 Stage 2
         }
         settingsFile.write(DataCache.serializeSettings(s))
         console.log("Settings saved")
@@ -1741,6 +1838,7 @@ MuseScore {
                 console.log("Restored standard voicing library (" + voicingsData.length + " voicings)")
                 statusMsg.text = "Loaded " + voicingsData.length + " voicings (standard library)"
                 statusMsg.color = theme.successText
+                applyExclusionPass()  // #210 Stage 2
             }
             _loadingTuningVoicings = false;
             return
@@ -1842,6 +1940,9 @@ MuseScore {
                 applyFilters()
             }
         }
+        // #210 Stage 2: rerun the exclusion pass against the new pool's
+        // tuning-mode tolerances.
+        applyExclusionPass()
         _loadingTuningVoicings = false
     }
 
@@ -1881,8 +1982,21 @@ MuseScore {
         return MelodyEngine.voicingDistance(a, b)
     }
 
+    // #210 Stage 2 — voicings hidden by the exclusion engine. Exposed
+    // so LibraryPanel/WalkthroughPanel can render the disclosure list.
+    property var hiddenVoicingsData: []
+
     function applyFilters() {
-        filteredData = FilterEngine.applyFilters(voicingsData, {
+        // Partition voicingsData into visible (no _excludedReason) and hidden.
+        var visible = []
+        var hidden = []
+        for (var pi = 0; pi < voicingsData.length; pi++) {
+            var pv = voicingsData[pi]
+            if (pv && pv._excludedReason) hidden.push(pv)
+            else visible.push(pv)
+        }
+        hiddenVoicingsData = hidden
+        filteredData = FilterEngine.applyFilters(visible, {
             filterContext: filterContext,
             filterCategory: filterCategory,
             filterQuality: filterQuality,
@@ -2853,6 +2967,14 @@ MuseScore {
             tuningListModel: tuningList.slice()
             theme: theme
             diagramPlacement: chordLibrary.diagramPlacement
+            // #210 Stage 2 — voicing exclusion engine surface
+            effectiveVoicingTolerances: ExclusionEngine.resolveTolerances(
+                chordLibrary.voicingToleranceMap,
+                chordLibrary.selectedTuning,
+                chordLibrary.activeMode
+            )
+            voicingOverrideCount: Object.keys(chordLibrary.userVoicingOverrides || {}).length
+            onClearVoicingOverridesRequested: chordLibrary.clearAllVoicingOverrides()
             builtInTunings: chordLibrary.builtInTunings
             saveTuningFn: function(name, pitches, numStrings, originalSlug) {
                 try {
@@ -3233,6 +3355,10 @@ MuseScore {
             suggestFingeringFn: function(v) { return suggestFingering(v) }
             onRemoveFromComparisonRequested: function(index) { chordLibrary.removeFromComparison(index) }
             onClearComparisonRequested: chordLibrary.clearComparison()
+            // #210 Stage 2 — hidden alts inside the walkthrough
+            hiddenAltVoicings: batchEngine.hiddenAltVoicings
+            onIncludeVoicingRequested: function(sig) { chordLibrary.setVoicingOverride(sig, "include") }
+            onClearVoicingOverridesRequested: chordLibrary.clearAllVoicingOverrides()
         }
 
         // === Tab 0: Library (extracted to ui/LibraryPanel.qml, #99) ===
@@ -3355,6 +3481,10 @@ MuseScore {
             onCompareRequested: function(voicing) { chordLibrary.addToComparison(voicing) }
             onClearComparisonRequested: chordLibrary.clearComparison()
             onRemoveFromComparisonRequested: function(index) { chordLibrary.removeFromComparison(index) }
+            // #210 Stage 2 — hidden voicing surface
+            hiddenVoicings: chordLibrary.hiddenVoicingsData
+            onIncludeVoicingRequested: function(sig) { chordLibrary.setVoicingOverride(sig, "include") }
+            onClearVoicingOverridesRequested: chordLibrary.clearAllVoicingOverrides()
 
             // --- Save to Library + Library Health (moved from Settings, #144) ---
             homePath: chordLibrary.homePath()

--- a/plugin/config/tuning-mode-tolerances.json
+++ b/plugin/config/tuning-mode-tolerances.json
@@ -1,0 +1,46 @@
+{
+  "schemaNote": "#210 Stage 2 — per-tuning-per-mode voicing exclusion thresholds. modes[] block defines defaults that apply across all tunings; tunings[<slug>][<mode>] overrides specific dimensions. ExclusionEngine.resolveTolerances() merges them.",
+  "modes": {
+    "chord-melody": {
+      "maxFret": 14,
+      "maxStretch": 6,
+      "maxMutedStrings": 3,
+      "minSoundingNotes": 3,
+      "requireRootInBass": false,
+      "allowOpenStrings": true,
+      "maxDifficultyTier": "advanced",
+      "excludedCategories": []
+    },
+    "comping": {
+      "maxFret": 12,
+      "maxStretch": 5,
+      "maxMutedStrings": 2,
+      "minSoundingNotes": 3,
+      "requireRootInBass": false,
+      "allowOpenStrings": true,
+      "maxDifficultyTier": "advanced",
+      "excludedCategories": ["quartal"]
+    },
+    "solo-guitar": {
+      "maxFret": 15,
+      "maxStretch": 7,
+      "maxMutedStrings": 3,
+      "minSoundingNotes": 3,
+      "requireRootInBass": false,
+      "allowOpenStrings": true,
+      "maxDifficultyTier": "expert",
+      "excludedCategories": []
+    },
+    "duo": {
+      "maxFret": 12,
+      "maxStretch": 5,
+      "maxMutedStrings": 2,
+      "minSoundingNotes": 3,
+      "requireRootInBass": false,
+      "allowOpenStrings": true,
+      "maxDifficultyTier": "advanced",
+      "excludedCategories": []
+    }
+  },
+  "tunings": {}
+}

--- a/plugin/model/BatchEngine.qml
+++ b/plugin/model/BatchEngine.qml
@@ -74,6 +74,8 @@ Item {
 
     // Alternative voicing state — grouped by bass string
     property var altVoicings: []
+    // #210 Stage 2 — alts hidden by exclusion engine for the current chord.
+    property var hiddenAltVoicings: []
     property int altCount: 0
     property int altIndex: 0
     property var bassStringGroups: ({})
@@ -445,8 +447,18 @@ Item {
         var nameParts = item.voicing.name.split(" — ")
         var shape = nameParts.length > 1 ? nameParts.slice(1).join(" — ") : item.voicing.category
 
-        // Load alternatives and group by bass string
-        altVoicings = findAllVoicings(item.root, item.quality, item.melodyMidi, item.bassMidi)
+        // Load alternatives and group by bass string. #210 Stage 2:
+        // partition out excluded voicings so the bass-string nav only
+        // surfaces visible alts; hidden ones go to the disclosure panel.
+        var allAlts = findAllVoicings(item.root, item.quality, item.melodyMidi, item.bassMidi)
+        var visible = []
+        var hidden = []
+        for (var ai = 0; ai < allAlts.length; ai++) {
+            if (allAlts[ai] && allAlts[ai]._excludedReason) hidden.push(allAlts[ai])
+            else visible.push(allAlts[ai])
+        }
+        altVoicings = visible
+        hiddenAltVoicings = hidden
         buildBassStringGroups()
 
         // Auto-select the bass string group containing the current voicing

--- a/plugin/model/ChordSelector.js
+++ b/plugin/model/ChordSelector.js
@@ -312,6 +312,9 @@ function findBestVoicing(voicingsData, targetRoot, quality, opts) {
     var quartalCandidates = []
     for (var i = 0; i < voicingsData.length; i++) {
         var v = voicingsData[i]
+        // #210 Stage 2: excluded voicings are not eligible for best-pick.
+        // They remain in findAllVoicings so the user can see + override.
+        if (v._excludedReason) continue
         if ((v.strings || 6) > maxStrings) continue
         if (v.root !== "C" && v.root !== targetRoot) continue
         if (v.chord_quality === quality) {

--- a/plugin/model/ExclusionEngine.js
+++ b/plugin/model/ExclusionEngine.js
@@ -1,0 +1,244 @@
+.pragma library
+
+// ExclusionEngine.js — per-tuning-per-mode voicing exclusion with user
+// overrides (#210 Stage 2).
+//
+// Given a voicing + tolerances + user overrides, returns either null
+// (voicing is visible) or {dimension, message} naming the first failing
+// dimension. Ordering chosen for UX meaningfulness — the most actionable
+// reason wins so the user sees something useful in the "Hidden (N)" UI.
+//
+// Tolerances shape (per-tuning-per-mode, with mode-level fallback):
+//   {
+//     maxFret:             int (e.g. 12),
+//     maxStretch:          int (e.g. 5),                  // absolute fret span
+//     maxMutedStrings:     int (e.g. 3),
+//     minSoundingNotes:    int (e.g. 3),
+//     requireRootInBass:   bool,
+//     allowOpenStrings:    bool,
+//     maxDifficultyTier:   "standard" | "advanced" | "expert",
+//     excludedCategories:  [string, ...]                  // category names to exclude
+//   }
+//
+// User overrides shape: { "<signatureKey>": "include" | "exclude" }
+//
+// Opts shape:
+//   {
+//     signatureKeyFn: function(voicing) -> string,   // typically ChordSelector.signatureKey
+//     difficultyFn:   function(voicing) -> { tier: "..." }  // typically FingeringEngine.computeDifficulty
+//   }
+
+// Dimension priority — first failure wins. User override > category >
+// difficulty > mute-count > stretch > maxFret > min-notes > root-in-bass
+// > open-strings. Ordering picks the most user-meaningful reason first
+// (a category exclusion is a clearer story than "9th finger barre too hard").
+var DIMENSION_ORDER = [
+    "userOverride",
+    "excludedCategories",
+    "maxDifficultyTier",
+    "maxMutedStrings",
+    "maxStretch",
+    "maxFret",
+    "minSoundingNotes",
+    "requireRootInBass",
+    "allowOpenStrings"
+]
+
+var TIER_RANK = { "standard": 0, "advanced": 1, "expert": 2 }
+
+function _absoluteFrets(voicing) {
+    var fretNumber = voicing.fret_number || 0
+    var dots = voicing.dots || []
+    var fretted = []
+    for (var i = 0; i < dots.length; i++) {
+        var f = fretNumber + (dots[i].fret - 1)
+        if (f > 0) fretted.push(f)
+    }
+    return fretted
+}
+
+function _bassInterval(voicing) {
+    // Bass = highest-numbered string that is sounding (fretted or open).
+    var mutes = voicing.mutes || []
+    var dots = voicing.dots || []
+    var opens = voicing.open || []
+    var intervals = voicing.intervals || []
+    var bassStr = 0
+    var bassIdx = -1
+    for (var d = 0; d < dots.length; d++) {
+        if (mutes.indexOf(dots[d].string) >= 0) continue
+        if (dots[d].string > bassStr) { bassStr = dots[d].string; bassIdx = d }
+    }
+    // Open strings can also be the bass when lower-numbered than fretted notes
+    // BUT open strings are usually fretted-equivalent at the same string; only
+    // count opens that aren't muted.
+    for (var o = 0; o < opens.length; o++) {
+        if (mutes.indexOf(opens[o]) >= 0) continue
+        if (opens[o] > bassStr) {
+            bassStr = opens[o]
+            // Open strings don't always have a parallel intervals entry — assume root
+            // if no specific record. This is a known approximation: voicings.json
+            // open-string voicings carry intervals in alphabetical/index order so
+            // we can't index parallel here. Caller should not enable requireRootInBass
+            // on voicings where opens are present without a richer schema.
+            bassIdx = -1
+            // Try to find a matching open interval. Some voicings tag opens'
+            // intervals at the end of the intervals array; we don't reliably know.
+            // For Stage 2, treat unknown-bass-from-open as "passes" (no exclude).
+        }
+    }
+    if (bassIdx >= 0 && bassIdx < intervals.length) return intervals[bassIdx]
+    return null  // unknown / no information — caller treats as passing
+}
+
+// Returns null if voicing is visible; otherwise { dimension, message }.
+function evaluateExclusion(voicing, tolerances, userOverrides, opts) {
+    if (!voicing) return null
+    opts = opts || {}
+
+    // --- userOverride (highest priority) ---
+    if (userOverrides && opts.signatureKeyFn) {
+        var sig = opts.signatureKeyFn(voicing)
+        if (sig && userOverrides[sig] === "exclude") {
+            return { dimension: "userOverride", message: "user-excluded" }
+        }
+        if (sig && userOverrides[sig] === "include") {
+            return null  // allowlist wins over all subsequent checks
+        }
+    }
+
+    if (!tolerances) return null
+
+    // --- excludedCategories ---
+    if (tolerances.excludedCategories && voicing.category) {
+        for (var ec = 0; ec < tolerances.excludedCategories.length; ec++) {
+            if (tolerances.excludedCategories[ec] === voicing.category) {
+                return {
+                    dimension: "excludedCategories",
+                    message: "category: " + voicing.category + " excluded by mode"
+                }
+            }
+        }
+    }
+
+    // --- maxDifficultyTier ---
+    if (tolerances.maxDifficultyTier && opts.difficultyFn) {
+        var diff = opts.difficultyFn(voicing)
+        var voicingTier = (diff && diff.tier) || "standard"
+        var maxRank = TIER_RANK[tolerances.maxDifficultyTier]
+        var voicingRank = TIER_RANK[voicingTier]
+        if (maxRank !== undefined && voicingRank !== undefined && voicingRank > maxRank) {
+            return {
+                dimension: "maxDifficultyTier",
+                message: "difficulty: " + voicingTier + " (mode max: " + tolerances.maxDifficultyTier + ")"
+            }
+        }
+    }
+
+    // --- maxMutedStrings ---
+    if (tolerances.maxMutedStrings !== undefined) {
+        var muteCount = (voicing.mutes || []).length
+        if (muteCount > tolerances.maxMutedStrings) {
+            return {
+                dimension: "maxMutedStrings",
+                message: "mutes: " + muteCount + " > max " + tolerances.maxMutedStrings
+            }
+        }
+    }
+
+    // --- maxStretch ---
+    if (tolerances.maxStretch !== undefined) {
+        var fretted = _absoluteFrets(voicing)
+        if (fretted.length >= 2) {
+            var minF = Math.min.apply(null, fretted)
+            var maxF = Math.max.apply(null, fretted)
+            var span = maxF - minF + 1  // span in frets, inclusive
+            if (span > tolerances.maxStretch) {
+                return {
+                    dimension: "maxStretch",
+                    message: "stretch: " + span + " > max " + tolerances.maxStretch
+                }
+            }
+        }
+    }
+
+    // --- maxFret ---
+    if (tolerances.maxFret !== undefined) {
+        var fretted2 = _absoluteFrets(voicing)
+        if (fretted2.length > 0) {
+            var maxF2 = Math.max.apply(null, fretted2)
+            if (maxF2 > tolerances.maxFret) {
+                return {
+                    dimension: "maxFret",
+                    message: "fret: " + maxF2 + " > max " + tolerances.maxFret
+                }
+            }
+        }
+    }
+
+    // --- minSoundingNotes ---
+    if (tolerances.minSoundingNotes !== undefined) {
+        var sounding = ((voicing.dots || []).length) + ((voicing.open || []).length)
+        if (sounding < tolerances.minSoundingNotes) {
+            return {
+                dimension: "minSoundingNotes",
+                message: "sounding: " + sounding + " < min " + tolerances.minSoundingNotes
+            }
+        }
+    }
+
+    // --- requireRootInBass ---
+    if (tolerances.requireRootInBass === true) {
+        var bassInt = _bassInterval(voicing)
+        // bassInt === null means unknown (opens-only voicings without parallel
+        // intervals data); treat as passing rather than excluding mysteriously.
+        if (bassInt !== null && bassInt !== "1") {
+            return {
+                dimension: "requireRootInBass",
+                message: "bass interval: " + bassInt + " (mode requires root in bass)"
+            }
+        }
+    }
+
+    // --- allowOpenStrings ---
+    if (tolerances.allowOpenStrings === false) {
+        if (voicing.open && voicing.open.length > 0) {
+            return {
+                dimension: "allowOpenStrings",
+                message: "open strings used (mode disallows)"
+            }
+        }
+    }
+
+    return null
+}
+
+// Resolve the effective tolerances for (tuning, mode) given a sparse override
+// map. Per-tuning-per-mode entries override per-mode entries, which override
+// the empty-object default.
+//
+// toleranceMap shape:
+//   {
+//     modes: { "chord-melody": {...}, "comping": {...}, ... },
+//     tunings: {
+//       "baritone": { "chord-melody": {...} },
+//       ...
+//     }
+//   }
+function resolveTolerances(toleranceMap, tuningSlug, modeId) {
+    var base = {}
+    if (!toleranceMap) return base
+    // Mode-level defaults.
+    if (toleranceMap.modes && toleranceMap.modes[modeId]) {
+        var m = toleranceMap.modes[modeId]
+        for (var k1 in m) base[k1] = m[k1]
+    }
+    // Per-tuning-per-mode overrides.
+    if (toleranceMap.tunings
+            && toleranceMap.tunings[tuningSlug]
+            && toleranceMap.tunings[tuningSlug][modeId]) {
+        var t = toleranceMap.tunings[tuningSlug][modeId]
+        for (var k2 in t) base[k2] = t[k2]
+    }
+    return base
+}

--- a/plugin/ui/HiddenVoicingsPanel.qml
+++ b/plugin/ui/HiddenVoicingsPanel.qml
@@ -1,0 +1,109 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+// HiddenVoicingsPanel — collapsible disclosure listing voicings hidden by
+// the exclusion engine (#210 Stage 2). Each row shows the voicing's name,
+// chord quality, and the failing-dimension reason chip. "Include" button
+// writes a user override that always-includes this signature going forward.
+//
+// Embedded by LibraryPanel (showing all hidden voicings in the current pool)
+// and WalkthroughPanel (showing hidden alts for the current chord).
+
+ColumnLayout {
+    id: hiddenPanel
+
+    property var hiddenVoicings: []  // array of voicings with _excludedReason set
+    property string titlePrefix: "Hidden"
+
+    signal includeRequested(string signatureKey)
+    signal clearAllOverridesRequested()
+
+    visible: hiddenVoicings.length > 0
+    spacing: 4
+    Layout.fillWidth: true
+
+    // Header / disclosure toggle
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 6
+
+        Button {
+            id: toggleBtn
+            text: (hiddenPanel.expanded ? "▼ " : "▶ ")
+                  + hiddenPanel.titlePrefix + " (" + hiddenPanel.hiddenVoicings.length + ")"
+            font.pixelSize: 10
+            ToolTip.visible: hovered
+            ToolTip.text: "Voicings hidden by the current tuning/mode tolerances. " +
+                          "Click a voicing's Include button to override."
+            onClicked: hiddenPanel.expanded = !hiddenPanel.expanded
+        }
+
+        Item { Layout.fillWidth: true }
+
+        Button {
+            visible: hiddenPanel.expanded
+            text: "Reset overrides"
+            font.pixelSize: 9
+            ToolTip.visible: hovered
+            ToolTip.text: "Clear all 'include' and 'exclude' overrides this user has set."
+            onClicked: hiddenPanel.clearAllOverridesRequested()
+        }
+    }
+
+    property bool expanded: false
+
+    // Hidden-list body
+    Repeater {
+        model: hiddenPanel.expanded ? hiddenPanel.hiddenVoicings : []
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 36
+            radius: 3
+            color: theme.cardBackground
+            border.color: theme.cardBorder
+            border.width: 1
+
+            property var v: modelData || {}
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 4
+                spacing: 6
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 1
+
+                    Label {
+                        text: (v.name || "(no name)") + "  —  " + (v.chord_quality || "?")
+                        font.pixelSize: 10
+                        font.bold: true
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+                    Label {
+                        text: v._excludedReason ? v._excludedReason.message : ""
+                        font.pixelSize: 9
+                        color: theme.warningText || theme.textSecondary
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+                }
+
+                Button {
+                    text: "Include"
+                    font.pixelSize: 9
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Always include this voicing in the visible pool, regardless of tolerances."
+                    onClicked: {
+                        if (v._signatureKey) {
+                            hiddenPanel.includeRequested(v._signatureKey)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugin/ui/LibraryPanel.qml
+++ b/plugin/ui/LibraryPanel.qml
@@ -87,6 +87,12 @@ Item {
     signal compareRequested(var voicing)
     signal clearComparisonRequested()
     signal removeFromComparisonRequested(int index)
+    // #210 Stage 2 — hidden voicing overrides
+    signal includeVoicingRequested(string signatureKey)
+    signal clearVoicingOverridesRequested()
+
+    // #210 Stage 2 — list of voicings hidden by exclusion engine
+    property var hiddenVoicings: []
     signal scaleFilterChanged(string scaleName)
     signal profileChanged(string profileId)
     signal modeChanged(string modeId)
@@ -690,6 +696,14 @@ Item {
             suggestFingeringFn: libraryPanel.suggestFingeringFn
             onRemoveRequested: function(index) { libraryPanel.removeFromComparisonRequested(index) }
             onClearRequested: libraryPanel.clearComparisonRequested()
+        }
+
+        // Hidden voicings disclosure (#210 Stage 2)
+        HiddenVoicingsPanel {
+            hiddenVoicings: libraryPanel.hiddenVoicings
+            titlePrefix: "Show hidden"
+            onIncludeRequested: function(sig) { libraryPanel.includeVoicingRequested(sig) }
+            onClearAllOverridesRequested: libraryPanel.clearVoicingOverridesRequested()
         }
 
         // ─────────────────────────────────────────────

--- a/plugin/ui/SettingsPanel.qml
+++ b/plugin/ui/SettingsPanel.qml
@@ -87,6 +87,10 @@ Item {
     signal backupRestoreRequested()
     // Import from URL (#67)
     signal urlImportRequested(string url)
+    // #210 Stage 2 — voicing exclusion engine surface
+    signal clearVoicingOverridesRequested()
+    property var effectiveVoicingTolerances: ({})
+    property int voicingOverrideCount: 0
     property string backupStatus: ""
     property color backupStatusColor: "black"
 
@@ -359,6 +363,81 @@ Item {
                                 font.pixelSize: 10
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
+                            }
+                        }
+                    }
+
+                    // === Voicing Tolerances (#210 Stage 2) ===
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: tolColumn.implicitHeight + 16
+                        color: theme.consoleBg
+                        radius: 4
+                        border.color: theme.divider
+
+                        ColumnLayout {
+                            id: tolColumn
+                            anchors.fill: parent
+                            anchors.margins: 8
+                            spacing: 4
+
+                            Label {
+                                text: "VOICING TOLERANCES"
+                                font.pixelSize: 11
+                                font.bold: true
+                            }
+                            Label {
+                                text: "Effective thresholds for the current tuning + mode. Hand-edit plugin/config/tuning-mode-tolerances.json to customize. Per-signature include/exclude overrides are managed via the 'Hidden voicings' lists in the Library tab and Walkthrough."
+                                font.pixelSize: 9
+                                color: theme.textMuted
+                                wrapMode: Text.WordWrap
+                                Layout.fillWidth: true
+                            }
+                            // Read-only dimension grid
+                            Grid {
+                                columns: 2
+                                columnSpacing: 12
+                                rowSpacing: 2
+                                Layout.fillWidth: true
+
+                                Label { text: "Max fret:"; font.pixelSize: 9; color: theme.textSecondary }
+                                Label { text: settingsPanel.effectiveVoicingTolerances.maxFret !== undefined ? String(settingsPanel.effectiveVoicingTolerances.maxFret) : "—"; font.pixelSize: 9 }
+
+                                Label { text: "Max stretch (frets):"; font.pixelSize: 9; color: theme.textSecondary }
+                                Label { text: settingsPanel.effectiveVoicingTolerances.maxStretch !== undefined ? String(settingsPanel.effectiveVoicingTolerances.maxStretch) : "—"; font.pixelSize: 9 }
+
+                                Label { text: "Max muted strings:"; font.pixelSize: 9; color: theme.textSecondary }
+                                Label { text: settingsPanel.effectiveVoicingTolerances.maxMutedStrings !== undefined ? String(settingsPanel.effectiveVoicingTolerances.maxMutedStrings) : "—"; font.pixelSize: 9 }
+
+                                Label { text: "Min sounding notes:"; font.pixelSize: 9; color: theme.textSecondary }
+                                Label { text: settingsPanel.effectiveVoicingTolerances.minSoundingNotes !== undefined ? String(settingsPanel.effectiveVoicingTolerances.minSoundingNotes) : "—"; font.pixelSize: 9 }
+
+                                Label { text: "Max difficulty tier:"; font.pixelSize: 9; color: theme.textSecondary }
+                                Label { text: settingsPanel.effectiveVoicingTolerances.maxDifficultyTier || "—"; font.pixelSize: 9 }
+
+                                Label { text: "Excluded categories:"; font.pixelSize: 9; color: theme.textSecondary }
+                                Label { text: (settingsPanel.effectiveVoicingTolerances.excludedCategories || []).join(", ") || "(none)"; font.pixelSize: 9 }
+
+                                Label { text: "Require root in bass:"; font.pixelSize: 9; color: theme.textSecondary }
+                                Label { text: settingsPanel.effectiveVoicingTolerances.requireRootInBass ? "yes" : "no"; font.pixelSize: 9 }
+
+                                Label { text: "Allow open strings:"; font.pixelSize: 9; color: theme.textSecondary }
+                                Label { text: settingsPanel.effectiveVoicingTolerances.allowOpenStrings === false ? "no" : "yes"; font.pixelSize: 9 }
+                            }
+                            RowLayout {
+                                Layout.fillWidth: true
+                                Label {
+                                    text: "User overrides set: " + settingsPanel.voicingOverrideCount
+                                    font.pixelSize: 9
+                                    color: theme.textSecondary
+                                    Layout.fillWidth: true
+                                }
+                                Button {
+                                    text: "Clear all overrides"
+                                    font.pixelSize: 9
+                                    enabled: settingsPanel.voicingOverrideCount > 0
+                                    onClicked: settingsPanel.clearVoicingOverridesRequested()
+                                }
                             }
                         }
                     }

--- a/plugin/ui/WalkthroughPanel.qml
+++ b/plugin/ui/WalkthroughPanel.qml
@@ -42,6 +42,11 @@ ColumnLayout {
     property var compareVoicings: []
     property var suggestFingeringFn: function(v) { return [] }
 
+    // Hidden alts (#210 Stage 2). Voicings for the current chord that the
+    // exclusion engine has hidden. Renders as a disclosure list at the
+    // bottom of the alt navigation.
+    property var hiddenAltVoicings: []
+
     // Lock states (readable by parent for bass string selection)
     readonly property bool melodyLocked: typeof melodyLockBtn !== "undefined" && melodyLockBtn ? melodyLockBtn.checked : false
     readonly property bool bassLocked: typeof bassLockBtn !== "undefined" && bassLockBtn ? bassLockBtn.checked : false
@@ -60,6 +65,9 @@ ColumnLayout {
     // #196 — tray controls shared with LibraryPanel
     signal removeFromComparisonRequested(int index)
     signal clearComparisonRequested()
+    // #210 Stage 2 — hidden voicing overrides
+    signal includeVoicingRequested(string signatureKey)
+    signal clearVoicingOverridesRequested()
 
     // Section data + mode list (wired from parent)
     property var scoreSections: []
@@ -99,6 +107,15 @@ ColumnLayout {
         suggestFingeringFn: walkthroughPanel.suggestFingeringFn
         onRemoveRequested: function(index) { walkthroughPanel.removeFromComparisonRequested(index) }
         onClearRequested: walkthroughPanel.clearComparisonRequested()
+    }
+
+    // Hidden alts disclosure (#210 Stage 2). Voicings excluded for this
+    // chord under the current tuning/mode tolerances. Auto-hides when none.
+    HiddenVoicingsPanel {
+        hiddenVoicings: walkthroughPanel.hiddenAltVoicings
+        titlePrefix: "Hidden alts"
+        onIncludeRequested: function(sig) { walkthroughPanel.includeVoicingRequested(sig) }
+        onClearAllOverridesRequested: walkthroughPanel.clearVoicingOverridesRequested()
     }
 
     // Header row with title and nav buttons

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -1005,6 +1005,193 @@ class TestUnionVoicings:
         """)
 
 
+# === ExclusionEngine.js — per-tuning-per-mode exclusion (#210) ===
+
+
+class TestExclusionEngine:
+    """Test ExclusionEngine.js exclusion + override behavior."""
+
+    def test_no_tolerances_returns_null(self):
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [{string:6,fret:1}], mutes: [], open: [],
+                      intervals: ["1"], fret_number: 5, category: "shell" };
+            assertEqual(evaluateExclusion(v, null, null, null), null,
+                "no tolerances -> visible");
+            assertEqual(evaluateExclusion(v, {}, null, null), null,
+                "empty tolerances -> visible");
+        """)
+
+    def test_excluded_categories_dimension(self):
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [], mutes: [], open: [],
+                      intervals: [], fret_number: 5, category: "quartal" };
+            var t = { excludedCategories: ["quartal"] };
+            var r = evaluateExclusion(v, t, null, null);
+            assertEqual(r.dimension, "excludedCategories", "category excluded");
+            assert(r.message.indexOf("quartal") >= 0, "message names category");
+        """)
+
+    def test_max_difficulty_tier_dimension(self):
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [{string:6,fret:1}], mutes: [], open: [],
+                      intervals: ["1"], fret_number: 5, category: "shell" };
+            var t = { maxDifficultyTier: "advanced" };
+            var difficultyFn = function(_) { return { tier: "expert" }; };
+            var r = evaluateExclusion(v, t, null, { difficultyFn: difficultyFn });
+            assertEqual(r.dimension, "maxDifficultyTier", "expert > advanced");
+        """)
+
+    def test_max_difficulty_tier_passes_when_within_limit(self):
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [], mutes: [], open: [],
+                      intervals: [], fret_number: 5 };
+            var t = { maxDifficultyTier: "advanced" };
+            var difficultyFn = function(_) { return { tier: "standard" }; };
+            assertEqual(evaluateExclusion(v, t, null, { difficultyFn: difficultyFn }), null,
+                "standard within advanced -> visible");
+        """)
+
+    def test_max_muted_strings_dimension(self):
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [{string:1,fret:1}], mutes: [2,3,4,5], open: [],
+                      intervals: ["1"], fret_number: 5 };
+            var t = { maxMutedStrings: 3 };
+            var r = evaluateExclusion(v, t, null, null);
+            assertEqual(r.dimension, "maxMutedStrings", "4 mutes > 3 max");
+        """)
+
+    def test_max_stretch_dimension(self):
+        # Dots at fret_number 1 with relative frets 1 and 7 → absolute 1 and 7
+        # → stretch 7 (inclusive). Should fail max=5.
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [{string:6,fret:1},{string:1,fret:7}],
+                      mutes: [], open: [], intervals: ["1","5"], fret_number: 1 };
+            var t = { maxStretch: 5 };
+            var r = evaluateExclusion(v, t, null, null);
+            assertEqual(r.dimension, "maxStretch", "stretch 7 > max 5");
+        """)
+
+    def test_max_fret_dimension(self):
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [{string:6,fret:1}], mutes: [], open: [],
+                      intervals: ["1"], fret_number: 14 };
+            var t = { maxFret: 12 };
+            var r = evaluateExclusion(v, t, null, null);
+            assertEqual(r.dimension, "maxFret", "fret 14 > max 12");
+        """)
+
+    def test_min_sounding_notes_dimension(self):
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [{string:6,fret:1}, {string:5,fret:1}],
+                      mutes: [], open: [], intervals: ["1","5"], fret_number: 5 };
+            var t = { minSoundingNotes: 3 };
+            var r = evaluateExclusion(v, t, null, null);
+            assertEqual(r.dimension, "minSoundingNotes", "2 sounding < 3 min");
+        """)
+
+    def test_require_root_in_bass_dimension(self):
+        # Bass string (highest-numbered sounding) is string 6 with interval "5" → not root.
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6,
+                      dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                      mutes: [], open: [],
+                      intervals: ["5","1","3"], fret_number: 5 };
+            var t = { requireRootInBass: true };
+            var r = evaluateExclusion(v, t, null, null);
+            assertEqual(r.dimension, "requireRootInBass", "bass is 5th, not root");
+        """)
+
+    def test_allow_open_strings_dimension(self):
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [], mutes: [], open: [3,4],
+                      intervals: [], fret_number: 0 };
+            var t = { allowOpenStrings: false };
+            var r = evaluateExclusion(v, t, null, null);
+            assertEqual(r.dimension, "allowOpenStrings", "opens disallowed");
+        """)
+
+    def test_user_override_include_wins_over_tolerance(self):
+        # Acceptance criterion: allowlisted signature always passes.
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [], mutes: [1,2,3,4,5], open: [],
+                      intervals: [], fret_number: 5, category: "quartal" };
+            // Would fail BOTH maxMutedStrings AND excludedCategories.
+            var t = { maxMutedStrings: 3, excludedCategories: ["quartal"] };
+            var overrides = { "my-sig": "include" };
+            var opts = { signatureKeyFn: function(_) { return "my-sig"; } };
+            assertEqual(evaluateExclusion(v, t, overrides, opts), null,
+                "allowlist wins over all tolerance failures");
+        """)
+
+    def test_user_override_exclude_wins_over_tolerance(self):
+        # Acceptance criterion: denylisted signature always fails.
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [{string:6,fret:1}], mutes: [], open: [],
+                      intervals: ["1"], fret_number: 5, category: "shell" };
+            // Would pass everything.
+            var t = { maxMutedStrings: 3, excludedCategories: [] };
+            var overrides = { "my-sig": "exclude" };
+            var opts = { signatureKeyFn: function(_) { return "my-sig"; } };
+            var r = evaluateExclusion(v, t, overrides, opts);
+            assertEqual(r.dimension, "userOverride", "denylist beats passing checks");
+        """)
+
+    def test_dimension_priority_category_before_difficulty(self):
+        # When two tolerances both fail, the higher-priority one wins.
+        # Category exclusion is higher priority than difficulty.
+        assert_js("ExclusionEngine.js", """
+            var v = { strings: 6, dots: [{string:6,fret:1}], mutes: [], open: [],
+                      intervals: ["1"], fret_number: 5, category: "quartal" };
+            var t = { excludedCategories: ["quartal"], maxDifficultyTier: "standard" };
+            var difficultyFn = function(_) { return { tier: "expert" }; };
+            var r = evaluateExclusion(v, t, null, { difficultyFn: difficultyFn });
+            assertEqual(r.dimension, "excludedCategories",
+                "category check fires before difficulty");
+        """)
+
+    def test_resolve_tolerances_mode_only(self):
+        assert_js("ExclusionEngine.js", """
+            var map = { modes: { "comping": { maxMutedStrings: 2 } } };
+            var t = resolveTolerances(map, "standard", "comping");
+            assertEqual(t.maxMutedStrings, 2, "mode default applied");
+        """)
+
+    def test_resolve_tolerances_tuning_overrides_mode(self):
+        assert_js("ExclusionEngine.js", """
+            var map = {
+                modes: { "comping": { maxMutedStrings: 2, maxFret: 12 } },
+                tunings: { "baritone": { "comping": { maxFret: 14 } } }
+            };
+            var t = resolveTolerances(map, "baritone", "comping");
+            assertEqual(t.maxMutedStrings, 2, "mode default preserved");
+            assertEqual(t.maxFret, 14, "tuning override applied");
+        """)
+
+    def test_findbest_skips_excluded_voicings(self):
+        # findBestVoicing must not return a voicing with _excludedReason set,
+        # even if it would otherwise score highest.
+        assert_js("ChordSelector.js", """
+            var excluded = {
+                id: "v-excluded", root: "C", chord_quality: "dom7",
+                category: "shell", fret_number: 5, mutes: [], open: [],
+                dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                intervals: ["1","b7","3"], strings: 6,
+                _excludedReason: { dimension: "userOverride", message: "user-excluded" }
+            };
+            var visible = {
+                id: "v-visible", root: "C", chord_quality: "dom7",
+                category: "drop2", fret_number: 5, mutes: [], open: [],
+                dots: [{string:5,fret:3},{string:4,fret:2},{string:3,fret:3}],
+                intervals: ["1","3","b7"], strings: 6
+            };
+            var pick = findBestVoicing([excluded, visible], "C", "dom7", {
+                maxStrings: 6, semitoneMap: {C:0}
+            });
+            assertEqual(pick.id, "v-visible",
+                "excluded voicing is not selectable as best");
+        """)
+
+
 # === RevoiceMemory.js — per-chord choice persistence (#197) ===
 
 


### PR DESCRIPTION
## Context

Stage 1 (#209) unioned calculator output with voicings.json. The result
included voicings the curated set deliberately omits (expert-difficulty,
excessive mutes, awkward stretches, omitted categories). Without
exclusion, these flood the user. Stage 2 adds the exclusion engine that
makes the unioned pool safe to surface.

## Goal

Hide voicings failing any of 8 per-tuning-per-mode tolerance dimensions.
Show them in disclosure UIs with reason chips + per-signature
include/exclude overrides that persist.

## What landed

- **New** `plugin/model/ExclusionEngine.js` — pure JS .pragma library.
  Two functions: `evaluateExclusion(voicing, tolerances, userOverrides, opts)`,
  `resolveTolerances(toleranceMap, tuning, mode)`. Eight dimensions in priority
  order; first-failing wins.
- **New** `plugin/config/tuning-mode-tolerances.json` — mode-level
  defaults + sparse per-tuning overrides.
- **New** `plugin/ui/HiddenVoicingsPanel.qml` — shared disclosure
  component used by Library + Walkthrough.
- **ChordLibrary.qml** — loader, exclusion pass (clones voicings,
  attaches `_excludedReason` + `_signatureKey`), `setVoicingOverride`,
  `clearAllVoicingOverrides`, `applyFilters` partitions
  visible/hidden. Settings persistence round-trip for
  `userVoicingOverrides`.
- **BatchEngine.qml** — `altVoicings` partitioned into visible alts +
  `hiddenAltVoicings` per chord.
- **ChordSelector.findBestVoicing** — skip voicings with
  `_excludedReason` set.
- **LibraryPanel.qml** + **WalkthroughPanel.qml** — embed
  `HiddenVoicingsPanel`.
- **SettingsPanel.qml** — read-only "Voicing Tolerances" section +
  "Clear all overrides" action.

## The 8 dimensions

| Priority | Dimension | Becomes hard cutoff |
|---|---|---|
| 1 | userOverride (allowlist/denylist) | (overrides everything) |
| 2 | excludedCategories | NEW (was soft scoring) |
| 3 | maxDifficultyTier | NEW (was soft scoring) |
| 4 | maxMutedStrings | already calc-side, now mode-scoped |
| 5 | maxStretch | already calc-side, now mode-scoped |
| 6 | maxFret | already calc-side, now mode-scoped |
| 7 | minSoundingNotes | already calc-side, now mode-scoped |
| 8 | requireRootInBass, allowOpenStrings | already calc-side, now mode-scoped |

## Acceptance (from #210)

- [x] `test_exclusion_engine_dimensions_attributed` (15 dimension-specific tests covering this)
- [x] `test_user_override_include_wins_over_tolerance` — ticket AC
- [x] `test_user_override_exclude_wins_over_tolerance` — ticket AC
- [x] `test_findbest_skips_excluded_voicings` — integration with selector
- [x] UI: "Show hidden (N)" / "Hidden alts (N)" disclosure in Library + Walkthrough
- [x] Per-card "Include" button persists override
- [x] Settings tab gets "Voicing Tolerances" section (read-only + Clear all)
- [x] 192 tests pass (was 176)
- [x] Perf bench 10.64ms (vs 10.76 baseline)

## Scope decision — Settings is read-only

The Settings section displays the effective tolerances for the current
mode + tuning, plus a "Clear all overrides" action. Per-dimension form
editing (full editor) is a deferred follow-up. Engine works fine with
JSON defaults; users wanting custom tolerances hand-edit
`plugin/config/tuning-mode-tolerances.json` for now.

Rationale: full editor is real UI work (three dropdowns + 8 controls +
save plumbing) without clear evidence yet of which dimensions users
actually want to dial in. File the editor ticket after Stage 3 ships
based on real feedback.

## Falsification (from ticket)

> Revert the exclusion engine.
> `test_exclusion_engine_dimensions_attributed` goes red because no
> dimension-to-reason mapping survives.

Implemented across 10 dimension-specific tests covering every
dimension's failure case.

## Self-Review

`plans/self-review-210-stage2-exclusion.md`