### PR TITLE
feat(pipeline): Stage 1 OCR survives laptop close (nohup-detach + ingest-only recovery)

### DIFF
--- a/pipelines/master-distillation/ocr/reingest.py
+++ b/pipelines/master-distillation/ocr/reingest.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Re-ingest a Stage 1 OCR run from its local ocr-output/raw-transcript.txt.
+
+Use this when:
+  - the in-flight Stage 1 was running with stale code that had a buggy
+    indexer (e.g. the pre-fix FF-strip bug that collapsed pages), or
+  - the orchestrator died mid-ingest after the rsync-down completed, or
+  - you want to re-apply an updated indexer to an existing OCR outbox
+    without re-OCRing on cyberpower.
+
+The cyberpower outbox (ocr-output/raw-transcript.txt) is the authoritative
+artifact. This script reads it, runs the current `_index_form_feed_transcript`
+helper, and rewrites raw-transcript.txt + pages.json at the run-dir root.
+Stage state is bumped to awaiting-review for s1.
+
+Usage:
+  python3 pipelines/master-distillation/ocr/reingest.py <run_id>
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PIPELINE_DIR = REPO_ROOT / "pipelines" / "master-distillation"
+sys.path.insert(0, str(PIPELINE_DIR))
+
+from lib.paths import RUNS_ROOT  # noqa: E402
+from stages.s1_extract import OCR_DEFAULTS  # noqa: E402
+from stages.s1_extract import _index_form_feed_transcript  # noqa: E402
+
+
+def main(run_id: str) -> int:
+    run_dir = RUNS_ROOT / run_id
+    if not run_dir.exists():
+        print(f"run dir not found: {run_dir}", file=sys.stderr)
+        return 2
+
+    output_dir = run_dir / "ocr-output"
+    raw_file = output_dir / "raw-transcript.txt"
+
+    # If the local outbox is empty, try to rsync from cyberpower. This
+    # handles the case where the orchestrator died after the remote runner
+    # finished but before the rsync-down step.
+    if not raw_file.exists():
+        output_dir.mkdir(parents=True, exist_ok=True)
+        remote = f"{OCR_DEFAULTS['user']}@{OCR_DEFAULTS['host']}"
+        remote_outbox = f"~/jazz-ocr/outbox/{run_id}/"
+        print(f"local outbox empty; rsyncing from {remote}:{remote_outbox} ...")
+        try:
+            subprocess.run(
+                ["rsync", "-a", f"{remote}:{remote_outbox}", f"{output_dir}/"],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            print(f"rsync from cyberpower failed: {exc}", file=sys.stderr)
+            return 2
+
+    if not raw_file.exists():
+        print(
+            f"OCR output not found at {raw_file} after attempted rsync; "
+            f"check that cyberpower:{f'~/jazz-ocr/outbox/{run_id}/'} has a "
+            f"raw-transcript.txt.",
+            file=sys.stderr,
+        )
+        return 2
+
+    transcript, pages_index = _index_form_feed_transcript(raw_file.read_text())
+
+    (run_dir / "raw-transcript.txt").write_text(transcript)
+    (run_dir / "pages.json").write_text(json.dumps(pages_index, indent=2) + "\n")
+
+    # Update stage-state so s1 is awaiting-review and s2 is unblocked
+    # on --advance. We don't touch upstream/downstream stages.
+    state_file = run_dir / "stage-state.json"
+    if state_file.exists():
+        state = json.loads(state_file.read_text())
+        s1 = state["stages"].get("s1", {})
+        s1["status"] = "awaiting-review"
+        s1["outputs"] = [
+            f"pipelines/master-distillation/runs/{run_id}/raw-transcript.txt",
+            f"pipelines/master-distillation/runs/{run_id}/pages.json",
+            f"re-ingested: {len(pages_index['pages'])} pages, {len(transcript):,} characters",
+        ]
+        s1["error_message"] = None
+        state_file.write_text(json.dumps(state, indent=2) + "\n")
+
+    print(
+        f"re-ingested {len(pages_index['pages'])} pages "
+        f"({len(transcript):,} chars) for run {run_id}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: reingest.py <run_id>", file=sys.stderr)
+        sys.exit(64)
+    sys.exit(main(sys.argv[1]))

--- a/pipelines/master-distillation/stages/s1_extract.py
+++ b/pipelines/master-distillation/stages/s1_extract.py
@@ -26,6 +26,7 @@ import json
 import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 from lib.paths import BookPaths, rel_to_repo
@@ -234,23 +235,60 @@ def _extract_with_ocr(
         check=True,
     )
 
-    # 3. ssh exec the runner with config-derived env overrides.
+    # 3. ssh-launch the runner under nohup so it's INDEPENDENT of this
+    # SSH session. The remote process survives laptop sleep / lid close /
+    # SSH disconnect — only the local poll loop (next step) cares about
+    # connectivity, and that re-establishes on wake. If the laptop dies
+    # entirely mid-run, the remote runner still finishes and the outbox
+    # is recoverable via `ocr/reingest.py <run_id>`.
     env_prefix = (
         f"OCR_VISION_MODEL={cfg['vision_model']} "
         f"OCR_CONF_THRESHOLD={cfg['confidence_threshold']} "
         f"OCR_MIN_CHARS_PER_PAGE={cfg['min_chars_per_page']} "
     )
+    launch_cmd = (
+        f"nohup bash -c '{env_prefix}~/jazz-ocr/bin/run.sh {book.run_id}' "
+        f"</dev/null >~/jazz-ocr/{book.run_id}.log 2>&1 & disown; "
+        f"sleep 1; pgrep -af 'ocr_runner.*{book.run_id}' >/dev/null"
+    )
     subprocess.run(
-        ["ssh", remote, f"{env_prefix}bash ~/jazz-ocr/bin/run.sh {book.run_id}"],
+        ["ssh", remote, launch_cmd],
         check=True,
     )
 
-    # 4. rsync results back.
-    remote_outbox = f"~/jazz-ocr/outbox/{book.run_id}/"
+    # 4. Poll cyberpower until the runner exits and the outbox transcript
+    # appears. Robust to laptop sleep (the poll just pauses on sleep and
+    # resumes on wake — the remote runner doesn't care).
+    remote_outbox = f"~/jazz-ocr/outbox/{book.run_id}"
+    poll_interval = 30
+    while True:
+        probe = subprocess.run(
+            ["ssh", remote,
+             f"if pgrep -f 'ocr_runner.*{book.run_id}' >/dev/null; then "
+             f"echo RUNNING; "
+             f"elif [ -f {remote_outbox}/raw-transcript.txt ]; then "
+             f"echo DONE; "
+             f"else "
+             f"echo CRASHED; "
+             f"fi"],
+            capture_output=True, text=True, check=True,
+        )
+        status = probe.stdout.strip()
+        if status == "DONE":
+            break
+        if status == "CRASHED":
+            raise RuntimeError(
+                f"OCR runner exited without producing outbox. "
+                f"Check ~/jazz-ocr/{book.run_id}.log on {host}."
+            )
+        # status == "RUNNING": keep waiting.
+        time.sleep(poll_interval)
+
+    # 5. rsync results back.
     subprocess.run(
         [
             "rsync", "-a",
-            f"{remote}:{remote_outbox}",
+            f"{remote}:{remote_outbox}/",
             f"{output_dir}/",
         ],
         check=True,


### PR DESCRIPTION
Closes #317.

## Summary

Makes Stage 1 OCR durable to laptop close / sleep / relocation. Previously the cyberpower runner was a child of the local SSH session — sleep > ~3min SSH timeout = SIGHUP cascade = runner dies. After this PR the runner is parented to systemd/init via `nohup ... & disown`, and the local Python is a thin polling coordinator.

## Files changed

| File | Change |
|---|---|
| `pipelines/master-distillation/stages/s1_extract.py` | `_extract_with_ocr` now launches the runner detached and polls cyberpower every 30s for completion. `time` import added. |
| `pipelines/master-distillation/ocr/reingest.py` | NEW — recovery tool. Reads cyberpower outbox via rsync (if local copy missing) + rebuilds `raw-transcript.txt` + `pages.json` via the centralized `_index_form_feed_transcript`. Updates stage-state to awaiting-review. |

## Live verification

During the overnight 2026-05-25/26 runs, the OLD pre-PR code path:
- Launched Van Eps Vol 1 Stage 1 (334pp). Local Python orchestrator survived because laptop stayed open ~6 hours; cyberpower runner finished; outbox was written. Lucky.
- Local Python then ingested with stale in-memory code that had the FF-strip bug → produced single-page corrupted output.

The NEW recovery path (`reingest.py`) rebuilt both Van Eps (334 pages / 262K chars) and Baker (65 pages / 78K chars) from the cyberpower outboxes — confirming the recovery story works end-to-end.

## Test plan

- [x] 66/66 tests pass
- [x] `reingest.py` verified live on two real runs
- [ ] CI (will be red on the pre-existing baseline failures; ignore — none introduced by this PR)
- [ ] Next OCR run uses the new code path and verifies the laptop-close survival story intentionally (deferred to next book through the pipeline; #317 references this as the empirical confirmation step)

## Out of scope

- Adding an `awaiting-ocr` state to the state machine for true async runs (the user could close laptop, come back, run `resume` and get the rsync-and-ingest). Current PR keeps the orchestrator blocking on poll, which is durable enough for laptop sleep + relocation; explicit async would be a larger redesign.

Refs #297 #315 #316.