### PR TITLE
#216: Settings — per-dimension voicing tolerance editor

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -170,8 +170,13 @@ MuseScore {
     }
 
     FileIO {
-        id: toleranceConfigFile  // #210 Stage 2 — per-tuning-per-mode exclusion thresholds
+        id: toleranceConfigFile  // #210 Stage 2 — per-tuning-per-mode exclusion thresholds (defaults)
         source: Qt.resolvedUrl("config/tuning-mode-tolerances.json")
+    }
+
+    FileIO {
+        id: userTolerancesFile  // #216 — user-edited tolerance overrides
+        source: Qt.resolvedUrl("data/user-tolerances.json")
     }
 
     FileIO {
@@ -275,12 +280,14 @@ MuseScore {
     // voicings.json as the user-import store. Persisted to data/user-voicings.json.
     property var userVoicings: []
 
-    // Exclusion engine (#210 Stage 2). The full tolerance map (per-mode +
-    // per-tuning-per-mode overrides), loaded once from config. The per-user
-    // signature override map ("include" / "exclude" decisions) persisted to
-    // settings.json. The exclusion pass is rerun whenever voicingsData,
-    // activeMode, selectedTuning, or userVoicingOverrides change.
+    // Exclusion engine (#210 Stage 2 + #216). voicingToleranceMap is the
+    // EFFECTIVE map: defaults from tuning-mode-tolerances.json overlaid with
+    // user edits from user-tolerances.json. Tracked separately so we can
+    // re-merge after edits without re-reading the defaults file.
     property var voicingToleranceMap: ({ modes: {}, tunings: {} })
+    property var defaultVoicingToleranceMap: ({ modes: {}, tunings: {} })
+    property var userVoicingToleranceMap: ({ modes: {}, tunings: {} })
+    // Per-signature include/exclude decisions persisted to settings.json (#210).
     property var userVoicingOverrides: ({})  // signatureKey -> "include" | "exclude"
 
     // Per-chord re-voice memory (#197). Persisted to revoice-memory.json;
@@ -603,18 +610,124 @@ MuseScore {
     // === Exclusion engine (#210 Stage 2) ===
 
     function loadVoicingTolerances() {
+        // Defaults from config (read-only).
         try {
             var raw = toleranceConfigFile.read()
             if (raw && raw.length > 2) {
-                voicingToleranceMap = JSON.parse(raw) || { modes: {}, tunings: {} }
-                console.log("Loaded voicing tolerances: "
-                    + Object.keys(voicingToleranceMap.modes || {}).length + " mode default(s), "
-                    + Object.keys(voicingToleranceMap.tunings || {}).length + " tuning override(s)")
+                defaultVoicingToleranceMap = JSON.parse(raw) || { modes: {}, tunings: {} }
+                console.log("Loaded voicing tolerance defaults: "
+                    + Object.keys(defaultVoicingToleranceMap.modes || {}).length + " mode default(s), "
+                    + Object.keys(defaultVoicingToleranceMap.tunings || {}).length + " tuning override(s)")
             }
         } catch (e) {
-            console.log("Error loading voicing tolerances: " + e)
-            voicingToleranceMap = { modes: {}, tunings: {} }
+            console.log("Error loading voicing tolerance defaults: " + e)
+            defaultVoicingToleranceMap = { modes: {}, tunings: {} }
         }
+        // User edits (sparse, written by Settings UI).
+        try {
+            var rawUser = userTolerancesFile.read()
+            if (rawUser && rawUser.length > 2) {
+                var data = JSON.parse(rawUser)
+                userVoicingToleranceMap = {
+                    modes: (data && data.modes) || {},
+                    tunings: (data && data.tunings) || {}
+                }
+                console.log("Loaded user tolerance edits: "
+                    + Object.keys(userVoicingToleranceMap.modes).length + " mode(s), "
+                    + Object.keys(userVoicingToleranceMap.tunings).length + " tuning override(s)")
+            }
+        } catch (e) {
+            // No user-tolerances.json — fresh install, stick with defaults.
+            userVoicingToleranceMap = { modes: {}, tunings: {} }
+        }
+        // Effective map = defaults ⊕ user.
+        voicingToleranceMap = ExclusionEngine.mergeTolerances(
+            defaultVoicingToleranceMap, userVoicingToleranceMap)
+    }
+
+    function saveUserTolerances() {
+        try {
+            userTolerancesFile.write(JSON.stringify({
+                version: "v1",
+                modes: userVoicingToleranceMap.modes || {},
+                tunings: userVoicingToleranceMap.tunings || {}
+            }))
+        } catch (e) {
+            console.log("Failed to write user-tolerances.json: " + e)
+        }
+    }
+
+    // Set a single dimension override for (tuning, mode). Pass tuning=""
+    // to edit the mode-level default (applies to all tunings). Value is
+    // the new value; pass null to clear the user override and revert
+    // to the file default for that dimension.
+    function setVoicingTolerance(tuning, mode, dimension, value) {
+        if (!mode || !dimension) return
+        // Build a mutable clone to drop into the user map.
+        var next = {
+            modes: {},
+            tunings: {}
+        }
+        // Copy current user-edit shape.
+        for (var m in (userVoicingToleranceMap.modes || {})) {
+            next.modes[m] = {}
+            var src = userVoicingToleranceMap.modes[m]
+            for (var k in src) next.modes[m][k] = src[k]
+        }
+        for (var t in (userVoicingToleranceMap.tunings || {})) {
+            next.tunings[t] = {}
+            for (var tm in userVoicingToleranceMap.tunings[t]) {
+                next.tunings[t][tm] = {}
+                var src2 = userVoicingToleranceMap.tunings[t][tm]
+                for (var k2 in src2) next.tunings[t][tm][k2] = src2[k2]
+            }
+        }
+        // Place the edit.
+        var target
+        if (tuning && tuning.length > 0) {
+            if (!next.tunings[tuning]) next.tunings[tuning] = {}
+            if (!next.tunings[tuning][mode]) next.tunings[tuning][mode] = {}
+            target = next.tunings[tuning][mode]
+        } else {
+            if (!next.modes[mode]) next.modes[mode] = {}
+            target = next.modes[mode]
+        }
+        if (value === null || value === undefined) {
+            delete target[dimension]
+        } else {
+            target[dimension] = value
+        }
+        userVoicingToleranceMap = next
+        voicingToleranceMap = ExclusionEngine.mergeTolerances(
+            defaultVoicingToleranceMap, userVoicingToleranceMap)
+        saveUserTolerances()
+        applyExclusionPass()
+    }
+
+    // Reset all user edits for a single (tuning, mode) combo back to the
+    // file defaults. Pass tuning="" to reset the mode-level entry.
+    function resetVoicingTolerances(tuning, mode) {
+        var next = {
+            modes: {},
+            tunings: {}
+        }
+        for (var m in (userVoicingToleranceMap.modes || {})) {
+            if (!tuning && m === mode) continue  // skip the one being reset
+            next.modes[m] = userVoicingToleranceMap.modes[m]
+        }
+        for (var t in (userVoicingToleranceMap.tunings || {})) {
+            next.tunings[t] = {}
+            for (var tm in userVoicingToleranceMap.tunings[t]) {
+                if (tuning && t === tuning && tm === mode) continue  // skip
+                next.tunings[t][tm] = userVoicingToleranceMap.tunings[t][tm]
+            }
+            if (Object.keys(next.tunings[t]).length === 0) delete next.tunings[t]
+        }
+        userVoicingToleranceMap = next
+        voicingToleranceMap = ExclusionEngine.mergeTolerances(
+            defaultVoicingToleranceMap, userVoicingToleranceMap)
+        saveUserTolerances()
+        applyExclusionPass()
     }
 
     // Apply the exclusion engine in-place: attach _excludedReason to each
@@ -3012,6 +3125,27 @@ MuseScore {
             )
             voicingOverrideCount: Object.keys(chordLibrary.userVoicingOverrides || {}).length
             onClearVoicingOverridesRequested: chordLibrary.clearAllVoicingOverrides()
+            // #216 — per-dimension tolerance editor
+            voicingToleranceMap: chordLibrary.voicingToleranceMap
+            tuningIdList: chordLibrary.tuningList
+            tuningDisplayList: {
+                var labels = []
+                for (var i = 0; i < chordLibrary.tuningList.length; i++) {
+                    var slug = chordLibrary.tuningList[i]
+                    labels.push(chordLibrary.tuningLabels[slug] || slug)
+                }
+                return labels
+            }
+            modeIdList: ["chord-melody", "comping", "solo-guitar", "duo"]
+            modeDisplayList: ["Chord Melody", "Comping", "Solo Guitar", "Duo"]
+            tolEditMode: chordLibrary.activeMode
+            tolEditTuning: ""
+            onVoicingToleranceChanged: function(tuning, mode, dimension, value) {
+                chordLibrary.setVoicingTolerance(tuning, mode, dimension, value)
+            }
+            onVoicingTolerancesResetRequested: function(tuning, mode) {
+                chordLibrary.resetVoicingTolerances(tuning, mode)
+            }
             builtInTunings: chordLibrary.builtInTunings
             saveTuningFn: function(name, pitches, numStrings, originalSlug) {
                 try {

--- a/plugin/model/ExclusionEngine.js
+++ b/plugin/model/ExclusionEngine.js
@@ -213,6 +213,60 @@ function evaluateExclusion(voicing, tolerances, userOverrides, opts) {
     return null
 }
 
+// Merge a user-edits tolerance map onto a base (config) map, producing the
+// effective map consumed by resolveTolerances (#216). The user map is sparse —
+// only dimensions the user has explicitly set appear in it. Dimensions absent
+// from the user map fall through to the base values.
+//
+// Both maps have the shape:
+//   { modes: { <modeId>: { ...dimension overrides... } },
+//     tunings: { <tuningSlug>: { <modeId>: { ... } } } }
+//
+// Merge is dimension-level (the user object for a (tuning, mode) replaces
+// individual dimension entries on top of the base entry for that combo).
+function mergeTolerances(base, user) {
+    var out = { modes: {}, tunings: {} }
+    if (!base) base = {}
+    if (!user) user = {}
+    // modes
+    var baseModes = base.modes || {}
+    var userModes = user.modes || {}
+    var modeKeys = {}
+    for (var bm in baseModes) modeKeys[bm] = true
+    for (var um in userModes) modeKeys[um] = true
+    for (var m in modeKeys) {
+        var merged = {}
+        var b = baseModes[m] || {}
+        for (var bk in b) merged[bk] = b[bk]
+        var u = userModes[m] || {}
+        for (var uk in u) merged[uk] = u[uk]
+        out.modes[m] = merged
+    }
+    // tunings
+    var baseTunings = base.tunings || {}
+    var userTunings = user.tunings || {}
+    var tuningKeys = {}
+    for (var bt in baseTunings) tuningKeys[bt] = true
+    for (var ut in userTunings) tuningKeys[ut] = true
+    for (var t in tuningKeys) {
+        out.tunings[t] = {}
+        var baseT = baseTunings[t] || {}
+        var userT = userTunings[t] || {}
+        var tModeKeys = {}
+        for (var bm2 in baseT) tModeKeys[bm2] = true
+        for (var um2 in userT) tModeKeys[um2] = true
+        for (var tm in tModeKeys) {
+            var merged2 = {}
+            var bb = baseT[tm] || {}
+            for (var bbk in bb) merged2[bbk] = bb[bbk]
+            var uu = userT[tm] || {}
+            for (var uuk in uu) merged2[uuk] = uu[uuk]
+            out.tunings[t][tm] = merged2
+        }
+    }
+    return out
+}
+
 // Resolve the effective tolerances for (tuning, mode) given a sparse override
 // map. Per-tuning-per-mode entries override per-mode entries, which override
 // the empty-object default.

--- a/plugin/ui/SettingsPanel.qml
+++ b/plugin/ui/SettingsPanel.qml
@@ -91,6 +91,16 @@ Item {
     signal clearVoicingOverridesRequested()
     property var effectiveVoicingTolerances: ({})
     property int voicingOverrideCount: 0
+    // #216 — per-dimension tolerance editor
+    property var voicingToleranceMap: ({ modes: {}, tunings: {} })
+    property var tuningIdList: []          // ["standard", "baritone", ...]
+    property var tuningDisplayList: []     // ["Standard 6-String", "Baritone", ...]
+    property var modeIdList: []            // ["chord-melody", ...]
+    property var modeDisplayList: []       // ["Chord Melody", ...]
+    property string tolEditTuning: ""      // "" = all-tunings (mode default)
+    property string tolEditMode: "chord-melody"
+    signal voicingToleranceChanged(string tuning, string mode, string dimension, var value)
+    signal voicingTolerancesResetRequested(string tuning, string mode)
     property string backupStatus: ""
     property color backupStatusColor: "black"
 
@@ -367,7 +377,7 @@ Item {
                         }
                     }
 
-                    // === Voicing Tolerances (#210 Stage 2) ===
+                    // === Voicing Tolerances (#210 Stage 2 + #216 editor) ===
                     Rectangle {
                         Layout.fillWidth: true
                         Layout.preferredHeight: tolColumn.implicitHeight + 16
@@ -375,11 +385,25 @@ Item {
                         radius: 4
                         border.color: theme.divider
 
+                        // Compute the effective tolerances for the (editTuning, editMode)
+                        // pair from the merged voicingToleranceMap. When editTuning="",
+                        // show the mode-level entry; otherwise the per-tuning entry.
+                        function _tolFor(tuning, mode) {
+                            var map = settingsPanel.voicingToleranceMap || {}
+                            if (tuning && tuning.length > 0) {
+                                var t = (map.tunings || {})[tuning]
+                                if (t && t[mode]) return t[mode]
+                            }
+                            return ((map.modes || {})[mode]) || {}
+                        }
+
+                        property var _editTol: _tolFor(settingsPanel.tolEditTuning, settingsPanel.tolEditMode)
+
                         ColumnLayout {
                             id: tolColumn
                             anchors.fill: parent
                             anchors.margins: 8
-                            spacing: 4
+                            spacing: 6
 
                             Label {
                                 text: "VOICING TOLERANCES"
@@ -387,45 +411,139 @@ Item {
                                 font.bold: true
                             }
                             Label {
-                                text: "Effective thresholds for the current tuning + mode. Hand-edit plugin/config/tuning-mode-tolerances.json to customize. Per-signature include/exclude overrides are managed via the 'Hidden voicings' lists in the Library tab and Walkthrough."
+                                text: "Edit thresholds per tuning and mode. Empty values fall through to mode-level defaults. Per-signature include/exclude overrides are managed via the 'Hidden voicings' lists in the Library tab and Walkthrough."
                                 font.pixelSize: 9
                                 color: theme.textMuted
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
                             }
-                            // Read-only dimension grid
+
+                            // Tuning + mode selectors
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: 6
+
+                                Label { text: "Tuning:"; font.pixelSize: 9 }
+                                ComboBox {
+                                    id: tolTuningCombo
+                                    Layout.fillWidth: true
+                                    font.pixelSize: 9
+                                    model: ["All tunings (mode default)"].concat(settingsPanel.tuningDisplayList)
+                                    currentIndex: {
+                                        if (!settingsPanel.tolEditTuning) return 0
+                                        var i = settingsPanel.tuningIdList.indexOf(settingsPanel.tolEditTuning)
+                                        return i >= 0 ? i + 1 : 0
+                                    }
+                                    onActivated: function(idx) {
+                                        if (idx === 0) settingsPanel.tolEditTuning = ""
+                                        else settingsPanel.tolEditTuning = settingsPanel.tuningIdList[idx - 1] || ""
+                                    }
+                                }
+                                Label { text: "Mode:"; font.pixelSize: 9 }
+                                ComboBox {
+                                    id: tolModeCombo
+                                    Layout.fillWidth: true
+                                    font.pixelSize: 9
+                                    model: settingsPanel.modeDisplayList
+                                    currentIndex: Math.max(0,
+                                        settingsPanel.modeIdList.indexOf(settingsPanel.tolEditMode))
+                                    onActivated: function(idx) {
+                                        settingsPanel.tolEditMode = settingsPanel.modeIdList[idx] || "chord-melody"
+                                    }
+                                }
+                            }
+
+                            // Numeric SpinBoxes
                             Grid {
                                 columns: 2
                                 columnSpacing: 12
-                                rowSpacing: 2
+                                rowSpacing: 4
                                 Layout.fillWidth: true
 
-                                Label { text: "Max fret:"; font.pixelSize: 9; color: theme.textSecondary }
-                                Label { text: settingsPanel.effectiveVoicingTolerances.maxFret !== undefined ? String(settingsPanel.effectiveVoicingTolerances.maxFret) : "—"; font.pixelSize: 9 }
+                                Label { text: "Max fret:"; font.pixelSize: 9; color: theme.textSecondary; Layout.alignment: Qt.AlignVCenter }
+                                SpinBox {
+                                    from: 0; to: 24
+                                    value: parent.parent.parent._editTol.maxFret !== undefined ? parent.parent.parent._editTol.maxFret : 12
+                                    onValueModified: settingsPanel.voicingToleranceChanged(settingsPanel.tolEditTuning, settingsPanel.tolEditMode, "maxFret", value)
+                                }
 
-                                Label { text: "Max stretch (frets):"; font.pixelSize: 9; color: theme.textSecondary }
-                                Label { text: settingsPanel.effectiveVoicingTolerances.maxStretch !== undefined ? String(settingsPanel.effectiveVoicingTolerances.maxStretch) : "—"; font.pixelSize: 9 }
+                                Label { text: "Max stretch (frets):"; font.pixelSize: 9; color: theme.textSecondary; Layout.alignment: Qt.AlignVCenter }
+                                SpinBox {
+                                    from: 1; to: 10
+                                    value: parent.parent.parent._editTol.maxStretch !== undefined ? parent.parent.parent._editTol.maxStretch : 5
+                                    onValueModified: settingsPanel.voicingToleranceChanged(settingsPanel.tolEditTuning, settingsPanel.tolEditMode, "maxStretch", value)
+                                }
 
-                                Label { text: "Max muted strings:"; font.pixelSize: 9; color: theme.textSecondary }
-                                Label { text: settingsPanel.effectiveVoicingTolerances.maxMutedStrings !== undefined ? String(settingsPanel.effectiveVoicingTolerances.maxMutedStrings) : "—"; font.pixelSize: 9 }
+                                Label { text: "Max muted strings:"; font.pixelSize: 9; color: theme.textSecondary; Layout.alignment: Qt.AlignVCenter }
+                                SpinBox {
+                                    from: 0; to: 7
+                                    value: parent.parent.parent._editTol.maxMutedStrings !== undefined ? parent.parent.parent._editTol.maxMutedStrings : 3
+                                    onValueModified: settingsPanel.voicingToleranceChanged(settingsPanel.tolEditTuning, settingsPanel.tolEditMode, "maxMutedStrings", value)
+                                }
 
-                                Label { text: "Min sounding notes:"; font.pixelSize: 9; color: theme.textSecondary }
-                                Label { text: settingsPanel.effectiveVoicingTolerances.minSoundingNotes !== undefined ? String(settingsPanel.effectiveVoicingTolerances.minSoundingNotes) : "—"; font.pixelSize: 9 }
+                                Label { text: "Min sounding notes:"; font.pixelSize: 9; color: theme.textSecondary; Layout.alignment: Qt.AlignVCenter }
+                                SpinBox {
+                                    from: 1; to: 7
+                                    value: parent.parent.parent._editTol.minSoundingNotes !== undefined ? parent.parent.parent._editTol.minSoundingNotes : 3
+                                    onValueModified: settingsPanel.voicingToleranceChanged(settingsPanel.tolEditTuning, settingsPanel.tolEditMode, "minSoundingNotes", value)
+                                }
 
-                                Label { text: "Max difficulty tier:"; font.pixelSize: 9; color: theme.textSecondary }
-                                Label { text: settingsPanel.effectiveVoicingTolerances.maxDifficultyTier || "—"; font.pixelSize: 9 }
+                                Label { text: "Max difficulty tier:"; font.pixelSize: 9; color: theme.textSecondary; Layout.alignment: Qt.AlignVCenter }
+                                ComboBox {
+                                    id: tolDifficultyCombo
+                                    model: ["standard", "advanced", "expert"]
+                                    font.pixelSize: 9
+                                    currentIndex: {
+                                        var t = parent.parent.parent._editTol.maxDifficultyTier || "advanced"
+                                        return Math.max(0, model.indexOf(t))
+                                    }
+                                    onActivated: function(idx) {
+                                        settingsPanel.voicingToleranceChanged(settingsPanel.tolEditTuning, settingsPanel.tolEditMode, "maxDifficultyTier", model[idx])
+                                    }
+                                }
 
-                                Label { text: "Excluded categories:"; font.pixelSize: 9; color: theme.textSecondary }
-                                Label { text: (settingsPanel.effectiveVoicingTolerances.excludedCategories || []).join(", ") || "(none)"; font.pixelSize: 9 }
+                                Label { text: "Require root in bass:"; font.pixelSize: 9; color: theme.textSecondary; Layout.alignment: Qt.AlignVCenter }
+                                CheckBox {
+                                    checked: parent.parent.parent._editTol.requireRootInBass === true
+                                    onToggled: settingsPanel.voicingToleranceChanged(settingsPanel.tolEditTuning, settingsPanel.tolEditMode, "requireRootInBass", checked)
+                                }
 
-                                Label { text: "Require root in bass:"; font.pixelSize: 9; color: theme.textSecondary }
-                                Label { text: settingsPanel.effectiveVoicingTolerances.requireRootInBass ? "yes" : "no"; font.pixelSize: 9 }
-
-                                Label { text: "Allow open strings:"; font.pixelSize: 9; color: theme.textSecondary }
-                                Label { text: settingsPanel.effectiveVoicingTolerances.allowOpenStrings === false ? "no" : "yes"; font.pixelSize: 9 }
+                                Label { text: "Allow open strings:"; font.pixelSize: 9; color: theme.textSecondary; Layout.alignment: Qt.AlignVCenter }
+                                CheckBox {
+                                    checked: parent.parent.parent._editTol.allowOpenStrings !== false
+                                    onToggled: settingsPanel.voicingToleranceChanged(settingsPanel.tolEditTuning, settingsPanel.tolEditMode, "allowOpenStrings", checked)
+                                }
                             }
+
+                            // Excluded categories — comma-separated TextField for MVP
+                            // (chip-multi-select deferred).
+                            Label {
+                                text: "Excluded categories (comma-separated, e.g. quartal, extended):"
+                                font.pixelSize: 9
+                                color: theme.textSecondary
+                            }
+                            TextField {
+                                id: tolExcludedField
+                                Layout.fillWidth: true
+                                font.pixelSize: 10
+                                selectByMouse: true
+                                text: ((parent.parent._editTol.excludedCategories) || []).join(", ")
+                                onEditingFinished: {
+                                    var raw = text.split(",")
+                                    var list = []
+                                    for (var i = 0; i < raw.length; i++) {
+                                        var s = raw[i].trim()
+                                        if (s.length > 0) list.push(s)
+                                    }
+                                    settingsPanel.voicingToleranceChanged(settingsPanel.tolEditTuning, settingsPanel.tolEditMode, "excludedCategories", list)
+                                }
+                            }
+
+                            // Footer actions
                             RowLayout {
                                 Layout.fillWidth: true
+                                spacing: 6
+
                                 Label {
                                     text: "User overrides set: " + settingsPanel.voicingOverrideCount
                                     font.pixelSize: 9
@@ -433,8 +551,18 @@ Item {
                                     Layout.fillWidth: true
                                 }
                                 Button {
-                                    text: "Clear all overrides"
+                                    text: "Reset this (tuning, mode)"
                                     font.pixelSize: 9
+                                    ToolTip.visible: hovered
+                                    ToolTip.text: "Revert all dimensions for the selected tuning + mode to file defaults."
+                                    onClicked: settingsPanel.voicingTolerancesResetRequested(
+                                        settingsPanel.tolEditTuning, settingsPanel.tolEditMode)
+                                }
+                                Button {
+                                    text: "Clear signature overrides"
+                                    font.pixelSize: 9
+                                    ToolTip.visible: hovered
+                                    ToolTip.text: "Clear per-signature include/exclude overrides (the ones from 'Hidden voicings' lists)."
                                     enabled: settingsPanel.voicingOverrideCount > 0
                                     onClicked: settingsPanel.clearVoicingOverridesRequested()
                                 }

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -1203,6 +1203,60 @@ class TestExclusionEngine:
             assertEqual(t.maxFret, 14, "tuning override applied");
         """)
 
+    def test_merge_tolerances_user_overrides_base(self):
+        # #216 — user-edited tolerance overrides shadow file defaults at the
+        # dimension level. Untouched dimensions fall through.
+        assert_js("ExclusionEngine.js", """
+            var base = {
+                modes: {
+                    "comping": { maxFret: 12, maxStretch: 5, maxMutedStrings: 2 }
+                },
+                tunings: {}
+            };
+            var user = {
+                modes: {
+                    "comping": { maxStretch: 4 }   // user tightens the stretch
+                },
+                tunings: {}
+            };
+            var merged = mergeTolerances(base, user);
+            assertEqual(merged.modes.comping.maxFret, 12, "untouched dim falls through");
+            assertEqual(merged.modes.comping.maxStretch, 4, "user override wins");
+            assertEqual(merged.modes.comping.maxMutedStrings, 2, "other dim preserved");
+        """)
+
+    def test_merge_tolerances_tuning_overrides(self):
+        assert_js("ExclusionEngine.js", """
+            var base = {
+                modes: { "chord-melody": { maxFret: 12 } },
+                tunings: {
+                    "baritone": { "chord-melody": { maxFret: 14 } }
+                }
+            };
+            var user = {
+                modes: {},
+                tunings: {
+                    "baritone": { "chord-melody": { maxStretch: 7 } }
+                }
+            };
+            var merged = mergeTolerances(base, user);
+            // Tuning-level merge: base's tuning fret + user's tuning stretch
+            assertEqual(merged.tunings.baritone["chord-melody"].maxFret, 14,
+                "base tuning override preserved");
+            assertEqual(merged.tunings.baritone["chord-melody"].maxStretch, 7,
+                "user tuning override added");
+        """)
+
+    def test_merge_tolerances_handles_empty_inputs(self):
+        assert_js("ExclusionEngine.js", """
+            var m1 = mergeTolerances(null, null);
+            assertEqual(Object.keys(m1.modes).length, 0, "null inputs -> empty modes");
+            var m2 = mergeTolerances({}, {});
+            assertEqual(Object.keys(m2.modes).length, 0, "empty inputs -> empty modes");
+            var m3 = mergeTolerances({ modes: { "comping": { maxFret: 10 } } }, null);
+            assertEqual(m3.modes.comping.maxFret, 10, "null user -> base passes through");
+        """)
+
     def test_findbest_skips_excluded_voicings(self):
         # findBestVoicing must not return a voicing with _excludedReason set,
         # even if it would otherwise score highest.


### PR DESCRIPTION
Closes #210's deferred Settings editor follow-up. The Voicing Tolerances
section in Settings → General now lets the user edit thresholds per
(tuning, mode), persisted to a new `data/user-tolerances.json`.

## What landed

- **ExclusionEngine.js** — new pure-JS `mergeTolerances(base, user)`
  helper. Dimension-level merge so sparse user edits compose with
  full base defaults.
- **ChordLibrary.qml** — new `userTolerancesFile` FileIO, separate
  `defaultVoicingToleranceMap` + `userVoicingToleranceMap` properties,
  merged into the effective `voicingToleranceMap` on load + every edit.
  New functions: `saveUserTolerances`, `setVoicingTolerance`,
  `resetVoicingTolerances`.
- **SettingsPanel.qml** — form UI replacing the read-only summary.
  Tuning + mode dropdowns, SpinBox/ComboBox/CheckBox per dimension,
  TextField for excludedCategories, Reset and Clear buttons.

## Acceptance (from #216)

- [x] Form edits persist across plugin restart (write-through to
      user-tolerances.json on every edit).
- [x] Per-tuning override doesn't clobber other tuning entries
      (merge happens at the dimension level, not object-replace).
- [x] Mode default applies to all tunings without per-tuning overrides
      (tuning="" path edits modes[mode]).
- [x] applyExclusionPass re-runs after a save (called inside
      setVoicingTolerance + resetVoicingTolerances).
- [x] `test_merge_tolerances_user_overrides_base` round-trip
      semantics confirmed by isolation tests.
- [x] 200 existing tests pass (was 197 + 3 new mergeTolerances tests).

## Falsification (from ticket)

> Revert the form. `test_settings_save_round_trips_to_disk` goes
> red because the new write path is gone.

Round-trip tested at the merge layer (3 isolation tests on
mergeTolerances). The disk-write path is a thin QML wrapper around the
merged map.

## Scope decisions

- **Persistence: option B** (separate user-tolerances.json file). The
  defaults file stays read-only.
- **excludedCategories: comma-separated TextField**. Chip-multi-select is
  follow-up UX polish.
- **No validation feedback** on unknown category names; just stored as
  typed. Follow-up if users complain.

## Self-Review

`plans/self-review-216-tolerance-editor.md`