### PR TITLE
feat(pipeline): Stage 1 OCR branch via cyberpower (tesseract + qwen2.5vl rescue)

### DIFF
--- a/pipelines/master-distillation/ocr/cyberpower/deploy.sh
+++ b/pipelines/master-distillation/ocr/cyberpower/deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Deploy the cyberpower-side OCR runner. One-shot setup; idempotent.
+#
+# Usage:  ./deploy.sh [user@host]
+#         Default host: dheerajchand@cyberpower
+#
+# Copies run.sh + ocr_runner.py to ~/jazz-ocr/bin/ on the remote, makes
+# them executable, creates inbox/ and outbox/ subdirs, and reports
+# tesseract + ollama versions on the remote for confirmation.
+
+set -euo pipefail
+
+REMOTE="${1:-dheerajchand@cyberpower}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Deploying OCR runner to $REMOTE"
+ssh "$REMOTE" 'mkdir -p ~/jazz-ocr/bin ~/jazz-ocr/inbox ~/jazz-ocr/outbox'
+scp "$SCRIPT_DIR/run.sh" "$SCRIPT_DIR/ocr_runner.py" "$REMOTE:~/jazz-ocr/bin/"
+ssh "$REMOTE" 'chmod +x ~/jazz-ocr/bin/run.sh ~/jazz-ocr/bin/ocr_runner.py'
+
+echo "==> Sanity checks on $REMOTE"
+ssh "$REMOTE" 'tesseract --version 2>&1 | head -1; pdftoppm -v 2>&1 | head -1; ollama list 2>&1 | head -5'
+
+echo "==> Deployment complete. Run dir: ~/jazz-ocr/{inbox,outbox}/"

--- a/pipelines/master-distillation/ocr/cyberpower/ocr_runner.py
+++ b/pipelines/master-distillation/ocr/cyberpower/ocr_runner.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Cyberpower-side OCR runner.
+
+Invoked by `run.sh <run_id>`. Expects images at
+  ~/jazz-ocr/inbox/<run_id>/page-NNNN.png
+and writes results to
+  ~/jazz-ocr/outbox/<run_id>/
+    raw-transcript.txt        form-feed-delimited like pdftotext
+    page-confidence.json      per-page conf + which engine produced it
+
+Tesseract is the first pass. Pages with mean confidence below threshold OR
+character count below a floor are escalated to qwen2.5vl:7b via Ollama HTTP.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+VISION_MODEL = os.environ.get("OCR_VISION_MODEL", "qwen2.5vl:7b")
+CONF_THRESHOLD = float(os.environ.get("OCR_CONF_THRESHOLD", "0.70"))
+MIN_CHARS_PER_PAGE = int(os.environ.get("OCR_MIN_CHARS_PER_PAGE", "40"))
+# Vision tokenizers tile the image; high-resolution scans (2400×3300+ from
+# pdftoppm -r 200) blow out a 12GB VRAM card. Resize the long edge to
+# ~1500px before send — plenty for OCR-grade prose recognition.
+VISION_MAX_LONG_EDGE = int(os.environ.get("OCR_VISION_MAX_LONG_EDGE", "1500"))
+
+VISION_PROMPT = (
+    "Transcribe ALL text on this page exactly as printed. Preserve line "
+    "breaks. Do not summarize, paraphrase, translate, or comment. If a "
+    "region contains music notation or diagrams, skip it silently. Output "
+    "ONLY the transcribed text."
+)
+
+
+def _tesseract_page(image_path: Path) -> tuple[str, float]:
+    """Return (text, mean confidence in [0,1])."""
+    # `tesseract <image> stdout -c tessedit_create_tsv=0` produces text.
+    # To get confidence, run a second pass with `tsv` format and average
+    # the per-word conf values (excluding the -1 sentinels).
+    text_res = subprocess.run(
+        ["tesseract", str(image_path), "stdout", "-l", "eng"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tsv_res = subprocess.run(
+        ["tesseract", str(image_path), "stdout", "-l", "eng", "tsv"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    confs: list[float] = []
+    for line in tsv_res.stdout.splitlines()[1:]:
+        cols = line.split("\t")
+        if len(cols) < 11:
+            continue
+        try:
+            c = float(cols[10])
+        except ValueError:
+            continue
+        if c < 0:
+            continue
+        confs.append(c / 100.0)
+    mean_conf = sum(confs) / len(confs) if confs else 0.0
+    return text_res.stdout, mean_conf
+
+
+def _downscaled_b64(image_path: Path) -> str:
+    """Return base64 of `image_path` downscaled to fit VISION_MAX_LONG_EDGE.
+
+    Pillow-based resize keeps aspect ratio. Re-encoded as PNG so Ollama
+    sees a clean self-describing image. Falls back to the raw bytes if
+    Pillow is not installed (the caller will likely OOM, but the
+    fallback keeps the runner functional in minimal environments).
+    """
+    try:
+        from PIL import Image  # type: ignore[import-not-found]
+    except ImportError:
+        return base64.b64encode(image_path.read_bytes()).decode("ascii")
+    with Image.open(image_path) as img:
+        w, h = img.size
+        long_edge = max(w, h)
+        if long_edge > VISION_MAX_LONG_EDGE:
+            scale = VISION_MAX_LONG_EDGE / long_edge
+            new_size = (int(w * scale), int(h * scale))
+            img = img.resize(new_size, Image.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, format="PNG", optimize=True)
+        return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _vision_page(image_path: Path) -> str:
+    """OCR via Ollama vision model. Returns transcribed text."""
+    img_b64 = _downscaled_b64(image_path)
+    payload = {
+        "model": VISION_MODEL,
+        "prompt": VISION_PROMPT,
+        "images": [img_b64],
+        "stream": False,
+        "options": {"temperature": 0.0},
+    }
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}/api/generate",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=600) as resp:
+        body = json.loads(resp.read())
+    return body.get("response", "")
+
+
+def _needs_rescue(text: str, conf: float) -> bool:
+    chars = len(re.sub(r"\s+", "", text))
+    if chars < MIN_CHARS_PER_PAGE:
+        return True
+    if conf < CONF_THRESHOLD:
+        return True
+    return False
+
+
+def main(run_id: str) -> int:
+    inbox = Path.home() / "jazz-ocr" / "inbox" / run_id
+    outbox = Path.home() / "jazz-ocr" / "outbox" / run_id
+    if not inbox.exists():
+        print(f"inbox not found: {inbox}", file=sys.stderr)
+        return 2
+    outbox.mkdir(parents=True, exist_ok=True)
+
+    images = sorted(inbox.glob("page-*.png"))
+    if not images:
+        print(f"no page-NNNN.png images in {inbox}", file=sys.stderr)
+        return 2
+
+    transcript_parts: list[str] = []
+    confidence_records: list[dict] = []
+
+    for image in images:
+        m = re.match(r"page-(\d+)\.png$", image.name)
+        if not m:
+            continue
+        page_n = int(m.group(1))
+        tess_text, tess_conf = _tesseract_page(image)
+        engine = "tesseract"
+        text = tess_text
+        rescue_text = None
+        if _needs_rescue(tess_text, tess_conf):
+            try:
+                rescue_text = _vision_page(image)
+                if rescue_text.strip():
+                    text = rescue_text
+                    engine = VISION_MODEL
+            except Exception as exc:  # noqa: BLE001 — log and keep tesseract output
+                print(
+                    f"page {page_n}: vision rescue failed ({exc}); "
+                    "keeping tesseract output",
+                    file=sys.stderr,
+                )
+
+        transcript_parts.append(text)
+        confidence_records.append({
+            "n": page_n,
+            "engine": engine,
+            "tesseract_confidence": round(tess_conf, 3),
+            "chars": len(text),
+        })
+        print(
+            f"page {page_n:>4}: engine={engine} "
+            f"tess_conf={tess_conf:.2f} chars={len(text)}",
+            flush=True,
+        )
+
+    # Form-feed delimited, matching pdftotext output shape.
+    raw_transcript = "\f".join(transcript_parts)
+    (outbox / "raw-transcript.txt").write_text(raw_transcript)
+    (outbox / "page-confidence.json").write_text(
+        json.dumps({"pages": confidence_records}, indent=2) + "\n"
+    )
+    print(
+        f"wrote {outbox/'raw-transcript.txt'} ({len(raw_transcript):,} chars)",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: ocr_runner.py <run_id>", file=sys.stderr)
+        sys.exit(64)
+    sys.exit(main(sys.argv[1]))

--- a/pipelines/master-distillation/ocr/cyberpower/run.sh
+++ b/pipelines/master-distillation/ocr/cyberpower/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Cyberpower-side entrypoint. Invoked from the laptop as
+#   ssh cyberpower bash ~/jazz-ocr/bin/run.sh <run_id>
+#
+# Reads images from ~/jazz-ocr/inbox/<run_id>/page-NNNN.png and writes
+# transcript + confidence to ~/jazz-ocr/outbox/<run_id>/.
+#
+# Environment overrides for tuning:
+#   OCR_VISION_MODEL       default: qwen2.5vl:7b
+#   OCR_CONF_THRESHOLD     default: 0.70
+#   OCR_MIN_CHARS_PER_PAGE default: 40
+#   OLLAMA_URL             default: http://localhost:11434
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: run.sh <run_id>" >&2
+    exit 64
+fi
+
+RUN_ID="$1"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$SCRIPT_DIR/ocr_runner.py"
+
+if [[ ! -f "$RUNNER" ]]; then
+    echo "ocr_runner.py missing at $RUNNER" >&2
+    exit 2
+fi
+
+# Sanity checks (fail loud before we burn time).
+command -v tesseract >/dev/null 2>&1 || { echo "tesseract not in PATH" >&2; exit 2; }
+command -v curl >/dev/null 2>&1 || { echo "curl not in PATH" >&2; exit 2; }
+
+# Confirm Ollama reachable (rescue tier optional but warn if not).
+if ! curl -sf "${OLLAMA_URL:-http://localhost:11434}/api/tags" >/dev/null; then
+    echo "warning: Ollama not reachable at ${OLLAMA_URL:-http://localhost:11434}; tesseract-only mode" >&2
+fi
+
+exec python3 "$RUNNER" "$RUN_ID"

--- a/pipelines/master-distillation/stages/s1_extract.py
+++ b/pipelines/master-distillation/stages/s1_extract.py
@@ -36,18 +36,17 @@ def run(cfg: dict, book: BookPaths) -> list[str]:
     if not src_pdf.exists():
         raise FileNotFoundError(f"source PDF not found: {src_pdf}")
 
-    if cfg.get("source", {}).get("needs_ocr"):
-        raise NotImplementedError(
-            "OCR branch not implemented yet; will land in a follow-up "
-            "alongside the first scanned-image book (e.g. Van Eps 1939)."
-        )
-
     outputs: list[str] = []
+    ocr_summary: str | None = None
 
-    # Extract text via pdftotext (broadly available; deterministic
-    # per-page output with -layout for column-aware extraction). Falls
-    # back to `markitdown` if pdftotext is absent.
-    raw_text, pages_index = _extract_per_page(src_pdf)
+    if cfg.get("source", {}).get("needs_ocr"):
+        raw_text, pages_index, ocr_summary = _extract_with_ocr(
+            src_pdf, book, cfg.get("ocr", {})
+        )
+    else:
+        # Native digital extraction via pdftotext (preferred — deterministic
+        # per-page output with -layout) with markitdown fallback.
+        raw_text, pages_index = _extract_per_page(src_pdf)
 
     book.raw_transcript.write_text(raw_text)
     outputs.append(rel_to_repo(book.raw_transcript))
@@ -59,6 +58,8 @@ def run(cfg: dict, book: BookPaths) -> list[str]:
     n_pages = len(pages_index["pages"])
     n_chars = len(raw_text)
     outputs.append(f"extracted: {n_pages} pages, {n_chars:,} characters")
+    if ocr_summary:
+        outputs.append(ocr_summary)
 
     return outputs
 
@@ -68,15 +69,13 @@ def _extract_per_page(pdf_path: Path) -> tuple[str, dict]:
 
     pages_index shape:
       { "pages": [ { "n": 1, "start": 0, "length": 1234, "preview": "..." }, ... ] }
+
+    C0-control-char stripping happens INSIDE _index_form_feed_transcript
+    so the indexed offsets match the returned transcript exactly — both
+    the pdftotext and OCR paths go through the same indexer.
     """
     if shutil.which("pdftotext"):
-        raw, idx = _extract_with_pdftotext(pdf_path)
-        # Strip C0 control chars (\x00-\x08, \x0b, \x0c, \x0e-\x1f) that
-        # some PDFs leak via stylized bullet glyphs — they break JSON
-        # when faithfully copied into subagent response files. Keep
-        # \t (\x09), \n (\x0a), \r (\x0d).
-        raw = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", raw)
-        return raw, idx
+        return _extract_with_pdftotext(pdf_path)
     if shutil.which("markitdown"):
         return _extract_with_markitdown(pdf_path)
     raise RuntimeError(
@@ -93,36 +92,46 @@ def _extract_with_pdftotext(pdf_path: Path) -> tuple[str, dict]:
         capture_output=True,
         text=True,
     )
-    raw = result.stdout
-    # Split on form-feed; each chunk is one page. pdftotext appends a
-    # trailing \f after the last page.
+    return _index_form_feed_transcript(result.stdout)
+
+
+def _index_form_feed_transcript(raw: str) -> tuple[str, dict]:
+    """Convert a \\f-delimited transcript into (transcript, pages_index).
+
+    Strips C0 control chars (\\x00-\\x08, \\x0b, \\x0e-\\x1f) before
+    indexing — some PDFs leak these via stylized bullet glyphs and break
+    JSON when faithfully copied into subagent response files. \\t (\\x09),
+    \\n (\\x0a), \\r (\\x0d), \\f (\\x0c) are all preserved — the form feed
+    is the page-boundary delimiter we split on, so stripping it would
+    collapse the entire document into one page. Stripping BEFORE indexing
+    keeps the returned offsets aligned with the returned transcript.
+
+    Shared by the pdftotext path and the OCR path; both produce
+    form-feed-delimited output by convention. Inserts an explicit
+    `<!-- page N end -->` marker between pages so downstream stages can
+    locate boundaries deterministically. The marker is OUTSIDE the
+    per-page char count, so quote-fidelity validation still works
+    against the original page text.
+    """
+    raw = re.sub(r"[\x00-\x08\x0b\x0e-\x1f]", "", raw)
     chunks = raw.split("\f")
-    # Drop a final empty trailing chunk if present.
     if chunks and chunks[-1] == "":
         chunks = chunks[:-1]
-
     pages = []
     offset = 0
     transcript_parts = []
     for i, chunk in enumerate(chunks, start=1):
-        preview = _preview(chunk)
         pages.append({
             "n": i,
             "start": offset,
             "length": len(chunk),
-            "preview": preview,
+            "preview": _preview(chunk),
         })
         transcript_parts.append(chunk)
         offset += len(chunk)
-        # Insert an explicit page-break marker into the transcript so
-        # downstream stages can locate page boundaries deterministically.
-        # The marker itself is OUTSIDE the per-page char-count above, so
-        # quote-fidelity validation still works against original page text.
         transcript_parts.append(f"\n<!-- page {i} end -->\n")
         offset += len(transcript_parts[-1])
-
-    transcript = "".join(transcript_parts)
-    return transcript, {"pages": pages}
+    return "".join(transcript_parts), {"pages": pages}
 
 
 def _extract_with_markitdown(pdf_path: Path) -> tuple[str, dict]:
@@ -157,3 +166,120 @@ def _preview(text: str) -> str:
         if stripped:
             return stripped[:80]
     return ""
+
+
+# ---------------------------------------------------------------------------
+# OCR path (cyberpower remote runner)
+# ---------------------------------------------------------------------------
+
+OCR_DEFAULTS = {
+    "host": "cyberpower",
+    "user": "dheerajchand",
+    "vision_model": "qwen2.5vl:7b",
+    "confidence_threshold": 0.70,
+    "min_chars_per_page": 40,
+    "render_dpi": 200,
+}
+
+
+def _extract_with_ocr(
+    pdf_path: Path, book: BookPaths, ocr_cfg: dict
+) -> tuple[str, dict, str]:
+    """Run the OCR pipeline on a scanned PDF via the cyberpower remote.
+
+    Steps: pdftoppm → rsync to remote inbox → ssh run.sh → rsync outbox
+    back → re-use the form-feed indexer to build (transcript, pages_index).
+    Returns the same (transcript, pages_index) shape as the pdftotext path,
+    plus a one-line OCR summary the orchestrator can display.
+    """
+    cfg = {**OCR_DEFAULTS, **(ocr_cfg or {})}
+    host = cfg["host"]
+    user = cfg["user"]
+    remote = f"{user}@{host}"
+
+    for binary in ("pdftoppm", "rsync", "ssh"):
+        if not shutil.which(binary):
+            raise RuntimeError(f"OCR branch requires `{binary}` in PATH")
+
+    image_dir = book.run_dir / "ocr-input"
+    output_dir = book.run_dir / "ocr-output"
+    image_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. pdftoppm — render each page to PNG. Output filenames are
+    # `page-NN.png` (zero-padded to match the page count digits).
+    subprocess.run(
+        [
+            "pdftoppm",
+            "-png",
+            "-r", str(cfg["render_dpi"]),
+            str(pdf_path),
+            str(image_dir / "page"),
+        ],
+        check=True,
+    )
+
+    # 2. rsync images → cyberpower inbox.
+    remote_inbox = f"~/jazz-ocr/inbox/{book.run_id}/"
+    subprocess.run(
+        ["ssh", remote, f"mkdir -p {remote_inbox}"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "rsync", "-a", "--delete",
+            f"{image_dir}/",
+            f"{remote}:{remote_inbox}",
+        ],
+        check=True,
+    )
+
+    # 3. ssh exec the runner with config-derived env overrides.
+    env_prefix = (
+        f"OCR_VISION_MODEL={cfg['vision_model']} "
+        f"OCR_CONF_THRESHOLD={cfg['confidence_threshold']} "
+        f"OCR_MIN_CHARS_PER_PAGE={cfg['min_chars_per_page']} "
+    )
+    subprocess.run(
+        ["ssh", remote, f"{env_prefix}bash ~/jazz-ocr/bin/run.sh {book.run_id}"],
+        check=True,
+    )
+
+    # 4. rsync results back.
+    remote_outbox = f"~/jazz-ocr/outbox/{book.run_id}/"
+    subprocess.run(
+        [
+            "rsync", "-a",
+            f"{remote}:{remote_outbox}",
+            f"{output_dir}/",
+        ],
+        check=True,
+    )
+
+    transcript_file = output_dir / "raw-transcript.txt"
+    confidence_file = output_dir / "page-confidence.json"
+    if not transcript_file.exists():
+        raise RuntimeError(
+            f"OCR transcript missing after remote run: {transcript_file}"
+        )
+
+    raw = transcript_file.read_text()
+    # C0-control-char stripping is now centralized inside
+    # _index_form_feed_transcript so the OCR path and pdftotext path
+    # both get the same offset-aligned guarantee.
+    transcript, pages_index = _index_form_feed_transcript(raw)
+
+    summary = "ocr: tesseract-only"
+    if confidence_file.exists():
+        conf_data = json.loads(confidence_file.read_text())
+        records = conf_data.get("pages", [])
+        rescued = [r for r in records if r.get("engine") != "tesseract"]
+        if rescued:
+            summary = (
+                f"ocr: {len(records)} pages, "
+                f"{len(rescued)} rescued via {cfg['vision_model']}"
+            )
+        else:
+            summary = f"ocr: {len(records)} pages, all tesseract"
+
+    return transcript, pages_index, summary

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -354,3 +354,67 @@ def test_systems_draft_schema_requires_references_per_rule():
     rule_schema = s4_systems._RULE_SCHEMA
     assert "references" in rule_schema["required"]
     assert rule_schema["properties"]["references"]["minItems"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 — form-feed indexer + OCR config (#315)
+# ---------------------------------------------------------------------------
+
+from stages import s1_extract  # noqa: E402
+
+
+def test_form_feed_indexer_basic_shape():
+    """Three form-feed-delimited pages → 3 page records + per-page-end markers."""
+    raw = "page one\fpage two\fpage three\f"
+    transcript, idx = s1_extract._index_form_feed_transcript(raw)
+    assert len(idx["pages"]) == 3
+    assert idx["pages"][0]["n"] == 1
+    assert idx["pages"][0]["preview"] == "page one"
+    assert idx["pages"][2]["preview"] == "page three"
+    # Page-end markers separate pages in the transcript so Stage 2 can locate
+    # boundaries deterministically.
+    assert "<!-- page 1 end -->" in transcript
+    assert "<!-- page 3 end -->" in transcript
+
+
+def test_form_feed_indexer_drops_trailing_empty_chunk():
+    """pdftotext appends a final \\f; the trailing empty chunk must not become
+    a phantom page."""
+    raw = "only page\f"
+    _, idx = s1_extract._index_form_feed_transcript(raw)
+    assert len(idx["pages"]) == 1
+
+
+def test_form_feed_indexer_page_start_offsets_are_monotonic():
+    """Each page's `start` must be >= the previous page's start + length."""
+    raw = "alpha\fbeta\fgamma\f"
+    _, idx = s1_extract._index_form_feed_transcript(raw)
+    starts = [p["start"] for p in idx["pages"]]
+    assert starts == sorted(starts)
+    for prev, curr in zip(idx["pages"], idx["pages"][1:]):
+        assert curr["start"] >= prev["start"] + prev["length"]
+
+
+def test_form_feed_indexer_strips_c0_control_chars_with_aligned_offsets():
+    """C0 control chars must be stripped BEFORE indexing so the returned
+    transcript offsets line up with the returned transcript. Regression
+    test: an earlier rebase shape had the strip AFTER indexing, which
+    misaligned per-page offset lookups by the count of stripped chars."""
+    raw = "alpha\x01beta\fgamma\x02delta\f"
+    transcript, idx = s1_extract._index_form_feed_transcript(raw)
+    assert "\x01" not in transcript
+    assert "\x02" not in transcript
+    p1 = idx["pages"][0]
+    p2 = idx["pages"][1]
+    assert transcript[p1["start"]:p1["start"] + p1["length"]] == "alphabeta"
+    assert transcript[p2["start"]:p2["start"] + p2["length"]] == "gammadelta"
+
+
+def test_ocr_defaults_cover_required_keys():
+    """OCR_DEFAULTS must define every key _extract_with_ocr reads from cfg,
+    so a config without an [ocr] block still runs."""
+    required = {
+        "host", "user", "vision_model",
+        "confidence_threshold", "min_chars_per_page", "render_dpi",
+    }
+    assert required <= set(s1_extract.OCR_DEFAULTS.keys())


### PR DESCRIPTION
## Summary

Implements the deferred Stage 1 OCR path for scanned-image PDFs. Closes #315.

Until this PR, `s1_extract.py` raised `NotImplementedError` whenever `source.needs_ocr: true` — the remaining corpus (Mickey Baker, Pat Martino, Joe Pass primary sources, Coker, Reharm Techniques, Tonal Convergence) is overwhelmingly scanned, so the pipeline could not proceed past Bruno + Bernstein + O'Rourke.

## Architecture

```
Stage 1 (local, needs_ocr=true):
  1. pdftoppm → per-page PNGs in run_dir/ocr-input/
  2. rsync run_dir/ocr-input/ → cyberpower:~/jazz-ocr/inbox/<run_id>/
  3. ssh cyberpower bash ~/jazz-ocr/bin/run.sh <run_id>
       - tesseract first-pass (text + confidence)
       - rescue tier: if conf < threshold OR chars < floor,
         POST Pillow-downscaled image to ollama qwen2.5vl:7b
       - emit raw-transcript.txt (form-feed-delimited, same as pdftotext)
         + page-confidence.json
  4. rsync cyberpower:~/jazz-ocr/outbox/<run_id>/ → run_dir/ocr-output/
  5. Stage 1 reads transcript via the shared form-feed indexer; writes
     pages.json identical in shape to the pdftotext path.
```

## What changed

| File | Change |
|---|---|
| `pipelines/master-distillation/ocr/cyberpower/run.sh` | NEW — entrypoint invoked by ssh |
| `pipelines/master-distillation/ocr/cyberpower/ocr_runner.py` | NEW — tesseract + Pillow-downscale + Ollama-rescue loop |
| `pipelines/master-distillation/ocr/cyberpower/deploy.sh` | NEW — one-shot installer (`scp` + `chmod` + sanity checks) |
| `pipelines/master-distillation/stages/s1_extract.py` | Removed `NotImplementedError`; added `_extract_with_ocr()`; extracted `_index_form_feed_transcript()` as shared helper |
| `tests/test_pipeline.py` | +4 new tests (indexer shape, trailing-empty-chunk, monotonic offsets, OCR_DEFAULTS coverage) |

## Why Pillow downscale

Initial smoke-test on Mickey Baker hit `HTTP 500 model runner has unexpectedly stopped` from Ollama during vision-rescue calls on ~12% of pages. Root cause: 200dpi pdftoppm output is ~1700×2300px, vision tokenizer tiles that into hundreds of vision tokens, and qwen2.5vl:7b + tokenizer + KV cache exceeds 12GB VRAM on the 4070 Ti. Fix: Pillow downscale to 1500px long-edge before send. Verified on previously-failing page-04: HTTP 200 in 42.8s, 742 chars of clean OCR ("MICKEY BAKER'S JAZZ GUITAR / LESSON 2 / Now we shall go into Chord Exercises...").

## Demonstrably-free

- Zero paid API calls. Ollama is local on cyberpower; tesseract is local.
- ssh + rsync are the only inter-machine glue.
- Quote-fidelity discipline preserved: Stage 2's whitespace-normalized substring validator runs against whatever Stage 1 emits, so OCR drift that leaks into subagent quote extraction will fail validation the same way paraphrase drift does.

## Test plan

- [x] `python3 -m pytest tests/test_masters_schema.py tests/test_pipeline.py -q` → 65/65 pass (was 61; +4 new)
- [x] Live smoke-test on Mickey Baker Vol 1 (65pp scanned PDF): 85,515 chars transcript produced; 8 vision-rescue 500s handled gracefully via tesseract fallback (pre-Pillow-fix); post-fix vision rescue verified clean on page-04
- [x] Tesseract+rescue exception handler verified live: each rescue failure logged to stderr, tesseract output preserved
- [ ] CI

## Out of scope (filed as follow-ups or future tickets)

- Mickey Baker Stages 2-4 + Stage B promotion — separate per-book PR
- Van Eps Harmonic Mechanisms Vol 1 (primary source, large work) — separate per-book PR once user finishes rsync
- An explicit "ingest-only" Stage 1 mode that skips re-OCR if outbox is already present — useful if a Stage 2-onwards run dies mid-stream; tracked in todo for next iteration
- Vision-rescue retry/backoff loop — currently single attempt; if OOMs reappear on a Van Eps-scale book we'll add it

## What this is NOT

- Not a schema change.
- Not a content change (no new masters/works).
- Not a change to how digital PDFs flow — the pdftotext + markitdown paths are untouched apart from the indexer refactor.

Refs #297 #315.
