### PR TITLE
data(pipeline): queue 20 remaining PDFs + QUEUE.md inventory

### DIFF
--- a/pipelines/master-distillation/QUEUE.md
+++ b/pipelines/master-distillation/QUEUE.md
@@ -1,0 +1,100 @@
+# Pipeline queue
+
+A flat inventory of every PDF that has a config in `configs/`. Use this to decide
+what to run next and to track Stage B disposition.
+
+## Conventions
+
+- **Status**: ✅ promoted to masters.json · 🟦 in pipeline · 🟨 queued, not started · 🟥 skip-promote, corpus-only · ❓ author TBD post-OCR
+- **OCR?**: y = needs_ocr=true; cyberpower OCR branch routes it
+- **Source**: digital (pdftotext) or scanned (OCR via #316/#318)
+- Per-config disposition is in the config file's header comment
+
+## Already-promoted (no work needed)
+
+| Master | Work | Stage B PR | Source |
+|---|---|---|---|
+| benson | method-vol-1-chord-construction | #304 | digital (319pp) |
+| jimmy-bruno | the-art-of-picking | #313 | digital (51pp) |
+| peter-bernstein | improvisation-method-as-documented-2023 | #314 | digital (30pp) |
+| mickey-baker | complete-course-in-jazz-guitar | #319 | OCR (65pp) |
+| van-eps | harmonic-mechanisms-vol-1 | #322 | OCR (334pp) |
+| greg-orourke | complete-chord-melody | #321 corpus-only | digital (318pp) |
+
+## Queue (20 configs, ready to run)
+
+OCR-required books route through the cyberpower OCR branch. Digital books run
+straight through pdftotext. Order below is the suggested run order.
+
+### Tier 1 — Fill existing master slots (high curatorial value, low risk)
+
+| # | Config | Master:Work | Pages | OCR? | Stage B shape | Status |
+|---|---|---|---|---|---|---|
+| 1 | `van-eps-1939-method.toml` | van-eps:1939-method | 42 | y | FILL existing slot (master entry pre-dates pipeline; has summary+refs only, no corpus or systems[]) | 🟨 |
+| 2 | `baker-vol-2.toml` | mickey-baker:complete-course-vol-2 | 49 | y | Sibling work[] | 🟨 |
+| 3 | `pass-guitar-method.toml` | joe-pass:guitar-method | 34 | y | Sibling work[] | 🟨 |
+| 4 | `pass-guitar-chords.toml` | joe-pass:guitar-chords | 26 | y | Sibling work[] | 🟨 |
+| 5 | `greene-modern-chord-progressions.toml` | ted-greene:modern-chord-progressions | 106 | y | Sibling work[] | 🟨 |
+
+### Tier 2 — New primary-source masters
+
+| # | Config | Master:Work | Pages | OCR? | Stage B shape | Status |
+|---|---|---|---|---|---|---|
+| 6 | `martino-linear-expressions.toml` | pat-martino:linear-expressions | 63 | y | NEW master | 🟨 |
+| 7 | `coker-elements-jazz-language.toml` | jerry-coker:elements-of-the-jazz-language | 154 | y | NEW master | 🟨 |
+
+### Tier 3 — Benson sibling works (digital, batchable)
+
+| # | Config | Master:Work | Pages | OCR? | Stage B shape | Status |
+|---|---|---|---|---|---|---|
+| 8 | `benson-vol-2-advanced-harmony.toml` | benson:method-vol-2-advanced-harmony | 322 | n | Sibling work[] | 🟨 |
+| 9 | `benson-vol-3-technique-arpeggios.toml` | benson:method-vol-3-technique-arpeggios | 351 | n | Sibling work[] | 🟨 |
+| 10 | `benson-vol-4-approach-tones.toml` | benson:method-vol-4-approach-tones | 372 | n | Sibling work[] | 🟨 |
+| 11 | `benson-vol-5-melodic-minor.toml` | benson:method-vol-5-melodic-minor | 434 | n | Sibling work[] (largest book in queue) | 🟨 |
+| 12 | `benson-vol-6-giant-lines.toml` | benson:method-vol-6-giant-lines | 145 | n | Sibling work[] | 🟨 |
+| 13 | `benson-vol-7-blues-ideas.toml` | benson:method-vol-7-blues-ideas | 227 | n | Sibling work[] | 🟨 |
+
+### Tier 4 — Author/disposition TBD (decide at Stage B per #320)
+
+| # | Config | Master:Work (provisional) | Pages | OCR? | Stage B disposition | Status |
+|---|---|---|---|---|---|---|
+| 14 | `tbd-reharmonization-techniques.toml` | _pending:tbd-master | 190 | y | Identify author from Stage 1 transcript; promote (if recognized) or corpus-only (per #320) | ❓ |
+| 15 | `tbd-tonal-convergence.toml` | _pending:tbd-master | 84 | y | Same: identify from Stage 1; promote or corpus-only | ❓ |
+| 16 | `tbd-chord-melody-series-1-beginning.toml` | _pending:tbd-master | 98 | y | Identify from Stage 1; corpus-only is most likely outcome given series style | ❓ |
+| 17 | `tbd-chord-melody-series-2-intermediate.toml` | _pending:tbd-master | 98 | y | Same series as 16 | ❓ |
+| 18 | `tbd-chord-melody-series-3-mastering.toml` | _pending:tbd-master | 63 | y | Same series as 16 | ❓ |
+
+### Tier 5 — Corpus-only (per #320 criterion)
+
+| # | Config | Master:Work | Pages | OCR? | Stage B disposition | Status |
+|---|---|---|---|---|---|---|
+| 19 | `orourke-beginners-guide.toml` | greg-orourke:beginners-guide-to-jazz-guitar | 197 | n | Corpus-only (same author as #321 skip-promote) | 🟥 |
+| 20 | `all-fourths-tuning.toml` | _pending:tbd-master | 66 | n | Alt-tuning niche material. Corpus-only or skip entirely; decide at Stage B | ❓ |
+
+## Operational notes
+
+- **Run one book at a time.** Cyberpower vision-rescue contention means concurrent Stage 1 runs serialize on Ollama anyway. Sequential is cleaner.
+- **Per-book branch.** Each run gets its own `feature/<book-slug>` branch off `develop`; Stage B is the merge point. Mirrors what we did for Bruno / Bernstein / Baker / Van Eps Vol 1.
+- **Stage 4 subagent timeout protocol.** For books over ~150 pages (Benson Vols 2-5, Reharmonization Techniques), use the tight-cap Stage 4 prompt shape from Van Eps Vol 1's PR #322 to avoid the systems-draft subagent stream timeout.
+- **Stage B promotion eligibility.** Per #320, anything not clearly primary-source by a recognized jazz-tradition figure stays under `masters-corpus/` without masters.json promotion. Promote later if the criterion ticket #320 resolves to a less restrictive rule.
+
+## How to run a queued book
+
+```bash
+# new run from config
+python3 pipelines/master-distillation/run.py new-run \
+  pipelines/master-distillation/configs/<config-slug>.toml
+
+# at each `awaiting-llm` gate, fill the response file via subagent / direct write
+# at each `awaiting-review` gate, run --advance to move forward
+
+python3 pipelines/master-distillation/run.py advance <run-id>
+python3 pipelines/master-distillation/run.py resume <run-id>
+
+# Stage 1 OCR runs survive laptop close (see #318); recovery via:
+python3 pipelines/master-distillation/ocr/reingest.py <run-id>
+```
+
+## Refs
+
+#220 #297 #313 #314 #315 #316 #318 #319 #320 #321 #322 #323 #324 #325 #326 #327 #328 #329.

--- a/pipelines/master-distillation/configs/all-fourths-tuning.toml
+++ b/pipelines/master-distillation/configs/all-fourths-tuning.toml
@@ -1,0 +1,31 @@
+# Queued via #329. Stage B: edge-case alt-tuning material. Stage B disposition per #320 — likely corpus-only or skip given alt-tuning niche.
+
+[master]
+id = "_pending:tbd-master"
+name = "(All-fourths tuning material — author TBD)"
+
+[work]
+id = "all-fourths-tuning-for-jazz-guitar"
+title = "All Fourths Tuning for Jazz Guitar"
+year = 2010
+instrument_scope = "all-fourths"
+
+[source]
+pdf = "~/Desktop/parse_these/All_Fourths_Tuning_for_Jazz_Guitar_for_n.pdf"
+needs_ocr = false
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/baker-vol-2.toml
+++ b/pipelines/master-distillation/configs/baker-vol-2.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: sibling work[] under mickey-baker master (Vol 1 promoted in #319).
+
+[master]
+id = "mickey-baker"
+name = "Mickey Baker"
+
+[work]
+id = "complete-course-vol-2"
+title = "Mickey Baker's Complete Course in Jazz Guitar, Volume 2"
+year = 1959
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/mickey-baker-complete-course-in-jazz-guitar-2pdf_compress.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/benson-vol-2-advanced-harmony.toml
+++ b/pipelines/master-distillation/configs/benson-vol-2-advanced-harmony.toml
@@ -1,0 +1,31 @@
+# Queued via #329. Stage B: sibling work[] under benson master. Replaces _placeholder slot if it exists.
+
+[master]
+id = "benson"
+name = "George Benson"
+
+[work]
+id = "method-vol-2-advanced-harmony"
+title = "The George Benson Method, Vol. 2 — Advanced Harmony"
+year = 2019
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/George Benson Method/THE-GEORGE-BENSON-METHOD-VOL-2-Advanced-Harmony-1st-Edition.pdf"
+needs_ocr = false
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/benson-vol-3-technique-arpeggios.toml
+++ b/pipelines/master-distillation/configs/benson-vol-3-technique-arpeggios.toml
@@ -1,0 +1,31 @@
+# Queued via #329. Stage B: sibling work[] under benson master.
+
+[master]
+id = "benson"
+name = "George Benson"
+
+[work]
+id = "method-vol-3-technique-arpeggios"
+title = "The George Benson Method, Vol. 3 — Technique, Arpeggios, The Secret of the Two Chords"
+year = 2019
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/George Benson Method/THE-GEORGE-BENSON-METHOD-VOL-3-George-Benson-Technique-Arpeggios-The-Secret-of-the-Two-Chords-Â©-1st-Edition.pdf"
+needs_ocr = false
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/benson-vol-4-approach-tones.toml
+++ b/pipelines/master-distillation/configs/benson-vol-4-approach-tones.toml
@@ -1,0 +1,31 @@
+# Queued via #329. Stage B: sibling work[] under benson master.
+
+[master]
+id = "benson"
+name = "George Benson"
+
+[work]
+id = "method-vol-4-approach-tones"
+title = "The George Benson Method, Vol. 4 — Approach Tones, Dorian, Mixolydian and Harmonic Minor World"
+year = 2019
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/George Benson Method/THE-GEORGE-BENSON-METHOD-VOL-4-Approach-Tones-Dorian-Mixolydian-and-Harmonic-Minor-World-1st-Edition.pdf"
+needs_ocr = false
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/benson-vol-5-melodic-minor.toml
+++ b/pipelines/master-distillation/configs/benson-vol-5-melodic-minor.toml
@@ -1,0 +1,31 @@
+# Queued via #329. Stage B: sibling work[] under benson master. Largest book in the queue (434 pp); expect Stage 4 subagent timeout protocol from Van Eps Vol 1 to apply.
+
+[master]
+id = "benson"
+name = "George Benson"
+
+[work]
+id = "method-vol-5-melodic-minor"
+title = "The George Benson Method, Vol. 5 — Melodic Minor World, Bebop Scales, Symmetric Ideas and Concepts"
+year = 2019
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/George Benson Method/THE-GEORGE-BENSON-METHOD-VOL-5-Melodic-Minor-World-Bebop-Scales-Symmetric-Ideas-and-Concepts-Â©-1st-Edition.pdf"
+needs_ocr = false
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/benson-vol-6-giant-lines.toml
+++ b/pipelines/master-distillation/configs/benson-vol-6-giant-lines.toml
@@ -1,0 +1,31 @@
+# Queued via #329. Stage B: sibling work[] under benson master.
+
+[master]
+id = "benson"
+name = "George Benson"
+
+[work]
+id = "method-vol-6-giant-lines"
+title = "The George Benson Method, Vol. 6 — The Secret of the Giant Lines"
+year = 2019
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/George Benson Method/THE-GEORGE-BENSON-METHOD-VOL-6-The-Secret-of-the-Giant-Lines-1st-Edition.pdf"
+needs_ocr = false
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/benson-vol-7-blues-ideas.toml
+++ b/pipelines/master-distillation/configs/benson-vol-7-blues-ideas.toml
@@ -1,0 +1,31 @@
+# Queued via #329. Stage B: sibling work[] under benson master.
+
+[master]
+id = "benson"
+name = "George Benson"
+
+[work]
+id = "method-vol-7-blues-ideas"
+title = "The George Benson Method, Vol. 7 — Ultimate Advanced Blues Ideas"
+year = 2019
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/George Benson Method/THE-GEORGE-BENSON-METHOD-VOL-7-Ultimate-Advanced-Blues-Ideas-Â©-1st-Edition.pdf"
+needs_ocr = false
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/coker-elements-jazz-language.toml
+++ b/pipelines/master-distillation/configs/coker-elements-jazz-language.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: NEW master jerry-coker. Pedagogue + saxophonist, broadly applicable jazz language.
+
+[master]
+id = "jerry-coker"
+name = "Jerry Coker"
+
+[work]
+id = "elements-of-the-jazz-language"
+title = "Jerry Coker — Elements of the Jazz Language for the Developing Improviser"
+year = 1991
+instrument_scope = "any"
+
+[source]
+pdf = "~/Desktop/parse_these/COKER, Jerry - Elements Of The Jazz Language.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/greene-modern-chord-progressions.toml
+++ b/pipelines/master-distillation/configs/greene-modern-chord-progressions.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: sibling work[] under ted-greene master (Chord Chemistry already in master).
+
+[master]
+id = "ted-greene"
+name = "Ted Greene"
+
+[work]
+id = "modern-chord-progressions"
+title = "Modern Chord Progressions — Jazz and Classical Voicings for Guitar"
+year = 1976
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/Modern Chord Progressions - Jazz And Classical Voicings For Guitar - Ted Greene.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/martino-linear-expressions.toml
+++ b/pipelines/master-distillation/configs/martino-linear-expressions.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: NEW master pat-martino. Linear-expressions / minor-conversion approach to jazz line-playing.
+
+[master]
+id = "pat-martino"
+name = "Pat Martino"
+
+[work]
+id = "linear-expressions"
+title = "Pat Martino — Linear Expressions"
+year = 1983
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/Guitar-Book-Pat-Martino-Linear-Expressions.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/orourke-beginners-guide.toml
+++ b/pipelines/master-distillation/configs/orourke-beginners-guide.toml
@@ -1,0 +1,31 @@
+# Queued via #329. Stage B: corpus-only per #320 (author=www.jazzguitar.be = same O'Rourke domain as #321; skip-promotion convention).
+
+[master]
+id = "greg-orourke"
+name = "Greg O'Rourke"
+
+[work]
+id = "beginners-guide-to-jazz-guitar"
+title = "The Beginner's Guide to Jazz Guitar"
+year = 2017
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/The_Beginners_Guide_To_Jazz_Guitar.pdf"
+needs_ocr = false
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/pass-guitar-chords.toml
+++ b/pipelines/master-distillation/configs/pass-guitar-chords.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: sibling work[] under joe-pass master (Method primary already in master; this adds the Chords companion volume).
+
+[master]
+id = "joe-pass"
+name = "Joe Pass"
+
+[work]
+id = "guitar-chords"
+title = "Joe Pass Guitar Chords"
+year = 1971
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/Joe Pass Guitar Chords.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/pass-guitar-method.toml
+++ b/pipelines/master-distillation/configs/pass-guitar-method.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: sibling work[] under joe-pass master.
+
+[master]
+id = "joe-pass"
+name = "Joe Pass"
+
+[work]
+id = "guitar-method"
+title = "Joe Pass Guitar Method"
+year = 1972
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/Joe Pass Guitar Method.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/tbd-chord-melody-series-1-beginning.toml
+++ b/pipelines/master-distillation/configs/tbd-chord-melody-series-1-beginning.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: AUTHOR TBD. Same series as configs 11 + 12. PowerPDF/VSPDF.DLL producer metadata, no author in PDF properties.
+
+[master]
+id = "_pending:tbd-master"
+name = "(TBD post-OCR)"
+
+[work]
+id = "chord-melody-series-1-beginning"
+title = "(Mystery series) 1 — Beginning"
+year = 2000
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/1- Beginning.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/tbd-chord-melody-series-2-intermediate.toml
+++ b/pipelines/master-distillation/configs/tbd-chord-melody-series-2-intermediate.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: AUTHOR TBD. Same series as 10 + 12.
+
+[master]
+id = "_pending:tbd-master"
+name = "(TBD post-OCR)"
+
+[work]
+id = "chord-melody-series-2-intermediate"
+title = "(Mystery series) 2 — Intermediate"
+year = 2000
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/2- Intermediate.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/tbd-chord-melody-series-3-mastering.toml
+++ b/pipelines/master-distillation/configs/tbd-chord-melody-series-3-mastering.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: AUTHOR TBD. Same series as 10 + 11.
+
+[master]
+id = "_pending:tbd-master"
+name = "(TBD post-OCR)"
+
+[work]
+id = "chord-melody-series-3-mastering"
+title = "(Mystery series) 3 — Mastering Chord Melody"
+year = 2000
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/3 - Mastering Chord Melody.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/tbd-reharmonization-techniques.toml
+++ b/pipelines/master-distillation/configs/tbd-reharmonization-techniques.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: AUTHOR TBD. Read Stage 1 transcript to identify; promote/skip per #320. Title is well-known but multiple books share it; possibly Felts (Berklee) or other.
+
+[master]
+id = "_pending:tbd-master"
+name = "(TBD post-OCR)"
+
+[work]
+id = "reharmonization-techniques"
+title = "Reharmonization Techniques"
+year = 2000
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/Reharmonization Techniques.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/tbd-tonal-convergence.toml
+++ b/pipelines/master-distillation/configs/tbd-tonal-convergence.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: AUTHOR TBD. Read Stage 1 transcript to identify; promote/skip per #320.
+
+[master]
+id = "_pending:tbd-master"
+name = "(TBD post-OCR)"
+
+[work]
+id = "system-of-tonal-convergence"
+title = "A System of Tonal Convergence"
+year = 2000
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/A System of Tonal Convergence.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"

--- a/pipelines/master-distillation/configs/van-eps-1939-method.toml
+++ b/pipelines/master-distillation/configs/van-eps-1939-method.toml
@@ -1,0 +1,39 @@
+# Queued via #329. Stage B: FILL existing van-eps:1939-method work entry (currently has summary+references only; no corpus or systems[]).
+
+[master]
+id = "van-eps"
+name = "George Van Eps"
+
+[work]
+id = "1939-method"
+title = "The George Van Eps Method for Guitar"
+year = 1939
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/Desktop/parse_these/The_George_Van_Eps_Method_for_Guitar.documents.pdf"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"


### PR DESCRIPTION
Closes #329. Stages every PDF in \`~/Desktop/parse_these/\` for run-ready pipeline execution.

## What lands

- **20 new \`.toml\` configs** under \`pipelines/master-distillation/configs/\` (one per unprocessed PDF).
- **\`pipelines/master-distillation/QUEUE.md\`** inventory with Tier 1-5 ordering, status per-book, Stage B disposition, and operational notes.

## Tier breakdown

| Tier | Description | Count |
|---|---|---|
| 1 | Fill existing master slots (van-eps 1939, baker vol 2, pass method/chords, greene MCP) | 5 |
| 2 | New primary-source masters (Martino, Coker) | 2 |
| 3 | Benson sibling works (Vols 2-7, digital) | 6 |
| 4 | TBD-author OCR books (reharm, tonal-convergence, chord-melody-1/2/3) | 5 |
| 5 | Corpus-only per #320 (O'Rourke Beginners Guide, all-fourths-tuning) | 2 |

## Why now

The user request: "queue everything up so we can figure out the consumption engine." With all books queued and run-ready, the engine team has visibility into the full curatorial corpus shape **before** committing to engine schema. The applied_lessons[] pattern from #328 can extend across the corpus once each master has at least one work through Stage B.

## Verification

- All 26 configs (20 new + 6 existing) parse cleanly via \`tomllib\` and reference PDFs that exist on disk. Sanity-check script reported "errors: 0".
- No runtime effect. Configs are inert until \`run.py new-run\` invokes them.
- Tests unaffected — no code change in this PR.

## Operational notes (excerpted from QUEUE.md)

- Run **one book at a time**. Cyberpower vision-rescue contention means concurrent Stage 1 runs serialize through Ollama anyway.
- Per-book branch: each run gets \`feature/<book-slug>\` off \`develop\`; Stage B is the merge point.
- For books over ~150 pages (Benson Vols 2-5, Reharmonization Techniques): use the tight-cap Stage 4 prompt shape from #322 to avoid systems-draft subagent stream timeout.
- Stage B promotion eligibility per #320: TBD-author books (Tier 4) get author identification post-OCR, then promote/skip per the criterion.

## What this is NOT

- Not running any of the queued books. That's per-book operational decision.
- Not deciding Stage B promotion for TBD-author books. Decided at Stage B per #320.
- Not a schema change.

Refs #220 #297 #313 #314 #315 #316 #318 #319 #320 #321 #322 #323 #324 #325 #326 #327 #328.