### PR TITLE
fix(schema): #295 roll back masters.schema.json payload-kind enum to predecessor-designed names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ CI runs on every push to main/develop and on all PRs (`.github/workflows/test.ym
 
 **System IDs** are `<master>:<slug>` (e.g. `van-eps:harmonized-scale`). A leading `_placeholder:` prefix marks an intentionally-empty system whose interior is pending design (relaxes the non-empty-members rule).
 
-**Engine payload `kind`** is either one of the 12 canonical CamelCase kinds — `PositionContinuity`, `VoiceMotion`, `RegisterBand`, `ContraryMotion`, `StringSetPreference`, `OmissionPriority`, `TextureCycle`, `DensityBand`, `ApproachAlignment`, `BassIndependence`, `ChordToneSpelling`, `GuideToneTracking` — or a `_pending:<kebab-slug>` placeholder for kinds awaiting design.
+**Engine payload `kind`** is either one of 12 named kinds traced to predecessor session 260521-aware-nebula's `plans/schema-systems-model.md` (lines 121-134) — `PositionContinuity`, `VoiceMotion`, `StringSetTransition`, `SymmetryMovement`, `FamilyCoherence`, `SubstitutionExpand`, `DensityFloor`, `DensityCeiling`, `OmissionAllow`, `ColorToneRequire`, `NCTHarmonization`, `TextureCycle` — or a `_pending:<kebab-slug>` placeholder for kinds awaiting definition. A formal glossary defining each kind's semantics is pending; until then these names are nominal labels, not behavioral contracts. (PR #290 originally shipped a 12-name enum where 9 names were invented without design source; #295 rolled them back to the predecessor-designed set.)
 
 **Validate** with:
 

--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Masters' Lessons Bookshelf (#220 / #276 Stage A)",
-  "description": "Schema for plugin/data/masters.json. Stage A introduces a dual-shape window: each master may declare legacy 'principles' (v1) and/or new 'systems' (systems-with-three-layers per docs/design-philosophy.md). At least one of the two must be present. Per-master migration is tracked in #277-#285; Stage C will deprecate 'principles'.",
+  "title": "Masters' Lessons Bookshelf (#220 / #276 Stage A / #295 enum provenance fix)",
+  "description": "Schema for plugin/data/masters.json. Stage A introduces a dual-shape window: each master may declare legacy 'principles' (v1) and/or new 'systems' (systems-with-three-layers per docs/design-philosophy.md). At least one of the two must be present. Per-master migration is tracked in #277-#285; Stage C will deprecate 'principles'. The engine_payload.kind enum was rolled back in #295 from the originally-shipped invented names to the 12 names with design provenance in predecessor session 260521-aware-nebula's schema-systems-model.md.",
   "type": "object",
   "required": ["version", "masters"],
   "properties": {
@@ -158,6 +158,7 @@
     "engine_payload": {
       "type": "object",
       "required": ["kind"],
+      "description": "Each rule carries one engine_payload. `kind` must be one of the 12 named kinds traced to predecessor session 260521-aware-nebula's plans/schema-systems-model.md (lines 121-134), OR a `_pending:<kebab>` placeholder for kinds awaiting definition. A glossary defining each kind's semantics is a separate work item — until then these names are nominal labels, not contracts.",
       "properties": {
         "kind": {
           "anyOf": [
@@ -165,16 +166,16 @@
               "enum": [
                 "PositionContinuity",
                 "VoiceMotion",
-                "RegisterBand",
-                "ContraryMotion",
-                "StringSetPreference",
-                "OmissionPriority",
-                "TextureCycle",
-                "DensityBand",
-                "ApproachAlignment",
-                "BassIndependence",
-                "ChordToneSpelling",
-                "GuideToneTracking"
+                "StringSetTransition",
+                "SymmetryMovement",
+                "FamilyCoherence",
+                "SubstitutionExpand",
+                "DensityFloor",
+                "DensityCeiling",
+                "OmissionAllow",
+                "ColorToneRequire",
+                "NCTHarmonization",
+                "TextureCycle"
               ]
             },
             { "type": "string", "pattern": "^_pending:[a-z0-9-]+$" }


### PR DESCRIPTION
## Summary

PR #290 shipped \`engine_payload.kind\` with a 12-name enum where **9 of 12 names were invented without design provenance**. Cross-session verification with predecessor agent (session 260521-aware-nebula) revealed the discrepancy. This PR rolls the enum back to the 12 names traced to \`plans/schema-systems-model.md\` lines 121-134 in the predecessor's session.

## Provenance check

\`\`\`
grep -lE 'RegisterBand|ContraryMotion|StringSetPreference|OmissionPriority|DensityBand|ApproachAlignment|BassIndependence|ChordToneSpelling|GuideToneTracking' \\
  /Users/dheerajchand/.craft-agent/workspaces/my-workspace/sessions/260521-aware-nebula/plans/*.md
\`\`\`
→ zero matches. Those 9 names existed nowhere in design history.

\`\`\`
grep -nE 'PositionContinuity|VoiceMotion|StringSetTransition|SymmetryMovement|FamilyCoherence|SubstitutionExpand|DensityFloor|DensityCeiling|OmissionAllow|ColorToneRequire|NCTHarmonization|TextureCycle' \\
  /Users/dheerajchand/.craft-agent/workspaces/my-workspace/sessions/260521-aware-nebula/plans/schema-systems-model.md
\`\`\`
→ 12 hits in lines 121-134, defining each name with a one-line semantic comment.

## Backward compatibility

- \`plugin/data/masters.json\` has 0 systems / 0 engine_payloads → no data affected.
- Existing tests use \`PositionContinuity\` and \`VoiceMotion\` (preserved) and \`MadeUpKind\` (negative case, preserved). No test churn.
- PR #294 (works[] layer, open) is unaffected — touches different schema blocks and references only the 3 overlap-set names in its fixtures.

## What this doesn't do

A formal glossary defining each kind's behavioral semantics is **still pending**. The rolled-back names are nominal labels traced to design, not behavioral contracts. Stage B per-master migration (#277-#285) remains blocked on that glossary.

## Test plan

- [x] \`python scripts/validate.py --target masters --verbose\` — 9 masters pass
- [x] \`python3 -m pytest tests/test_masters_schema.py -v\` — 13/13 pass with zero modifications
- [x] \`grep -rE '<9 invented names>' .\` — zero hits across repo
- [ ] CI on this PR

## Lessons

The new memory rule \`feedback_named_constants_need_provenance.md\` codifies the failure mode: schema constants need the same Goal-source provenance as code claims. Self-review must grep names against non-self artifacts, not just confirm presence in the file under edit.

Fixes #295. Refs #276 #277 #290 #293 #294.