### PR TITLE
content(masters): Joe Pass primary-source upgrade from 1977 Method PDF

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -60,6 +60,8 @@ This project builds on the work of many researchers, musicians, and open-source 
   - Chords archive: https://tedgreene.com/teaching/chords.asp
 - **George Van Eps** (1913-1998) — 7-string guitar pioneer, diagonal barre technique, harmonic mechanisms approach.
 - **Joe Pass** (1929-1994) — Economical chord voicing approach, three-shape system.
+  - Pass, Joe, and Bill Thrasher. *Joe Pass Guitar Style.* Gwyn Publishing, 1971.
+  - Pass, Joe. *The Joe Pass Guitar Method.* Chappell & Co., 1977 (distributed by Hal Leonard, HL00347734). Source for the six-Chord-Forms positional system (p. 4), the three- to four-note voicing-with-voice-leading principle (p. 30, head note to "Blues for Nina"; voice-leading panel p. 31), and the dominant-alteration/tritone substitution lattice (p. 25 head note to "Joe's Blues"; p. 30). PDF not redistributed (commercial copyright).
 - **Paul Vachon** — "How to Read Ted Greene Chord Diagrams." [PDF](https://tedgreene.com/images/lessons/students/PaulVachon/HowToReadTedGreeneChordDiagrams.pdf)
 - **James Hober** — V-System mathematical formalization. [PDF](https://tedgreene.com/images/lessons/v_system/02_V-System_Introduction.pdf)
 - **Marten Falk** — Guitar teacher at Lilla Akademien; fingering rules used by Norman & Grozman.

--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -330,6 +330,60 @@
             {
               "source": "Joe Pass Guitar Style",
               "citation": "Pass and Thrasher. Joe Pass Guitar Style. Gwyn, 1971."
+            },
+            {
+              "source": "Joe Pass Guitar Method",
+              "citation": "Pass, Joe. The Joe Pass Guitar Method. Chappell & Co., 1977 (Hal Leonard HL00347734), p. 4: 'With the Chord Forms acting as points of anchor or reference, the ability to create an improvised scale or melody will be unhampered by the struggle to find the notes.'"
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "six-chord-forms-position-system",
+          "name": "Six Chord Forms as positional substrate",
+          "summary": "Pass's framework divides the fingerboard into six overlapping positional regions named for the chord shape that anchors each one — C, A, G, E, D, and Intermediate Forms — each spanning roughly five to six frets. Choosing a voicing is therefore also choosing a position: the player picks the Form whose chord shape lets the melody, bass, and inner voices sit inside one hand position. This is the spatial substrate that makes the walking-bass-plus-chord-stabs and runs-from-chord-shapes principles physically executable.",
+          "voicingStyleTags": ["pass"],
+          "playStyleTags": ["block", "sequential"],
+          "applies_to_modes": ["solo-guitar", "chord-melody", "comping"],
+          "tolerance_hints": {},
+          "references": [
+            {
+              "source": "Joe Pass Guitar Method",
+              "citation": "Pass, Joe. The Joe Pass Guitar Method. Chappell & Co., 1977 (Hal Leonard HL00347734), p. 4: 'Below are six diagrams which are usually learned by all guitarists when beginning to play in first position [...]. All scales are played vertically within each form whose object is to provide a framework in which to function.' The six forms enumerated are C, A, G, E, D (1st inversion of C), and Intermediate (top part of C)."
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "three-to-four-note-voicings-with-voice-leading",
+          "name": "Three- to four-note voicings linked by voice-leading",
+          "summary": "For unaccompanied solo work Pass deliberately reduces voicings to three or four sounding notes and connects successive chords through common tones or stepwise inner-voice motion. Full six-string block chords are avoided as the default. The principle complements drop-2/drop-3 chord-melody — drop voicings supply the shape, this principle constrains the density and the linkage between adjacent chords. Engine signal: floor voicings at three sounding notes; rank candidates that share tones with the previous voicing higher.",
+          "voicingStyleTags": ["pass"],
+          "playStyleTags": ["block", "sequential"],
+          "applies_to_modes": ["solo-guitar", "chord-melody"],
+          "tolerance_hints": {
+            "minSoundingNotes": 3
+          },
+          "references": [
+            {
+              "source": "Joe Pass Guitar Method",
+              "citation": "Pass, Joe. The Joe Pass Guitar Method. Chappell & Co., 1977 (Hal Leonard HL00347734), p. 30, head note to 'Blues for Nina': 'All changes should be reduced to three- or four-note chords. And for better movement, voicings should lead into one another or have a common tone connecting them. Nobs contains several examples of this technique.' The 'EXAMPLES OF VOICE LEADING' panel on p. 31 demonstrates the principle with the sequence Dm9 → C13 → C9(b5) → C9(6)/C7 → Fmaj7."
+            }
+          ],
+          "example_voicing_signatures": []
+        },
+        {
+          "id": "dominant-alteration-substitution-lattice",
+          "name": "Dominant alteration and tritone substitution lattice",
+          "summary": "A written 'simple' dominant chord licenses an entire family of altered and extended substitutes — 9, 13, 9(6), 11, +9, b9, +5, b5 — plus the tritone substitute and its altered family. In the *Joe Pass Guitar Method* this is stated as an explicit rule for the whole 'Blues for Nina / Nobs / Alison / Grete' set: any of these alterations 'may be substituted for simple Dominants.' On Joe's Blues, plain G7 expands to G13, G9, G9(6), G7+9, G7(b9); E7 expands to E+9/Em9/E13/E9 or the tritone family Bb9/Bb+9/Bbm9/Bb13. Engine signal: when ranking voicings against a notated dominant, the altered/extended family and the tritone substitute should both be eligible candidates carrying Pass's style tag.",
+          "voicingStyleTags": ["pass"],
+          "playStyleTags": ["block"],
+          "applies_to_modes": ["solo-guitar", "chord-melody", "comping"],
+          "tolerance_hints": {},
+          "references": [
+            {
+              "source": "Joe Pass Guitar Method",
+              "citation": "Pass, Joe. The Joe Pass Guitar Method. Chappell & Co., 1977 (Hal Leonard HL00347734). 'Joe's Blues' head note, p. 25, enumerates substitutes for G7 (G13/G9/G9(6)/G7+9/G7(b9)), Bm7 in bar 8 (F13/F9/F+9/Fm9, or B7/B9/B13), and E7 (E+9/Em9/E13/E9 or the tritone-substitute family Bb9/Bb+9/Bbm9/Bb13/Bb9). 'Blues for Nina' head note, p. 30: 'Throughout, +9/b9/13/9(6)/11/+5/b5 may be substituted for simple Dominants.'"
             }
           ],
           "example_voicing_signatures": []


### PR DESCRIPTION
## Summary

Refines the `joe-pass` master entry with three new primary-source principles drawn from *The Joe Pass Guitar Method* (Chappell & Co., 1977; current Hal Leonard distribution HL00347734) and adds the Method's p. 4 citation to the existing `runs-from-chord-shapes` principle that it corroborates. PDF redistribution is not done — commercial copyright; principles in our own words with verbatim citations only.

Refs: #230
First PR in the `~/Desktop/parse_these/` walkthrough (Approach A, refinement-first). Think gate: `plans/think-process-parse-these.md` in session `260521-aware-nebula`.

## New principles

| ID | Source location | Engine signal |
|---|---|---|
| `six-chord-forms-position-system` | *Method* p. 4 — six diagrams enumerated (C/A/G/E/D/Intermediate), 5-6 fret regions, "framework in which to function" | None — concept-level, would need new `positionStability` tolerance key |
| `three-to-four-note-voicings-with-voice-leading` | *Method* p. 30, "Blues for Nina" head note (verbatim quote) + p. 31 voice-leading panel demo Dm9→C13→C9(b5)→C9(6)/C7→Fmaj7 | `tolerance_hints.minSoundingNotes: 3` |
| `dominant-alteration-substitution-lattice` | *Method* p. 25 ("Joe's Blues" substitution catalogue: G7→G13/G9/G7+9/G7(b9); E7↔Bb7 tritone family) + p. 30 ("+9/b9/13/9(6)/11/+5/b5 may be substituted for simple Dominants") | None — concept-level, would need new `dominantAlterationOpen` tolerance key |

## Changes

- `plugin/data/masters.json` — joe-pass principles 4 → 7 + one citation added to `runs-from-chord-shapes`. No other masters touched. (+54 lines)
- `REFERENCES.md` — Joe Pass entry expanded with full bibliographic citations for 1971 *Guitar Style* (Gwyn) and 1977 *Method* (Chappell/Hal Leonard), with per-page source index. (+2 lines)

## Engine integration

- All three new principles tagged `voicingStyleTags: ["pass"]` — they flow through the Track-3 (#222) consumption path identically to the existing four.
- `MastersStore.deriveTolerancesFromMaster` "stricter wins" fold: the new `minSoundingNotes: 3` sits between existing joe-pass values of 2 and 4 — fold picks 4 (unchanged behavior).
- Two of three new principles set `tolerance_hints: {}` deliberately. Engine integration of `positionStability` and `dominantAlterationOpen` keys is filed as out-of-scope follow-up.

## Verification

- `python3 -m pytest tests/test_js_modules.py tests/test_core.py -q` → **290 passed** (same as pre-edit baseline).
- `python3 scripts/validate.py -v` → "Valid. 820 voicing(s) passed schema validation." Pre-existing voicings.json warnings unchanged.
- JSON parses; joe-pass principle count = 7; masters total = 9.

## Copyright posture

- 1977 *Method* is commercial (Chappell, Hal Leonard reprint). Principles in our own words with verbatim quotes for falsifiability; PDF not committed; no `masters-corpus/joe-pass/` directory.

## Test plan

- [x] pytest baseline (290) preserved
- [x] scripts/validate.py passes
- [x] JSON parses, principle count correct
- [ ] Owner spot-check that the three new principles read correctly against the Method PDF
- [ ] Owner confirms engine-integration follow-ups (`positionStability`, `dominantAlterationOpen`) are worth a separate ticket vs. dropped

## Follow-ups

- Joe Pass *Guitar Chords* (also in `~/Desktop/parse_these/`) is a sibling primary source — second `joe-pass` refinement PR per one-PDF-one-PR cadence.
- Engine vocabulary expansion if owner wants the two concept-level principles to influence ranking.

Self-review note: `plans/self-review-239-joe-pass-method.md` (session `260521-aware-nebula` plans dir).

🤖 Generated with Craft Agent (Claude Code)