### PR TITLE
fix(scripts/library_hygiene): #291 derive context from modes[] when legacy field absent

### DIFF
--- a/scripts/library_hygiene.py
+++ b/scripts/library_hygiene.py
@@ -162,12 +162,23 @@ def audit(data: dict, tuning: dict[int, int]) -> dict:
                 })
 
     # 3. Cross-context: same shape in different contexts
+    # The legacy 'context' field was replaced by 'modes' (see
+    # schema/voicings.schema.json). Derive a comparable single label from
+    # modes[0] when 'context' is absent so the cross-context analysis still
+    # runs on current data. Voicings with neither field fall back to
+    # "unknown" — they group together but won't masquerade as a real bucket.
+    def _context_of(v: dict) -> str:
+        if "context" in v:
+            return v["context"]
+        modes = v.get("modes") or []
+        return modes[0] if modes else "unknown"
+
     by_shape_context: dict[tuple, list] = defaultdict(list)
     for v in voicings:
         shape = shape_fingerprint(v)
         by_shape_context[shape].append({
             "id": v["id"],
-            "context": v["context"],
+            "context": _context_of(v),
             "category": v["category"],
         })
 
@@ -186,7 +197,7 @@ def audit(data: dict, tuning: dict[int, int]) -> dict:
         by_shape_type[shape].append({
             "id": v["id"],
             "category": v["category"],
-            "context": v["context"],
+            "context": _context_of(v),
         })
 
     for shape, group in by_shape_type.items():


### PR DESCRIPTION
## Summary

\`scripts/library_hygiene.py\` was crashing with \`KeyError: 'context'\` because the legacy \`context\` field has been removed from every voicing in \`plugin/data/voicings.json\` (820/820 missing). The schema (\`schema/voicings.schema.json\`) explicitly notes \`modes\` "Replaces the legacy context field."

Adds a defensive \`_context_of(v)\` helper that prefers \`v[\"context\"]\` for any voicing that still has it, falls back to \`modes[0]\`, else \`\"unknown\"\`. CI's 'Validate voicing library / Run library hygiene check' goes green.

The analytic value of cross-context-via-\`modes[0]\` under modes-as-array semantics is a separate redesign question, deliberately out of scope for this hot-fix.

## Test plan

- [x] \`python3 scripts/library_hygiene.py\` runs end-to-end locally; ends with "Total: 386 groups flagged for review" instead of KeyError
- [ ] CI 'Validate voicing library' goes green on this PR

Fixes #291