### PR TITLE
#211 Stage 3: drop voicings.json from runtime; calculator + user-voicings.json are the sources

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -113,10 +113,9 @@ MuseScore {
         source: Qt.resolvedUrl("settings.json")
     }
 
-    FileIO {
-        id: localCacheFile
-        source: Qt.resolvedUrl("data/voicings.json")
-    }
+    // #211 Stage 3 — localCacheFile removed; voicings.json is no longer a
+    // runtime load target. The calculator generates the standard pool;
+    // user imports persist to user-voicings.json (see userVoicingsFile below).
 
     FileIO {
         id: exportFile
@@ -158,6 +157,16 @@ MuseScore {
     FileIO {
         id: standardCalculatedFile  // #209 Stage 1 — cached calculator output for standard tuning
         source: Qt.resolvedUrl("data/standard-calculated.json")
+    }
+
+    FileIO {
+        id: userVoicingsFile  // #211 Stage 3 — user-imported voicings (replaces voicings.json runtime role)
+        source: Qt.resolvedUrl("data/user-voicings.json")
+    }
+
+    FileIO {
+        id: voicingsJsonForMigration  // #211 Stage 3 — read ONCE if revoice memory is v1, then never again
+        source: Qt.resolvedUrl("data/voicings.json")
     }
 
     FileIO {
@@ -261,6 +270,10 @@ MuseScore {
     // unioned with voicingsData by signatureKey to expand the candidate pool.
     // Cached to data/standard-calculated.json; invalidated by constraints hash.
     property var calculatedStandardVoicings: []
+
+    // User-imported voicings (#211 Stage 3). Replaces the previous role of
+    // voicings.json as the user-import store. Persisted to data/user-voicings.json.
+    property var userVoicings: []
 
     // Exclusion engine (#210 Stage 2). The full tolerance map (per-mode +
     // per-tuning-per-mode overrides), loaded once from config. The per-user
@@ -549,6 +562,44 @@ MuseScore {
             + after + " unique")
     }
 
+    // #211 Stage 3 — assemble the runtime pool from calculator + user imports.
+    // Replaces the previous voicings.json-driven flow. Standard tuning's pool
+    // = union(calculatedStandardVoicings, userVoicings), deduped by signature.
+    function rebuildStandardPool() {
+        var pool = ChordSelector.unionVoicings(calculatedStandardVoicings, userVoicings)
+        voicingsData = pool
+        dataLoaded = true
+        console.log("Rebuilt standard pool: " + (calculatedStandardVoicings || []).length
+            + " calculator + " + (userVoicings || []).length + " user -> "
+            + pool.length + " unique")
+    }
+
+    function loadUserVoicings() {
+        try {
+            var raw = userVoicingsFile.read()
+            if (raw && raw.length > 2) {
+                var data = JSON.parse(raw)
+                userVoicings = (data && data.voicings) || []
+                console.log("Loaded " + userVoicings.length + " user voicings")
+            }
+        } catch (e) {
+            // No file or empty — start clean.
+            userVoicings = []
+        }
+    }
+
+    function saveUserVoicings() {
+        try {
+            userVoicingsFile.write(JSON.stringify({
+                version: "v1",
+                count: userVoicings.length,
+                voicings: userVoicings
+            }))
+        } catch (e) {
+            console.log("Failed to write user-voicings.json: " + e)
+        }
+    }
+
     // === Exclusion engine (#210 Stage 2) ===
 
     function loadVoicingTolerances() {
@@ -587,6 +638,16 @@ MuseScore {
             // Cache signature on the clone so UI override actions can
             // identify the voicing without re-computing.
             clone._signatureKey = ChordSelector.signatureKey(v)
+            // #211 Stage 3 — calculator voicings that match a curated
+            // signature inherit the curated name/category for display.
+            // (User imports already carry their own name/category and
+            // typically won't match a curated signature; if they do,
+            // curated wins — same precedence as Stage 1's union.)
+            var curatedHit = curatedShapeLookup[clone._signatureKey]
+            if (curatedHit) {
+                if (curatedHit.name) clone.name = curatedHit.name
+                if (curatedHit.category) clone.category = curatedHit.category
+            }
             clone._excludedReason = ExclusionEngine.evaluateExclusion(
                 v, tolerances, userVoicingOverrides, opts)
             if (clone._excludedReason) hidden++
@@ -626,12 +687,47 @@ MuseScore {
         try {
             var raw = revoiceMemoryFile.read()
             revoiceMemory = RevoiceMemory.parseMemory(raw)
-            console.log("Loaded revoice memory: "
+            // #211 Stage 3 — migrate v1 (id-keyed) to v2 (signature-keyed).
+            // Reads voicings.json ONE last time to build {id -> signatureKey}.
+            // After this point, runtime never reads voicings.json again.
+            if (revoiceMemory.version === "v1") {
+                console.log("Migrating revoice memory v1 -> v2")
+                var idToSig = _buildIdToSignatureLookup()
+                RevoiceMemory.migrateFromV1(revoiceMemory, idToSig)
+                if (revoiceMemory._droppedIds && revoiceMemory._droppedIds.length > 0) {
+                    console.log("Dropped " + revoiceMemory._droppedIds.length
+                        + " unresolvable choice(s) during v1->v2 migration")
+                }
+                saveRevoiceMemory()
+            }
+            console.log("Loaded revoice memory ("
+                + revoiceMemory.version + "): "
                 + Object.keys(revoiceMemory.scopes).length + " scope(s)")
         } catch (e) {
             console.log("No revoice memory; starting fresh")
-            revoiceMemory = { version: "v1", scopes: {} }
+            revoiceMemory = { version: "v2", scopes: {} }
         }
+    }
+
+    // #211 Stage 3 — one-time helper for v1->v2 migration. Reads voicings.json
+    // (the source-of-truth-at-time-of-migration), maps each id to its
+    // signature key. Empty map on file-missing (memory's unresolvable
+    // entries are dropped with diagnostics).
+    function _buildIdToSignatureLookup() {
+        var lookup = {}
+        try {
+            var raw = voicingsJsonForMigration.read()
+            if (!raw || raw.length < 2) return lookup
+            var data = JSON.parse(raw)
+            var arr = (data && data.voicings) || (Array.isArray(data) ? data : [])
+            for (var i = 0; i < arr.length; i++) {
+                var v = arr[i]
+                if (v && v.id) lookup[v.id] = ChordSelector.signatureKey(v)
+            }
+        } catch (e) {
+            console.log("Migration lookup: voicings.json unreadable: " + e)
+        }
+        return lookup
     }
 
     function saveRevoiceMemory() {
@@ -1110,20 +1206,12 @@ MuseScore {
         loadRevoiceMemory()
         loadSettings()
         loadTuningStringCount()
-        if (!dataLoaded) {
-            // Try local cache first (contains imports), fall back to URL
-            if (!loadFromCache()) {
-                fetchVoicings()
-            }
-        }
-        // Stage 1 (#209): union calculator output for standard tuning.
-        // Runs after voicings.json is loaded; populates voicingsData with the
-        // unioned pool. Standard tuning is what's loaded by default at startup;
-        // if the user switches tunings, loadTuningVoicings handles non-standard.
+        // #211 Stage 3 — voicings.json no longer loaded at runtime. The
+        // standard-tuning pool is built from calculator output + user
+        // imports. Non-standard tunings still flow through loadTuningVoicings.
         loadCalculatedStandard()
-        applyStandardUnion()
-        // Stage 2 (#210): apply exclusion engine to the (unioned) pool.
-        // Re-runs on tuning/mode changes via property change handlers below.
+        loadUserVoicings()
+        rebuildStandardPool()
         applyExclusionPass()
         // Auto-select CM context if none saved
         if (!filterContext) {
@@ -1136,30 +1224,18 @@ MuseScore {
         startupTuningTimer.start()
     }
 
+    // #211 Stage 3 — voicings.json is no longer the runtime source for
+    // standard tuning. The functions below are kept as no-ops so the
+    // surviving UI handlers (URL Apply, Reset, Refresh, Reset Data,
+    // import-merge, fixDuplicates) don't crash. Migrating those callers to
+    // calculator-based actions is a follow-up.
     function loadFromCache() {
-        try {
-            var raw = localCacheFile.read()
-            var cached = DataCache.parseCache(raw)
-            if (cached) {
-                voicingsData = cached
-                dataLoaded = true
-                rebuildFilterLists()
-                refreshFilteredTunings()
-                applyFilters()
-                statusMsg.text = "Loaded " + voicingsData.length + " voicings (cached)"
-                statusMsg.color = theme.successText
-                console.log("Loaded " + cached.length + " voicings from local cache")
-                return true
-            }
-        } catch (e) {
-            console.log("No local cache, fetching from URL")
-        }
+        console.log("loadFromCache is deprecated (#211 Stage 3); ignoring")
         return false
     }
 
     function saveToCache() {
-        localCacheFile.write(DataCache.serializeCache(voicingsData))
-        console.log("Saved " + voicingsData.length + " voicings to local cache")
+        console.log("saveToCache is deprecated (#211 Stage 3); use saveUserVoicings()")
     }
 
     // === Settings persistence ===
@@ -1493,14 +1569,17 @@ MuseScore {
             tags: ["custom", category]
         }
 
-        // Add to library and save
-        var merged = voicingsData.slice()
-        merged.push(voicing)
-        voicingsData = merged
+        // #211 Stage 3 — user imports go to user-voicings.json, NOT
+        // back to voicings.json. The pool rebuilds from calculator output
+        // unioned with userVoicings, then the exclusion pass runs.
+        var nextUser = userVoicings.slice()
+        nextUser.push(voicing)
+        userVoicings = nextUser
+        saveUserVoicings()
+        rebuildStandardPool()
         rebuildFilterLists()
         refreshFilteredTunings()
-        applyFilters()
-        saveToCache()
+        applyExclusionPass()  // re-runs applyFilters internally
 
         var keyNote = targetRoot === "C" ? "" : " (reprojected from " + targetRoot + ")"
         settingsPanel.saveStatus = "Saved: " + voicing.name + keyNote
@@ -1644,47 +1723,15 @@ MuseScore {
 
     // === Data fetching ===
 
+    // #211 Stage 3 — voicings.json is no longer a runtime source. The
+    // calculator generates the standard pool; users append to user-voicings.json.
+    // fetchVoicings is kept as a no-op so existing Import-panel UI handlers
+    // don't crash; if a user clicks "Apply URL" or "Refresh", the request is
+    // ignored with a status message.
     function fetchVoicings() {
-        statusMsg.text = "Loading voicings..."
-        statusMsg.color = theme.textSecondary
-        var xhr = new XMLHttpRequest()
-        xhr.onreadystatechange = function() {
-            if (xhr.readyState === XMLHttpRequest.DONE) {
-                if (xhr.status === 200) {
-                    try {
-                        var data = JSON.parse(xhr.responseText)
-                        voicingsData = data.voicings || []
-                        dataLoaded = true
-                        // Stage 1 (#209): the union runs whenever voicingsData
-                        // is freshly populated; deduped so it's idempotent.
-                        applyStandardUnion()
-                        rebuildFilterLists()
-                        refreshFilteredTunings()
-                        applyFilters()
-                        saveToCache()
-                        // T-001: trigger tuning-specific voicings now that data is loaded.
-                        // loadTuningVoicings() in onRun ran before this async callback,
-                        // so non-standard tunings need a second call here.
-                        if (selectedTuning !== "standard") {
-                            loadTuningVoicings()
-                        }
-                        statusMsg.text = "Loaded " + voicingsData.length + " voicings"
-                        statusMsg.color = theme.successText
-                    } catch (e) {
-                        statusMsg.text = "Failed to parse voicings: " + e
-                        statusMsg.color = theme.errorText
-                    }
-                } else if (xhr.status === 0) {
-                    statusMsg.text = "Could not reach URL. Check connection or URL."
-                    statusMsg.color = theme.errorText
-                } else {
-                    statusMsg.text = "Failed to fetch: HTTP " + xhr.status
-                    statusMsg.color = theme.errorText
-                }
-            }
-        }
-        xhr.open("GET", jsonUrl)
-        xhr.send()
+        statusMsg.text = "URL fetch is deprecated — pool is generated locally"
+        statusMsg.color = theme.textMuted
+        console.log("fetchVoicings is a no-op in #211 Stage 3")
     }
 
     // === Filtering ===

--- a/plugin/model/BatchEngine.qml
+++ b/plugin/model/BatchEngine.qml
@@ -213,8 +213,10 @@ Item {
         item.voicing = voicing
 
         // Persist alt selection for next session (#197).
-        if (revoiceMemoryRecordFn && voicing.id) {
-            revoiceMemoryRecordFn(item.text, voicing.id)
+        // #211 Stage 3 — record by signature so memory survives id changes.
+        if (revoiceMemoryRecordFn) {
+            var sig = voicing._signatureKey || ChordSelector.signatureKey(voicing)
+            if (sig) revoiceMemoryRecordFn(item.text, sig)
         }
 
         // Update clipboard
@@ -388,11 +390,14 @@ Item {
                             // a specific voicing for this chord-symbol last time
                             // under the same (mode, style, tuning), restore it.
                             if (voicing && revoiceMemoryGetFn) {
-                                var savedId = revoiceMemoryGetFn(text)
-                                if (savedId) {
+                                // #211 Stage 3 — memory stores signatureKey (v2).
+                                // Match alts by signature, not by voicing.id.
+                                var savedSig = revoiceMemoryGetFn(text)
+                                if (savedSig) {
                                     var alts = findAllVoicings(parsed.root, parsed.quality, melodyMidi, bassMidi, chords.length)
                                     for (var sai = 0; sai < alts.length; sai++) {
-                                        if (alts[sai].id === savedId) { voicing = alts[sai]; break }
+                                        var altSig = alts[sai]._signatureKey || ChordSelector.signatureKey(alts[sai])
+                                        if (altSig === savedSig) { voicing = alts[sai]; break }
                                     }
                                 }
                             }
@@ -598,8 +603,10 @@ Item {
         item.voicing = newVoicing
 
         // Persist the user's choice for next session (#197).
-        if (revoiceMemoryRecordFn && newVoicing.id) {
-            revoiceMemoryRecordFn(item.text, newVoicing.id)
+        // #211 Stage 3 — record by signature.
+        if (revoiceMemoryRecordFn) {
+            var newSig = newVoicing._signatureKey || ChordSelector.signatureKey(newVoicing)
+            if (newSig) revoiceMemoryRecordFn(item.text, newSig)
         }
 
         // Regenerate clipboard XML

--- a/plugin/model/RevoiceMemory.js
+++ b/plugin/model/RevoiceMemory.js
@@ -20,8 +20,15 @@
 // mode/style/tuning resets the saved choices"). When the user comes back with
 // the same axes, prior choices are restored.
 
+// Schema versioning:
+//   v1 — choice values are voicing IDs (introduced in #197).
+//   v2 — choice values are root-relative signature keys (#211 Stage 3).
+//        Stable across voicings.json removal because signatures are
+//        computed from the voicing's shape, not from any persisted id.
+var CURRENT_VERSION = "v2"
+
 function emptyMemory() {
-    return { version: "v1", scopes: {} }
+    return { version: CURRENT_VERSION, scopes: {} }
 }
 
 function buildScopeKey(scorePath, mode, style, tuning) {
@@ -96,10 +103,47 @@ function parseMemory(raw) {
     try {
         var m = JSON.parse(raw)
         if (!m || typeof m !== "object") return emptyMemory()
-        if (m.version !== "v1") return emptyMemory()
+        // Accept both v1 and v2 schemas; caller handles migration when v1.
+        if (m.version !== "v1" && m.version !== "v2") return emptyMemory()
         if (!m.scopes || typeof m.scopes !== "object") return emptyMemory()
         return m
     } catch (e) {
         return emptyMemory()
     }
+}
+
+// Migrate v1 (id-keyed) memory to v2 (signature-keyed) (#211 Stage 3).
+// Caller provides idToSigLookup — a map { voicingId -> signatureKey } built
+// from voicings.json one last time before the runtime read paths are dropped.
+//
+// Mutates `memory` in place AND returns it. Choices whose voicingId can't
+// be resolved (e.g. voicing was removed from voicings.json across upgrades)
+// are dropped, with a log line per dropped entry returned via the result's
+// `droppedIds` array.
+//
+// No-op if memory is already v2.
+function migrateFromV1(memory, idToSigLookup) {
+    if (!memory) return emptyMemory()
+    if (memory.version === "v2") return memory
+    if (memory.version !== "v1") return memory  // unknown — leave alone
+    var droppedIds = []
+    var scopes = memory.scopes || {}
+    for (var scopeKey in scopes) {
+        var scope = scopes[scopeKey]
+        var choices = (scope && scope.choices) || {}
+        var newChoices = {}
+        for (var chord in choices) {
+            var id = choices[chord]
+            var sig = idToSigLookup ? idToSigLookup[id] : null
+            if (sig) {
+                newChoices[chord] = sig
+            } else {
+                droppedIds.push({ scopeKey: scopeKey, chordSymbol: chord, voicingId: id })
+            }
+        }
+        scope.choices = newChoices
+    }
+    memory.version = "v2"
+    memory._droppedIds = droppedIds  // surfaced for diagnostic logging
+    return memory
 }

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -985,6 +985,42 @@ class TestUnionVoicings:
             assertEqual(u.length, 2, "different quality, both kept");
         """)
 
+    def test_calculator_voicing_inherits_curated_display_name(self):
+        # #211 Stage 3: when a calculator voicing's signature matches a
+        # curated lookup entry, its display name/category come from the
+        # curated entry. We exercise buildCuratedLookup + signatureKey
+        # directly (the QML applyExclusionPass calls both); the test
+        # confirms the lookup-by-signature works for downstream display.
+        assert_js("ChordSelector.js", """
+            var payload = {
+                shapes: [{
+                    signature: {
+                        strings: 6, mutes: [], opens: [],
+                        pairs: [[3, "3"], [4, "b7"], [6, "1"]]
+                    },
+                    name: "Shell 137 — root on top",
+                    category: "shell",
+                    boost: 60
+                }]
+            };
+            var lookup = buildCuratedLookup(payload);
+            var calculatorVoicing = {
+                id: "calc-gen-1",
+                name: "dom7 fret 1",     // calculator's generic name
+                category: "generated",   // calculator's generic category
+                strings: 6, mutes: [], open: [],
+                dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                intervals: ["1","b7","3"]
+            };
+            var sig = signatureKey(calculatorVoicing);
+            var curated = lookup[sig];
+            assert(curated !== undefined, "calculator signature hits curated lookup");
+            assertEqual(curated.name, "Shell 137 — root on top",
+                "curated name available to attach");
+            assertEqual(curated.category, "shell",
+                "curated category available to attach");
+        """)
+
     def test_voicing_schema_accepts_reserved_fields(self):
         # Schema reservation for Track 2/3 (#212): voicings may carry
         # voicingStyle and playStyle. They round-trip through union
@@ -1199,9 +1235,10 @@ class TestRevoiceMemory:
     """Test RevoiceMemory.js scope-keyed choice storage."""
 
     def test_empty_memory_starts_with_no_scopes(self):
+        # Default version bumped to "v2" by #211 Stage 3 (signature-keyed).
         assert_js("RevoiceMemory.js", """
             var m = emptyMemory();
-            assertEqual(m.version, "v1", "version stamped");
+            assertEqual(m.version, "v2", "version stamped");
             assertEqual(Object.keys(m.scopes).length, 0, "no scopes yet");
         """)
 
@@ -1276,12 +1313,82 @@ class TestRevoiceMemory:
         """)
 
     def test_parse_memory_handles_corrupt_input(self):
+        # Updated for #211 Stage 3 — empty memory is now v2.
         assert_js("RevoiceMemory.js", """
-            assertEqual(parseMemory("").version, "v1", "empty string -> empty memory");
-            assertEqual(parseMemory("not json").version, "v1", "invalid json -> empty memory");
-            assertEqual(parseMemory('{"version":"v0"}').version, "v1", "wrong version -> empty");
-            var ok = parseMemory('{"version":"v1","scopes":{"a":{"choices":{"F7":"v1"},"ts":1}}}');
-            assertEqual(ok.scopes.a.choices.F7, "v1", "valid memory parses through");
+            assertEqual(parseMemory("").version, "v2", "empty string -> empty v2 memory");
+            assertEqual(parseMemory("not json").version, "v2", "invalid json -> empty v2 memory");
+            assertEqual(parseMemory('{"version":"v0"}').version, "v2", "unknown version -> empty");
+            // v1 memories still parse (caller migrates).
+            var v1 = parseMemory('{"version":"v1","scopes":{"a":{"choices":{"F7":"v1"},"ts":1}}}');
+            assertEqual(v1.version, "v1", "v1 still parseable");
+            assertEqual(v1.scopes.a.choices.F7, "v1", "v1 choices preserved");
+            // v2 memories parse straight through.
+            var v2 = parseMemory('{"version":"v2","scopes":{"a":{"choices":{"F7":"sig123"},"ts":1}}}');
+            assertEqual(v2.version, "v2", "v2 parses");
+            assertEqual(v2.scopes.a.choices.F7, "sig123", "v2 signature value");
+        """)
+
+    def test_revoice_memory_migrates_v1_to_v2(self):
+        # #211 Stage 3 ticket falsifier. v1 memory + an idToSig lookup
+        # produces a v2 memory with signatures in choices.
+        assert_js("RevoiceMemory.js", """
+            var memory = {
+                version: "v1",
+                scopes: {
+                    "scope-a": { choices: { "F7": "id-shell-137", "Cm7": "id-drop2" }, ts: 1000 },
+                    "scope-b": { choices: { "Bbmaj7": "id-shell-137" }, ts: 2000 }
+                }
+            };
+            var idToSig = {
+                "id-shell-137": "sig-shell-137",
+                "id-drop2": "sig-drop2"
+            };
+            migrateFromV1(memory, idToSig);
+            assertEqual(memory.version, "v2", "schema bumped");
+            assertEqual(memory.scopes["scope-a"].choices.F7, "sig-shell-137",
+                "F7 choice rewritten");
+            assertEqual(memory.scopes["scope-a"].choices.Cm7, "sig-drop2",
+                "Cm7 choice rewritten");
+            assertEqual(memory.scopes["scope-b"].choices.Bbmaj7, "sig-shell-137",
+                "scope-b also rewritten");
+            assertEqual((memory._droppedIds || []).length, 0, "nothing dropped");
+        """)
+
+    def test_revoice_memory_v2_round_trip(self):
+        # Post-migration, get/record operate on signatures as values.
+        assert_js("RevoiceMemory.js", """
+            var m = emptyMemory();
+            assertEqual(m.version, "v2", "starts at v2");
+            var key = buildScopeKey("/p.mscz", "chord-melody", "default", "standard");
+            recordChoice(m, key, "F7", "sig-shell-137", 1000);
+            assertEqual(getChoice(m, key, "F7"), "sig-shell-137",
+                "signature retrievable");
+        """)
+
+    def test_revoice_memory_migration_drops_unresolvable_ids(self):
+        assert_js("RevoiceMemory.js", """
+            var memory = {
+                version: "v1",
+                scopes: {
+                    "scope-a": { choices: { "F7": "id-known", "Cm7": "id-missing" }, ts: 1000 }
+                }
+            };
+            var idToSig = { "id-known": "sig-known" };  // id-missing not in lookup
+            migrateFromV1(memory, idToSig);
+            assertEqual(memory.scopes["scope-a"].choices.F7, "sig-known",
+                "resolvable id rewritten");
+            assertEqual(memory.scopes["scope-a"].choices.Cm7, undefined,
+                "unresolvable id dropped");
+            assertEqual((memory._droppedIds || []).length, 1,
+                "drop logged for surfaceable diagnostics");
+        """)
+
+    def test_revoice_memory_migration_is_noop_on_v2(self):
+        assert_js("RevoiceMemory.js", """
+            var m = { version: "v2", scopes: { "a": { choices: { "F7": "sig" }, ts: 1 } } };
+            migrateFromV1(m, {});
+            assertEqual(m.version, "v2", "still v2");
+            assertEqual(m.scopes.a.choices.F7, "sig", "untouched");
         """)
 
 


### PR DESCRIPTION
## Context

Stage 1 (#209) unioned calculator output with voicings.json. Stage 2
(#210) added the exclusion engine. Stage 3 finishes the migration:
voicings.json is no longer a runtime source; the calculator generates
the standard pool; user imports persist to a new user-voicings.json.

## Goal

- voicings.json removed from runtime load paths.
- User imports route to a new file.
- RevoiceMemory migrates id-keyed (v1) → signature-keyed (v2).
- Calculator voicings inherit curated names where signatures match.

## What landed

- **ChordLibrary.qml** — new functions: loadUserVoicings,
  saveUserVoicings, rebuildStandardPool, _buildIdToSignatureLookup.
  `onRun` now calls loadCalculatedStandard + loadUserVoicings +
  rebuildStandardPool. loadFromCache/fetchVoicings/saveToCache
  deprecated as no-ops. localCacheFile FileIO removed.
- **RevoiceMemory.js** — schema bumped to v2 (signature-keyed). New
  `migrateFromV1(memory, idToSigLookup)` function. parseMemory accepts
  both v1 and v2.
- **BatchEngine.qml** — memory-match and record sites now use
  signatureKey instead of voicing.id.
- **applyExclusionPass** — calculator voicings inherit curated name +
  category when their signature matches a curated lookup entry.
- **saveVoicingToLibrary** — writes to userVoicings + saveUserVoicings
  + rebuildStandardPool instead of voicingsData + saveToCache.

## Acceptance (from revised #211)

- [x] voicings.json not referenced by any **runtime load path** (only
      a migration-only FileIO remains; fires at most once per user)
- [x] User imports save to user-voicings.json
- [x] User imports load at startup and appear in the pool
- [x] test_revoice_memory_migrates_v1_to_v2 — ticket falsifier
- [x] test_revoice_memory_v2_round_trip
- [x] test_calculator_voicing_inherits_curated_display_name
- [x] 197 tests pass (was 192)
- [x] Perf bench 10.82ms (vs 10.76 baseline)

## Scope correction during implementation

Original ticket assumed user imports already lived in
additional-shapes.json. They didn't — they routed to voicings.json via
saveToCache. Per project owner: nobody is using the plugin in
production yet, so no one-time migration of historical user imports
needed. This PR introduces user-voicings.json as the forward store;
historical imports in voicings.json are not salvaged. Ticket body was
updated to reflect this before implementation.

## AC interpretation note

One runtime FileIO reference to voicings.json remains — the migration
path that fires at most once per user during v1→v2 RevoiceMemory
migration. After that, voicings.json is never read by runtime code.
This satisfies the spirit of "not loaded into the candidate pool" but
not a strict grep-fenced read of the AC. A future cleanup ticket could
move the migration to an install-time Python script if you want the
grep to be strictly empty.

## Falsification (from ticket)

> Revert the migration. test_revoice_memory_migrates_v1_to_v2 goes
> red because saved choices keyed on the old voicing.id no longer
> resolve in the calculator-output pool (which uses different IDs).

Implemented; test name matches verbatim.

## Self-Review

`plans/self-review-211-stage3-drop-voicings-json.md`