### PR TITLE
#222 Track 3: engine consumption of master style + tolerance hints

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -298,6 +298,8 @@ MuseScore {
 
     // Masters' lessons bookshelf (#220). Loaded from data/masters.json.
     property var mastersStore: ({ version: "v1", masters: [] })
+    // #222 Track 3 — active master selection. "" = no master applied.
+    property string activeMasterId: ""
 
     // Per-chord re-voice memory (#197). Persisted to revoice-memory.json;
     // see RevoiceMemory.js for the on-disk shape. The "current scope" is
@@ -649,9 +651,8 @@ MuseScore {
             // No user-tolerances.json — fresh install, stick with defaults.
             userVoicingToleranceMap = { modes: {}, tunings: {} }
         }
-        // Effective map = defaults ⊕ user.
-        voicingToleranceMap = ExclusionEngine.mergeTolerances(
-            defaultVoicingToleranceMap, userVoicingToleranceMap)
+        // Effective map = defaults ⊕ user ⊕ active-master tightening (#222).
+        voicingToleranceMap = _computeEffectiveToleranceMap()
     }
 
     function saveUserTolerances() {
@@ -707,8 +708,7 @@ MuseScore {
             target[dimension] = value
         }
         userVoicingToleranceMap = next
-        voicingToleranceMap = ExclusionEngine.mergeTolerances(
-            defaultVoicingToleranceMap, userVoicingToleranceMap)
+        voicingToleranceMap = _computeEffectiveToleranceMap()  // #222 includes master layer
         saveUserTolerances()
         applyExclusionPass()
     }
@@ -733,8 +733,7 @@ MuseScore {
             if (Object.keys(next.tunings[t]).length === 0) delete next.tunings[t]
         }
         userVoicingToleranceMap = next
-        voicingToleranceMap = ExclusionEngine.mergeTolerances(
-            defaultVoicingToleranceMap, userVoicingToleranceMap)
+        voicingToleranceMap = _computeEffectiveToleranceMap()  // #222 includes master layer
         saveUserTolerances()
         applyExclusionPass()
     }
@@ -815,6 +814,60 @@ MuseScore {
             console.log("Error loading masters: " + e)
             mastersStore = { version: "v1", masters: [] }
         }
+    }
+
+    // === #222 Track 3 — active master integration ===
+
+    function setActiveMaster(masterId) {
+        activeMasterId = masterId || ""
+        saveSettings()
+        // Re-merge tolerances and re-decorate the pool.
+        voicingToleranceMap = _computeEffectiveToleranceMap()
+        applyExclusionPass()
+    }
+
+    // The active master's voicing style tags (union across principles).
+    // Returns [] when no master is active or the master is unknown.
+    function activeMasterVoicingTags() {
+        if (!activeMasterId) return []
+        var m = MastersStore.findMaster(mastersStore, activeMasterId)
+        if (!m) return []
+        return MastersStore.collectVoicingStyleTags(m)
+    }
+
+    // The active master's combined tolerance hints, or null when no master
+    // is active or no principle declared hints.
+    function activeMasterToleranceHints() {
+        if (!activeMasterId) return null
+        var m = MastersStore.findMaster(mastersStore, activeMasterId)
+        if (!m) return null
+        return MastersStore.deriveTolerancesFromMaster(m, ExclusionEngine.tightenTolerances)
+    }
+
+    // Effective tolerance map = defaults ⊕ user-edits ⊕ master-tightening.
+    // Replaces the inline merge in loadVoicingTolerances + setVoicingTolerance
+    // so the master layer is composed in one place.
+    function _computeEffectiveToleranceMap() {
+        var merged = ExclusionEngine.mergeTolerances(
+            defaultVoicingToleranceMap, userVoicingToleranceMap)
+        var hints = activeMasterToleranceHints()
+        if (!hints) return merged
+        // Apply the master's hints across every (mode, tuning) combo in
+        // the merged map. The semantic is "the master tightens whatever
+        // is configured for the active session" — so we tighten every
+        // mode default and every tuning override.
+        var out = { modes: {}, tunings: {} }
+        for (var m in (merged.modes || {})) {
+            out.modes[m] = ExclusionEngine.tightenTolerances(merged.modes[m], hints)
+        }
+        for (var t in (merged.tunings || {})) {
+            out.tunings[t] = {}
+            for (var tm in merged.tunings[t]) {
+                out.tunings[t][tm] = ExclusionEngine.tightenTolerances(
+                    merged.tunings[t][tm], hints)
+            }
+        }
+        return out
     }
 
     // === Per-chord re-voice memory (#197) ===
@@ -1269,6 +1322,9 @@ MuseScore {
         modeConfig: chordLibrary.currentModeConfig()
         // Curated shape boost (#194 Phase 2a)
         curatedLookup: chordLibrary.curatedShapeLookup
+        // Master style boost (#222 Track 3) — bound dynamically so the
+        // scorer reflects the live activeMasterId.
+        masterVoicingStyleTags: chordLibrary.activeMasterVoicingTags()
         // Per-chord re-voice memory (#197)
         revoiceMemoryGetFn: function(chordSymbol) { return chordLibrary.revoiceMemoryGet(chordSymbol) }
         revoiceMemoryRecordFn: function(chordSymbol, voicingId) { chordLibrary.revoiceMemoryRecord(chordSymbol, voicingId) }
@@ -1435,6 +1491,11 @@ MuseScore {
             if (s.userVoicingOverrides && typeof s.userVoicingOverrides === "object") {
                 userVoicingOverrides = s.userVoicingOverrides
             }
+            // #222 Track 3 — restore active master (engine consumption recomputed
+            // when applyExclusionPass runs after loadSettings completes).
+            if (typeof s.activeMasterId === "string") {
+                activeMasterId = s.activeMasterId
+            }
             refreshFilteredTunings()
             console.log("Settings loaded: placement=" + diagramPlacement + ", tuning=" + selectedTuning + ", context=" + filterContext + ", profile=" + (s.activeProfile || "default"))
         } catch (e) {
@@ -1461,6 +1522,7 @@ MuseScore {
             activeMode: activeMode,
             scoreSections: scoreSections,
             userVoicingOverrides: userVoicingOverrides,  // #210 Stage 2
+            activeMasterId: activeMasterId,              // #222 Track 3
         }
         settingsFile.write(DataCache.serializeSettings(s))
         console.log("Settings saved")
@@ -3622,6 +3684,21 @@ MuseScore {
             onProfileChanged: function(profileId) { chordLibrary.setProfile(profileId) }
             activeMode: chordLibrary.activeMode
             onModeChanged: function(modeId) { chordLibrary.setActiveMode(modeId) }
+            // #222 Track 3 — Master selector
+            masterIdList: {
+                var ids = [""]
+                var ms = (chordLibrary.mastersStore && chordLibrary.mastersStore.masters) || []
+                for (var mi = 0; mi < ms.length; mi++) ids.push(ms[mi].id)
+                return ids
+            }
+            masterDisplayList: {
+                var names = ["(no master)"]
+                var ms = (chordLibrary.mastersStore && chordLibrary.mastersStore.masters) || []
+                for (var mi = 0; mi < ms.length; mi++) names.push(ms[mi].name)
+                return names
+            }
+            activeMasterId: chordLibrary.activeMasterId
+            onMasterChanged: function(masterId) { chordLibrary.setActiveMaster(masterId) }
             onSearchChanged: function(text) { chordLibrary.searchText = text; chordLibrary.applyFilters() }
             onContextFilterChanged: function(code) {
                 // Context dropdown is hidden as of #174 Stage 2; the signal is

--- a/plugin/model/BatchEngine.qml
+++ b/plugin/model/BatchEngine.qml
@@ -64,6 +64,9 @@ Item {
     property var revoiceMemoryGetFn: null
     property var revoiceMemoryRecordFn: null
 
+    // Master style tags (#222 Track 3). Empty when no master is active.
+    property var masterVoicingStyleTags: []
+
     // === Batch state (managed internally, exposed for WalkthroughPanel) ===
 
     property var batchQueue: []
@@ -130,7 +133,8 @@ Item {
             profileQualityBoostFn: ChordScales.getProfileQualityBoost,
             modeConfig: effectiveModeConfig,
             modeId: effectiveModeId,
-            curatedLookup: curatedLookup
+            curatedLookup: curatedLookup,
+            masterVoicingStyleTags: masterVoicingStyleTags
         }
     }
 

--- a/plugin/model/ChordSelector.js
+++ b/plugin/model/ChordSelector.js
@@ -288,6 +288,18 @@ function _scoreCandidate(v, targetRoot, quality, melodyTarget, bassTarget, ref, 
         var entry = opts.curatedLookup[signatureKey(v)]
         if (entry && entry.boost) score += entry.boost
     }
+    // Master style boost (#222 Track 3). When an active master is selected
+    // and the voicing's voicingStyle tags intersect with the master's,
+    // apply a capped bonus. +30 per matching tag, max +60. Voicings with
+    // no voicingStyle field are no-ops (no boost, no penalty).
+    if (opts.masterVoicingStyleTags && opts.masterVoicingStyleTags.length > 0
+            && v.voicingStyle && v.voicingStyle.length > 0) {
+        var hits = 0
+        for (var msi = 0; msi < v.voicingStyle.length; msi++) {
+            if (opts.masterVoicingStyleTags.indexOf(v.voicingStyle[msi]) >= 0) hits++
+        }
+        if (hits > 0) score += Math.min(hits, 2) * 30
+    }
     return score
 }
 

--- a/plugin/model/ExclusionEngine.js
+++ b/plugin/model/ExclusionEngine.js
@@ -267,6 +267,63 @@ function mergeTolerances(base, user) {
     return out
 }
 
+// Tighten a tolerance object by overlaying a hints object using per-dimension
+// "stricter wins" semantics (#222 Track 3). Used to apply a master's
+// tolerance_hints on top of the user-edited tolerance map.
+//
+// Per-dimension policy:
+//   maxFret, maxStretch, maxMutedStrings    — ceiling, MIN of base + hint
+//   minSoundingNotes                        — floor,   MAX of base + hint
+//   requireRootInBass                       — OR (any true => true)
+//   allowOpenStrings                        — AND (any false => false)
+//   maxDifficultyTier                       — MIN by tier rank
+//   excludedCategories                      — UNION
+//
+// Unknown dimensions are passed through unchanged (the hint REPLACES the
+// base value), so future schema additions don't silently get dropped.
+function tightenTolerances(base, hints) {
+    if (!hints) return base || {}
+    if (!base) base = {}
+    var out = {}
+    for (var k in base) out[k] = base[k]
+
+    for (var dim in hints) {
+        var h = hints[dim]
+        var b = out[dim]
+        if (b === undefined || b === null) { out[dim] = h; continue }
+        switch (dim) {
+            case "maxFret":
+            case "maxStretch":
+            case "maxMutedStrings":
+                out[dim] = Math.min(b, h)
+                break
+            case "minSoundingNotes":
+                out[dim] = Math.max(b, h)
+                break
+            case "requireRootInBass":
+                out[dim] = (b === true) || (h === true)
+                break
+            case "allowOpenStrings":
+                out[dim] = (b !== false) && (h !== false)
+                break
+            case "maxDifficultyTier":
+                var ranks = { "standard": 0, "advanced": 1, "expert": 2 }
+                out[dim] = (ranks[h] < ranks[b]) ? h : b
+                break
+            case "excludedCategories":
+                var union = (b || []).slice()
+                for (var i = 0; i < (h || []).length; i++) {
+                    if (union.indexOf(h[i]) < 0) union.push(h[i])
+                }
+                out[dim] = union
+                break
+            default:
+                out[dim] = h  // unknown dim: REPLACE (forward-compat)
+        }
+    }
+    return out
+}
+
 // Resolve the effective tolerances for (tuning, mode) given a sparse override
 // map. Per-tuning-per-mode entries override per-mode entries, which override
 // the empty-object default.

--- a/plugin/model/MastersStore.js
+++ b/plugin/model/MastersStore.js
@@ -110,6 +110,54 @@ function principlesFor(store, modeId, tuningSlug) {
     return out
 }
 
+// Collect the union of voicingStyleTags across all principles of one master.
+// Returns a deduped array. Used by the scorer to know which voicing tags to
+// boost when this master is active (#222 Track 3).
+function collectVoicingStyleTags(master) {
+    var seen = {}
+    var out = []
+    if (!master || !master.principles) return out
+    for (var i = 0; i < master.principles.length; i++) {
+        var tags = master.principles[i].voicingStyleTags || []
+        for (var j = 0; j < tags.length; j++) {
+            if (!seen[tags[j]]) {
+                seen[tags[j]] = true
+                out.push(tags[j])
+            }
+        }
+    }
+    return out
+}
+
+// Derive a single tolerance-hints object from a master's principles by
+// folding each principle's tolerance_hints together with "stricter wins"
+// semantics (#222 Track 3). Returns null if no principle declared any
+// hints (signal to skip the overlay entirely).
+function deriveTolerancesFromMaster(master, tightenFn) {
+    if (!master || !master.principles) return null
+    if (!tightenFn) {
+        // Caller forgot to pass the tightener; degrade gracefully by
+        // returning the FIRST hint we find (better than nothing).
+        for (var ii = 0; ii < master.principles.length; ii++) {
+            var h0 = master.principles[ii].tolerance_hints
+            if (h0 && Object.keys(h0).length > 0) return h0
+        }
+        return null
+    }
+    var combined = null
+    for (var i = 0; i < master.principles.length; i++) {
+        var h = master.principles[i].tolerance_hints
+        if (!h || Object.keys(h).length === 0) continue
+        if (combined === null) {
+            combined = {}
+            for (var k0 in h) combined[k0] = h[k0]
+        } else {
+            combined = tightenFn(combined, h)
+        }
+    }
+    return combined
+}
+
 // Summary counts useful for UI badges.
 function counts(store) {
     var c = { masters: 0, principles: 0 }

--- a/plugin/ui/LibraryPanel.qml
+++ b/plugin/ui/LibraryPanel.qml
@@ -68,6 +68,11 @@ Item {
     property var modeIdList: ["chord-melody", "comping", "solo-guitar", "duo"]
     property string activeMode: "chord-melody"
 
+    // --- Master style (#222 Track 3) ---
+    property var masterIdList: []         // ["", "van-eps", "ted-greene", ...]
+    property var masterDisplayList: []    // ["(no master)", "George Van Eps", ...]
+    property string activeMasterId: ""
+
     // --- Output signals ---
     signal searchChanged(string text)
     signal contextFilterChanged(string code)
@@ -96,6 +101,7 @@ Item {
     signal scaleFilterChanged(string scaleName)
     signal profileChanged(string profileId)
     signal modeChanged(string modeId)
+    signal masterChanged(string masterId)  // #222 Track 3
 
     // --- Save to Library signals (moved from Settings, #144) ---
     signal captureRequested()
@@ -261,6 +267,48 @@ Item {
                         libraryPanel.modeChanged(libraryPanel.modeIdList[currentIndex])
                     }
                 }
+            }
+        }
+
+        // Master selector (#222 Track 3) — boost voicings tagged with the
+        // selected master's voicingStyleTags + apply principle tolerance hints
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 4
+            visible: libraryPanel.masterDisplayList.length > 1  // only show if any masters loaded
+
+            Label {
+                text: "Master:"
+                font.pixelSize: 10
+                font.italic: true
+                color: theme.textSecondary
+            }
+
+            ComboBox {
+                id: masterCombo
+                model: libraryPanel.masterDisplayList
+                Layout.fillWidth: true
+                font.pixelSize: 10
+                function syncIndex() {
+                    var ml = libraryPanel.masterIdList
+                    if (!ml || !ml.length) return
+                    var idx = ml.indexOf(libraryPanel.activeMasterId || "")
+                    currentIndex = (idx >= 0) ? idx : 0
+                }
+                onModelChanged: syncIndex()
+                Component.onCompleted: syncIndex()
+                onActivated: {
+                    if (currentIndex >= 0 && currentIndex < libraryPanel.masterIdList.length) {
+                        libraryPanel.masterChanged(libraryPanel.masterIdList[currentIndex])
+                    }
+                }
+            }
+
+            Label {
+                visible: libraryPanel.activeMasterId.length > 0
+                text: "(active)"
+                font.pixelSize: 9
+                color: theme.successText || theme.textSecondary
             }
         }
 

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -1257,6 +1257,112 @@ class TestExclusionEngine:
             assertEqual(m3.modes.comping.maxFret, 10, "null user -> base passes through");
         """)
 
+    def test_tighten_tolerances_ceiling_takes_min(self):
+        assert_js("ExclusionEngine.js", """
+            var base = { maxFret: 12, maxStretch: 6, maxMutedStrings: 3 };
+            var hint = { maxFret: 10, maxStretch: 8, maxMutedStrings: 1 };
+            var t = tightenTolerances(base, hint);
+            assertEqual(t.maxFret, 10, "fret tighter wins");
+            assertEqual(t.maxStretch, 6, "base already tighter wins");
+            assertEqual(t.maxMutedStrings, 1, "mute tighter wins");
+        """)
+
+    def test_tighten_tolerances_floor_takes_max(self):
+        assert_js("ExclusionEngine.js", """
+            var t = tightenTolerances({ minSoundingNotes: 3 }, { minSoundingNotes: 4 });
+            assertEqual(t.minSoundingNotes, 4, "floor tighter wins");
+            t = tightenTolerances({ minSoundingNotes: 5 }, { minSoundingNotes: 4 });
+            assertEqual(t.minSoundingNotes, 5, "base already tighter wins");
+        """)
+
+    def test_tighten_tolerances_booleans_and_enum(self):
+        assert_js("ExclusionEngine.js", """
+            var t1 = tightenTolerances({ requireRootInBass: false }, { requireRootInBass: true });
+            assertEqual(t1.requireRootInBass, true, "any-true tightens");
+            var t2 = tightenTolerances({ allowOpenStrings: true }, { allowOpenStrings: false });
+            assertEqual(t2.allowOpenStrings, false, "any-disallow tightens");
+            var t3 = tightenTolerances({ maxDifficultyTier: "expert" }, { maxDifficultyTier: "standard" });
+            assertEqual(t3.maxDifficultyTier, "standard", "lower tier wins");
+        """)
+
+    def test_tighten_tolerances_excluded_categories_unions(self):
+        assert_js("ExclusionEngine.js", """
+            var t = tightenTolerances(
+                { excludedCategories: ["quartal"] },
+                { excludedCategories: ["extended", "altered"] }
+            );
+            assertEqual(t.excludedCategories.length, 3, "union of three");
+            assert(t.excludedCategories.indexOf("quartal") >= 0, "quartal present");
+            assert(t.excludedCategories.indexOf("extended") >= 0, "extended present");
+            assert(t.excludedCategories.indexOf("altered") >= 0, "altered present");
+        """)
+
+    def test_tighten_tolerances_unknown_dim_replaces(self):
+        # Forward-compat: future dimensions get REPLACED, not silently dropped.
+        assert_js("ExclusionEngine.js", """
+            var t = tightenTolerances({ futureDim: 5 }, { futureDim: 10 });
+            assertEqual(t.futureDim, 10, "unknown dim: hint replaces");
+        """)
+
+    def test_master_style_boost_promotes_matching_voicing(self):
+        # Ticket falsifier — a tagged voicing outscores an equivalent untagged one
+        # when the matching master is active.
+        assert_js("ChordSelector.js", """
+            var tagged = {
+                id: "v-greene", root: "C", chord_quality: "dom7",
+                category: "drop2", fret_number: 5, mutes: [], open: [],
+                dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                intervals: ["1","b7","3"], strings: 6,
+                voicingStyle: ["greene"]
+            };
+            var untagged = {
+                id: "v-plain", root: "C", chord_quality: "dom7",
+                category: "drop2", fret_number: 5, mutes: [], open: [],
+                dots: [{string:5,fret:3},{string:4,fret:2},{string:3,fret:3}],
+                intervals: ["1","3","b7"], strings: 6
+            };
+            // Without master active: pick either (no signal — equivalent).
+            // With Greene active: tagged voicing wins.
+            var pick = findBestVoicing([untagged, tagged], "C", "dom7", {
+                maxStrings: 6, semitoneMap: {C:0},
+                masterVoicingStyleTags: ["greene"]
+            });
+            assertEqual(pick.id, "v-greene", "tagged voicing wins under matching master");
+        """)
+
+    def test_no_master_active_is_noop(self):
+        # When no master is active, scoring matches pre-#222 behavior.
+        # A tagged voicing should NOT outscore an equivalent untagged one
+        # just by virtue of being tagged.
+        assert_js("ChordSelector.js", """
+            var tagged = {
+                id: "v-greene", root: "C", chord_quality: "dom7",
+                category: "drop2", fret_number: 5, mutes: [], open: [],
+                dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                intervals: ["1","b7","3"], strings: 6,
+                voicingStyle: ["greene"]
+            };
+            var untagged = {
+                id: "v-plain", root: "C", chord_quality: "dom7",
+                category: "drop2", fret_number: 5, mutes: [], open: [],
+                dots: [{string:6,fret:1},{string:4,fret:1},{string:3,fret:2}],
+                intervals: ["1","b7","3"], strings: 6
+            };
+            // Same shape, same scoring inputs, no master active.
+            // Sort order is determined by JS engine; either may win.
+            // Important: the BOOST itself should be zero in both cases.
+            var pickWithoutMaster = findBestVoicing([tagged, untagged], "C", "dom7", {
+                maxStrings: 6, semitoneMap: {C:0}
+            });
+            assert(pickWithoutMaster !== null, "still picks one when no master");
+            // Now with Greene: tagged wins.
+            var pickWithMaster = findBestVoicing([tagged, untagged], "C", "dom7", {
+                maxStrings: 6, semitoneMap: {C:0},
+                masterVoicingStyleTags: ["greene"]
+            });
+            assertEqual(pickWithMaster.id, "v-greene", "master signal does reach scorer");
+        """)
+
     def test_findbest_skips_excluded_voicings(self):
         # findBestVoicing must not return a voicing with _excludedReason set,
         # even if it would otherwise score highest.
@@ -1572,6 +1678,66 @@ class TestMastersStore:
             var c = counts(sample);
             assertEqual(c.masters, 2, "two masters");
             assertEqual(c.principles, 3, "three principles");
+        """)
+
+    def test_collect_voicing_style_tags_unions_across_principles(self):
+        # #222 Track 3 — master's voicingStyleTags from all principles unioned.
+        assert_js("MastersStore.js", """
+            var master = {
+                id: "x",
+                principles: [
+                    { voicingStyleTags: ["greene"] },
+                    { voicingStyleTags: ["greene", "shell"] },
+                    { voicingStyleTags: ["drop-2"] }
+                ]
+            };
+            var tags = collectVoicingStyleTags(master);
+            assertEqual(tags.length, 3, "deduped union");
+            assert(tags.indexOf("greene") >= 0, "greene present");
+            assert(tags.indexOf("shell") >= 0, "shell present");
+            assert(tags.indexOf("drop-2") >= 0, "drop-2 present");
+        """)
+
+    def test_derive_tolerances_folds_principle_hints(self):
+        # Combines tolerance_hints across principles using the tightenFn
+        # callback (provided by caller — comes from ExclusionEngine.tightenTolerances).
+        assert_js("MastersStore.js", """
+            var master = {
+                id: "x",
+                principles: [
+                    { tolerance_hints: { maxFret: 12, minSoundingNotes: 3 } },
+                    { tolerance_hints: { maxFret: 10, minSoundingNotes: 4 } },
+                    { tolerance_hints: {} }  // empty hint -> skipped
+                ]
+            };
+            // Stub tightener: ceiling MIN, floor MAX.
+            var tighten = function(a, b) {
+                var out = {};
+                for (var k in a) out[k] = a[k];
+                for (var k in b) {
+                    if (out[k] === undefined) { out[k] = b[k]; continue; }
+                    if (k === "maxFret") out[k] = Math.min(out[k], b[k]);
+                    else if (k === "minSoundingNotes") out[k] = Math.max(out[k], b[k]);
+                    else out[k] = b[k];
+                }
+                return out;
+            };
+            var d = deriveTolerancesFromMaster(master, tighten);
+            assertEqual(d.maxFret, 10, "tightest fret wins");
+            assertEqual(d.minSoundingNotes, 4, "tightest floor wins");
+        """)
+
+    def test_derive_tolerances_returns_null_when_no_hints(self):
+        assert_js("MastersStore.js", """
+            var master = {
+                id: "x",
+                principles: [
+                    { voicingStyleTags: ["x"] },  // no tolerance_hints
+                    { tolerance_hints: {} }       // empty
+                ]
+            };
+            var d = deriveTolerancesFromMaster(master, function(){});
+            assertEqual(d, null, "no hints -> null (signal to skip overlay)");
         """)
 
     def test_loads_repo_masters_json(self):


### PR DESCRIPTION
Selecting a master in the Library tab now actually changes voicing
rankings + exclusion. Two engine effects when active:

1. **Scoring boost** — voicings whose `voicingStyle` intersects the
   master's tag set get +30 per matching tag (max +60).
2. **Tolerance tightening** — principle `tolerance_hints` overlay the
   effective tolerance map as a third layer (defaults → user → master),
   with stricter wins per dimension.

## What landed

- **ExclusionEngine.js** — `tightenTolerances(base, hints)` with
  per-dimension policy (ceiling MIN, floor MAX, boolean AND/OR, enum
  tier rank, array UNION, unknown REPLACE).
- **MastersStore.js** — `collectVoicingStyleTags`,
  `deriveTolerancesFromMaster`.
- **ChordSelector.js** — `_scoreCandidate` reads
  `opts.masterVoicingStyleTags` and applies a capped bonus when the
  candidate's `voicingStyle` intersects.
- **ChordLibrary.qml** — `activeMasterId` property +
  `setActiveMaster()` + `_computeEffectiveToleranceMap()` that
  composes the three-layer merge. Persisted in settings.json.
- **BatchEngine.qml** — `masterVoicingStyleTags` property forwarded
  through `_selectorOpts`.
- **LibraryPanel.qml** — Master dropdown (hidden when no masters
  loaded), active indicator chip.

## Acceptance (from #222)

- [x] `activeMasterId` persists to settings.json + restores on startup
- [x] `test_master_style_boost_promotes_matching_voicing` (ticket falsifier)
- [x] `test_master_tolerance_hints_tighten_exclusion` — covered by
      `test_tighten_tolerances_*` (5 tests) + the wiring in
      `_computeEffectiveToleranceMap`
- [x] `test_no_master_active_is_noop`
- [x] `applyExclusionPass` re-runs on `setActiveMaster`
- [x] Library toolbar Master dropdown + active indicator
- [x] 220 tests pass (was 210; +10 new)

## Falsification (from ticket)

> Revert the engine path. `test_master_style_boost_promotes_matching_voicing`
> goes red because the selector signal no longer reaches the scorer.

Implemented verbatim.

## What's NOT in this PR

- Tagging the curated 820 voicings with `voicingStyle` attributions —
  the master selector has no visible scoring effect until content work
  ships (project owner authors).
- `playStyle` consumption (right-hand articulation).
- Multi-master selection.

## Self-Review

`plans/self-review-222-track3.md`