### PR TITLE
content: Van Eps upgrade from web-sourced to primary-source (1939 6-string Method PDF)

### DIFF
--- a/docs/research/masters/README.md
+++ b/docs/research/masters/README.md
@@ -47,7 +47,7 @@ an inference.
 
 | Master | Research file | Status |
 |---|---|---|
-| George Van Eps | `george-van-eps.md` | web-researched, 5 documented principles |
+| George Van Eps | `george-van-eps.md` | **primary-source (1939 Method PDF)**, 7 documented principles. 7-string Harmonic Mechanisms principles pending separate pass. |
 | Ted Greene | `ted-greene.md` | corpus-extracted, 5 documented principles |
 | Joe Pass | `joe-pass.md` | web-researched, 4 documented principles |
 | Martin Taylor | `martin-taylor.md` | web-researched, 4 documented principles |
@@ -57,7 +57,7 @@ an inference.
 | Johnny Smith | `johnny-smith.md` | web-researched, 3 documented principles |
 | Jody Fisher | `jody-fisher.md` | web-researched, 2 documented principles (small by design — pedagogue, not stylist) |
 
-**Bookshelf total: 9 masters, 36 principles.**
+**Bookshelf total: 9 masters, 38 principles.**
 
 Each research file follows the same shape: web sources table,
 per-principle source attribution with quotes, a "what was REMOVED"

--- a/docs/research/masters/george-van-eps.md
+++ b/docs/research/masters/george-van-eps.md
@@ -1,100 +1,256 @@
 # George Van Eps — research notes
 
-**Primary source type:** web research + indirect reference to *Harmonic
-Mechanisms for Guitar* (Mel Bay, 3 vols; not in repo).
-**Last research pass:** 2026-05-21 (#228).
-**Principle entries:** 5 in `masters.json` (was 2 seeds before this pass).
+**Primary source type:** primary-source PDF of the 1939-era Van Eps
+Method for Guitar (Epiphone Inc., NY) consulted in-session via the
+project owner's attached copy. NOT committed to repo — the underlying
+publication's copyright status differs from the Greene corpus (which
+is openly distributed by the estate).
+**Last research pass:** 2026-05-21 (this PR, after a web-source-only
+first pass).
+**Principle entries:** 7 in `masters.json` (was 5 after the web pass;
+all rewritten against the primary source).
 
-## Web sources
+## What changed and why
 
-| URL | Used for |
-|---|---|
-| <https://www.jazzguitarlessons.net/blog/george-van-eps> | "Lap piano" style; the 10th-interval-anchor technique; quote on inner-voice melody |
-| <https://www.guitarplayer.com/players/george-van-eps-my-guitar> | 7-string tuning ("standard six-string with the 7th string tuned down a fifth"); confirmation of "lap piano" as Van Eps's term |
-| <https://robmackillop.net/george-van-eps-method-for-guitar/> | Mechanical exercise content: 6 formations in C, rootless voicings (F triad for Dm7), banjo-derived picking, "mini barres" left-hand technique |
-| <https://grokipedia.com/page/George_Van_Eps> | "Lap piano" timeline (developed in 1930s); confirmation of independent bass + inner counterpoint |
+The first research pass (#228) relied on secondary web sources —
+Rob MacKillop's analysis at robmackillop.net, the
+jazzguitarlessons.net profile, the Guitar Player feature.
+That pass introduced two specific claims I now have to correct:
+
+1. **"Banjo-derived arpeggio picking"** — MacKillop's
+   interpretation. Van Eps's own text in the 1939 Method (page 3,
+   "Pick and Wrist Action" + Ex. 2 instructions) describes the
+   technique as **pulsation picking** with wrist axis over the top
+   note for dynamic predominance. No mention of banjo origin in the
+   primary source. Replaced with `pulsation-picking-top-voice-emphasis`.
+
+2. **"Rootless voicings → ii-V-I cadence (F triad implies Dm7)"** —
+   also MacKillop's analytical gloss. Ex. 1's own instructions
+   describe it as "a harmonized major scale in triads" — diatonic
+   triads. The "F triad is rootless Dm7" reading isn't in Van Eps's
+   own text. Removed; replaced with `harmonized-scale-foundation`
+   which describes what Ex. 1 actually is.
+
+## Source identification
+
+The PDF consulted is the 1939-era Epiphone Inc. publication. The
+title page identifies it as **The George Van Eps Method for Guitar**
+($2.50 cover price, Epiphone Inc., New York), distributed via
+DjangoBooks.com with a Glenn Thompson watermark. The Foreword refers
+to "succeeding volumes in preparation for publication in the near
+future," confirming this is volume 1 of an intended multi-volume
+series; the later 3-volume *Harmonic Mechanisms for Guitar* (Mel Bay,
+1980-1982) is the mature realization of that series.
+
+Important: **this is a 6-string method**. The 7-string (low A) work
+is in Harmonic Mechanisms and on the 7-string recordings (Mellow
+Guitar, 1956 and after). All 7 principles below are tagged
+`applies_to_tunings: ["standard"]` — they're documented for the
+6-string. 7-string-specific principles will need a separate research
+pass against Harmonic Mechanisms.
 
 ## Sources per principle
 
-### 1. `lap-piano-polyphonic-style`
+### 1. `harmonized-scale-foundation`
 
-Quoted Van Eps from jazzguitarlessons.net:
-> "I'm more interested in having every voice in a chord be a melody
-> that both stands by itself and works with the others."
+Direct from the Foreword + every chord-quality section's first
+exercise. The method's organizing principle is harmonizing the
+relevant scale in triads:
+- Ex. 1 (Major chords): harmonized major scale in triads
+- Ex. 26 (Minor chords): harmonized minor scale in triads
+- Ex. 33 (Seventh chords): built on the seventh arpeggio
+- Ex. 48 (Diminished chords): harmonized diminished
 
-Guitar Player profile confirms "lap piano" as Van Eps's own term;
-Grokipedia provides the 1930s development timeline.
+Van Eps's solfeggio quote from the Foreword:
+> "Think of the tonic of every key as 'do'; this is called the
+> Solfeggio system. Therefore if you are in E flat, consider the E
+> flat as 'do'. Through this system all keys are equal and therefore
+> you will not favor any particular key or keys."
 
-### 2. `independent-bass-counterpoint`
+### 2. `six-fingering-string-sets`
 
-Van Eps quote (jazzguitarlessons.net):
-> "I wanted things to happen, voices to move, not just, 'Oh, that's
-> a chord,' dunh-dunh, dunh-dunh. I wanted something to go de da da
-> duh inside the chord, or for the bass to move a little bit."
+The "Explanation of the String Chart" page (p. 6) introduces the
+formal notation: sets of 3 (1|3, 2|3, 3|3, 4|3), sets of 4 (1|4,
+2|4, 3|4), broken sets (1|B3, 2|B3, 3|B3, broken 1st of 3 = B1|3,
+B2|3, B3|3), broken sets of 4 (1|B4, 2|B4), broken sets of 2
+(1|B2, 2|B2, 3|B2, 4|B2), and the A-prefixed broken sets (A|1,
+A|2, A|3).
 
-Guitar Player notes the 7-string tuning: "standard six-string tuning
-with the seventh string tuned down a fifth." From low E to a fifth
-down = A; this matches the canonical Van Eps low-A 7-string.
+Ex. 1's instructions document the six-form structure of the
+harmonized major scale:
+> "1st form — from C up to F"
+> "2nd form — from C up to C sharp (D if possible)"
+> "3rd form — from C up to F"
+> "4th form — from A flat up to D flat (D if possible)"
+> "5th form — from A flat up to E"
+> "6th form — from F sharp up to C sharp"
 
-### 3. `10th-interval-anchor`
+The legato principle: "in making these quick shifts, do not rush
+the tempo. Plant your fingers solidly and firmly on the fingerboard.
+After releasing the pressure on a formation get used to forming the
+next position while the hand is in motion."
 
-jazzguitarlessons.net documents the technique:
-> "The technique emphasizes holding down a 10th interval on strings,
-> and playing arpeggios as inner lines, and then moving the patterns
-> up and down the major, melodic minor, and harmonic minor scales."
+### 3. `outer-voice-anchor-inner-motion`
 
-### 4. `rootless-voicings-for-cadences`
+The "hold outer voices while inner moves" device appears across
+many exercises. Direct quotes from the primary source:
 
-Rob MacKillop's analysis of *Harmonic Mechanisms* Exercise 1:
-> "An F triad (C-F-A) where a diatonic A minor might be expected,
-> which Rob MacKillop later explains creates a Dm7 voicing —
-> enabling the ii-V-I cadence fundamental to jazz."
+**Ex. 14 (Three forms):**
+> "The upper (melodic) line is in half notes while the two lower
+> voices are in whole notes. Make sure they sustain their full
+> value. Practice all three forms equally as the purpose throughout
+> this method is balanced technique."
 
-And the 6-formation structure:
-> "The method teaches six 'formations' of chords in C Major, with
-> transposition to all 12 keys required."
+**Ex. 20:**
+> "A variation of the major scale with the top voice in quarter
+> notes and the bottom voices in whole notes."
 
-### 5. `banjo-derived-arpeggio-picking`
+**Ex. 57:**
+> "The top line is in quarter notes and the harmonic structure is
+> in whole notes. Make sure the whole notes are held for their
+> full value."
 
-Rob MacKillop's analysis:
-> "An arpeggio picking method which GVE wants us to master and use
-> on all these exercises, reportedly derived from banjo fingerstyle
-> technique."
+**Ex. 60 (Two forms):**
+> "The moving voice is in the middle of the structure, which
+> presents a difficulty as the up-stroke must pick the middle note
+> while the two outside notes are sounding. Make sure you do not
+> deaden either of the sustaining voices with the up-stroke."
 
-And on left-hand support:
-> "The method requires 'mini barres' — 'flattening the last joint of
-> their left-hand fingers' for efficiency across formations."
+**Ex. 82:**
+> "Individual control of the fingers is developed in this exercise.
+> In the first measure the third and fourth fingers play the two
+> upper voices in quarter notes while the first and second fingers
+> sustain the lower voices in whole notes."
+
+This is the seed of what later (in Harmonic Mechanisms, 1980s)
+became known as the "lap piano" style — but the device is
+documented decades earlier in this 1939 method.
+
+### 4. `chromatic-tenths-with-middle-voice`
+
+Direct quote from Ex. 37 instructions (the first of a series of
+stretching exercises):
+> "You will notice that the middle note remains the same while the
+> other two voices move around the middle voice in chromatic tenths.
+> This is the first exercise using a broken set of three strings.
+> (See page 6.) Pay close attention to the set markings under the
+> staff in all these exercises. Practice in all keys in straight
+> down strokes, then with arpeggio picking. Be careful in the latter
+> as you have to jump over a string with the pick."
+
+The chromatic 10ths principle was correctly captured in the
+web-sourced first pass via jazzguitarlessons.net's gloss, but now
+we have it from the source itself.
+
+### 5. `pulsation-picking-top-voice-emphasis`
+
+From "The Pick and Wrist Action" (p. 3) of the primary source:
+> "In a complete wrist action the wrist imitates a twisting motion
+> with each stroke, very much like flicking something off your hand.
+> See that you use a quick and accurate stroke, eliminating all
+> excess movement because you want the notes to sound simultaneously,
+> not one by one. When playing on inside strings use the next
+> highest string as a pick-stop. The axis of your wrist should be
+> directly over the highest note as the top note should predominate.
+> In other words if you are picking the B, D, and G strings as a
+> triad, the axis should be over the B string with the result that
+> the D string will sound softly, the G string a little louder, and
+> the B string will be the loudest, which is dynamically correct."
+
+And from Ex. 2 (which introduces "arpeggio picking" as Van Eps's
+term):
+> "The pick passes over each string and accents it with a slight
+> kick, which is more of a pulsation... using the pulsation
+> principle you will be able to maintain a steady tempo and you
+> will not strike two strings at once."
+
+### 6. `finger-flattening-fifth-finger`
+
+Direct quote from Ex. 16 (Three forms):
+> "This exercise must be practiced very carefully as we introduce
+> a new principle in the first two forms which is the 'breaking'
+> (or flattening from an arched position) of the first joint of
+> the fingers. In the first form at the second and third measures,
+> you flatten the first joint of the second finger to produce the
+> added note, which brings this principle into the classification
+> of a fifth finger. It is a very difficult maneuver because the
+> finger that is doing the flattening must sustain another note
+> during the process... This flattening principle must be practiced
+> methodically as it must be reliable rhythmically and should be
+> done with a snap."
+
+Van Eps's own term is "fifth finger" — MacKillop's "mini barre"
+description is functionally equivalent but Van Eps's own naming
+is more specific (it's an added-note technique, not a barre proper).
+
+### 7. `string-deadening-for-open-voicings`
+
+Direct quote from Ex. 58 (Two forms) and its footnote:
+> "This is the first diminished chord exercise in open voicing. It
+> is necessary to 'deaden' a string. This is taken care of by the
+> fingering. For instance, in the first form the D string (IV) is
+> stopped from vibrating with the second finger while that finger
+> is used for the note on the A (V) string. Practice slowly and
+> observe all markings.
+>
+> *i.e. The pick strikes that string, but the left hand finger
+> does not let it sound clearly."
+
+A specific Van Eps mechanic for executing open voicings (skipping
+intermediate strings) with a sweep-friendly pick motion.
 
 ## What was REMOVED
 
-- `comping-with-self` renamed to `independent-bass-counterpoint` with
-  the Van Eps quote replacing the generic seed text.
-- `vertical-structures` removed — the claim ("bass note as part of
-  unified vertical structure") wasn't directly sourced and overlapped
-  with the lap-piano principle. The replacement principles cover the
-  documented content better.
+- `lap-piano-polyphonic-style` (web-sourced) — kept the IDEA but
+  re-attributed via `outer-voice-anchor-inner-motion` to the actual
+  exercises that document it in 1939. The "lap piano" term itself
+  appears to be from later interviews/profiles, not the primary
+  text.
+- `independent-bass-counterpoint` (web-sourced, 7-string-specific) —
+  REMOVED from this pass. Will be re-added when 7-string Harmonic
+  Mechanisms is researched. The 1939 method is 6-string.
+- `10th-interval-anchor` (web-sourced) — REPLACED with the more
+  precise `chromatic-tenths-with-middle-voice` which has direct
+  primary-source citation from Ex. 37.
+- `rootless-voicings-for-cadences` (MacKillop's gloss) — REMOVED.
+  Ex. 1 is harmonized-scale-in-triads, not a rootless-ii-V-I
+  pedagogy in Van Eps's own framing.
+- `banjo-derived-arpeggio-picking` (MacKillop's claim) — REPLACED
+  with `pulsation-picking-top-voice-emphasis`, which is what
+  Van Eps actually documents.
 
 ## Followups
 
-- **Direct citation from *Harmonic Mechanisms for Guitar*** (Mel Bay,
-  3 vols, 1980-1982) — not in our corpus. Would strengthen every
-  principle here with verbatim exercise references.
+- **7-string Harmonic Mechanisms (3 vols, Mel Bay, 1980-1982)** —
+  the canonical 7-string method. Will need a separate research pass
+  to add:
+  - Independent low-A bass voice principles
+  - The mature "lap piano" framing
+  - Whatever inner-voice / counterpoint principles are introduced
+    that weren't already in the 1939 method
+- **Mellow Guitar (1956)** + later 7-string recordings as
+  example-voicing references.
 - **Howard Alden interviews** — Alden was Van Eps's most direct
-  student; primary-source material on his teaching method would
-  ground the lineage claims.
-- **Mellow Guitar (1956)** + Van Eps's other recordings as
-  example-voicing reference points.
+  inheritor; his published commentary may add nuance.
+- **Etude Study from p. 40** — Van Eps's pedagogy for composing
+  one's own etudes; not encoded as a principle (it's a meta-practice
+  rule) but worth noting in the research file.
 
 ## Bibliography
 
+- **Van Eps, George.** *The George Van Eps Method for Guitar*.
+  Epiphone Inc., New York, ca. 1939. Primary source consulted via
+  PDF (Glenn Thompson copy, DjangoBooks.com distribution). Not in
+  the repo corpus.
 - Van Eps, George. *Harmonic Mechanisms for Guitar*, vols 1-3. Mel
-  Bay Publications, 1980-1982.
+  Bay Publications, 1980-1982. Cited; not yet directly consulted.
 - *George Van Eps (1913-1998)* — jazzguitarlessons.net.
   <https://www.jazzguitarlessons.net/blog/george-van-eps>
 - *George Van Eps Method for Guitar* — Rob MacKillop, musician.
   <https://robmackillop.net/george-van-eps-method-for-guitar/>
-- *Wondrous… unique… exquisite: The seven-string guitars and smooth
-  "lap-piano" style of George Van Eps* — Guitar Player.
+  (Secondary source; corrected against the primary in this pass.)
+- *The seven-string guitars and smooth "lap-piano" style of George
+  Van Eps* — Guitar Player.
   <https://www.guitarplayer.com/players/george-van-eps-my-guitar>
 - *George Van Eps* — Grokipedia.
   <https://grokipedia.com/page/George_Van_Eps>

--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -7,109 +7,134 @@
       "name": "George Van Eps",
       "lived": "1913-1998",
       "traditions": ["chord-melody", "jazz", "swing"],
-      "instrument": "7-string (low A) and 6-string",
-      "biography": "Pioneer of the 7-string electric guitar with the added low A string. Developed a body of theory treating the guitar as a contrapuntal instrument: independent bass, inner voices, and melody moving simultaneously, often beneath sustained chord shapes.",
+      "instrument": "6-string (the 1939 Method) and later 7-string (low A; Harmonic Mechanisms, Mel Bay, 1980-82)",
+      "biography": "Pianistic master of the guitar whose body of method work began with the 1939-era Epiphone-published Van Eps Method (6-string) and matured into the 3-volume Harmonic Mechanisms for Guitar (Mel Bay, 1980-1982) on the 7-string with low A. The principles below are sourced from the 6-string 1939 method (primary source verified). 7-string-specific principles from Harmonic Mechanisms (lap-piano style, independent bass counterpoint on the low A) are pending a separate research pass.",
       "principles": [
         {
-          "id": "lap-piano-polyphonic-style",
-          "name": "Lap piano polyphonic style",
-          "summary": "Van Eps treats the guitar as a polyphonic instrument with three independent voices — bass, inner voices, melody — moving simultaneously like a pianist's left hand, right hand, and inner motion. He developed this style in the 1930s for solo performance, emulating a full piano accompaniment on a single instrument. His own words: 'I'm more interested in having every voice in a chord be a melody that both stands by itself and works with the others.'",
+          "id": "harmonized-scale-foundation",
+          "name": "Harmonized scale as foundational vocabulary",
+          "summary": "Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex. 33-47) with the 7th-arpeggio scale; diminished chords (Ex. 48-82) with the harmonized diminished. The harmonized scale IS the vocabulary; voicings derive from running it through different fingerings. Practice in all 12 keys via the solfeggio system: 'Think of the tonic of every key as do.'",
           "voicingStyleTags": ["van-eps"],
-          "playStyleTags": ["sequential"],
-          "applies_to_modes": ["solo-guitar", "chord-melody"],
+          "playStyleTags": [],
+          "applies_to_modes": ["chord-melody", "comping", "solo-guitar"],
+          "applies_to_tunings": ["standard"],
           "tolerance_hints": {
-            "minSoundingNotes": 4
-          },
-          "references": [
-            {
-              "source": "jazzguitarlessons.net — George Van Eps (1913-1998)",
-              "url": "https://www.jazzguitarlessons.net/blog/george-van-eps",
-              "citation": "Documents the 'lap piano' style and quotes Van Eps directly on inner-voice melody."
-            },
-            {
-              "source": "Guitar Player — Van Eps profile",
-              "url": "https://www.guitarplayer.com/players/george-van-eps-my-guitar",
-              "citation": "Notes 'lap piano' as Van Eps's own term; describes the smooth/effortless sound and the bass counterpoint."
-            }
-          ],
-          "example_voicing_signatures": []
-        },
-        {
-          "id": "independent-bass-counterpoint",
-          "name": "Independent bass counterpoint (7th string)",
-          "summary": "On the 7-string (low A tuning), the 7th string carries an independent bass voice with its own melodic motion — chromatic neighbor tones, tonic-dominant pedal, walking patterns — while the upper voices sustain or move on their own timeline. Van Eps: 'I wanted things to happen, voices to move… for the bass to move a little bit.' The 7-string was designed specifically for this purpose; he debuted it on Mellow Guitar (1956).",
-          "voicingStyleTags": ["van-eps"],
-          "playStyleTags": ["sequential"],
-          "applies_to_modes": ["chord-melody", "solo-guitar"],
-          "applies_to_tunings": ["7string-van-eps"],
-          "tolerance_hints": {
-            "minSoundingNotes": 4
-          },
-          "references": [
-            {
-              "source": "jazzguitarlessons.net — George Van Eps",
-              "url": "https://www.jazzguitarlessons.net/blog/george-van-eps",
-              "citation": "Quotes Van Eps on bass motion: 'for the bass to move a little bit.'"
-            },
-            {
-              "source": "Harmonic Mechanisms for Guitar (Mel Bay, 3 vols, 1980-1982)",
-              "citation": "Van Eps, George. The canonical method work."
-            }
-          ],
-          "example_voicing_signatures": []
-        },
-        {
-          "id": "10th-interval-anchor",
-          "name": "10th-interval anchor with inner arpeggios",
-          "summary": "A central Harmonic Mechanisms device: hold a 10th interval (bass note to a third 10 frets above) while inner voices arpeggiate underneath. The 10th is the chord's outer frame; the inner motion harmonizes through major, melodic minor, and harmonic minor scales, generating triads and 7th-chord inversions inside the held outer voices.",
-          "voicingStyleTags": ["van-eps"],
-          "playStyleTags": ["sequential"],
-          "applies_to_modes": ["chord-melody", "solo-guitar"],
-          "tolerance_hints": {
-            "maxStretch": 10,
             "minSoundingNotes": 3
           },
           "references": [
             {
-              "source": "jazzguitarlessons.net — George Van Eps",
-              "url": "https://www.jazzguitarlessons.net/blog/george-van-eps",
-              "citation": "Describes the technique: 'holding down a 10th interval on strings, and playing arpeggios as inner lines, and then moving the patterns up and down the major, melodic minor, and harmonic minor scales.'"
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939)",
+              "citation": "Foreword + Ex. 1 (major) / Ex. 26 (minor) / Ex. 33 (7th) / Ex. 48 (diminished). Quoted: 'All exercises presented in this volume have been carefully tested through years of teaching. Each one has a definite purpose for development of the hand, no matter how insignificant it may seem to the student.' Solfeggio quote also from Foreword."
             }
           ],
           "example_voicing_signatures": []
         },
         {
-          "id": "rootless-voicings-for-cadences",
-          "name": "Rootless voicings for ii-V-I cadences",
-          "summary": "Van Eps's Method exercises use chord shapes that omit the root to imply richer harmony: an F triad (C-F-A) on the C major formation creates a Dm7 voicing without spelling Dm7 explicitly, enabling the ii-V-I cadence. The rootless approach was a precursor to the bebop-piano voicing convention that came later. Each of his six 'formations' in C Major transposes to all 12 keys.",
+          "id": "six-fingering-string-sets",
+          "name": "Six fingering forms across string sets",
+          "summary": "Every chord pattern is practiced in up to six different fingerings on different string-set positions: sets of 3 (1|3, 2|3, 3|3, 4|3), sets of 4 (1|4, 2|4, 3|4), and 'broken' sets (1|B3, 2|B3, 3|B3 — sets that skip an intermediate string). The fingerings cover the entire fingerboard with the same harmonic content. The six forms of Ex. 1 cover roughly: 1st form C-up-to-F; 2nd C-to-C#(D); 3rd C-to-F; 4th Ab-to-Db(D); 5th Ab-to-E; 6th F#-to-C#. Practiced legato; finger placement is 'next-position-forming while the hand is in motion' (legato principle).",
           "voicingStyleTags": ["van-eps"],
-          "playStyleTags": ["sequential"],
-          "applies_to_modes": ["comping", "chord-melody"],
+          "playStyleTags": [],
+          "applies_to_modes": ["chord-melody", "comping", "solo-guitar"],
+          "applies_to_tunings": ["standard"],
           "tolerance_hints": {
-            "requireRootInBass": false
+            "minSoundingNotes": 3
           },
           "references": [
             {
-              "source": "Rob MacKillop — George Van Eps Method for Guitar",
-              "url": "https://robmackillop.net/george-van-eps-method-for-guitar/",
-              "citation": "Analyses Exercise 1: 'an F triad (C-F-A) where a diatonic A minor might be expected, which... creates a Dm7 voicing — enabling the ii-V-I cadence fundamental to jazz.'"
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939)",
+              "citation": "Explanation of String Chart (p. 6) and Ex. 1 instructions (p. 8). Each set has a notation symbol (1|3, 2|3, ..., 1|B3, etc.). The six-form scope is documented in the Ex. 1 instructions: '1st form C up to F, 2nd form C up to C sharp (D if possible)...'"
             }
           ],
           "example_voicing_signatures": []
         },
         {
-          "id": "banjo-derived-arpeggio-picking",
-          "name": "Banjo-derived arpeggio picking",
-          "summary": "Right-hand technique uses an arpeggio picking style 'derived from banjo fingerstyle technique.' Van Eps requires this articulation across all the Harmonic Mechanisms exercises — chords are unrolled note-by-note in a defined sequence, not strummed. Left-hand support uses 'mini barres' (flattening the last joint of fingers) for efficiency moving between formations.",
+          "id": "outer-voice-anchor-inner-motion",
+          "name": "Outer-voice anchor with inner voice motion",
+          "summary": "Hold outer voices (top or bass) while inner voices move — Van Eps's central polyphonic device. Documented across multiple exercises: Ex. 14 ('the upper melodic line is in half notes while the two lower voices are in whole notes'); Ex. 20 (top quarter notes, bottom whole notes); Ex. 57 ('the top line is in quarter notes and the harmonic structure is in whole notes'); Ex. 60-65 ('the moving voice is in the middle of the structure'); Ex. 82 ('the third and fourth fingers play the two upper voices in quarter notes while the first and second fingers sustain the lower voices in whole notes'). Pre-figures the 'lap piano' / Harmonic Mechanisms aesthetic.",
           "voicingStyleTags": ["van-eps"],
-          "playStyleTags": ["sequential", "hybrid-pick"],
+          "playStyleTags": ["sequential"],
+          "applies_to_modes": ["chord-melody", "solo-guitar"],
+          "applies_to_tunings": ["standard"],
+          "tolerance_hints": {
+            "minSoundingNotes": 3
+          },
+          "references": [
+            {
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939)",
+              "citation": "Exercises 14, 18, 20, 37, 40, 42, 46, 57, 60-65, 67-68, 82. Ex. 82: 'Individual control of the fingers is developed in this exercise. In the first measure the third and fourth fingers play the two upper voices in quarter notes while the first and second fingers sustain the lower voices in whole notes.'"
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "chromatic-tenths-with-middle-voice",
+          "name": "Chromatic 10ths with middle voice motion",
+          "summary": "Specific stretching-exercise mechanic from Ex. 37: hold a 10th interval between outer voices while the middle voice moves chromatically. Van Eps's own description: 'the middle note remains the same while the other two voices move around the middle voice in chromatic tenths.' Uses a 'broken set of three strings' (one string between the two outer voices is skipped). Each form is then transposed to all 12 keys.",
+          "voicingStyleTags": ["van-eps"],
+          "playStyleTags": ["sequential"],
+          "applies_to_modes": ["chord-melody", "solo-guitar"],
+          "applies_to_tunings": ["standard"],
+          "tolerance_hints": {
+            "minSoundingNotes": 3
+          },
+          "references": [
+            {
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939), Ex. 37",
+              "citation": "Direct quote from Ex. 37 instructions: 'The middle note remains the same while the other two voices move around the middle voice in chromatic tenths. This is the first exercise using a broken set of three strings.'"
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "pulsation-picking-top-voice-emphasis",
+          "name": "Pulsation picking with top-voice emphasis",
+          "summary": "Right-hand technique: pick passes over each string with 'a slight kick, which is more of a pulsation' rather than picking each note individually. Wrist axis is positioned directly over the highest note 'as the top note should predominate.' Built-in dynamic stratification across a triad: '...the D string will sound softly, the G string a little louder, and the B string will be the loudest, which is dynamically correct.' Inside-string playing uses the next-higher string as a pick-stop on downstrokes.",
+          "voicingStyleTags": ["van-eps"],
+          "playStyleTags": ["sequential"],
           "applies_to_modes": ["chord-melody", "solo-guitar", "comping"],
+          "applies_to_tunings": ["standard"],
           "tolerance_hints": {},
           "references": [
             {
-              "source": "Rob MacKillop — George Van Eps Method for Guitar",
-              "url": "https://robmackillop.net/george-van-eps-method-for-guitar/",
-              "citation": "Documents the picking method 'derived from banjo fingerstyle technique' and the 'mini barres' left-hand mechanic."
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939)",
+              "citation": "'Pick and Wrist Action' section (p. 3) + Ex. 2 instructions (p. 9). Ex. 2: 'The pick passes over each string and accents it with a slight kick, which is more of a pulsation... using the pulsation principle you will be able to maintain a steady tempo and you will not strike two strings at once.' Picking section: '...the top note should predominate.'"
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "finger-flattening-fifth-finger",
+          "name": "Finger flattening for added notes ('fifth finger')",
+          "summary": "Left-hand technique: deliberately flatten the first joint of a finger from its arched position to produce an additional note on a neighboring string, classified as a 'fifth finger' addition. Introduced in Ex. 16 ('the breaking, or flattening from an arched position, of the first joint of the fingers'); difficult because the flattening finger must continue to sustain another note during the process. Practiced 'with a snap,' rhythmically reliable. Voicings designed with this technique fit one more note than the four fingers alone could reach.",
+          "voicingStyleTags": ["van-eps"],
+          "playStyleTags": [],
+          "applies_to_modes": ["chord-melody", "solo-guitar"],
+          "applies_to_tunings": ["standard"],
+          "tolerance_hints": {},
+          "references": [
+            {
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939), Ex. 16",
+              "citation": "Direct quote from Ex. 16: 'This exercise must be practiced very carefully as we introduce a new principle in the first two forms which is the breaking (or flattening from an arched position) of the first joint of the fingers. In the first form at the second and third measures, you flatten the first joint of the second finger to produce the added note, which brings this principle into the classification of a fifth finger.'"
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "string-deadening-for-open-voicings",
+          "name": "String deadening for open voicings",
+          "summary": "Left-hand technique for open voicings on non-adjacent strings: the pick strikes a string while a left-hand finger touches (deadens) it to silence the note. Ex. 58 documents the mechanic precisely: 'the D string (IV) is stopped from vibrating with the second finger while that finger is used for the note on the A (V) string. (i.e. The pick strikes that string, but the left hand finger does not let it sound clearly.)' Enables voicings where the pick can sweep cleanly across all strings while only the intended notes ring.",
+          "voicingStyleTags": ["van-eps"],
+          "playStyleTags": [],
+          "applies_to_modes": ["chord-melody", "solo-guitar"],
+          "applies_to_tunings": ["standard"],
+          "tolerance_hints": {
+            "allowOpenStrings": true
+          },
+          "references": [
+            {
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939), Ex. 58",
+              "citation": "Direct quote from Ex. 58 (the first diminished open-voicing exercise) and its footnote: 'In the first form the D string (IV) is stopped from vibrating with the second finger while that finger is used for the note on the A (V) string... *i.e. The pick strikes that string, but the left hand finger does not let it sound clearly.'"
             }
           ],
           "example_voicing_signatures": []


### PR DESCRIPTION
Project owner provided a PDF of the 1939-era Epiphone-published
*George Van Eps Method for Guitar* — volume 1 of an intended
multi-volume series that matured into Mel Bay's *Harmonic Mechanisms*
in 1980-82. This PR replaces every Van Eps principle with one
grounded in direct quotes from that primary source.

## What was wrong with the web-sourced version

Two specific claims I had to retract:

- **"Banjo-derived arpeggio picking"** was Rob MacKillop's
  interpretation. Van Eps's own text (page 3, Ex. 2 instructions)
  describes the technique as **pulsation picking** with no banjo
  reference. Corrected.
- **"Rootless voicings for ii-V-I (F triad = Dm7)"** was also
  MacKillop's analytical gloss. Ex. 1 in Van Eps's own framing is
  just "a harmonized major scale in triads." Removed.

Additionally, the **"lap piano polyphonic style"** seed didn't
appear in the 1939 text — the term surfaces in later interviews
and Harmonic Mechanisms framing. Concept preserved via the
documented outer-voice-anchor exercises (14, 18, 20, 57, 60-65,
82); name retired.

## 7 primary-source principles (was 5)

All `applies_to_tunings: ["standard"]` since the 1939 method is
a 6-string method:

1. `harmonized-scale-foundation` — every chord-quality category
   starts with harmonizing the scale in triads (Foreword + Ex. 1, 26, 33, 48)
2. `six-fingering-string-sets` — formal string-set taxonomy (p. 6)
   + the six-form scope of Ex. 1
3. `outer-voice-anchor-inner-motion` — documented across Ex. 14, 18,
   20, 37, 57, 60-65, 67-68, 82 with direct quotes
4. `chromatic-tenths-with-middle-voice` — Ex. 37 direct quote
5. `pulsation-picking-top-voice-emphasis` — replaces "banjo-derived"
   claim with Van Eps's own description
6. `finger-flattening-fifth-finger` — Ex. 16 quoted in full;
   Van Eps's own term is "fifth finger"
7. `string-deadening-for-open-voicings` — Ex. 58 documents the
   left-hand-mutes-while-picking mechanic explicitly

## What about the 7-string?

The 1939 method is **6-string**. Van Eps's 7-string (low A) work
matured later in *Harmonic Mechanisms* (Mel Bay, 1980-82) — that
material isn't in the source consulted here. The bio notes this and
flags 7-string-specific principles (independent low-A bass voice,
the mature "lap piano" framing) as a separate research-pass
followup.

## Why the PDF isn't committed

The 1939 Epiphone publication's copyright status differs from
Greene's openly-distributed estate corpus. The PDF has Glenn
Thompson / DjangoBooks.com watermarks suggesting commercial
redistribution. Read in-session for principle extraction only.

## Research doc

`docs/research/masters/george-van-eps.md` rewritten with verbatim
primary-source quotes for each principle. Includes a "What was
REMOVED" section flagging the corrections. README status table
updated.

## Acceptance

- [x] Van Eps section has 7 primary-source principles
- [x] Each principle cites the 1939 Method directly with exercise
      number and quote
- [x] Research file documents the corrections from the web-sourced
      first pass
- [x] applies_to_tunings: ["standard"] set on all principles
      (6-string method)
- [x] 220 tests pass (no engine changes)

## Self-Review

Trivial-change declaration: content + docs edit. 3 files modified
(masters.json + 2 docs). No engine or schema changes. Track 3
plumbing (#222) consumes the updated principle entries without
modification.

## Closes

- #228 (with updated content from primary source)