### PR TITLE
feat(schema): #276 Stage A — dual-shape masters schema (principles | systems)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,22 @@ CI runs on every push to main/develop and on all PRs (`.github/workflows/test.ym
 - **Signal handler scoping trap**: Inside `ChildComponent { onSignal: { propName = val } }`, `propName` resolves to the child's property if it declares one, NOT the parent's. Always qualify: `chordLibrary.propName = val`. This caused #154 — context/tuning switching silently wrote to LibraryPanel copies instead of ChordLibrary's canonical state.
 - **Duplicate function names**: QML does not allow two functions with the same name in a component — even if they have different parameter counts. The plugin will fail to load with "Duplicate method name" in the log. Always check `grep -n "function " plugin/ChordLibrary.qml | sed 's/(.*//; s/.*function //' | sort | uniq -d` before committing.
 
+## Masters schema (#220 / #276 Stage A)
+
+`plugin/data/masters.json` is governed by `schema/masters.schema.json`. The schema declares a **dual-shape window**: each master may carry the legacy `principles[]` array, the new `systems[]` array (systems-with-three-layers per `docs/design-philosophy.md`), or both. At least one is required. Per-master migrations land in #277-#285; Stage C will drop `principles`.
+
+**System IDs** are `<master>:<slug>` (e.g. `van-eps:harmonized-scale`). A leading `_placeholder:` prefix marks an intentionally-empty system whose interior is pending design (relaxes the non-empty-members rule).
+
+**Engine payload `kind`** is either one of the 12 canonical CamelCase kinds — `PositionContinuity`, `VoiceMotion`, `RegisterBand`, `ContraryMotion`, `StringSetPreference`, `OmissionPriority`, `TextureCycle`, `DensityBand`, `ApproachAlignment`, `BassIndependence`, `ChordToneSpelling`, `GuideToneTracking` — or a `_pending:<kebab-slug>` placeholder for kinds awaiting design.
+
+**Validate** with:
+
+```
+python scripts/validate.py --target masters
+```
+
+**MastersStore.js** accessors for systems (alongside the existing principle accessors): `allSystems(store)`, `findSystem(store, masterId, systemId)`, `preferencesFor(store, masterId)`, `findPreferenceById(store, prefId)`, plus `counts(store)` now reports `systems`.
+
 ---
 
-*Last updated: 2026-04-16*
+*Last updated: 2026-05-22*

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -139,7 +139,7 @@ If a decision is load-bearing enough to outlive the conversation that produced i
 |---|---|
 | Project framing for AI agents | [`.agents/skills/jazz-system/SKILL.md`](../.agents/skills/jazz-system/SKILL.md) |
 | Project conventions (existing) | [`CLAUDE.md`](../CLAUDE.md) |
-| Master schema (planned) | `schema/masters.schema.json` (rewrite per #249) |
+| Master schema | [`schema/masters.schema.json`](../schema/masters.schema.json) — Stage A dual-shape window per #276; per-master migration in #277-#285 |
 | Voicing descriptor schema (planned) | `schema/voicings.schema.json` (extend per #249's voicing-descriptor pairing) |
 | Base-case content (planned) | `docs/base-case-berklee-content.md` (to be written) |
 | Open architecture tickets | #240, #241, #242, #243, #244, #245, #246, #247, #248, #249, #250, #251 |

--- a/plugin/model/MastersStore.js
+++ b/plugin/model/MastersStore.js
@@ -3,7 +3,12 @@
 // MastersStore.js — load + validate + query the Masters' Lessons bookshelf
 // (#220).
 //
-// Source-of-truth file: plugin/data/masters.json. Schema:
+// Source-of-truth file: plugin/data/masters.json. Authoritative schema:
+// schema/masters.schema.json. Each Master may declare legacy `principles[]`
+// AND/OR new `systems[]` (#276 Stage A dual-shape window). Per-master
+// migration lands in #277-#285; Stage C removes `principles`.
+//
+// Legacy shape:
 //   {
 //     version: "v1",
 //     masters: [
@@ -160,11 +165,80 @@ function deriveTolerancesFromMaster(master, tightenFn) {
 
 // Summary counts useful for UI badges.
 function counts(store) {
-    var c = { masters: 0, principles: 0 }
+    var c = { masters: 0, principles: 0, systems: 0 }
     if (!store || !store.masters) return c
     c.masters = store.masters.length
     for (var i = 0; i < store.masters.length; i++) {
         c.principles += (store.masters[i].principles || []).length
+        c.systems += (store.masters[i].systems || []).length
     }
     return c
+}
+
+// --- Systems accessors (#276 Stage A) -----------------------------------
+// Each Master may carry a `systems[]` array alongside `principles[]` per
+// the dual-shape window in schema/masters.schema.json. Per-master migration
+// from principles -> systems lands in #277-#285.
+
+// Flat list of every system across all masters with attribution.
+// Returns [{ masterId, masterName, system }, ...].
+function allSystems(store) {
+    var out = []
+    if (!store || !store.masters) return out
+    for (var i = 0; i < store.masters.length; i++) {
+        var m = store.masters[i]
+        var ss = m.systems || []
+        for (var j = 0; j < ss.length; j++) {
+            out.push({ masterId: m.id, masterName: m.name, system: ss[j] })
+        }
+    }
+    return out
+}
+
+// Find a system by (masterId, systemId); returns null if not found.
+function findSystem(store, masterId, systemId) {
+    var master = findMaster(store, masterId)
+    if (!master || !master.systems) return null
+    for (var i = 0; i < master.systems.length; i++) {
+        if (master.systems[i].id === systemId) return master.systems[i]
+    }
+    return null
+}
+
+// Flat list of preferences across systems. If masterId is provided, scope
+// to that master; otherwise scan all masters.
+// Returns [{ masterId, masterName, systemId, preference }, ...].
+function preferencesFor(store, masterId) {
+    var out = []
+    if (!store || !store.masters) return out
+    for (var i = 0; i < store.masters.length; i++) {
+        var m = store.masters[i]
+        if (masterId && m.id !== masterId) continue
+        var ss = m.systems || []
+        for (var j = 0; j < ss.length; j++) {
+            var prefs = ss[j].preferences || []
+            for (var k = 0; k < prefs.length; k++) {
+                out.push({
+                    masterId: m.id,
+                    masterName: m.name,
+                    systemId: ss[j].id,
+                    preference: prefs[k]
+                })
+            }
+        }
+    }
+    return out
+}
+
+// Find the first preference by id across all systems of all masters.
+// Returns { masterId, masterName, systemId, preference } or null.
+function findPreferenceById(store, preferenceId) {
+    if (!preferenceId) return null
+    var hits = preferencesFor(store, null)
+    for (var i = 0; i < hits.length; i++) {
+        if (hits[i].preference && hits[i].preference.id === preferenceId) {
+            return hits[i]
+        }
+    }
+    return null
 }

--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Masters' Lessons Bookshelf (#220 / #276 Stage A)",
+  "description": "Schema for plugin/data/masters.json. Stage A introduces a dual-shape window: each master may declare legacy 'principles' (v1) and/or new 'systems' (systems-with-three-layers per docs/design-philosophy.md). At least one of the two must be present. Per-master migration is tracked in #277-#285; Stage C will deprecate 'principles'.",
+  "type": "object",
+  "required": ["version", "masters"],
+  "properties": {
+    "version": { "const": "v1" },
+    "schemaNote": { "type": "string" },
+    "masters": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/master" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "master": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9_-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "lived": { "type": "string" },
+        "traditions": { "type": "array", "items": { "type": "string" } },
+        "instrument": { "type": "string" },
+        "biography": { "type": "string" },
+        "principles": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/principle" }
+        },
+        "systems": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/system" }
+        }
+      },
+      "anyOf": [
+        { "required": ["principles"] },
+        { "required": ["systems"] }
+      ],
+      "additionalProperties": true
+    },
+    "principle": {
+      "type": "object",
+      "required": ["id", "name", "summary"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9_-]+$" },
+        "name": { "type": "string" },
+        "summary": { "type": "string" },
+        "voicingStyleTags": { "type": "array", "items": { "type": "string" } },
+        "playStyleTags": { "type": "array", "items": { "type": "string" } },
+        "applies_to_modes": { "type": "array", "items": { "type": "string" } },
+        "applies_to_tunings": { "type": "array", "items": { "type": "string" } },
+        "tolerance_hints": { "type": "object" },
+        "references": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["source"],
+            "properties": {
+              "source": { "type": "string" },
+              "citation": { "type": "string" },
+              "url": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "example_voicing_signatures": { "type": "array" }
+      },
+      "additionalProperties": true
+    },
+    "system": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^(_placeholder:)?[a-z0-9_-]+:[a-z0-9_-]+$",
+          "description": "Format '<master>:<system-slug>'. A '_placeholder:' prefix marks a system whose interior is intentionally empty pending design — placeholder shape relaxes the non-empty-members rule."
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string" },
+        "members": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/taxonomy" }
+        },
+        "traversal_rules": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/rule" }
+        },
+        "modification_rules": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/rule" }
+        },
+        "preferences": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/preference" }
+        },
+        "examples": { "type": "array" },
+        "references": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["source"],
+            "properties": {
+              "source": { "type": "string" },
+              "citation": { "type": "string" },
+              "url": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "description": "Placeholder shape: id begins with '_placeholder:'; members/rules may be omitted or empty.",
+          "properties": {
+            "id": { "pattern": "^_placeholder:[a-z0-9_-]+:[a-z0-9_-]+$" }
+          },
+          "required": ["id"]
+        },
+        {
+          "description": "Real shape: non-empty members[] AND at least one of traversal_rules or modification_rules non-empty.",
+          "properties": {
+            "id": { "pattern": "^[a-z0-9_-]+:[a-z0-9_-]+$" },
+            "members": { "type": "array", "minItems": 1 }
+          },
+          "required": ["members"],
+          "anyOf": [
+            { "properties": { "traversal_rules":   { "type": "array", "minItems": 1 } }, "required": ["traversal_rules"] },
+            { "properties": { "modification_rules":{ "type": "array", "minItems": 1 } }, "required": ["modification_rules"] }
+          ]
+        }
+      ],
+      "additionalProperties": true
+    },
+    "taxonomy": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string" },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "rule": {
+      "type": "object",
+      "required": ["id", "name", "engine_payload"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string" },
+        "engine_payload": { "$ref": "#/$defs/engine_payload" }
+      },
+      "additionalProperties": true
+    },
+    "engine_payload": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "enum": [
+                "PositionContinuity",
+                "VoiceMotion",
+                "RegisterBand",
+                "ContraryMotion",
+                "StringSetPreference",
+                "OmissionPriority",
+                "TextureCycle",
+                "DensityBand",
+                "ApproachAlignment",
+                "BassIndependence",
+                "ChordToneSpelling",
+                "GuideToneTracking"
+              ]
+            },
+            { "type": "string", "pattern": "^_pending:[a-z0-9-]+$" }
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "preference": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string" },
+        "engine_payload": { "$ref": "#/$defs/engine_payload" }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Validate voicings.json against the JSON schema and verify note accuracy.
+"""Validate plugin data files against their JSON schemas.
 
 Usage:
     python scripts/validate.py
+    python scripts/validate.py --target voicings
+    python scripts/validate.py --target masters
     python scripts/validate.py --data path/to/voicings.json
     python scripts/validate.py --verbose
     python scripts/validate.py --tuning tunings/7string-low-b.json
@@ -24,6 +26,17 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_SCHEMA = REPO_ROOT / "schema" / "voicings.schema.json"
 DEFAULT_DATA = REPO_ROOT / "plugin" / "data" / "voicings.json"
 DEFAULT_TUNING = REPO_ROOT / "plugin" / "tunings" / "7string-van-eps.json"
+
+TARGETS = {
+    "voicings": {
+        "schema": REPO_ROOT / "schema" / "voicings.schema.json",
+        "data":   REPO_ROOT / "plugin" / "data" / "voicings.json",
+    },
+    "masters": {
+        "schema": REPO_ROOT / "schema" / "masters.schema.json",
+        "data":   REPO_ROOT / "plugin" / "data" / "masters.json",
+    },
+}
 
 # Chromatic note names (using sharps and flats consistently)
 CHROMATIC = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
@@ -224,6 +237,84 @@ def validate(schema_path: Path, data_path: Path, verbose: bool = False) -> bool:
     return False
 
 
+def validate_masters(schema_path: Path, data_path: Path, verbose: bool = False) -> bool:
+    """Schema-validate plugin/data/masters.json and run masters-specific
+    consistency checks. See schema/masters.schema.json for the dual-shape
+    window (principles[] legacy / systems[] new)."""
+    with open(schema_path) as f:
+        schema = json.load(f)
+    with open(data_path) as f:
+        data = json.load(f)
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+
+    if errors:
+        print(f"INVALID. {len(errors)} schema error(s) found:\n", file=sys.stderr)
+        for i, error in enumerate(errors, 1):
+            path = " > ".join(str(p) for p in error.absolute_path) or "(root)"
+            print(f"  {i}. [{path}] {error.message}", file=sys.stderr)
+        return False
+
+    masters = data.get("masters", [])
+    print(f"Valid. {len(masters)} master(s) passed schema validation.")
+
+    warnings = _check_masters_consistency(data)
+    if warnings:
+        print(f"\n{len(warnings)} consistency warning(s):", file=sys.stderr)
+        for w in warnings:
+            print(f"  - {w}", file=sys.stderr)
+
+    if verbose:
+        n_p = sum(len(m.get("principles", [])) for m in masters)
+        n_s = sum(len(m.get("systems", [])) for m in masters)
+        print(f"\n--- Summary ---")
+        print(f"Masters: {len(masters)}")
+        print(f"Principles (legacy): {n_p}")
+        print(f"Systems (new): {n_s}")
+
+    return True
+
+
+def _check_masters_consistency(data: dict) -> list[str]:
+    """Cross-cutting checks beyond JSON Schema for masters.json."""
+    warnings: list[str] = []
+    seen_master_ids: set[str] = set()
+
+    for m in data.get("masters", []):
+        mid = m.get("id", "<no-id>")
+        if mid in seen_master_ids:
+            warnings.append(f"Duplicate master id: {mid}")
+        seen_master_ids.add(mid)
+
+        seen_principle_ids: set[str] = set()
+        for p in m.get("principles", []) or []:
+            pid = p.get("id", "<no-id>")
+            if pid in seen_principle_ids:
+                warnings.append(f"{mid}: duplicate principle id '{pid}'")
+            seen_principle_ids.add(pid)
+
+        seen_system_ids: set[str] = set()
+        for s in m.get("systems", []) or []:
+            sid = s.get("id", "<no-id>")
+            if sid in seen_system_ids:
+                warnings.append(f"{mid}: duplicate system id '{sid}'")
+            seen_system_ids.add(sid)
+
+            # Per docs/design-philosophy.md, system ids carry an owner prefix
+            # '<master>:<slug>' (optionally '_placeholder:'-prefixed). The
+            # owner prefix should match the enclosing master's id.
+            bare = sid[len("_placeholder:"):] if sid.startswith("_placeholder:") else sid
+            owner_prefix = bare.split(":", 1)[0] if ":" in bare else ""
+            if owner_prefix and owner_prefix != mid:
+                warnings.append(
+                    f"{mid}: system id '{sid}' owner prefix '{owner_prefix}' "
+                    f"does not match master id"
+                )
+
+    return warnings
+
+
 def _check_consistency(data: dict) -> list[str]:
     """Run additional consistency checks beyond schema validation."""
     warnings = []
@@ -369,32 +460,46 @@ def _print_summary(data: dict) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Validate voicings.json")
+    parser = argparse.ArgumentParser(description="Validate plugin data files")
     parser.add_argument(
-        "--schema", type=Path, default=DEFAULT_SCHEMA, help="Path to JSON schema"
+        "--target",
+        choices=sorted(TARGETS.keys()),
+        default="voicings",
+        help="Which data file to validate (default: voicings)",
     )
     parser.add_argument(
-        "--data", type=Path, default=DEFAULT_DATA, help="Path to voicings.json"
+        "--schema", type=Path, default=None, help="Override schema path"
+    )
+    parser.add_argument(
+        "--data", type=Path, default=None, help="Override data path"
     )
     parser.add_argument(
         "--tuning", type=Path, default=DEFAULT_TUNING,
-        help="Path to tuning config JSON (default: config/tunings/standard.json)"
+        help="Path to tuning config JSON (voicings target only)"
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="Show summary")
     args = parser.parse_args()
 
-    if not args.schema.exists():
-        print(f"Schema not found: {args.schema}", file=sys.stderr)
+    target = TARGETS[args.target]
+    schema_path = args.schema or target["schema"]
+    data_path = args.data or target["data"]
+
+    if not schema_path.exists():
+        print(f"Schema not found: {schema_path}", file=sys.stderr)
         sys.exit(1)
-    if not args.data.exists():
-        print(f"Data not found: {args.data}", file=sys.stderr)
+    if not data_path.exists():
+        print(f"Data not found: {data_path}", file=sys.stderr)
         sys.exit(1)
 
-    valid = validate(args.schema, args.data, args.verbose)
+    if args.target == "masters":
+        ok = validate_masters(schema_path, data_path, args.verbose)
+        sys.exit(0 if ok else 1)
+
+    valid = validate(schema_path, data_path, args.verbose)
 
     # Load tuning and run all checks
     tuning = _load_tuning(args.tuning)
-    with open(args.data) as f:
+    with open(data_path) as f:
         data = json.load(f)
 
     # Consistency checks

--- a/tests/test_masters_schema.py
+++ b/tests/test_masters_schema.py
@@ -1,0 +1,245 @@
+"""Schema tests for plugin/data/masters.json (#276 Stage A).
+
+Covers the dual-shape window introduced in schema/masters.schema.json:
+each master may declare legacy `principles[]`, new `systems[]`, or both;
+at least one is required. System ids follow `<master>:<slug>` and may
+be prefixed with `_placeholder:`. Engine payload kinds are either one of
+12 CamelCase canonical kinds or a `_pending:<kebab>` placeholder.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "schema" / "masters.schema.json"
+DATA_PATH = REPO_ROOT / "plugin" / "data" / "masters.json"
+
+
+@pytest.fixture(scope="module")
+def schema():
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def validator(schema):
+    return Draft202012Validator(schema)
+
+
+def _base_master(extra=None):
+    m = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "principles": [
+            {
+                "id": "harmonized-scale",
+                "name": "Harmonized scale",
+                "summary": "...",
+            }
+        ],
+    }
+    if extra:
+        m.update(extra)
+    return m
+
+
+def _doc(masters):
+    return {"version": "v1", "masters": masters}
+
+
+# === Positive cases ===
+
+def test_existing_masters_json_validates(validator):
+    data = json.loads(DATA_PATH.read_text())
+    errors = list(validator.iter_errors(data))
+    assert errors == [], [e.message for e in errors]
+
+
+def test_legacy_principles_only_is_valid(validator):
+    doc = _doc([_base_master()])
+    assert list(validator.iter_errors(doc)) == []
+
+
+def test_systems_only_is_valid(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "systems": [
+            {
+                "id": "van-eps:harmonized-scale",
+                "name": "Harmonized scale",
+                "members": [{"id": "triad-major", "name": "Major triad"}],
+                "traversal_rules": [
+                    {
+                        "id": "step-up",
+                        "name": "Step up",
+                        "engine_payload": {"kind": "PositionContinuity"},
+                    }
+                ],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+def test_placeholder_system_allows_empty_interior(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "systems": [
+            {
+                "id": "_placeholder:van-eps:future-system",
+                "name": "Future system",
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+def test_pending_payload_kind_is_valid(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "systems": [
+            {
+                "id": "van-eps:foo",
+                "name": "Foo",
+                "members": [{"id": "x", "name": "X"}],
+                "modification_rules": [
+                    {
+                        "id": "swap",
+                        "name": "Swap",
+                        "engine_payload": {"kind": "_pending:swap-thing"},
+                    }
+                ],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+def test_both_principles_and_systems_is_valid(validator):
+    master = _base_master({
+        "systems": [
+            {
+                "id": "van-eps:harmonized-scale",
+                "name": "Harmonized scale",
+                "members": [{"id": "m", "name": "M"}],
+                "traversal_rules": [
+                    {
+                        "id": "t",
+                        "name": "T",
+                        "engine_payload": {"kind": "VoiceMotion"},
+                    }
+                ],
+            }
+        ],
+    })
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+# === Negative cases ===
+
+def test_master_without_principles_or_systems_is_invalid(validator):
+    bad = {"id": "x", "name": "X"}
+    errors = list(validator.iter_errors(_doc([bad])))
+    assert errors, "master with neither principles nor systems must fail"
+
+
+def test_wrong_version_rejected(validator):
+    doc = {"version": "v2", "masters": [_base_master()]}
+    assert list(validator.iter_errors(doc))
+
+
+def test_unknown_payload_kind_rejected(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "systems": [
+            {
+                "id": "van-eps:foo",
+                "name": "Foo",
+                "members": [{"id": "x", "name": "X"}],
+                "traversal_rules": [
+                    {
+                        "id": "r",
+                        "name": "R",
+                        "engine_payload": {"kind": "MadeUpKind"},
+                    }
+                ],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master])))
+
+
+def test_pending_payload_must_be_kebab(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "systems": [
+            {
+                "id": "van-eps:foo",
+                "name": "Foo",
+                "members": [{"id": "x", "name": "X"}],
+                "traversal_rules": [
+                    {
+                        "id": "r",
+                        "name": "R",
+                        "engine_payload": {"kind": "_pending:NotKebab"},
+                    }
+                ],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master])))
+
+
+def test_system_id_must_have_owner_prefix(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "systems": [
+            {
+                "id": "harmonized-scale",
+                "name": "Harmonized scale",
+                "members": [{"id": "m", "name": "M"}],
+                "traversal_rules": [
+                    {
+                        "id": "t",
+                        "name": "T",
+                        "engine_payload": {"kind": "PositionContinuity"},
+                    }
+                ],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master])))
+
+
+def test_real_system_must_have_members_and_a_rule(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "systems": [
+            {"id": "van-eps:empty", "name": "Empty"}
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master])))
+
+
+def test_real_system_with_members_but_no_rules_is_invalid(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "systems": [
+            {
+                "id": "van-eps:members-only",
+                "name": "Members only",
+                "members": [{"id": "x", "name": "X"}],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master])))


### PR DESCRIPTION
## Summary

Introduces `schema/masters.schema.json` governing `plugin/data/masters.json` with a **dual-shape window** per #276 Stage A: each master may carry the legacy `principles[]` array, the new `systems[]` array (systems-with-three-layers per `docs/design-philosophy.md`), or both. At least one is required. Per-master migration tracked in #277-#285; Stage C will drop `principles`.

- Schema: `_placeholder:` prefix relaxes the non-empty-members rule for systems pending design; `engine_payload.kind` is either one of 12 canonical CamelCase kinds (PositionContinuity / VoiceMotion / RegisterBand / ContraryMotion / StringSetPreference / OmissionPriority / TextureCycle / DensityBand / ApproachAlignment / BassIndependence / ChordToneSpelling / GuideToneTracking) or a `_pending:<kebab>` placeholder.
- `scripts/validate.py` grows `--target {voicings,masters}`; `--target masters` runs schema + masters-specific consistency checks (duplicate ids, system-id owner-prefix match).
- `plugin/model/MastersStore.js` gains `allSystems` / `findSystem` / `preferencesFor` / `findPreferenceById`; `counts()` now reports `systems` alongside `principles`.
- `tests/test_masters_schema.py`: 13 positive/negative cases covering both shapes, placeholder relaxation, payload-kind enum + `_pending:` pattern, owner-prefix enforcement, real-system minimums.
- `CLAUDE.md` gains a "Masters schema" section; `docs/design-philosophy.md` lineage row for the schema is no longer `(planned)`.

**Backward compatibility:** existing `plugin/data/masters.json` (9 masters, 41 principles, 0 systems) validates clean with zero data changes.

## Test plan

- [x] `python scripts/validate.py --target masters --verbose` — 9 masters pass
- [x] `python scripts/validate.py --target voicings` — 820 voicings pass (no regressions; pre-existing data warnings unchanged)
- [x] `python3 -m pytest tests/test_masters_schema.py -v` — 13/13 pass
- [x] `python3 -m pytest tests/ -q` — 319/323 pass; 4 failures are pre-existing `TestClipboardPipeline` env tests (launchd/pasteboard machinery), unrelated to this diff
- [ ] CI on this PR

Refs #220 #249 #250 #251

Companion CI tickets surfaced during housekeeping: #288 (test_gp5_export_runs missing MuseScore binary), #289 (Windows MAX_PATH on two tests).