### PR TITLE
feat(masters): promote Joe Pass into masters.json under systems[] layer (single-method-shape, alongside principles[])

### DIFF
--- a/docs/payload-kinds.md
+++ b/docs/payload-kinds.md
@@ -156,7 +156,7 @@ These act on a single voicing in isolation, before or independent of consecutive
 - `bonus`/`penalty`.
 - `applies_to_chord_types` — optional.
 
-**Worked example.** **TODO**: write when the first rule explicitly using `ColorToneRequire` against specific named degrees lands in a rebuild doc. Today the kind exists only as the predecessor's one-line comment in `plans/schema-systems-model.md` line 132 ("voicings exposing color tones rank higher"). The Phrygian "characteristic note: b2" pattern in Benson Vol 1's Stage 4 is the closest concrete usage, but it was filed by Stage 4 against this kind without prior rebuild-doc precedent — so citing it would be self-referential.
+**Worked example.** Joe Pass R5.5 (`joe-pass:dominant-substitution-lattice`): "Color tones (b9, +9, b5, +5) are baseline in dom7 lines, not optional." Encoded as `{ kind: "ColorToneRequire", required_degrees_options: ["b9", "+9", "b5", "+5"], applies_to_chord_types: ["dom7"], bonus: 15 }`. Source: `plans/pass-system-rebuild.md` System 5 R5.5, citing Method ch1-6 p. 9: "Against almost any Dominant 7th Chord, I will include the b9, +9, b5, or +5 in my lines." This is the first rebuild-doc citation that grounds `ColorToneRequire` against specific degrees with explicit rationale.
 
 **Boundary notes.** This is a SINGLE-VOICING content rule about which tones must/should appear. NOT about how to handle non-chord tones in a melodic line (that's `NCTHarmonization`). NOT about "avoid notes" — those are tones to AVOID exposing, which is the inverse and currently has no kind (Benson Vol 1's "Avoid Note Suppression" was filed under `NCTHarmonization` and arguably belongs under `_pending:avoid-note-suppression` — see Audit).
 
@@ -168,7 +168,7 @@ These act on a single voicing in isolation, before or independent of consecutive
 - `appetite` — `0` (never harmonize NCT) through `1.0` (always harmonize).
 - `nct_treatment_per_type` — optional map `{passing: 0.3, neighbor: 0.5, suspension: 0.8, ...}`.
 
-**Worked example.** **TODO**: write when the first rule explicitly using `NCTHarmonization` against a melodic NCT context lands in a rebuild doc. Today the kind exists only as the predecessor's one-line comment in `plans/schema-systems-model.md` line 133 ("harmonize/skip non-chord tones with appetite N"). No rebuild-doc cites it against a specific rule.
+**Worked example.** Joe Pass R4.2 (`joe-pass:harmonic-restraint`): "Don't harmonize every note — you don't need a chord for every note." Encoded as `{ kind: "NCTHarmonization", appetite: 0.3 }`. Source: `plans/pass-system-rebuild.md` System 4 R4.2, citing Sam Blakelock interview quote of Pass; corroborated by Method's improvisation chapters where single-note lines dominate page-count. Low appetite (0.3) encodes Pass's restraint — the inverse of an aggressive harmonizer like Greene who would carry harmony under every melody note.
 
 **Boundary notes.** **This is about MELODY-DRIVEN harmonization** — given a non-chord tone in the melody, do you find a voicing that includes it (harmonize) or leave it bare? **It is NOT about "avoid notes" in the modal-harmony sense.** Avoid notes are mode-degree-specific notes that the modal taxonomy says should not be ended on or sustained over the underlying chord; that is a different concept and currently has no dedicated kind. Benson Vol 1's "Avoid Note Suppression" was filed here in the systems-draft and is one of the three audit findings below.
 
@@ -203,6 +203,8 @@ If no name above matches what your rule does, use `_pending:<short-kebab-slug>`.
 | `_pending:avoid-note-suppression` | Don't FEATURE / sustain mode-specific "avoid notes" over the underlying chord; inverse of `NCTHarmonization` which is about harmonizing-NCTs, not suppressing avoid notes | Benson Vol 1 Harmonic Fields (regenerated systems-draft per #298 audit) |
 | `_pending:practice-prescription` | Rule that prescribes practice workflow (sequence, key-coverage, mastery-before-progression) rather than a voicing-engine constraint | Van Eps R1.2 (all-keys Solfeggio); Benson Study Devices Protocol (folded into summary prose per #298 audit) |
 | `_pending:right-hand-technique-tag` | Documentation-only right-hand technique tagging; future tagging on selected voicings, no v1 engine ranking impact | Van Eps R3.1 (pulsation picking + top-voice emphasis) |
+| `_pending:degree-bypass` | A rule that elides a specific scale-degree chord from the progression entirely (no replacement); structurally distinct from `SubstitutionExpand` which expands the candidate pool | Joe Pass R4.4 ("Forget the II — focus on the V") |
+| `_pending:tritone-substitution` | The specific tritone-related-pair symmetry within dominant family — preserves alteration palette across the symmetric root pair; narrower mechanic than `SubstitutionExpand` | Joe Pass R5.2 (tritone color-passthrough p. 25) |
 
 These are candidate names for future kind-additions, each warranting its own ticket per #256's `_pending:` workflow.
 

--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -847,6 +847,553 @@
           ],
           "example_voicing_signatures": []
         }
+      ],
+      "systems": [
+        {
+          "id": "joe-pass:six-chord-forms",
+          "name": "Six Chord Forms (Position System)",
+          "summary": "Pass partitions the fretboard into six overlapping positional regions, each anchored on a chord shape: C, A, G, E, D, and Intermediate (top part of C Form). Each Form occupies ~5-6 frets, defines a scale-fingering window, and serves as the spatial reference for chord-melody and improvisation work. Position is identified by which Form anchors the hand; movement between Forms uses pivot-finger shifts.",
+          "members": [
+            {
+              "id": "c-form",
+              "name": "C Form",
+              "summary": "Anchor at C major shape; canonical pivot for Pass's chord-melody."
+            },
+            {
+              "id": "a-form",
+              "name": "A Form"
+            },
+            {
+              "id": "g-form",
+              "name": "G Form"
+            },
+            {
+              "id": "e-form",
+              "name": "E Form"
+            },
+            {
+              "id": "d-form",
+              "name": "D Form",
+              "summary": "First inversion of C Form."
+            },
+            {
+              "id": "intermediate-form",
+              "name": "Intermediate Form",
+              "summary": "Top part of C Form; secondary."
+            }
+          ],
+          "traversal_rules": [
+            {
+              "id": "R1.1-pivot-finger-shift",
+              "name": "Pivot-finger shift to next Form",
+              "summary": "To move between Forms, use the 1st or 4th finger to play two consecutive notes; the second note lands the hand in the next Form.",
+              "engine_payload": {
+                "kind": "StringSetTransition",
+                "pivot_finger_options": [
+                  1,
+                  4
+                ]
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "ch5-1, p. 19: 'one can shift to any string by using either the first finger or fourth finger to play two notes. This will place the hand on the next Chord Form.'"
+                }
+              ]
+            },
+            {
+              "id": "R1.2-same-form-continuity",
+              "name": "Same-Form continuity preferred",
+              "summary": "While the musical context permits, stay in one Form across consecutive voicings to keep scale fingerings and melody-line landing positions consistent.",
+              "engine_payload": {
+                "kind": "PositionContinuity",
+                "system_ref": "joe-pass:six-chord-forms",
+                "same_region_threshold_frets": 6
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "Implicit across pp. 4-21; explicit cross-ref ch8-3 p. 23: 'When playing a Dominant 7th Chord or Scale, one Chord Form must be kept in mind.'"
+                }
+              ]
+            }
+          ],
+          "preferences": [
+            {
+              "id": "P1-chord-form-order",
+              "name": "Chord-form preference order",
+              "summary": "Pass mentions A, E, C, D as the four core Forms; G and Intermediate are secondary. A and E come first in his enumeration.",
+              "engine_payload": {
+                "kind": "PositionContinuity",
+                "preferred_form_order": [
+                  "a-form",
+                  "e-form",
+                  "c-form",
+                  "d-form",
+                  "g-form",
+                  "intermediate-form"
+                ]
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 6: 'By mastering all the scales in the A — E — C/D Chord Forms, which are basically similar, the student will have covered the fingerboard quite thoroughly.'"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "joe-pass:three-harmonic-families",
+          "name": "Three Harmonic Families (Major / Minor / Dominant)",
+          "summary": "Pass partitions all chord qualities into three families that share voicing-pool characteristics. Major covers maj6/maj7/maj9/maj13/6-9; Minor covers m6/m7/m9/m-maj7/m11; Dominant covers dom7/dom9/dom13 and ALL altered/extended dominants, with diminished and augmented as subspecies of Dominant. Within a family, voicing-level substitution is free (a written maj7 admits maj6, maj9, maj13, 6/9 with no harmonic re-analysis).",
+          "members": [
+            {
+              "id": "major-family",
+              "name": "Major family",
+              "summary": "Covers maj6, maj7, maj9, maj13, 6/9."
+            },
+            {
+              "id": "minor-family",
+              "name": "Minor family",
+              "summary": "Covers m6, m7, m9, m-maj7, m11."
+            },
+            {
+              "id": "dominant-family",
+              "name": "Dominant family",
+              "summary": "Covers dom7/9/13 and all altered/extended dominants; diminished and augmented are subspecies."
+            }
+          ],
+          "traversal_rules": [
+            {
+              "id": "R2.1-family-coherent-comping",
+              "name": "Family-coherent comping preferred",
+              "summary": "When traversing a chord progression, voicings drawn from the same family share recognition cues; mixing families is fine but is itself a compositional choice.",
+              "engine_payload": {
+                "kind": "FamilyCoherence",
+                "system_ref": "joe-pass:three-harmonic-families"
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 16: 'the underlying chord sequence for this study should be analyzed, remembering that it can be broken down into three simple chord types: Major, Minor, and Dominant 7th (Aug./Dim.).'"
+                }
+              ]
+            }
+          ],
+          "modification_rules": [
+            {
+              "id": "R2.3-within-family-substitution",
+              "name": "Within-family substitution is free",
+              "summary": "A written maj7 admits maj6, maj9, maj13, 6/9 as voicing-level substitutes — same family, same listener recognition.",
+              "engine_payload": {
+                "kind": "SubstitutionExpand",
+                "expansion_within_family": true
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 16 + cross-reference Complete Chord Melody Module 2 which credits this concept to Pass by name."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "joe-pass:voicing-density-and-voice-leading",
+          "name": "Voicing Density and Voice Leading",
+          "summary": "Pass treats voicing-internal density and inter-voicing motion as coupled. Solo work runs on 3-4 sounding notes; walking-bass texture drops to 2-3-note stabs; 5-6-note block chords are the avoided default. Voice motion preferences are common-tone first, stepwise inner as fallback.",
+          "members": [
+            {
+              "id": "shell-2-note",
+              "name": "2-note shell"
+            },
+            {
+              "id": "core-3-note",
+              "name": "3-note core"
+            },
+            {
+              "id": "full-4-note",
+              "name": "4-note full voicing"
+            },
+            {
+              "id": "block-5-plus",
+              "name": "5+ block (avoided default)"
+            },
+            {
+              "id": "drop-2",
+              "name": "Drop-2 voicing shape"
+            },
+            {
+              "id": "drop-3",
+              "name": "Drop-3 voicing shape"
+            },
+            {
+              "id": "walking-bass-plus-stab",
+              "name": "Walking bass + 2-note chord stab"
+            }
+          ],
+          "traversal_rules": [
+            {
+              "id": "R3.1-2-voice-motion-preferences",
+              "name": "Common-tone preferred, stepwise inner as fallback",
+              "summary": "Voicings should lead into one another or have a common tone connecting them; stepwise inner-voice motion is the fallback when no common tone is available.",
+              "engine_payload": {
+                "kind": "VoiceMotion",
+                "preferred_order": [
+                  "common-tone",
+                  "stepwise-inner",
+                  "leap",
+                  "parallel"
+                ]
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 30: 'voicings should lead into one another or have a common tone connecting them.' Worked example pp. 31-32 (Dm9 → C13 → C7(b5) → C9(6)/C7 → Fmaj7) demonstrates per-transition shared tones."
+                }
+              ]
+            }
+          ],
+          "modification_rules": [
+            {
+              "id": "R3.4a-density-ceiling-solo",
+              "name": "Density ceiling — 4 sounding notes in solo work",
+              "summary": "Five- or six-note block chords are NOT Pass's default for solo work.",
+              "engine_payload": {
+                "kind": "DensityCeiling",
+                "max_sounding_notes": 4,
+                "context_filter": "solo"
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 30: 'All changes should be reduced to three- or four-note chords.'"
+                }
+              ]
+            },
+            {
+              "id": "R3.4b-density-floor-solo",
+              "name": "Density floor — 3 sounding notes in solo work",
+              "summary": "Pass's solo arrangements use at least 3 sounding notes; bare 2-note voicings are walking-bass territory, not solo.",
+              "engine_payload": {
+                "kind": "DensityFloor",
+                "min_sounding_notes": 3,
+                "context_filter": "solo"
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 30 same passage: 'three- or four-note chords' establishes 3 as the floor for solo contexts."
+                }
+              ]
+            },
+            {
+              "id": "R3.5-walking-bass-texture",
+              "name": "Walking-bass texture with 2-note chord stabs",
+              "summary": "Bass walks every beat; chord stabs land off-beats with 2-3-note voicings rather than full block chords.",
+              "engine_payload": {
+                "kind": "TextureCycle",
+                "texture_sequence": [
+                  "bass",
+                  "chord-stab"
+                ],
+                "stab_density": 2
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "Joe's Blues worked example pp. 25-29; corroborated by PR #239 walking-bass-plus-chord-stabs principle (originally from Joe Pass Guitar Style 1971)."
+                }
+              ]
+            },
+            {
+              "id": "R3.6-drop-shapes-default",
+              "name": "Drop-2 and Drop-3 are the default chord-melody shapes",
+              "summary": "Method's pp. 31-32 worked examples are predominantly drop-2 shapes; drop-3 is the secondary chord-melody shape.",
+              "engine_payload": {
+                "kind": "_pending:voicing-respacing",
+                "shapes": [
+                  "drop-2",
+                  "drop-3"
+                ]
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "pp. 31-32 worked examples; explicit drop-2 / drop-3 terminology elsewhere in Pass's secondary literature."
+                }
+              ]
+            }
+          ],
+          "preferences": [
+            {
+              "id": "P3-voice-motion-order",
+              "name": "Voice-motion preference order",
+              "summary": "Pass's explicit preference: common-tone first, then stepwise inner, then leap, parallel last (avoided).",
+              "engine_payload": {
+                "kind": "VoiceMotion",
+                "preferred_order": [
+                  "common-tone",
+                  "stepwise-inner",
+                  "leap",
+                  "parallel"
+                ],
+                "bonus_per_position": [
+                  20,
+                  10,
+                  0,
+                  -5
+                ]
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 30 same passage as R3.1."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "joe-pass:harmonic-restraint",
+          "name": "Harmonic Restraint (Three-Textures Cycling)",
+          "summary": "The question of whether to harmonize a given melody note at all. Pass cycles through three textures within one solo arrangement — harmonize, leave-as-single-note, dip-out-to-bass-only — weaving rather than maintaining a single texture. Color comes from chord alteration (System 5), not from harmonizing every note.",
+          "members": [
+            {
+              "id": "harmonize",
+              "name": "Harmonize the melody note"
+            },
+            {
+              "id": "leave-as-single-note",
+              "name": "Leave melody note bare (no harmonization)"
+            },
+            {
+              "id": "dip-out-to-bass-only",
+              "name": "Drop to bass-only texture momentarily"
+            }
+          ],
+          "traversal_rules": [
+            {
+              "id": "R4.1-texture-cycling",
+              "name": "Cycle between bass/chord/melody textures within an arrangement",
+              "summary": "The arrangement weaves between three textures rather than maintaining one. Per Pass's own framing: 'You don't have to play bass, chord, melody all the time — dip in and out between all three.'",
+              "engine_payload": {
+                "kind": "TextureCycle",
+                "texture_sequence": [
+                  "bass",
+                  "chord",
+                  "melody"
+                ]
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "Secondary-source quote of Pass, corroborated by Method's improvisation chapters where single-note lines dominate page-count."
+                }
+              ]
+            }
+          ],
+          "modification_rules": [
+            {
+              "id": "R4.2-low-nct-harmonization",
+              "name": "Don't harmonize every note (low NCT-harmonization appetite)",
+              "summary": "Pass's restraint: 'You don't need a chord for every note.' Solo arrangements deliberately leave melodic NCT passages as bare single-note lines.",
+              "engine_payload": {
+                "kind": "NCTHarmonization",
+                "appetite": 0.3
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "Sam Blakelock interview quoting Pass; corroborated by Method's improvisation chapters' page-count dominance of single-note lines over chord-density."
+                }
+              ]
+            },
+            {
+              "id": "R4.4-bypass-ii-in-ii-V",
+              "name": "Bypass the ii in ii-V-I — focus on the V",
+              "summary": "Pass's specific habit of leaving the ii bar as a single-note line and harmonizing only the V resolution. Functional shorthand: the V carries the ii's information.",
+              "engine_payload": {
+                "kind": "_pending:degree-bypass",
+                "bypass_degree": "ii"
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "Pass quote: 'Forget the II — focus on the V.' Secondary-source corroborated; Method's worked examples consistently apply this in ii-V passages."
+                }
+              ]
+            }
+          ],
+          "preferences": [
+            {
+              "id": "P4-nct-harmonization-appetite",
+              "name": "Low NCT-harmonization appetite",
+              "summary": "Lower than the bookshelf default; encodes Pass's restraint distinct from Greene's aggressive harmonization.",
+              "engine_payload": {
+                "kind": "NCTHarmonization",
+                "appetite": 0.3
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "Same Blakelock-quoted passage as R4.2."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "joe-pass:dominant-substitution-lattice",
+          "name": "Dominant Substitution Lattice",
+          "summary": "Pass's richest system and the engine-active one. Any written dominant chord admits an expansion-set of related qualities (dom9, dom13, dom7+9, dom7b9, dom7+5, dom7b5, dom7b13, dom-alt). Tritone-related pairs and diminished-symmetry quartets group roots; color tones (b9, +9, b5, +5) are baseline-not-optional even when 'playing the written changes'.",
+          "members": [
+            {
+              "id": "dom7",
+              "name": "dom7 (root quality)"
+            },
+            {
+              "id": "dom9",
+              "name": "dom9"
+            },
+            {
+              "id": "dom13",
+              "name": "dom13"
+            },
+            {
+              "id": "dom7+9",
+              "name": "dom7+9"
+            },
+            {
+              "id": "dom7b9",
+              "name": "dom7b9"
+            },
+            {
+              "id": "dom7+5",
+              "name": "dom7+5"
+            },
+            {
+              "id": "dom7b5",
+              "name": "dom7b5"
+            },
+            {
+              "id": "dom7b13",
+              "name": "dom7b13"
+            },
+            {
+              "id": "dom-alt",
+              "name": "dom-alt (general altered)"
+            },
+            {
+              "id": "tritone-pair",
+              "name": "Tritone-related root pair (C7 ↔ F#7)",
+              "summary": "Twelve canonical pairs covering all roots."
+            },
+            {
+              "id": "diminished-quartet",
+              "name": "Diminished-symmetry root quartet",
+              "summary": "{D7, F7, Ab7, B7}, {Db7, E7, G7, Bb7}, {C7, Eb7, Gb7, A7} — three quartets cover all twelve."
+            }
+          ],
+          "traversal_rules": [
+            {
+              "id": "R5.2-tritone-color-passthrough",
+              "name": "Tritone substitution carries color alteration through",
+              "summary": "E7 admits Bb9/Bb+9/Bbm9/Bb13 — same alteration palette on the tritone-related root. The symmetric-pair member carries the same color tones.",
+              "engine_payload": {
+                "kind": "_pending:tritone-substitution",
+                "preserves_alteration": true
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 25 (ch9-2): 'Bm7 can be replaced by F13/F9/F+9/Fm9. Bm7 can be changed to a Dominant 7th (B7) or B9/B13.'"
+                }
+              ]
+            }
+          ],
+          "modification_rules": [
+            {
+              "id": "R5.3-tune-wide-alteration-permission",
+              "name": "Tune-wide alteration permission",
+              "summary": "Throughout, +9/b9/13/9(6)/11/+5/b5 may be substituted for simple Dominants. This rule licenses substitution across the entire piece, not just one chord position.",
+              "engine_payload": {
+                "kind": "SubstitutionExpand",
+                "target_quality": "dom7",
+                "expansion_set": [
+                  "dom7",
+                  "dom9",
+                  "dom13",
+                  "dom6",
+                  "dom6/9",
+                  "dom11",
+                  "dom7+9",
+                  "dom7b9",
+                  "dom7+5",
+                  "dom7b5",
+                  "dom7b13",
+                  "dom-alt"
+                ],
+                "applies_to_contexts": [
+                  "entire-tune"
+                ]
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 30 (ch10-4): 'Throughout, +9/b9/13/9(6)/11/+5/b5 may be substituted for simple Dominants.'"
+                }
+              ]
+            },
+            {
+              "id": "R5.5-color-tones-baseline",
+              "name": "Color tones (b9, +9, b5, +5) are baseline in dom7 lines, not optional",
+              "summary": "Even when playing the written changes, Pass includes a color tone (b9, +9, b5, or +5) in his dom7 lines as the baseline expectation, not as an embellishment.",
+              "engine_payload": {
+                "kind": "ColorToneRequire",
+                "required_degrees_options": [
+                  "b9",
+                  "+9",
+                  "b5",
+                  "+5"
+                ],
+                "applies_to_chord_types": [
+                  "dom7"
+                ],
+                "bonus": 15
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "p. 9 (ch1-6): 'Against almost any Dominant 7th Chord, I will include the b9, +9, b5, or +5 in my lines.'"
+                }
+              ]
+            }
+          ],
+          "preferences": [
+            {
+              "id": "P5-substitution-aggressiveness",
+              "name": "High substitution aggressiveness",
+              "summary": "Pass's appetite for substitution is high — R5.3's 'throughout, may be substituted' + ch9-4 'Students must be able to choose freely from the alternatives' both signal aggressive expansion.",
+              "engine_payload": {
+                "kind": "SubstitutionExpand",
+                "appetite": 0.8,
+                "preferred_classes": [
+                  "primary-alteration",
+                  "tritone-sub",
+                  "ii-as-tritone-V"
+                ]
+              },
+              "references": [
+                {
+                  "source": "Pass, Joe. The Joe Pass Guitar Method. 1977. Chappell Music / Hal Leonard HL00347734.",
+                  "citation": "pp. 25, 30; ch9-4 'choose freely from the alternatives'."
+                }
+              ]
+            }
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
## Summary

**Stage B per-master PR for Joe Pass.** Third Stage B promotion in this session. Pass is the single-method-shape master per your framing earlier ("Joe Pass wrote a few books that clarified and demonstrated his ideas, there wasn't the discontinuity and opposition like GvE") — so this PR uses `master.systems[]` directly, **not** `works[]`.

## Architectural validation

This PR grounds the **third** of the schema's three shape variants in real data:

| Master | Shape | Status |
|---|---|---|
| Benson (PR #304) | `works[]`-only (multi-method, placeholders) | Merged |
| Van Eps (PR #305) | `principles[]` + `works[]` (dual-shape, w/ placeholder) | Merged |
| **Pass (this PR)** | `principles[]` + `systems[]` (dual-shape, no works) | This PR |

All three configurations the dual-shape window + works[] layer (#293) was designed for are now exercised. The remaining 6 masters can pick whichever pattern fits.

## The 5 systems

Sourced from predecessor session 260521-aware-nebula's `plans/pass-system-rebuild.md`:

| System | Members | Trav | Mod | Pref |
|---|---|---|---|---|
| `six-chord-forms` (position system: C/A/G/E/D/Intermediate) | 6 | 2 | — | 1 |
| `three-harmonic-families` (major/minor/dominant taxonomy) | 3 | 1 | 1 | — |
| `voicing-density-and-voice-leading` (3-4-note solo; drop-2/3; walking-bass) | 7 | 1 | 4 | 1 |
| `harmonic-restraint` (three-textures cycling; don't harmonize every note; bypass-ii) | 3 | 1 | 2 | 1 |
| `dominant-substitution-lattice` (tune-wide alteration; color tones baseline) | 11 | 1 | 2 | 1 |

Every rule cites Method page numbers (ch5-1 p.19, ch1-6 p.9, ch10-4 p.30, etc.).

## Notable "firsts"

This PR produces the first real-data uses of three previously-underspecified glossary kinds:

- **`TextureCycle`** — Pass R3.5 walking-bass-plus-chord-stabs texture; Pass R4.1 three-textures-cycling
- **`NCTHarmonization`** — Pass R4.2 low-appetite ("don't harmonize every note"); fills the TODO Worked Example in `docs/payload-kinds.md`
- **`ColorToneRequire`** — Pass R5.5 baseline color tones in dom7 lines (Method ch1-6 p.9: "I will include the b9, +9, b5, or +5 in my lines"); fills the TODO Worked Example

Two new `_pending:` slugs added to the catalog:
- `_pending:degree-bypass` — Pass R4.4 "Forget the II — focus on the V"
- `_pending:tritone-substitution` — Pass R5.2 tritone color-passthrough

## Engine_payload.kind discipline

Every kind is glossary-cataloged or `_pending:`. No invented names; no stretches. Where the rebuild flagged 7 items as docs/preferences/arrangement-data rather than engine rules, I skipped them and named the skips in `think-pass-stage-b.md`'s "Skipped rules" section — no rule-shaped encoding where none belongs.

## Test plan

- [x] `python scripts/validate.py --target masters --verbose` — "Valid. 10 master(s) passed. Masters: 10, Works: 9, Principles (legacy): 41 (preserved), Systems (new): 13"
- [x] `python3 -m pytest tests/test_masters_schema.py tests/test_pipeline.py -q` — 61/61 pass
- [ ] CI

## What this is NOT

- Not a schema change.
- Not a code change.
- Not a runtime change.
- No engine consumes Pass's systems[] yet — masters.json is curatorial data; the engine layer is downstream.

Refs #220 #276 #293 #297 #298 #303.
