### PR TITLE
feat(schema): #293 Stage A.1 — add optional works[] layer to master shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,21 +187,45 @@ CI runs on every push to main/develop and on all PRs (`.github/workflows/test.ym
 - **Signal handler scoping trap**: Inside `ChildComponent { onSignal: { propName = val } }`, `propName` resolves to the child's property if it declares one, NOT the parent's. Always qualify: `chordLibrary.propName = val`. This caused #154 — context/tuning switching silently wrote to LibraryPanel copies instead of ChordLibrary's canonical state.
 - **Duplicate function names**: QML does not allow two functions with the same name in a component — even if they have different parameter counts. The plugin will fail to load with "Duplicate method name" in the log. Always check `grep -n "function " plugin/ChordLibrary.qml | sed 's/(.*//; s/.*function //' | sort | uniq -d` before committing.
 
-## Masters schema (#220 / #276 Stage A)
+## Masters schema (#220 / #276 Stage A / #293 Stage A.1)
 
-`plugin/data/masters.json` is governed by `schema/masters.schema.json`. The schema declares a **dual-shape window**: each master may carry the legacy `principles[]` array, the new `systems[]` array (systems-with-three-layers per `docs/design-philosophy.md`), or both. At least one is required. Per-master migrations land in #277-#285; Stage C will drop `principles`.
+`plugin/data/masters.json` is governed by `schema/masters.schema.json`. The schema declares a **multi-shape window**: each master may carry any of the legacy `principles[]` array, the new `systems[]` array (systems-with-three-layers per `docs/design-philosophy.md`), or the `works[]` layer (multi-method masters). At least one is required. Per-master migrations land in #277-#285; Stage C will drop `principles`.
 
-**System IDs** are `<master>:<slug>` (e.g. `van-eps:harmonized-scale`). A leading `_placeholder:` prefix marks an intentionally-empty system whose interior is pending design (relaxes the non-empty-members rule).
+### Works (multi-method masters)
 
-**Engine payload `kind`** is either one of the 12 canonical CamelCase kinds — `PositionContinuity`, `VoiceMotion`, `RegisterBand`, `ContraryMotion`, `StringSetPreference`, `OmissionPriority`, `TextureCycle`, `DensityBand`, `ApproachAlignment`, `BassIndependence`, `ChordToneSpelling`, `GuideToneTracking` — or a `_pending:<kebab-slug>` placeholder for kinds awaiting design.
+Masters whose body of method content spans multiple books or eras place each one in `works[]`. Each work has `id` (kebab, master-local), `title` (required), and may carry `year`, `instrument_scope`, `summary`, `references`, and its own `systems[]`. Use this for Van Eps (1939 Method vs Harmonic Mechanisms 1980-82), Martin Taylor (multiple contradictory books), or any master where one prescription doesn't speak for the whole oeuvre. Single-method masters (Berklee codified consensus) put systems directly on `master.systems[]` and do NOT need `works[]`.
 
-**Validate** with:
+Cross-work systems are NOT modeled — the same idea appearing in three books with three prescriptions becomes three separate systems, one per work. The engine consults one work at a time.
+
+A work id may be prefixed `_placeholder:` (e.g. `_placeholder:harmonic-mechanisms`) for an entry whose content is pending research; its `systems[]` may be empty or absent.
+
+### System IDs
+
+- On `master.systems[]`: **2 segments** — `<master>:<slug>` (e.g. `berklee:guide-tone-tracking`).
+- On `master.works[*].systems[]`: **3 segments** — `<master>:<work>:<slug>` (e.g. `van-eps:1939-method:harmonized-scale`).
+- Either form may be prefixed `_placeholder:` for an intentionally-empty system whose interior is pending design.
+
+### Engine payload `kind`
+
+Either one of the 12 canonical CamelCase kinds — `PositionContinuity`, `VoiceMotion`, `RegisterBand`, `ContraryMotion`, `StringSetPreference`, `OmissionPriority`, `TextureCycle`, `DensityBand`, `ApproachAlignment`, `BassIndependence`, `ChordToneSpelling`, `GuideToneTracking` — or a `_pending:<kebab-slug>` placeholder for kinds awaiting design.
+
+### Validate
 
 ```
 python scripts/validate.py --target masters
 ```
 
-**MastersStore.js** accessors for systems (alongside the existing principle accessors): `allSystems(store)`, `findSystem(store, masterId, systemId)`, `preferencesFor(store, masterId)`, `findPreferenceById(store, prefId)`, plus `counts(store)` now reports `systems`.
+Runs schema validation plus consistency checks: duplicate ids (master/principle/system/work), system-id prefix-matches-enclosing-master, work-scoped system-id work-segment-matches-enclosing-work, and 2-vs-3-segment placement rules.
+
+### MastersStore.js accessors
+
+Systems (walk both master.systems and master.works[*].systems): `allSystems(store)`, `findSystem(store, masterId, systemId)`.
+
+Works: `allWorks(store)`, `findWork(store, masterId, workId)`, `systemsForWork(store, masterId, workId)`.
+
+Preferences: `preferencesFor(store, masterId)` (walks works), `findPreferenceById(store, prefId)`.
+
+`counts(store)` reports `{ masters, principles, systems, works }`. `systems` includes work-scoped systems.
 
 ---
 

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -121,6 +121,20 @@ A user wanting a more conservative experience can stay with `master: berklee, st
 
 ---
 
+## 6a. Works as the unit of authority (Stage A.1 amendment, #293)
+
+The unit of authority in instructional method literature is **the work, not the master.** Van Eps wrote two methods — the 1939 6-string and Harmonic Mechanisms 1980-82 (7-string, lap-piano counterpoint) — that share principles (harmonized scale as vocabulary) but diverge sharply (7-string-only bass independence on the low A). Martin Taylor has multiple books that contradict each other at the technique level, not cleanly by date. Splitting Van Eps into two pseudo-masters wouldn't generalize to Taylor and would duplicate biography/traditions.
+
+**Schema response:** masters may carry an optional `works[]` layer. Each work has its own `systems[]`. Multi-method masters (Van Eps, Taylor) use it; single-method masters (Berklee, anyone whose oeuvre is undivided) keep `systems[]` directly on the master.
+
+**Cross-work systems are not modeled.** If the same idea appears in three books with three prescriptions, those become three independent systems — one per work. The engine consults one work at a time. This is honest about contradictions instead of inventing "the canonical Taylor view of guide-tone tracking."
+
+**System ids reflect their layer:** `<master>:<slug>` at the master level, `<master>:<work>:<slug>` when inside a work. Both may carry the `_placeholder:` prefix for entries pending content.
+
+**Tracking:** schema in [`schema/masters.schema.json`](../schema/masters.schema.json) post-#293. Per-master migration tickets #277-#285 must decide for each master whether to use `works[]` or place systems at the master level; this is a thinking act, not a transform.
+
+---
+
 ## 7. Documentation discipline
 
 Project-defining decisions land in **three places, not one**:
@@ -139,7 +153,7 @@ If a decision is load-bearing enough to outlive the conversation that produced i
 |---|---|
 | Project framing for AI agents | [`.agents/skills/jazz-system/SKILL.md`](../.agents/skills/jazz-system/SKILL.md) |
 | Project conventions (existing) | [`CLAUDE.md`](../CLAUDE.md) |
-| Master schema | [`schema/masters.schema.json`](../schema/masters.schema.json) — Stage A dual-shape window per #276; per-master migration in #277-#285 |
+| Master schema | [`schema/masters.schema.json`](../schema/masters.schema.json) — Stage A dual-shape window (#276); Stage A.1 works layer (#293); per-master migration in #277-#285 |
 | Voicing descriptor schema (planned) | `schema/voicings.schema.json` (extend per #249's voicing-descriptor pairing) |
 | Base-case content (planned) | `docs/base-case-berklee-content.md` (to be written) |
 | Open architecture tickets | #240, #241, #242, #243, #244, #245, #246, #247, #248, #249, #250, #251 |

--- a/plugin/model/MastersStore.js
+++ b/plugin/model/MastersStore.js
@@ -4,9 +4,15 @@
 // (#220).
 //
 // Source-of-truth file: plugin/data/masters.json. Authoritative schema:
-// schema/masters.schema.json. Each Master may declare legacy `principles[]`
-// AND/OR new `systems[]` (#276 Stage A dual-shape window). Per-master
-// migration lands in #277-#285; Stage C removes `principles`.
+// schema/masters.schema.json. Each Master may declare any of:
+//   - principles[]  (#276 Stage A legacy, untouched)
+//   - systems[]     (#276 Stage A, for single-method masters like Berklee)
+//   - works[]       (#293 Stage A.1, for multi-method masters like Van Eps's
+//                    1939 Method vs Harmonic Mechanisms, or Martin Taylor's
+//                    multiple books)
+// At least one must be present. When a master has works[], its systems live
+// inside each work; the engine consults a specific work, not the master.
+// Per-master migration lands in #277-#285; Stage C removes `principles`.
 //
 // Legacy shape:
 //   {
@@ -163,25 +169,32 @@ function deriveTolerancesFromMaster(master, tightenFn) {
     return combined
 }
 
-// Summary counts useful for UI badges.
+// Summary counts useful for UI badges. `systems` includes both master-level
+// systems and any systems living inside works[].systems.
 function counts(store) {
-    var c = { masters: 0, principles: 0, systems: 0 }
+    var c = { masters: 0, principles: 0, systems: 0, works: 0 }
     if (!store || !store.masters) return c
     c.masters = store.masters.length
     for (var i = 0; i < store.masters.length; i++) {
-        c.principles += (store.masters[i].principles || []).length
-        c.systems += (store.masters[i].systems || []).length
+        var m = store.masters[i]
+        c.principles += (m.principles || []).length
+        c.systems += (m.systems || []).length
+        var ws = m.works || []
+        c.works += ws.length
+        for (var j = 0; j < ws.length; j++) {
+            c.systems += (ws[j].systems || []).length
+        }
     }
     return c
 }
 
-// --- Systems accessors (#276 Stage A) -----------------------------------
-// Each Master may carry a `systems[]` array alongside `principles[]` per
-// the dual-shape window in schema/masters.schema.json. Per-master migration
-// from principles -> systems lands in #277-#285.
+// --- Systems accessors (#276 Stage A, extended #293 Stage A.1) ----------
+// `allSystems` walks both master.systems and master.works[*].systems. Each
+// entry carries workId/workTitle (null for master-level systems) so UI
+// surfaces can render per-work provenance.
 
 // Flat list of every system across all masters with attribution.
-// Returns [{ masterId, masterName, system }, ...].
+// Returns [{ masterId, masterName, workId, workTitle, system }, ...].
 function allSystems(store) {
     var out = []
     if (!store || !store.masters) return out
@@ -189,40 +202,21 @@ function allSystems(store) {
         var m = store.masters[i]
         var ss = m.systems || []
         for (var j = 0; j < ss.length; j++) {
-            out.push({ masterId: m.id, masterName: m.name, system: ss[j] })
+            out.push({
+                masterId: m.id, masterName: m.name,
+                workId: null, workTitle: null,
+                system: ss[j]
+            })
         }
-    }
-    return out
-}
-
-// Find a system by (masterId, systemId); returns null if not found.
-function findSystem(store, masterId, systemId) {
-    var master = findMaster(store, masterId)
-    if (!master || !master.systems) return null
-    for (var i = 0; i < master.systems.length; i++) {
-        if (master.systems[i].id === systemId) return master.systems[i]
-    }
-    return null
-}
-
-// Flat list of preferences across systems. If masterId is provided, scope
-// to that master; otherwise scan all masters.
-// Returns [{ masterId, masterName, systemId, preference }, ...].
-function preferencesFor(store, masterId) {
-    var out = []
-    if (!store || !store.masters) return out
-    for (var i = 0; i < store.masters.length; i++) {
-        var m = store.masters[i]
-        if (masterId && m.id !== masterId) continue
-        var ss = m.systems || []
-        for (var j = 0; j < ss.length; j++) {
-            var prefs = ss[j].preferences || []
-            for (var k = 0; k < prefs.length; k++) {
+        var ws = m.works || []
+        for (var w = 0; w < ws.length; w++) {
+            var work = ws[w]
+            var wss = work.systems || []
+            for (var k = 0; k < wss.length; k++) {
                 out.push({
-                    masterId: m.id,
-                    masterName: m.name,
-                    systemId: ss[j].id,
-                    preference: prefs[k]
+                    masterId: m.id, masterName: m.name,
+                    workId: work.id, workTitle: work.title,
+                    system: wss[k]
                 })
             }
         }
@@ -230,8 +224,96 @@ function preferencesFor(store, masterId) {
     return out
 }
 
-// Find the first preference by id across all systems of all masters.
-// Returns { masterId, masterName, systemId, preference } or null.
+// Find a system by (masterId, systemId); checks master.systems first then
+// every works[*].systems. Returns null if not found.
+function findSystem(store, masterId, systemId) {
+    var master = findMaster(store, masterId)
+    if (!master) return null
+    var ss = master.systems || []
+    for (var i = 0; i < ss.length; i++) {
+        if (ss[i].id === systemId) return ss[i]
+    }
+    var ws = master.works || []
+    for (var w = 0; w < ws.length; w++) {
+        var wss = ws[w].systems || []
+        for (var k = 0; k < wss.length; k++) {
+            if (wss[k].id === systemId) return wss[k]
+        }
+    }
+    return null
+}
+
+// --- Works accessors (#293 Stage A.1) -----------------------------------
+
+// Flat list of every work across all masters with attribution.
+// Returns [{ masterId, masterName, work }, ...].
+function allWorks(store) {
+    var out = []
+    if (!store || !store.masters) return out
+    for (var i = 0; i < store.masters.length; i++) {
+        var m = store.masters[i]
+        var ws = m.works || []
+        for (var j = 0; j < ws.length; j++) {
+            out.push({ masterId: m.id, masterName: m.name, work: ws[j] })
+        }
+    }
+    return out
+}
+
+// Find a work by (masterId, workId); returns null if not found.
+function findWork(store, masterId, workId) {
+    var master = findMaster(store, masterId)
+    if (!master || !master.works) return null
+    for (var i = 0; i < master.works.length; i++) {
+        if (master.works[i].id === workId) return master.works[i]
+    }
+    return null
+}
+
+// Systems[] array of a specific work (empty array if work missing or empty).
+function systemsForWork(store, masterId, workId) {
+    var work = findWork(store, masterId, workId)
+    if (!work) return []
+    return work.systems || []
+}
+
+// Flat list of preferences across systems. If masterId is provided, scope
+// to that master; otherwise scan all masters. Walks both master.systems
+// and master.works[*].systems.
+// Returns [{ masterId, masterName, workId, systemId, preference }, ...].
+function preferencesFor(store, masterId) {
+    var out = []
+    if (!store || !store.masters) return out
+    for (var i = 0; i < store.masters.length; i++) {
+        var m = store.masters[i]
+        if (masterId && m.id !== masterId) continue
+        var buckets = [{ workId: null, systems: m.systems || [] }]
+        var ws = m.works || []
+        for (var w = 0; w < ws.length; w++) {
+            buckets.push({ workId: ws[w].id, systems: ws[w].systems || [] })
+        }
+        for (var b = 0; b < buckets.length; b++) {
+            var bk = buckets[b]
+            for (var j = 0; j < bk.systems.length; j++) {
+                var prefs = bk.systems[j].preferences || []
+                for (var k = 0; k < prefs.length; k++) {
+                    out.push({
+                        masterId: m.id,
+                        masterName: m.name,
+                        workId: bk.workId,
+                        systemId: bk.systems[j].id,
+                        preference: prefs[k]
+                    })
+                }
+            }
+        }
+    }
+    return out
+}
+
+// Find the first preference by id across all systems of all masters
+// (including all works). Returns { masterId, masterName, workId, systemId,
+// preference } or null.
 function findPreferenceById(store, preferenceId) {
     if (!preferenceId) return null
     var hits = preferencesFor(store, null)

--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Masters' Lessons Bookshelf (#220 / #276 Stage A)",
-  "description": "Schema for plugin/data/masters.json. Stage A introduces a dual-shape window: each master may declare legacy 'principles' (v1) and/or new 'systems' (systems-with-three-layers per docs/design-philosophy.md). At least one of the two must be present. Per-master migration is tracked in #277-#285; Stage C will deprecate 'principles'.",
+  "title": "Masters' Lessons Bookshelf (#220 / #276 Stage A / #293 Stage A.1)",
+  "description": "Schema for plugin/data/masters.json. Stage A introduced a dual-shape window (legacy 'principles' / new 'systems'). Stage A.1 (#293) adds an optional 'works' layer for multi-method masters: Van Eps's 1939 Method vs Harmonic Mechanisms, Martin Taylor's multiple books, etc. Each master must declare at least one of principles[], systems[], works[]. Per-master migration is tracked in #277-#285; Stage C will deprecate 'principles'.",
   "type": "object",
   "required": ["version", "masters"],
   "properties": {
@@ -31,12 +31,40 @@
         "systems": {
           "type": "array",
           "items": { "$ref": "#/$defs/system" }
+        },
+        "works": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/work" }
         }
       },
       "anyOf": [
         { "required": ["principles"] },
-        { "required": ["systems"] }
+        { "required": ["systems"] },
+        { "required": ["works"] }
       ],
+      "additionalProperties": true
+    },
+    "work": {
+      "description": "A discrete body of method content authored by the master — typically one book or one method era. Multi-method masters (e.g. Van Eps's 1939 Method vs Harmonic Mechanisms) place their systems inside the matching work so per-method divergence is legible. Single-method masters do not need works[] at all; their systems live directly on the master.",
+      "type": "object",
+      "required": ["id", "title"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^(_placeholder:)?[a-z0-9_-]+$",
+          "description": "Master-local kebab id (e.g. '1939-method', 'harmonic-mechanisms'). '_placeholder:' prefix marks a work whose interior is pending research; its systems[] may be empty or absent."
+        },
+        "title": { "type": "string", "minLength": 1 },
+        "year": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+        "instrument_scope": { "type": "string" },
+        "summary": { "type": "string" },
+        "systems": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/system" }
+        },
+        "references": { "$ref": "#/$defs/references" }
+      },
       "additionalProperties": true
     },
     "principle": {
@@ -51,19 +79,7 @@
         "applies_to_modes": { "type": "array", "items": { "type": "string" } },
         "applies_to_tunings": { "type": "array", "items": { "type": "string" } },
         "tolerance_hints": { "type": "object" },
-        "references": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["source"],
-            "properties": {
-              "source": { "type": "string" },
-              "citation": { "type": "string" },
-              "url": { "type": "string" }
-            },
-            "additionalProperties": true
-          }
-        },
+        "references": { "$ref": "#/$defs/references" },
         "example_voicing_signatures": { "type": "array" }
       },
       "additionalProperties": true
@@ -74,8 +90,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "pattern": "^(_placeholder:)?[a-z0-9_-]+:[a-z0-9_-]+$",
-          "description": "Format '<master>:<system-slug>'. A '_placeholder:' prefix marks a system whose interior is intentionally empty pending design — placeholder shape relaxes the non-empty-members rule."
+          "pattern": "^(_placeholder:)?[a-z0-9_-]+:[a-z0-9_-]+(?::[a-z0-9_-]+)?$",
+          "description": "Two- or three-segment id. Two-segment '<master>:<slug>' for systems living directly on master.systems (single-method masters). Three-segment '<master>:<work>:<slug>' for systems inside master.works[*].systems (multi-method masters). Optional '_placeholder:' prefix marks a system whose interior is intentionally empty pending design — placeholder shape relaxes the non-empty-members rule."
         },
         "name": { "type": "string", "minLength": 1 },
         "summary": { "type": "string" },
@@ -96,32 +112,20 @@
           "items": { "$ref": "#/$defs/preference" }
         },
         "examples": { "type": "array" },
-        "references": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["source"],
-            "properties": {
-              "source": { "type": "string" },
-              "citation": { "type": "string" },
-              "url": { "type": "string" }
-            },
-            "additionalProperties": true
-          }
-        }
+        "references": { "$ref": "#/$defs/references" }
       },
       "anyOf": [
         {
           "description": "Placeholder shape: id begins with '_placeholder:'; members/rules may be omitted or empty.",
           "properties": {
-            "id": { "pattern": "^_placeholder:[a-z0-9_-]+:[a-z0-9_-]+$" }
+            "id": { "pattern": "^_placeholder:[a-z0-9_-]+:[a-z0-9_-]+(?::[a-z0-9_-]+)?$" }
           },
           "required": ["id"]
         },
         {
           "description": "Real shape: non-empty members[] AND at least one of traversal_rules or modification_rules non-empty.",
           "properties": {
-            "id": { "pattern": "^[a-z0-9_-]+:[a-z0-9_-]+$" },
+            "id": { "pattern": "^[a-z0-9_-]+:[a-z0-9_-]+(?::[a-z0-9_-]+)?$" },
             "members": { "type": "array", "minItems": 1 }
           },
           "required": ["members"],
@@ -193,6 +197,19 @@
         "engine_payload": { "$ref": "#/$defs/engine_payload" }
       },
       "additionalProperties": true
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source"],
+        "properties": {
+          "source": { "type": "string" },
+          "citation": { "type": "string" },
+          "url": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
     }
   }
 }

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -268,16 +268,30 @@ def validate_masters(schema_path: Path, data_path: Path, verbose: bool = False) 
     if verbose:
         n_p = sum(len(m.get("principles", [])) for m in masters)
         n_s = sum(len(m.get("systems", [])) for m in masters)
+        n_w = sum(len(m.get("works", [])) for m in masters)
+        for m in masters:
+            for w in m.get("works", []) or []:
+                n_s += len(w.get("systems", []) or [])
         print(f"\n--- Summary ---")
         print(f"Masters: {len(masters)}")
+        print(f"Works: {n_w}")
         print(f"Principles (legacy): {n_p}")
-        print(f"Systems (new): {n_s}")
+        print(f"Systems (new, incl. work-scoped): {n_s}")
 
     return True
 
 
 def _check_masters_consistency(data: dict) -> list[str]:
-    """Cross-cutting checks beyond JSON Schema for masters.json."""
+    """Cross-cutting checks beyond JSON Schema for masters.json.
+
+    Covers:
+      - duplicate master / principle / system / work ids
+      - system id owner-prefix matches enclosing master
+      - work-scoped system id (3 segments) work-prefix matches enclosing work
+      - master-level system ids are 2 segments; work-scoped are 3 segments
+      - system ids are unique across (master.systems + all works[].systems)
+        within a single master
+    """
     warnings: list[str] = []
     seen_master_ids: set[str] = set()
 
@@ -294,25 +308,67 @@ def _check_masters_consistency(data: dict) -> list[str]:
                 warnings.append(f"{mid}: duplicate principle id '{pid}'")
             seen_principle_ids.add(pid)
 
-        seen_system_ids: set[str] = set()
+        # Aggregate every system id under this master across master.systems
+        # and every works[*].systems, so we can flag cross-bucket duplicates.
+        all_system_ids: set[str] = set()
+
         for s in m.get("systems", []) or []:
             sid = s.get("id", "<no-id>")
-            if sid in seen_system_ids:
+            if sid in all_system_ids:
                 warnings.append(f"{mid}: duplicate system id '{sid}'")
-            seen_system_ids.add(sid)
+            all_system_ids.add(sid)
+            _check_system_id(mid, None, sid, warnings, expect_segments=2)
 
-            # Per docs/design-philosophy.md, system ids carry an owner prefix
-            # '<master>:<slug>' (optionally '_placeholder:'-prefixed). The
-            # owner prefix should match the enclosing master's id.
-            bare = sid[len("_placeholder:"):] if sid.startswith("_placeholder:") else sid
-            owner_prefix = bare.split(":", 1)[0] if ":" in bare else ""
-            if owner_prefix and owner_prefix != mid:
-                warnings.append(
-                    f"{mid}: system id '{sid}' owner prefix '{owner_prefix}' "
-                    f"does not match master id"
-                )
+        seen_work_ids: set[str] = set()
+        for w in m.get("works", []) or []:
+            wid = w.get("id", "<no-id>")
+            if wid in seen_work_ids:
+                warnings.append(f"{mid}: duplicate work id '{wid}'")
+            seen_work_ids.add(wid)
+
+            for s in w.get("systems", []) or []:
+                sid = s.get("id", "<no-id>")
+                if sid in all_system_ids:
+                    warnings.append(f"{mid}: duplicate system id '{sid}'")
+                all_system_ids.add(sid)
+                _check_system_id(mid, wid, sid, warnings, expect_segments=3)
 
     return warnings
+
+
+def _check_system_id(
+    master_id: str,
+    work_id: str | None,
+    sid: str,
+    warnings: list[str],
+    expect_segments: int,
+) -> None:
+    """Verify a system id matches its enclosing master (and work if any).
+
+    expect_segments: 2 for master-level systems, 3 for work-scoped systems.
+    """
+    bare = sid[len("_placeholder:"):] if sid.startswith("_placeholder:") else sid
+    parts = bare.split(":") if bare else []
+
+    if len(parts) != expect_segments:
+        where = f"work '{work_id}'" if work_id else "master.systems"
+        warnings.append(
+            f"{master_id}: system id '{sid}' in {where} expected "
+            f"{expect_segments} colon-separated segments, got {len(parts)}"
+        )
+        return
+
+    if parts[0] != master_id:
+        warnings.append(
+            f"{master_id}: system id '{sid}' master prefix '{parts[0]}' "
+            f"does not match master id"
+        )
+
+    if expect_segments == 3 and work_id is not None and parts[1] != work_id:
+        warnings.append(
+            f"{master_id}: system id '{sid}' work segment '{parts[1]}' "
+            f"does not match enclosing work id '{work_id}'"
+        )
 
 
 def _check_consistency(data: dict) -> list[str]:

--- a/tests/test_masters_schema.py
+++ b/tests/test_masters_schema.py
@@ -243,3 +243,259 @@ def test_real_system_with_members_but_no_rules_is_invalid(validator):
         ],
     }
     assert list(validator.iter_errors(_doc([master])))
+
+
+# === Works layer (#293 Stage A.1) ===
+
+def _real_system_3seg(master_id: str, work_id: str, slug: str = "harmonized-scale") -> dict:
+    return {
+        "id": f"{master_id}:{work_id}:{slug}",
+        "name": "Harmonized scale",
+        "members": [{"id": "triad-major", "name": "Major triad"}],
+        "traversal_rules": [
+            {
+                "id": "step-up",
+                "name": "Step up",
+                "engine_payload": {"kind": "PositionContinuity"},
+            }
+        ],
+    }
+
+
+def test_works_only_master_is_valid(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "works": [
+            {
+                "id": "1939-method",
+                "title": "The George Van Eps Method for Guitar",
+                "year": 1939,
+                "instrument_scope": "6-string",
+                "systems": [_real_system_3seg("van-eps", "1939-method")],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+def test_works_plus_systems_plus_principles_is_valid(validator):
+    master = _base_master({
+        "systems": [
+            {
+                "id": "van-eps:legacy-system",
+                "name": "Legacy",
+                "members": [{"id": "x", "name": "X"}],
+                "traversal_rules": [
+                    {
+                        "id": "t", "name": "T",
+                        "engine_payload": {"kind": "VoiceMotion"},
+                    }
+                ],
+            }
+        ],
+        "works": [
+            {
+                "id": "1939-method",
+                "title": "The George Van Eps Method",
+                "systems": [_real_system_3seg("van-eps", "1939-method")],
+            }
+        ],
+    })
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+def test_placeholder_work_with_no_systems_is_valid(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "works": [
+            {
+                "id": "_placeholder:harmonic-mechanisms",
+                "title": "Harmonic Mechanisms for Guitar (7-string research pending)",
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+def test_work_scoped_system_with_2segment_id_is_rejected(validator):
+    """A system inside a work must carry the 3-segment id pattern. The
+    schema can't enforce structural location, but the consistency check
+    (validate.py) flags it. Still, the system id itself must match the
+    pattern; a 2-segment id inside a work is structurally wrong but
+    schema-legal — covered by the validator-level test below."""
+    # This is the schema-level companion: a deliberately-broken 1-segment
+    # id (no colons) is rejected by the pattern.
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "works": [
+            {
+                "id": "1939-method",
+                "title": "Method",
+                "systems": [
+                    {
+                        "id": "no-colons-at-all",
+                        "name": "Bad",
+                        "members": [{"id": "x", "name": "X"}],
+                        "traversal_rules": [
+                            {"id": "t", "name": "T",
+                             "engine_payload": {"kind": "VoiceMotion"}},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master])))
+
+
+def test_empty_works_array_rejected(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "works": [],
+        "principles": [
+            {"id": "p", "name": "P", "summary": "..."}
+        ],
+    }
+    # works[] present but empty violates minItems:1
+    assert list(validator.iter_errors(_doc([master])))
+
+
+def test_work_missing_title_rejected(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "works": [{"id": "1939-method"}],
+    }
+    assert list(validator.iter_errors(_doc([master])))
+
+
+def test_work_id_can_be_placeholder(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "works": [
+            {
+                "id": "_placeholder:future-method",
+                "title": "Future method",
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+def test_three_segment_placeholder_system_inside_work_is_valid(validator):
+    master = {
+        "id": "van-eps",
+        "name": "George Van Eps",
+        "works": [
+            {
+                "id": "harmonic-mechanisms",
+                "title": "Harmonic Mechanisms",
+                "systems": [
+                    {
+                        "id": "_placeholder:van-eps:harmonic-mechanisms:lap-piano",
+                        "name": "Lap piano counterpoint (research pending)",
+                    }
+                ],
+            }
+        ],
+    }
+    assert list(validator.iter_errors(_doc([master]))) == []
+
+
+# === Validator consistency checks (#293) ===
+
+def test_consistency_flags_3seg_system_with_wrong_master_prefix(monkeypatch):
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "validate_mod",
+        REPO_ROOT / "scripts" / "validate.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    data = _doc([{
+        "id": "van-eps",
+        "name": "Van Eps",
+        "works": [{
+            "id": "1939-method",
+            "title": "Method",
+            "systems": [{
+                "id": "wrong-master:1939-method:foo",
+                "name": "Foo",
+                "members": [{"id": "x", "name": "X"}],
+                "traversal_rules": [
+                    {"id": "t", "name": "T",
+                     "engine_payload": {"kind": "VoiceMotion"}},
+                ],
+            }],
+        }],
+    }])
+    warnings = mod._check_masters_consistency(data)
+    assert any("master prefix 'wrong-master'" in w for w in warnings), warnings
+
+
+def test_consistency_flags_3seg_system_with_wrong_work_segment():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "validate_mod",
+        REPO_ROOT / "scripts" / "validate.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    data = _doc([{
+        "id": "van-eps",
+        "name": "Van Eps",
+        "works": [{
+            "id": "1939-method",
+            "title": "Method",
+            "systems": [{
+                "id": "van-eps:wrong-work:foo",
+                "name": "Foo",
+                "members": [{"id": "x", "name": "X"}],
+                "traversal_rules": [
+                    {"id": "t", "name": "T",
+                     "engine_payload": {"kind": "VoiceMotion"}},
+                ],
+            }],
+        }],
+    }])
+    warnings = mod._check_masters_consistency(data)
+    assert any("work segment 'wrong-work'" in w for w in warnings), warnings
+
+
+def test_consistency_flags_2segment_system_inside_work():
+    """A system schema-valid by pattern but structurally misplaced (2-segment
+    id inside a work) is caught by the consistency check, not the schema."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "validate_mod",
+        REPO_ROOT / "scripts" / "validate.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    data = _doc([{
+        "id": "van-eps",
+        "name": "Van Eps",
+        "works": [{
+            "id": "1939-method",
+            "title": "Method",
+            "systems": [{
+                "id": "van-eps:foo",
+                "name": "Foo",
+                "members": [{"id": "x", "name": "X"}],
+                "traversal_rules": [
+                    {"id": "t", "name": "T",
+                     "engine_payload": {"kind": "VoiceMotion"}},
+                ],
+            }],
+        }],
+    }])
+    warnings = mod._check_masters_consistency(data)
+    assert any("expected 3 colon-separated segments" in w for w in warnings), warnings


### PR DESCRIPTION
## Summary

Stage A landed the dual-shape window (\`principles[]\` / \`systems[]\`) on \`schema/masters.schema.json\`. While planning Stage B per-master migration, the multi-method-master problem surfaced: Van Eps wrote two methods (1939 6-string vs Harmonic Mechanisms 1980-82) with significant divergence (lap-piano counterpoint is 7-string-only). Martin Taylor has multiple books that contradict at the technique level. Splitting masters into pseudo-masters per book doesn't generalize.

This PR adds an optional **\`works[]\` layer** so multi-method masters scope their systems to a specific work, while single-method masters (Berklee codified consensus) keep \`systems[]\` directly on the master. Strictly additive, backward-compatible.

## Schema changes

- \`master.anyOf\` extended from {principles, systems} to {principles, systems, works}. At least one required.
- New \`\$defs/work\`: requires \`id\` (master-local kebab) + \`title\`; optional \`year\`, \`instrument_scope\`, \`summary\`, \`references\`, \`systems[]\`.
- Work id supports \`_placeholder:\` prefix for entries pending research.
- System id pattern widened: master-level systems use \`<master>:<slug>\` (2 segments, unchanged); work-scoped systems use \`<master>:<work>:<slug>\` (3 segments, new).
- \`\$defs/references\` factored out of three inline copies (DRY).

## Validator + store

- \`scripts/validate.py\` consistency checks now flag: duplicate work ids per master, system ids non-unique across (master.systems + every works[].systems), 2-vs-3 segment placement mismatch, master/work prefix mismatch.
- \`plugin/model/MastersStore.js\` \`allSystems\` / \`findSystem\` / \`preferencesFor\` walk works[]; new \`allWorks\` / \`findWork\` / \`systemsForWork\` accessors; \`counts()\` reports \`works\`.

## Cross-work systems are NOT modeled

Same idea appearing in three books with three prescriptions becomes three independent systems, one per work. The engine consults one work at a time. This is honest about contradictions instead of inventing "the canonical Taylor view of guide-tone tracking."

## Test plan

- [x] \`python scripts/validate.py --target masters --verbose\` — 9 masters, 0 works, 41 principles, 0 systems pass schema validation. Existing data unchanged.
- [x] \`python3 -m pytest tests/test_masters_schema.py -v\` — 24/24 pass (13 from Stage A + 11 new)
- [x] \`python3 -m pytest tests/ -q\` — 330/334 pass; 4 fails are pre-existing TestClipboardPipeline env tests, unchanged from Stage A baseline
- [ ] CI on this PR

Unblocks Stage B (#277-#285). Each per-master ticket now decides whether to use \`works[]\` or place systems at the master level — a thinking act, not a transform.

Refs #293 #276 #277 #220