### PR TITLE
#229 content: refine Ted Greene from corpus + open docs/research/masters

### DIFF
--- a/docs/research/masters/README.md
+++ b/docs/research/masters/README.md
@@ -1,0 +1,61 @@
+# Masters' principles — research notes
+
+This directory documents the sources behind each entry in
+`plugin/data/masters.json`. One file per master, recording:
+
+- which sources we consulted
+- which specific claims in our principle entries are sourced where
+- which claims are inferred / general-knowledge and need verification
+- what we tried that didn't work (blocked URLs, OCR failures, etc.)
+
+The plugin's runtime only reads `masters.json`. These research files
+are maintainer reference — the "show your work" for the principle
+entries.
+
+## Why this directory exists
+
+Earlier in this project we shipped principle entries seeded from
+general knowledge without explicit source attribution. When we
+revisited Wes Montgomery's entry (October 2026), we found that two
+of the five principles couldn't be supported by accessible sources
+and had to be revised. The lesson: **encode only what can be
+documented.** This directory holds the documentation.
+
+The discipline going forward: for each master, before encoding a
+principle in `masters.json`, write the corresponding section in the
+research file. Cite the source verbatim where possible. If you can't
+find a source for a claim, either drop it or mark it explicitly as
+an inference.
+
+## Methodology
+
+1. **Primary sources first.** Original books and recordings (paraphrased
+   in our own words for the plugin; cited verbatim here for reference).
+2. **Corpus extracts second.** The Ted Greene corpus we scraped to
+   `plugin/data/masters-corpus/greene/` is primary text Greene wrote
+   himself. Extracted text + the original PDFs are both available;
+   citations in `ted-greene.md` reference specific files by name.
+3. **Web sources third.** Lesson sites and analyses (jazzguitar.be,
+   Jens Larsen, Voicelid Jazz Guitar, Fundamental Changes, Wikipedia,
+   etc.). URLs cited inline. Note blocks where we hit paywalls or 403s.
+4. **Hedge what isn't documented.** If a claim made it into `masters.json`
+   without a source, the research file says so explicitly and either
+   notes a follow-up (find the source) or recommends revising the
+   principle.
+
+## Status by master
+
+| Master | Research file | Status |
+|---|---|---|
+| George Van Eps | (not yet) | research pending — #228 |
+| Ted Greene | `ted-greene.md` | corpus-extracted, 5 documented principles |
+| Joe Pass | (not yet) | research pending — #230 |
+| Martin Taylor | (not yet) | research pending — #231 |
+| Wes Montgomery | `wes-montgomery.md` | web-researched, 5 documented principles |
+| Lenny Breau | (not yet) | research pending — #232 |
+| Jim Hall | (not yet) | research pending — #233 |
+| Johnny Smith | (not yet) | research pending — #234 |
+| Jody Fisher | (not yet) | research pending — #235 |
+
+Each ticketed master gets a research file when its principle entries
+are refined past the original seeds.

--- a/docs/research/masters/ted-greene.md
+++ b/docs/research/masters/ted-greene.md
@@ -1,0 +1,175 @@
+# Ted Greene — research notes
+
+**Source corpus:** `plugin/data/masters-corpus/greene/` (committed to repo
+from the MVP scrape in #220). 20 PDFs + matching `.txt` extracts.
+**Last research pass:** 2026-05-21 (#229).
+**Principle entries:** 5 in `masters.json` (was 2 seeds before this pass).
+
+## Corpus extraction limits
+
+Most of Greene's manuscripts are hand-drawn notation that did not OCR.
+The text extracts (`.txt` sidecars) are empty or near-empty for the
+notation-heavy files. The files with real prose content:
+
+| File | Size | What's in it |
+|---|---|---|
+| `01_WhoIsJamesHober.txt` | 8.9 KB | Hober's V-System intro; full prose |
+| `00_Welcome.txt` | 1.9 KB | V-System chapter index |
+| `ii7-V7-I_TedGreene_1974-11-28_and_29.txt` | 1.5 KB | Greene's prose on ii7 vs IVmaj7 |
+| `3-NoteChordsForThe_I_ChordInGBlues_WithLetter_TedGreene_1995-12-16.txt` | 1.4 KB | Letter to Bruce; no technique content |
+
+The remaining 16 files (counterpoint exercises, single-note lines,
+inversion tables, foggy-day arrangements, comping studies) are mostly
+or entirely notation. Encoding principles from those requires either
+running `--full` to expand the corpus AND a notation-reading pass,
+OR primary-source consultation against Chord Chemistry / Modern
+Chord Progressions.
+
+## Sources per principle
+
+### 1. `v-system-voicing-groups`
+
+> Four-note voicings are classified into 14 groups (V-1 through V-14)
+> ordered from most compact to most spread.
+
+**Primary source:** `01_WhoIsJamesHober.txt` (corpus), Hober's intro.
+Quoted verbatim:
+
+> "Notice that as you go from V-1 to V-14 the basic trend is to go
+> from the most compact to the most spread out (although V-13 and
+> V-14 are less spread out than V-11 and V-12). To me this is typical
+> of the Ted Greene approach: use logic to generate possibilities but
+> don't be so strict that you lose [practical results]."
+
+The 43-quality figure also from `01_WhoIsJamesHober.txt`:
+
+> "I asked him, 'So Ted, do you know how many four distinct note
+> chords there are?' And he instantly blurted out, 'Forty-three!'"
+
+**What we DON'T have:** the precise interval-spelling of each V-group
+(V-1 = which intervals exactly, V-2 = which, etc.). That detail lives
+in Hober's `Method 1 - How to Build` chapter, which we didn't scrape
+in the MVP. Followup: `--full` sweep, then encode the per-group
+interval signatures.
+
+### 2. `fixed-soprano-tour`
+
+> Hold the top voice (soprano) constant; cycle through all 14
+> V-System voicing groups.
+
+**Primary source:** `01_WhoIsJamesHober.txt` (corpus). Hober:
+
+> "I now call this a 'fixed soprano tour.' For a given chord, in
+> this case G7, the soprano is held constant, in this case on the
+> flat 7, and a G7 chord from each of the fourteen voicing groups
+> is shown."
+
+And:
+
+> "He had explained nothing to me about the V-System. And yet in a
+> single line of music notation he had concisely described and
+> implied the entire V-System…sort of."
+
+**Secondary reference:** tedgreene.com V-System chapter list
+(`00_Welcome.txt`) names "24. The Fixed Soprano Tour" as a chapter.
+
+### 3. `voice-leading-inner-motion`
+
+> Melody on top, bass anchors, inner voices move stepwise between
+> chord changes.
+
+**Primary source:** Chord Chemistry (Greene, 1971) — cited but not
+in our corpus. The V-System chapter list (`00_Welcome.txt`) names:
+
+> "20. Conversion" — the V-System device for moving between voicing
+> groups while preserving voice-leading economy.
+
+**Status:** the claim "melody on top, bass anchors, inner voices
+move stepwise" is the canonical description of Greene's voice-leading
+approach across multiple secondary sources. It IS the central idea
+of much of Modern Chord Progressions. The corpus extracts confirm
+"Conversion" as a named V-System chapter that handles between-voicing
+transitions; we infer the voice-leading-economy purpose from the
+chapter title + general knowledge. **A direct verbatim citation
+from Chord Chemistry would strengthen this principle.**
+
+### 4. `ii7-over-ivmaj7-substitution`
+
+> Greene's documented preference for ii7 over IVmaj7 in the IV-V-I
+> cadence, citing the strident major-7 interval of IVmaj7.
+
+**Primary source:** `ii7-V7-I_TedGreene_1974-11-28_and_29.txt`
+(corpus). Greene's own prose:
+
+> "You might wonder why IVmaj7, rather than ii7 wasn't used for IV.
+> It is because of the strongly dissonant interval of a major 7th
+> (between root and 7th) in the IVmaj7 — this was apparently harsher
+> to the ears of our forefathers than the mild dissonance of a minor
+> 7th in the ii7. To modern ears the IVmaj7 is just as nice as a ii7,
+> but through tradition and for other reasons not to be discussed
+> here, the ii7 has remained the favorite chord to precede V(7) with..."
+
+And on practice:
+
+> "Practice them in various keys, and decoration, and resolve them
+> to I. Then do them in minor keys, but use ii±7 - V(7) - i instead
+> of ii7 - V(7) - I."
+
+The "±7" notation is Greene's for the half-diminished (m7b5).
+
+### 5. `sequential-articulation`
+
+> Right-hand fingerstyle / hybrid-pick articulation; closely
+> associated with harp-harmonics.
+
+**Primary source:** Modern Chord Progressions (Greene, 1973) — cited
+but not in our corpus.
+
+**Corpus confirmation of harp-harmonics:**
+`3-NoteChordsForThe_I_ChordInGBlues_WithLetter_TedGreene_1995-12-16.txt`
+(letter to Bruce):
+
+> "An example: the harp-harmonics. At one time when people heard
+> it, it took their breath away. Now it's like it barely has the
+> power to move — it's just an unpleasant part of our species, I
+> guess. I hate it."
+
+Greene wished harp-harmonics retained their original impact;
+confirms the technique was in his vocabulary and he treasured it.
+
+**Status:** the broader "sequential articulation" claim (bass first,
+inner voices in sequence, melody on top) is the canonical description
+of Greene's right-hand approach across secondary sources but isn't
+verbatim in the corpus extracts. A direct citation from Modern Chord
+Progressions would strengthen this.
+
+## What was REMOVED from the previous Greene entry
+
+Nothing. The two seed principles (`voice-leading-inner-motion`,
+`sequential-articulation`) are kept; both are now better-sourced.
+Three new principles added on top of them.
+
+## Followups
+
+- **Run `scripts/fetch-greene-corpus.py --full`** to bring in the
+  remaining V-System chapters (the per-group interval definitions
+  for V-1 through V-14). That unlocks tagging actual voicings to
+  specific V-groups (`voicingStyleTags: ["greene-v1"]` etc.).
+- **Direct citation from Chord Chemistry** for the voice-leading
+  principle.
+- **Direct citation from Modern Chord Progressions** for sequential
+  articulation.
+- **Notation-reading pass** on the existing notation-heavy PDFs
+  (counterpoint, single-note lines, inversion tables) — owner work.
+
+## Bibliography
+
+- Greene, Ted. *Chord Chemistry*. Dale Zdenek Publications, 1971.
+- Greene, Ted. *Modern Chord Progressions*. Dale Zdenek Publications, 1973.
+- Hober, James. V-System Introduction. tedgreene.com.
+  <https://tedgreene.com/teaching/v_system.asp>
+- Greene, Ted. *ii7 - V(7) - I* (manuscript, 1974-11-28 and 1974-11-29).
+  Corpus: `ii7-V7-I_TedGreene_1974-11-28_and_29.pdf`.
+- Greene, Ted. Letter to Bruce on 3-note chords for the I chord in G
+  blues (1995-12-16). Corpus:
+  `3-NoteChordsForThe_I_ChordInGBlues_WithLetter_TedGreene_1995-12-16.pdf`.

--- a/docs/research/masters/wes-montgomery.md
+++ b/docs/research/masters/wes-montgomery.md
@@ -1,0 +1,151 @@
+# Wes Montgomery — research notes
+
+**Primary source type:** web research (no in-repo corpus; estate-managed
+free archive doesn't exist for Wes the way it does for Greene).
+**Last research pass:** 2026-05-21 (#226 + revision in this PR).
+**Principle entries:** 5 in `masters.json`.
+
+## Research method
+
+WebSearch + WebFetch from the running session. Sites consulted:
+
+| URL | Status | Used for |
+|---|---|---|
+| <https://en.wikipedia.org/wiki/Wes_Montgomery> | accessible | thumb-attack origin, three-tier arc (attributes to Wolf Marshall), superimposed triads quote |
+| <https://www.voicelidjazzguitar.com/jazz-guitar-blog/jazz-guitar-upper-structures-wes-montgomery-drop-2> | accessible | upper-structure triad substitution, drop-2 vehicle |
+| <https://www.fundamental-changes.com/wes-montgomery-video-lesson/> | accessible | three-tier arc, thumb "brush the strings" detail, tune list (Satin Doll, Four on Six) |
+| <http://jazzbluesabstracttruth.blogspot.com/2013/02/wes-montgomery-jazz-guitar-method.html> | accessible (via search indexing) | octave fingering: first finger lower note + deadens intermediate string; 3rd/4th finger upper octave |
+| <https://www.jazzguitar.be/blog/wes-montgomery-jazz-guitar-licks/> | **403 blocked** | indexed in search results; not directly readable |
+| <https://www.jazzguitar.be/blog/wes-montgomery-chord-solo/> | **403 blocked** | indexed only |
+| Jens Larsen drop-2 series | accessible via search indexing | drop-2 background; not Wes-specific in the extracts we saw |
+
+## Sources per principle
+
+### 1. `three-tier-chorus-development`
+
+> Single notes → octaves → block chords, each tier melodically motivated.
+
+**Wikipedia** attributes this to Wolf Marshall's pedagogy: Wes
+"typically would start a solo single notes, then break into octaves
+for a chorus or two, and finally finish his solo with a chorus or
+two using chordal melodies." Marshall is the canonical citation
+for this arc.
+
+**Fundamental Changes** restates it: "He would start off with single
+note lines, move onto octaves and finish with chords... to create
+solos with a bit of variation."
+
+**Recorded exemplar:** Fundamental Changes recommends "Four On Six"
+from *Smokin' at the Half Note* (1965).
+
+### 2. `octave-passage-construction`
+
+> First finger on lower note + dampens intermediate string;
+> 3rd or 4th finger on upper octave; string pairs 6&4, 5&3, 4&2, 3&1.
+
+**Jazz Blues Abstract Truth blog** documents Jesse Gress's
+description of the fingering mechanism (first finger lower / damp
+middle / upper-fingers octave above). The same blog mentions:
+
+- Gress's advice: focus on one note of the octave; let the other
+  shadow naturally
+- Wes practiced octaves on standards including "Sunny" and
+  "Tear It Down" (from his Hal Leonard method book)
+
+**Wikipedia** also notes Wes developed octaves partly to keep
+volume down when practicing late at night (avoid waking his kids).
+That biographical motivation isn't encoded in the principle — it's
+context.
+
+### 3. `block-chord-drop-2-predominance`
+
+> Drop-2 voicings as the primary block-chord vehicle.
+
+**Voicelid Jazz Guitar** documents drop-2 as "the vehicle for these
+ideas." Indexed search hit on jazzguitar.be (blocked from direct
+fetch) reinforces: Wes "stuck with chords played mainly on adjacent
+strings and drop 2 chord shapes."
+
+**Recorded exemplar:** *The Incredible Jazz Guitar of Wes Montgomery*
+(1960) — "D-Natural Blues" block-chord chorus.
+
+### 4. `thumb-attack-articulation`
+
+> Thumb-only right hand; downstroke for singles; brush/rake for chords.
+
+**Wikipedia** documents the origin: Wes adopted thumb-only technique
+after marriage when he had to practice quietly (didn't want to wake
+neighbors / wife). The technique stuck.
+
+**Fundamental Changes** describes the mechanics: "use the underside
+of his thumb, and he'd brush the strings."
+
+**Adrian Ingram's biographical study (Centerstream, 2008)** is the
+canonical book reference but we don't have it on disk — citation is
+secondary.
+
+### 5. `upper-structure-triad-substitution`
+
+> DbMaj7 over Bbm7-Eb7 as a unified "Db major field."
+
+**Voicelid Jazz Guitar** documents the strategy with the specific
+example:
+
+> "Over a Bbm7 chord: Stacking the 9th (C) while omitting the root
+> creates a DbMaj7 sound, which could then be repositioned over the
+> following Eb7."
+>
+> "Db becomes the b7. F becomes the 9. Ab becomes the 11 (sus4).
+> C becomes the 13."
+
+And:
+
+> "He would 'substitute a Gm7b5 shape over an Eb7' to outline
+> extensions without the root note present."
+
+**Wikipedia** complements with the general claim: Wes used
+"superimposed triads and arpeggios as the main source for his
+soloing ideas."
+
+## What was REMOVED from the previous Wes entry
+
+The earlier entry shipped a principle `blues-vocabulary-in-jazz-context`
+("altered-dominant voicings at blues-line destinations"). After
+research, this couldn't be sourced specifically — Wes's blues
+phrasing is documented in general, but the specific encoded claim
+about altered-dominant voicings at blues-line destinations was an
+inference I made, not a documented principle. Removed.
+
+Replaced with `upper-structure-triad-substitution`, which IS
+well-sourced.
+
+The earlier `block-chord-to-octave-parallelism` principle was also
+trimmed: my claim about "top voice continuity from the preceding
+octave passage" was an inference. The revised version focuses on
+the documented drop-2 predominance.
+
+## Followups
+
+- **Direct citation from Ingram's *Wes Montgomery*** (Centerstream
+  biographical study) for thumb mechanics.
+- **Unblock or replace jazzguitar.be sources** — the 403s blocked
+  detail extraction; we cited via search-result indexing only.
+- **Recording-based annotation pass** for specific transcribed
+  block-chord choruses (D-Natural Blues, Four on Six).
+
+## Bibliography
+
+- *Wes Montgomery* — Wikipedia.
+  <https://en.wikipedia.org/wiki/Wes_Montgomery>
+- *Wes Montgomery's Drop-2 + Upper Structures* — Voicelid Jazz Guitar.
+  <https://www.voicelidjazzguitar.com/jazz-guitar-blog/jazz-guitar-upper-structures-wes-montgomery-drop-2>
+- *Play Guitar Like Wes Montgomery* — Fundamental Changes.
+  <https://www.fundamental-changes.com/wes-montgomery-video-lesson/>
+- *Wes Montgomery Jazz Guitar Method: Octaves* — Jazz Blues Abstract
+  Truth (Gress excerpt).
+  <http://jazzbluesabstracttruth.blogspot.com/2013/02/wes-montgomery-jazz-guitar-method.html>
+- Ingram, Adrian. *Wes Montgomery*. Centerstream Publications, 2008.
+- Marshall, Wolf. Various pedagogical writings on Wes Montgomery
+  (cited via Wikipedia).
+- Montgomery, Wes. *Wes Montgomery Guitar Folio*. Hal Leonard
+  (posthumous transcriptions).

--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -55,12 +55,50 @@
       "lived": "1946-2005",
       "traditions": ["chord-melody", "jazz", "baroque", "blues", "gospel", "country"],
       "instrument": "6-string (low E)",
-      "biography": "Los Angeles teacher and player whose lessons reshaped how guitarists think about chord voicings, voice-leading, and the interaction of melody with harmony. Authored Chord Chemistry and Modern Chord Progressions; his estate (tedgreene.com) maintains his manuscript and lesson archive openly.",
+      "biography": "Los Angeles teacher and player whose lessons and the openly-distributed tedgreene.com archive reshaped how guitarists think about four-note voicings, voice-leading, and the relationship between melody and harmony. Authored Chord Chemistry (1971) and Modern Chord Progressions (1973). His V-System — a taxonomy of 14 voicing groups across 43 unique four-note chord qualities — is the canonical Greene framework.",
       "principles": [
+        {
+          "id": "v-system-voicing-groups",
+          "name": "V-System voicing groups",
+          "summary": "Four-note voicings are classified into 14 groups (V-1 through V-14) ordered from most compact to most spread: V-1 is the closest cluster, V-14 the widest, with V-13/V-14 less spread than V-11/V-12. Any chord quality (43 unique four-note qualities) can be voiced in any V-group; cycling through them gives every distinct way to spell the same chord. The framework is taxonomic, not prescriptive — Greene's pragmatic note: 'use logic to generate possibilities but don't be so strict that you lose [practical results].'",
+          "voicingStyleTags": ["greene", "greene-v-system"],
+          "playStyleTags": [],
+          "applies_to_modes": ["chord-melody", "comping", "solo-guitar"],
+          "tolerance_hints": {
+            "minSoundingNotes": 4
+          },
+          "references": [
+            {
+              "source": "tedgreene.com V-System archive (Hober's intro)",
+              "url": "https://tedgreene.com/teaching/v_system.asp",
+              "citation": "Hober, James. V-System Introduction. tedgreene.com. Corpus extract at plugin/data/masters-corpus/greene/01_WhoIsJamesHober.txt."
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "fixed-soprano-tour",
+          "name": "Fixed soprano tour",
+          "summary": "Hold the top voice (soprano) constant on a chosen melody note; cycle through all 14 V-System voicing groups to reveal every way Greene's system harmonizes underneath that note. For chord-melody work this is the engine: the melody fixes the soprano; the V-System provides the harmonic exploration. Hober: 'in a single line of music notation he had concisely described and implied the entire V-System.'",
+          "voicingStyleTags": ["greene", "greene-v-system"],
+          "playStyleTags": ["sequential"],
+          "applies_to_modes": ["chord-melody", "solo-guitar"],
+          "tolerance_hints": {
+            "minSoundingNotes": 4
+          },
+          "references": [
+            {
+              "source": "tedgreene.com V-System archive (Hober's 'Who Is James' chapter)",
+              "url": "https://tedgreene.com/teaching/v_system.asp",
+              "citation": "Hober, James. Who Is James? — V-System Introduction. Corpus extract at plugin/data/masters-corpus/greene/01_WhoIsJamesHober.txt."
+            }
+          ],
+          "example_voicing_signatures": []
+        },
         {
           "id": "voice-leading-inner-motion",
           "name": "Voice leading through inner motion",
-          "summary": "Melody stays on top while inner voices (alto, tenor) move stepwise between chord changes. The bass anchors, the top voice carries the melody, and the inner voices do the harmonic work — producing the sense of multiple lines weaving rather than block chords thudding.",
+          "summary": "Melody stays on top while inner voices (alto, tenor) move stepwise between chord changes. The bass anchors, the top voice carries the melody, and the inner voices do the harmonic work — producing the sense of multiple independent lines rather than block chords. The V-System's 'Conversion' method (Welcome chapter index, item 20) is the formal device for moving between V-groups while preserving voice-leading economy.",
           "voicingStyleTags": ["greene"],
           "playStyleTags": ["sequential"],
           "applies_to_modes": ["chord-melody", "solo-guitar"],
@@ -73,8 +111,25 @@
               "citation": "Greene, Ted. Chord Chemistry. Dale Zdenek, 1971."
             },
             {
-              "source": "tedgreene.com",
-              "url": "https://tedgreene.com/teaching/v_system.aspx"
+              "source": "tedgreene.com V-System archive",
+              "url": "https://tedgreene.com/teaching/v_system.asp",
+              "citation": "Welcome chapter; corpus extract at plugin/data/masters-corpus/greene/00_Welcome.txt."
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "ii7-over-ivmaj7-substitution",
+          "name": "ii7 preferred over IVmaj7 for the IV function",
+          "summary": "Greene's 1974 manuscript on ii7-V7-I documents the historical/aural preference for ii7 over IVmaj7 in the IV-V-I cadence: IVmaj7's root-to-7 major-7 interval is strident, while ii7's minor-7 interval is mild. The substitution defines the canonical jazz ii7-V7-I cadence; voicings supporting the ii7-V7-I motion (smooth root motion by 5ths, common-tone voice leading) are preferred. Minor variant: iiø7 - V(7) - i.",
+          "voicingStyleTags": ["greene"],
+          "playStyleTags": [],
+          "applies_to_modes": ["comping", "chord-melody"],
+          "tolerance_hints": {},
+          "references": [
+            {
+              "source": "Ted Greene, ii7 - V(7) - I (1974-11-28 and 1974-11-29)",
+              "citation": "Manuscript. Corpus extract at plugin/data/masters-corpus/greene/ii7-V7-I_TedGreene_1974-11-28_and_29.txt. Quoted: 'the strongly dissonant interval of a major 7th... was apparently harsher to the ears of our forefathers than the mild dissonance of a minor 7th in the ii7.'"
             }
           ],
           "example_voicing_signatures": []
@@ -82,7 +137,7 @@
         {
           "id": "sequential-articulation",
           "name": "Sequential articulation",
-          "summary": "Voicings are designed for hybrid-pick or fingerstyle plucking with a specific right-hand sequence: bass plucked first, then the inner voices in order, melody on top. The pluck order is part of the music; strumming the same shape sounds different.",
+          "summary": "Voicings are played with right-hand fingerstyle or hybrid-pick articulation rather than strummed — bass plucked first, inner voices in sequence, melody on top. The pluck order is part of the music; strumming the same shape produces a different effect. Closely associated with Greene's harp-harmonics technique (also Lenny Breau), which he treasured and lamented as overexposed (1995 letter).",
           "voicingStyleTags": ["greene"],
           "playStyleTags": ["sequential", "hybrid-pick"],
           "applies_to_modes": ["chord-melody", "solo-guitar"],
@@ -91,6 +146,10 @@
             {
               "source": "Modern Chord Progressions",
               "citation": "Greene, Ted. Modern Chord Progressions. Dale Zdenek, 1973."
+            },
+            {
+              "source": "Ted Greene letter to Bruce (1995-12-16)",
+              "citation": "Manuscript. Corpus extract at plugin/data/masters-corpus/greene/3-NoteChordsForThe_I_ChordInGBlues_WithLetter_TedGreene_1995-12-16.txt — Greene laments harp-harmonics losing their impact through overexposure."
             }
           ],
           "example_voicing_signatures": []
@@ -237,9 +296,9 @@
           "example_voicing_signatures": []
         },
         {
-          "id": "block-chord-to-octave-parallelism",
-          "name": "Block-chord-to-octave parallelism",
-          "summary": "When transitioning from the octave tier to the block-chord tier, the chord voicing places the destination note of the preceding octave passage on top. Voice-leading between adjacent block chords is typically half-step or whole-step in the top voice with parallel inner voices below — drop-2 voicings predominate because they keep the melody on the top string.",
+          "id": "block-chord-drop-2-predominance",
+          "name": "Block-chord drop-2 predominance",
+          "summary": "Wes's block-chord soloing uses drop-2 voicings as the primary vehicle — voicings on adjacent strings with the second-from-top voice dropped an octave. The melody lives on the top string of the voicing; chord tones fill in below. Voice-leading between adjacent block chords is typically smooth in the top voice with parallel inner motion.",
           "voicingStyleTags": ["montgomery", "drop-2"],
           "playStyleTags": ["block"],
           "applies_to_modes": ["solo-guitar", "chord-melody"],
@@ -248,8 +307,14 @@
           },
           "references": [
             {
-              "source": "The Incredible Jazz Guitar of Wes Montgomery (1960)",
-              "citation": "Recorded reference: 'D-Natural Blues' — block-chord chorus shows the octave-to-chord transition explicitly."
+              "source": "Voicelid Jazz Guitar — Drop-2 + Upper Structures",
+              "url": "https://www.voicelidjazzguitar.com/jazz-guitar-blog/jazz-guitar-upper-structures-wes-montgomery-drop-2",
+              "citation": "Documents drop-2 as 'the vehicle for these ideas' and notes Wes 'stuck with chords played mainly on adjacent strings and drop 2 chord shapes.'"
+            },
+            {
+              "source": "jazzguitar.be — Wes Montgomery chord soloing",
+              "url": "https://www.jazzguitar.be/blog/wes-montgomery-jazz-guitar-licks/",
+              "citation": "Indexed across the 40-licks article and Wes Montgomery chord-solo lesson."
             }
           ],
           "example_voicing_signatures": []
@@ -271,19 +336,26 @@
           "example_voicing_signatures": []
         },
         {
-          "id": "blues-vocabulary-in-jazz-context",
-          "name": "Blues vocabulary inside jazz repertoire",
-          "summary": "Single-note phrases pull from blues language — flat thirds, flat fifths, blues-scale-derived runs — even on tunes that aren't formally blues. The harmonic implication when these lines arrive at a block-chord destination favors altered-dominant voicings (7b9, 7#9, 7alt) and #11 colorations rather than vanilla diatonic substitutes.",
+          "id": "upper-structure-triad-substitution",
+          "name": "Upper-structure triad substitution",
+          "summary": "Over a ii7-V7 (or single dominant), Wes voices an upper-structure chord that omits the root: e.g., a DbMaj7 shape over Bbm7 (the 3-5-9-11), then the same DbMaj7 shape carries forward over the following Eb7 (becoming b7-9-sus4-13). Wes treats the entire ii-V interaction as a unified 'Db major field,' reducing cognitive load while generating sophisticated harmonic color. Lines and chord stabs both draw from this field — single-note phrases imply complex harmony.",
           "voicingStyleTags": ["montgomery"],
-          "playStyleTags": ["sequential"],
-          "applies_to_modes": ["solo-guitar"],
+          "playStyleTags": ["block", "sequential"],
+          "applies_to_modes": ["solo-guitar", "chord-melody", "comping"],
           "tolerance_hints": {
-            "excludedCategories": []
+            "minSoundingNotes": 3,
+            "requireRootInBass": false
           },
           "references": [
             {
-              "source": "Riverside-era recordings (1959-1963)",
-              "citation": "Recorded reference: 'Twisted Blues,' 'West Coast Blues,' 'Mr. Walker' — blues vocabulary on jazz tunes."
+              "source": "Voicelid Jazz Guitar — Drop-2 + Upper Structures",
+              "url": "https://www.voicelidjazzguitar.com/jazz-guitar-blog/jazz-guitar-upper-structures-wes-montgomery-drop-2",
+              "citation": "Documents Wes's chord-over-chord substitution: 'his lines imply complex harmony even when he plays single notes.'"
+            },
+            {
+              "source": "Wikipedia — Wes Montgomery",
+              "url": "https://en.wikipedia.org/wiki/Wes_Montgomery",
+              "citation": "Documents 'superimposed triads and arpeggios as the main source for his soloing ideas.'"
             }
           ],
           "example_voicing_signatures": []


### PR DESCRIPTION
Refines Ted Greene's section in masters.json using the V-System
material we already have on disk (scraped in #220), and opens
docs/research/masters/ as the home for the "show your work" behind
every principle entry.

## What landed

### masters.json — Ted Greene (5 principles, all sourced)

- **v-system-voicing-groups** (NEW) — 14-group taxonomy V-1 (most
  compact) → V-14 (most spread). Source: Hober's V-System intro.
- **fixed-soprano-tour** (NEW) — soprano-locked cycling through
  V-groups. Source: Hober quoting Greene's "single line of music
  notation" that "implied the entire V-System."
- **voice-leading-inner-motion** (refined) — now references the
  V-System "Conversion" chapter.
- **ii7-over-ivmaj7-substitution** (NEW) — Greene's 1974 doctrine
  on the strident major-7 interval. Direct corpus quote.
- **sequential-articulation** (refined) — adds the 1995 harp-harmonics
  letter excerpt.

### masters.json — Wes Montgomery revisions

Honest correction of two unsourced claims from #226:
- **REMOVED** `blues-vocabulary-in-jazz-context` (the specific
  encoded claim couldn't be sourced; the general "Wes used blues
  language" is true but the altered-dominant-at-blues-destinations
  framing was my fabrication).
- **REPLACED with** `upper-structure-triad-substitution` —
  well-documented at Voicelid Jazz Guitar + Wikipedia (DbMaj7 over
  Bbm7-Eb7 as a unified "Db major field").
- **TRIMMED** `block-chord-to-octave-parallelism` to its documented
  core (drop-2 predominance + melody-on-top); renamed
  `block-chord-drop-2-predominance`.

### docs/research/masters/ — new directory

Documents the sources behind each principle entry, separates verified
from inferred, lists blocked URLs and OCR gaps:
- `README.md` — methodology, per-master status table
- `ted-greene.md` — corpus verbatim quotes, what didn't OCR, followups
- `wes-montgomery.md` — web URLs used, what was 403'd, removed claims

Future masters get their own research files when their principle
entries are refined (per the existing #228 / #230-235 ticket plan).

## Acceptance

- [x] masters.json: Greene 5 principles, Wes 5 principles, 9 masters / 24
      principles total (was 9/21)
- [x] docs/research/masters/ exists with README + ted-greene.md +
      wes-montgomery.md
- [x] Every principle entry's references field cites a source we
      actually consulted (corpus file path or URL)
- [x] 220 tests pass

## What's NOT in this PR

- Notation-reading on the 16 OCR-failed Greene PDFs (followup).
- A `--full` Greene scrape to get the V-System per-group interval
  definitions (followup).
- Direct citations from Chord Chemistry / Modern Chord Progressions
  (followup — neither is in the corpus).
- Refinement of the other 7 masters (per #228 / #230-235).

## Self-Review

Trivial-change declaration: content + docs edit. No schema or engine
changes. The Track 3 plumbing (#222) consumes the refined principle
entries without modification. Verified by `git diff --stat`: 4 files
touched (1 data, 3 new docs).