### PR TITLE
feat(masters): Van Eps composite — principles[] grounded in both works + master-level STATEMENT.md

### DIFF
--- a/plugin/data/masters-corpus/van-eps/STATEMENT.md
+++ b/plugin/data/masters-corpus/van-eps/STATEMENT.md
@@ -1,0 +1,232 @@
+# George Van Eps — Composite Statement (1939 Method + Harmonic Mechanisms Vol 1)
+
+This master-level statement synthesizes the two primary-source works currently
+load-bearing for the `van-eps` master entry: *The George Van Eps Method for
+Guitar* (Epiphone Inc., 1939) and *Harmonic Mechanisms for Guitar, Volume 1*
+(Mel Bay, 2016 reissue of the mid-1980s original). It is the master-level
+companion to the per-work statements at
+`1939-method/derived/STATEMENT.md` and
+`harmonic-mechanisms-vol-1/derived/STATEMENT.md`. Volumes 2 and 3 of
+Harmonic Mechanisms remain pending acquisition; a `_placeholder:harmonic-mechanisms`
+entry in `masters.works[]` preserves that gap.
+
+## 1. Central thesis: the guitar as lap piano
+
+Van Eps's career-long thesis is that the guitar should be played as a
+self-contained polyphonic instrument — what he repeatedly calls a "lap piano"
+— rather than as a melodic single-line instrument with chordal accompaniment.
+The two works are different surface treatments of that single underlying
+claim. Both insist that every musical event on the instrument is a stack of
+independent contrapuntal voices, not a block of pitches that happens to sound
+together. Both organize practice around sustaining outer voices while inner
+voices animate the harmony beneath. Both treat the harmonized scale as the
+generative engine and the harmonic-mechanism vocabulary (triads → tetrads →
+extensions) as the substrate.
+
+Vol 1 opens with the explicit framing: "My books contain no single voice
+studies as such. All of the studies employ two or more voices" (Harmonic
+Mechanisms Vol 1, ch. 1). The 1939 Method makes the same commitment
+operationally: every exercise from Ex. 1 forward is a chordal study, never a
+single-line scale (1939 Method, Foreword + Ex. 1, p. 8). The two works
+differ in pedagogical scope and instrumental scope — the 1939 Method is a
+six-string distillation, Vol 1 a seven-string treatise — but they share a
+structural backbone.
+
+## 2. The 1939 Method as introductory distillation (~42 pp)
+
+*The George Van Eps Method for Guitar* was published in 1939 by Epiphone Inc.
+as a 42-page method book. It is Van Eps's earliest published systematic
+exposition of his approach, and it functions, in retrospect, as a
+compressed prospectus for the larger work that would appear four decades
+later as *Harmonic Mechanisms*. The 1939 Method is organized by
+chord-quality category: Examples 1–25 work the harmonized major scale in
+triads; Examples 26–32 the harmonized minor; Examples 33–47 the
+7th-arpeggio scale; Examples 48–82 the harmonized diminished. Every category
+is practiced across six fingering forms covering the entire fingerboard,
+and every form is run through all twelve keys via what Van Eps calls the
+Solfeggio principle: "Think of the tonic of every key as do" (1939 Method,
+Foreword).
+
+Layered on top of that organizational scaffold are Van Eps's signature
+techniques, all explicitly named: outer-voice anchor with chromatic inner
+motion (Examples 14, 18, 20, 37, 57, 60–65, 67–68, 82); pulsation picking
+with top-voice dynamic emphasis ('Pick and Wrist Action', p. 3, plus Ex. 2
+instructions, p. 9); left-hand finger-flattening as a virtual "fifth finger"
+(Ex. 16); and string-deadening as the enabling mechanism for open
+voicings. The chromatic 10ths with middle-voice motion exercise (Ex. 37)
+appears here in fully worked form: "The middle note remains the same while
+the other two voices move around the middle voice in chromatic tenths"
+(1939 Method, Ex. 37). That single exercise is the seed for an entire
+chapter of Harmonic Mechanisms Vol 1.
+
+What the 1939 Method does NOT do is the comprehensive exposition: it states
+each technique, demonstrates it across one or two paradigmatic exercises,
+and trusts the student to extend the technique across the harmonic terrain
+laid out by the four chord-quality scales. It is closer in spirit to a
+syllabus with worked examples than to a treatise.
+
+## 3. Harmonic Mechanisms Vol 1 as the comprehensive treatise (~334 pp)
+
+*Harmonic Mechanisms for Guitar, Volume 1* is the first volume of Van Eps's
+mature three-volume systematization, written for seven-string guitar (low A)
+and published by Mel Bay (current Mel Bay edition is the 2016 reissue of the
+mid-1980s original). At 334 pages, Vol 1 is roughly eight times the
+length of the 1939 Method, and its pedagogical strategy is correspondingly
+different. Rather than stating a technique and leaving extension to the
+student, Vol 1 works each technique exhaustively through every chord
+quality, every inversion, every string set, and every key transposition.
+
+The pedagogical arc moves from triadic harmony (Chapters 2–3: the Mighty
+Triads, mixed minors) through reductions and sixths-with-upper-line
+exercises (Chapters 4–5) to chromatic triad work with pedal and alternating
+bass (Chapters 6–7), then to the Super and Sub series for first- and
+second-inversion triads (Chapters 8–9), open voicings with multi-voice
+motion (Chapters 10–11), and finally the Fifth Finger Principle and
+advanced applications (Chapters 12–14). Throughout, Van Eps declares
+chromatics the organizing concern: "ALL THROUGH MY BOOKS THE EMPHASIS WILL
+BE ON 'CHROMATICS' — CHROMATICS, CHROMATICS, AND MORE CHROMATICS"
+(Harmonic Mechanisms Vol 1, ch. 6, p. 137). The chromatic scale itself is
+elevated to the role of universal source: "The chromatic scale contains
+every known scale, arpeggio, chord, harmonic situation, theme, etc. in all
+twelve keys" (Harmonic Mechanisms Vol 1, ch. 12, p. 257).
+
+Vol 1 also formalizes the notational vocabulary that the 1939 Method only
+sketches. The six fingering forms of the 1939 Method become a fully
+elaborated string-set notation: adjacent sets (1/3, 2/3, 3/3, 4/3), broken
+sets that skip a single intermediate string (1/B3, B1/3, etc.), and
+divided sets that skip two strings (D1/4, 1/D3) — all formally specified
+in the chapter 12 String Set Symbol System (Harmonic Mechanisms Vol 1,
+ch. 12, p. 258). The compressed Ex. 37 device from 1939 expands into the
+chapter 5 sixths-to-tenths and chapter 7 chromatic-third-to-tenth exercise
+machinery. The 1939 Method's brief mention of finger-flattening becomes
+the explicit Fifth Finger Principle of Vol 1 ch. 12: "the knack of
+sounding two notes simultaneously that are not located on the same fret,
+with one finger" (Harmonic Mechanisms Vol 1, ch. 12, p. 263). The
+joint-level execution is given in chapter 9: "The first joint of the
+second finger plays the double stop in flattened position (just the first
+joint flat, not the whole finger)" (Harmonic Mechanisms Vol 1, ch. 9,
+p. 185).
+
+## 4. Shared structural backbone
+
+Four concepts are unambiguously load-bearing in both works, and these are
+the cross-work principles captured in `masters.json` `van-eps.principles[]`:
+
+**Outer-voice anchor with inner-voice motion.** The 1939 Method documents
+this device across more than a dozen exercises, most explicitly Ex. 82:
+"the third and fourth fingers play the two upper voices in quarter notes
+while the first and second fingers sustain the lower voices in whole
+notes" (1939 Method, Ex. 82). Vol 1 elevates the device to the central
+load-bearing system of the entire book — every chord exercise is a
+four-part polyphonic texture, and the chapter 4 anchor-and-move drill
+"Run the moving voice up and down repeatedly in each station while making
+sure to sustain the whole note" (Harmonic Mechanisms Vol 1, ch. 4, p. 70)
+is the physical foundation for everything that follows. Chapter 6 makes
+the sustain demand explicit: "keep the pressure applied firmly while the
+quarter notes are in motion" (Harmonic Mechanisms Vol 1, ch. 6, p. 134).
+
+**Six fingering forms across string sets.** The 1939 Method introduces
+the six-form scope in the Ex. 1 instructions, with the String Chart on
+p. 6 providing the original 1|3, 2|3 notation. Vol 1 generalizes and
+formalizes that vocabulary into the full broken/divided set system in
+chapter 6 and chapter 12. Both works treat string-set traversal as the
+mechanism by which a harmonized scale covers the entire fingerboard with
+preserved harmonic content.
+
+**Harmonized-scale-as-organizing-principle.** The 1939 Method's whole
+organizational architecture begins with harmonizing the corresponding
+scale in triads for each chord-quality category. Vol 1's chapter 2,
+'The Mighty Triads', states the same priority: "Most of the studies in
+these books are based on, and relate to the 'triad' in one form or
+another. Closed and open voicings in all stages of separation are
+interesting and informative" (Harmonic Mechanisms Vol 1, ch. 2, p. 19).
+The harmonized scale is the vocabulary; voicings are derived by running
+that scale through the string-set fingerings.
+
+**Four-part chord construction (triads → tetrads → extensions).** The
+1939 Method follows the major → minor → 7th-arpeggio → diminished
+sequence implicitly. Vol 1 makes the tertian stacking explicit: triads
+first, then tetrads (seventh chords), then extended chords (9ths, 11ths,
+13ths), with extensions treated as substitution-expansions of their
+parent tetrads. The chord-quality categories are formalized as the six
+top-level family bins: major, minor, dominant, diminished, augmented,
+half-diminished.
+
+## 5. Where the two works diverge
+
+The 1939 Method emphasizes **technique mechanics**: how to pulse-pick,
+how to flatten a finger to extend the reach, how to deaden specific
+strings to enable open voicings, how to position the wrist over the
+top voice for dynamic stratification. Vol 1, by contrast, emphasizes
+**polyphonic-exercise machinery**: how to drill chromatic 10ths
+across all keys, how to run a harmonized scale through every string
+set, how to sustain a middle voice through extended reaches. The two
+works are pedagogically complementary rather than redundant — the 1939
+Method tells the student which physical mechanics to acquire; Vol 1
+provides the exhaustive exercise corpus on which to drill them.
+
+Three principles in the master entry are 1939-only and therefore use
+citation-only references without Vol 1 corollaries:
+**pulsation-picking-top-voice-emphasis** (Vol 1 treats right-hand
+attack in passing — ch. 6 "left and right hand attack must be together
+for best results" — but does not name pulsation picking as a discrete
+technique); **string-deadening-for-open-voicings** (Vol 1 addresses
+spacing-for-audibility in ch. 1 and uses selective string-set choice as
+the structural mechanism for open voicings instead of naming
+string-deadening as a discrete technique). The
+chromatic-tenths-with-middle-voice principle, while seeded by 1939
+Method's Ex. 37, is comprehensively expanded in Vol 1 chapters 5 and 7
+and is cross-referenced accordingly.
+
+The remaining four principles — harmonized-scale-foundation,
+six-fingering-string-sets, outer-voice-anchor-inner-motion,
+finger-flattening-fifth-finger — carry references to both works in
+`masters.json` `principles[*].references[]`, with chapter-level Vol 1
+provenance (`work_id`, `chapter_n`, `topic`, `quote_excerpt`) per the
+Vol 1 reference shape established in the work-level statement.
+
+## 6. Volumes 2 and 3 (pending)
+
+The `_placeholder:harmonic-mechanisms` entry in `masters.works[]`
+preserves the gap for the remaining two Mel Bay volumes. Pending
+content includes Van Eps's diagonal-barre technique (fret 10+
+innovation), 7th-string bass walking with the low A as a bass-line
+resource, the inner-voice independence extended to six- or
+seven-voice SATB+ textures, and the systematization of harmonic
+mechanisms across the full seven-string voicing inventory. Until
+PDFs are acquired and processed through the OCR pipeline, no
+principles should be added to the master entry from Vols 2–3, and
+the placeholder shape (no `systems[]`, no `references[]` claims about
+specific page content) must be preserved. The corpus tree under
+`van-eps/` currently contains only the `harmonic-mechanisms-vol-1/`
+work directory; Vols 2 and 3 will live in sibling directories with
+the same per-work `derived/STATEMENT.md` convention when they land.
+
+## 7. Companion documents
+
+This statement is intentionally a synthesis, not a substitute. For
+work-internal exposition, see:
+
+- `harmonic-mechanisms-vol-1/derived/STATEMENT.md` — Vol 1's
+  internal pedagogical arc, per-chapter summaries, and the four
+  systems-derived load-bearing structures
+  (`van-eps:harmonic-mechanisms-vol-1:inner-voice-independence`,
+  `:six-string-set-fingerings`, `:four-part-chord-construction`,
+  and the supporting taxonomy).
+- `1939-method/derived/...` — the 1939 Method's exercise-level
+  documentation, including Ex. 37, Ex. 82, and the Pick and Wrist
+  Action section, with the four 1939-internal systems
+  (`van-eps:1939-method:harmonized-scale-foundation`,
+  `:inner-voice-independence`, `:right-hand-technique`,
+  `:left-hand-mechanics`).
+- `masters.json` `van-eps` master entry — the cross-work
+  authoritative reference, with `principles[*].references[]`
+  carrying both 1939 and Vol 1 citations where corollaries exist
+  and citation-only fallbacks where they do not.
+
+The composite synthesis maintained here exists because the two
+works are unusually tightly coupled — the 1939 Method is not a
+historical curiosity superseded by Vol 1 but an active companion
+text that names mechanics Vol 1 assumes — and the cross-work
+references in `masters.json` should be read against the narrative
+synthesis given here rather than against either work alone.

--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -37,6 +37,14 @@
             {
               "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939)",
               "citation": "Foreword + Ex. 1 (major) / Ex. 26 (minor) / Ex. 33 (7th) / Ex. 48 (diminished). Quoted: 'All exercises presented in this volume have been carefully tested through years of teaching. Each one has a definite purpose for development of the hand, no matter how insignificant it may seem to the student.' Solfeggio quote also from Foreword."
+            },
+            {
+              "source": "Van Eps, George. Harmonic Mechanisms for Guitar, Volume 1. Mel Bay Publications (2016 reissue; original mid-1980s).",
+              "citation": "Chapter 2, 'The Mighty Triads'; Chapter 12, 'The Chromatic Scale as Universal Source'.",
+              "work_id": "harmonic-mechanisms-vol-1",
+              "chapter_n": 2,
+              "topic": "Triad as central unit (substrate of the entire book)",
+              "quote_excerpt": "Most of the studies in these books are based on, and relate to the “triad” in one form or another"
             }
           ],
           "example_voicing_signatures": []
@@ -64,6 +72,14 @@
             {
               "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939)",
               "citation": "Explanation of String Chart (p. 6) and Ex. 1 instructions (p. 8). Each set has a notation symbol (1|3, 2|3, ..., 1|B3, etc.). The six-form scope is documented in the Ex. 1 instructions: '1st form C up to F, 2nd form C up to C sharp (D if possible)...'"
+            },
+            {
+              "source": "Van Eps, George. Harmonic Mechanisms for Guitar, Volume 1. Mel Bay Publications (2016 reissue; original mid-1980s).",
+              "citation": "Chapter 6 / Chapter 12, 'String set symbol system' and 'Broken and divided sets'.",
+              "work_id": "harmonic-mechanisms-vol-1",
+              "chapter_n": 6,
+              "topic": "String-set symbol system and broken/divided sets",
+              "quote_excerpt": "When the Ist-2nd-4th-strings are employed (skipping the 3rd string) it is termed a broken set"
             }
           ],
           "example_voicing_signatures": []
@@ -92,6 +108,22 @@
             {
               "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939)",
               "citation": "Exercises 14, 18, 20, 37, 40, 42, 46, 57, 60-65, 67-68, 82. Ex. 82: 'Individual control of the fingers is developed in this exercise. In the first measure the third and fourth fingers play the two upper voices in quarter notes while the first and second fingers sustain the lower voices in whole notes.'"
+            },
+            {
+              "source": "Van Eps, George. Harmonic Mechanisms for Guitar, Volume 1. Mel Bay Publications (2016 reissue; original mid-1980s).",
+              "citation": "Chapter 6, 'Sustain pressure while articulating' (lap-piano texture demand).",
+              "work_id": "harmonic-mechanisms-vol-1",
+              "chapter_n": 6,
+              "topic": "Outer-voice sustain under inner articulation",
+              "quote_excerpt": "keep the pressure applied firmly while the quarter notes are in motion"
+            },
+            {
+              "source": "Van Eps, George. Harmonic Mechanisms for Guitar, Volume 1. Mel Bay Publications (2016 reissue; original mid-1980s).",
+              "citation": "Chapter 4, 'Hold the whole note while voice moves' (anchor-and-move drill).",
+              "work_id": "harmonic-mechanisms-vol-1",
+              "chapter_n": 4,
+              "topic": "Anchor-and-move drill: sustain whole note while other voice runs the scale",
+              "quote_excerpt": "Run the moving voice up and down"
             }
           ],
           "example_voicing_signatures": []
@@ -120,6 +152,14 @@
             {
               "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939), Ex. 37",
               "citation": "Direct quote from Ex. 37 instructions: 'The middle note remains the same while the other two voices move around the middle voice in chromatic tenths. This is the first exercise using a broken set of three strings.'"
+            },
+            {
+              "source": "Van Eps, George. Harmonic Mechanisms for Guitar, Volume 1. Mel Bay Publications (2016 reissue; original mid-1980s).",
+              "citation": "Chapter 5, 'Sixths opening up to tenths'; Chapter 7, chromatic third-to-tenth exercises.",
+              "work_id": "harmonic-mechanisms-vol-1",
+              "chapter_n": 5,
+              "topic": "Sixths-to-tenths expansion with inner-voice motion",
+              "quote_excerpt": "Sixths opening up to tenths"
             }
           ],
           "example_voicing_signatures": []
@@ -147,6 +187,10 @@
             {
               "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939)",
               "citation": "'Pick and Wrist Action' section (p. 3) + Ex. 2 instructions (p. 9). Ex. 2: 'The pick passes over each string and accents it with a slight kick, which is more of a pulsation... using the pulsation principle you will be able to maintain a steady tempo and you will not strike two strings at once.' Picking section: '...the top note should predominate.'"
+            },
+            {
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., 1939.",
+              "citation": "Generic citation of the 1939 method as primary source for the pulsation-picking right-hand mechanic with top-voice dynamic emphasis; Harmonic Mechanisms Vol 1 (2016) treats right-hand attack only in passing (e.g., ch. 6 'left and right hand attack must be together') and does not name pulsation picking. No Vol 1 corollary."
             }
           ],
           "example_voicing_signatures": []
@@ -171,6 +215,22 @@
             {
               "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939), Ex. 16",
               "citation": "Direct quote from Ex. 16: 'This exercise must be practiced very carefully as we introduce a new principle in the first two forms which is the breaking (or flattening from an arched position) of the first joint of the fingers. In the first form at the second and third measures, you flatten the first joint of the second finger to produce the added note, which brings this principle into the classification of a fifth finger.'"
+            },
+            {
+              "source": "Van Eps, George. Harmonic Mechanisms for Guitar, Volume 1. Mel Bay Publications (2016 reissue; original mid-1980s).",
+              "citation": "Chapter 12, 'THE FIFTH FINGER PRINCIPLE'; Chapter 9, second-finger flatten-then-arch hammer mechanic.",
+              "work_id": "harmonic-mechanisms-vol-1",
+              "chapter_n": 12,
+              "topic": "Fifth Finger Principle (one finger, two non-collinear notes)",
+              "quote_excerpt": "the knack of sounding two notes simultaneously that are not located on the same fret, with one finger"
+            },
+            {
+              "source": "Van Eps, George. Harmonic Mechanisms for Guitar, Volume 1. Mel Bay Publications (2016 reissue; original mid-1980s).",
+              "citation": "Chapter 9, 'Second-finger hammer mechanic' (joint-level flatten-then-arch).",
+              "work_id": "harmonic-mechanisms-vol-1",
+              "chapter_n": 9,
+              "topic": "Joint-level flatten-then-arch mechanic for sustained inner voice",
+              "quote_excerpt": "The first joint of the second finger plays the double stop in flattened position"
             }
           ],
           "example_voicing_signatures": []
@@ -197,6 +257,10 @@
             {
               "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., NY (ca. 1939), Ex. 58",
               "citation": "Direct quote from Ex. 58 (the first diminished open-voicing exercise) and its footnote: 'In the first form the D string (IV) is stopped from vibrating with the second finger while that finger is used for the note on the A (V) string... *i.e. The pick strikes that string, but the left hand finger does not let it sound clearly.'"
+            },
+            {
+              "source": "Van Eps, George. The George Van Eps Method for Guitar. Epiphone Inc., 1939.",
+              "citation": "Generic citation of the 1939 method as primary source for string-deadening as an enabler of open voicings. Harmonic Mechanisms Vol 1 (2016) addresses spacing-for-audibility (ch. 1) and selective string-set choice as the structural mechanism for open voicings rather than naming string-deadening as a discrete technique. No Vol 1 corollary."
             }
           ],
           "example_voicing_signatures": []


### PR DESCRIPTION
Closes #323. First composite-from-multiple-works PR.

## Summary

The van-eps master now has two real primary-source works:
- `1939-method` (via #305)
- `harmonic-mechanisms-vol-1` (via #322)
- `_placeholder:harmonic-mechanisms` (covers Vols 2/3, preserved)

This PR adds the **curatorial composite layer** on top — separate options preserved, composite added.

## What lands

1. **`plugin/data/masters.json`**: each of the 7 `van-eps.principles[]` entries gets a populated `references[]` array with 2-3 cross-work entries (16 references total). Each ref entry uses the schema's permitted shape (`additionalProperties=true`) to carry `work_id` / `chapter_n` / `topic` / `quote_excerpt` alongside the standard `source` / `citation`.

2. **`plugin/data/masters-corpus/van-eps/STATEMENT.md`** (~13.5KB): master-level narrative that explicitly synthesizes both works. Companion to the per-work STATEMENT files; does not replace them.

## Pattern established

Where a master has multiple real works[], the composite shape is:
- Per-work `derived/STATEMENT.md` files stay intact
- New master-level `STATEMENT.md` at `plugin/data/masters-corpus/<master>/STATEMENT.md`
- Master-level `principles[]` entries get cross-work `references[]` populated

No schema change required (the references schema's `additionalProperties=true` already permits the extra fields).

## Reference shape

```json
{
  "source": "Van Eps, George. Harmonic Mechanisms for Guitar, Vol. 1...",
  "citation": "Chapter 3, 'Inner-voice motion'",
  "work_id": "harmonic-mechanisms-vol-1",
  "chapter_n": 3,
  "topic": "Inner voice independence",
  "quote_excerpt": "5-15 word verbatim snippet from chapter file"
}
```

1939-only principles (pulsation, finger-flattening, string-deadening) get citation-only entries without `work_id`/`quote_excerpt` because the 1939 method predates the pipeline and has no chapter MD files. Honest about evidence shape.

## Test plan

- [x] `python3 scripts/validate.py --target masters --verbose` → "Valid. 13 master(s). Masters: 13, Works: 13, Principles: 41 (preserved), Systems: 54" — unchanged counts
- [x] `python3 -m pytest tests/test_masters_schema.py tests/test_pipeline.py -q` → 66/66 pass
- [x] All 7 principles have ≥2 references (verified by inspection)
- [ ] CI (pre-existing baseline red)

## What this is NOT

- Not a schema change.
- Not a removal of any existing artifact.
- Not a `master.systems[]` upgrade (that's a follow-up if cross-work systems become a repeating pattern).
- Not touching the `_placeholder:harmonic-mechanisms` work — Vols 2/3 stub preserved.

Refs #220 #276 #293 #297 #305 #322 #323.