### PR TITLE
fix(pipeline): #339 ops robustness — pdftoppm completion marker + OCR poll cap

### DIFF
--- a/pipelines/master-distillation/queue/process_one.sh
+++ b/pipelines/master-distillation/queue/process_one.sh
@@ -11,6 +11,17 @@
 #       reingest.py which has the canonical indexer.)
 #   $STATE_DIR/<slug>.done or .error
 #   $LOG_DIR/<slug>.stdout, $LOG_DIR/<slug>.stderr
+#
+# Exit codes:
+#   0 = success (.done marker written)
+#   2 = config / runner missing / source PDF missing
+#   3 = OCR runner finished but outbox missing transcript
+#   4 = pdftotext returned nonzero
+#
+# Single-writer invariant: acquire_lock is non-atomic but the daemon's
+# is_locked() check before dispatch ensures only one process_one.sh
+# instance runs per slug at a time. Running two daemons concurrently
+# would violate this.
 
 set -euo pipefail
 
@@ -63,16 +74,28 @@ if [ "$NEEDS_OCR" = "1" ] || [ "$NEEDS_OCR" = "true" ]; then
     OCR_RUN_ID="$SLUG"   # use slug as the run_id so paths are stable
     OCR_INBOX="$HOME/jazz-ocr/inbox/$OCR_RUN_ID"
     OCR_OUTBOX="$HOME/jazz-ocr/outbox/$OCR_RUN_ID"
+    OCR_INBOX_COMPLETE_MARKER="$OCR_INBOX/.pdftoppm-complete"
     mkdir -p "$OCR_INBOX"
 
-    if ! ls "$OCR_INBOX"/page-*.png >/dev/null 2>&1; then
+    # F1 fix (#339): use an explicit .pdftoppm-complete marker instead of
+    # a page-glob existence check. If a prior run was killed mid-render,
+    # the inbox would contain SOME page PNGs but be incomplete. The old
+    # check would skip re-rendering and feed a partial inbox to the OCR
+    # runner, producing silent under-extraction with a .done marker.
+    # The marker is written ONLY after pdftoppm exits successfully.
+    if [ -f "$OCR_INBOX_COMPLETE_MARKER" ]; then
+        log_line "$SLUG" "skipping pdftoppm (.pdftoppm-complete marker present)" \
+            | tee -a "$STDOUT_LOG"
+    else
+        # Clear any stale PNGs from a prior partial render before re-doing.
+        rm -f "$OCR_INBOX"/page-*.png
         log_line "$SLUG" "running pdftoppm into $OCR_INBOX" \
             | tee -a "$STDOUT_LOG"
         pdftoppm -png -r "$OCR_RENDER_DPI" "$PDF_PATH" "$OCR_INBOX/page" \
             >>"$STDOUT_LOG" 2>>"$STDERR_LOG"
-    else
-        log_line "$SLUG" "skipping pdftoppm (inbox already populated)" \
-            | tee -a "$STDOUT_LOG"
+        # Write marker only after success. If pdftoppm fails, set -e
+        # causes process_one.sh to exit; no marker, no false skip on retry.
+        date -Iseconds > "$OCR_INBOX_COMPLETE_MARKER"
     fi
 
     log_line "$SLUG" "running OCR runner" | tee -a "$STDOUT_LOG"

--- a/pipelines/master-distillation/stages/s1_extract.py
+++ b/pipelines/master-distillation/stages/s1_extract.py
@@ -273,6 +273,11 @@ OCR_DEFAULTS = {
     "confidence_threshold": 0.70,
     "min_chars_per_page": 40,
     "render_dpi": 200,
+    # F8 fix (#339): wall-clock cap on the remote-runner poll loop. If
+    # Ollama wedges and ocr_runner hangs, the orchestrator polls forever
+    # without this. 120 min is generous for 500-page books at observed
+    # rates; longer real-world runs go through reingest.py on timeout.
+    "max_wait_minutes": 120,
 }
 
 
@@ -377,8 +382,16 @@ def _extract_with_ocr(
     # 4. Poll cyberpower until the runner exits and the outbox transcript
     # appears. Robust to laptop sleep (the poll just pauses on sleep and
     # resumes on wake — the remote runner doesn't care).
+    #
+    # F8 fix (#339): bounded by max_wait_minutes. If Ollama wedges, the
+    # remote pgrep keeps returning RUNNING forever; without the cap the
+    # orchestrator polls indefinitely. On timeout we raise — the remote
+    # runner may still complete, in which case `reingest.py <run_id>` is
+    # the recovery path.
     remote_outbox = f"~/jazz-ocr/outbox/{book.run_id}"
     poll_interval = 30
+    max_wait_seconds = cfg["max_wait_minutes"] * 60
+    poll_start = time.monotonic()
     while True:
         probe = subprocess.run(
             ["ssh", remote,
@@ -399,7 +412,16 @@ def _extract_with_ocr(
                 f"OCR runner exited without producing outbox. "
                 f"Check ~/jazz-ocr/{book.run_id}.log on {host}."
             )
-        # status == "RUNNING": keep waiting.
+        # status == "RUNNING": check wall-clock cap before sleeping again.
+        elapsed = time.monotonic() - poll_start
+        if elapsed > max_wait_seconds:
+            raise RuntimeError(
+                f"OCR runner timed out after {cfg['max_wait_minutes']} min "
+                f"(still RUNNING on {host}). The remote runner may yet "
+                f"complete; recover via "
+                f"`python3 pipelines/master-distillation/ocr/reingest.py "
+                f"{book.run_id}`."
+            )
         time.sleep(poll_interval)
 
     # 5. rsync results back.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -416,8 +416,15 @@ def test_ocr_defaults_cover_required_keys():
     required = {
         "host", "user", "vision_model",
         "confidence_threshold", "min_chars_per_page", "render_dpi",
+        "max_wait_minutes",  # #339 F8 fix
     }
     assert required <= set(s1_extract.OCR_DEFAULTS.keys())
+
+
+def test_ocr_defaults_max_wait_minutes_is_positive():
+    """The poll-loop cap (#339 F8) must be a positive number; 0 would
+    immediately timeout, negative would loop forever (elapsed > -N false)."""
+    assert s1_extract.OCR_DEFAULTS["max_wait_minutes"] > 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #339.

## F1 — pdftoppm completion marker (process_one.sh)
Replace the page-glob existence check with an explicit `.pdftoppm-complete` marker. A run killed mid-render would otherwise leave a partial set of PNGs in the inbox; the old glob check would short-circuit on the next dispatch and silently feed an incomplete inbox to the OCR runner. Stale PNGs are now cleared before re-rendering, and the marker is written only after pdftoppm exits successfully (`set -e` ensures we don't reach the write on failure).

## F8 — OCR poll cap (s1_extract.py)
Add `max_wait_minutes` to `OCR_DEFAULTS` (default 120). The poll loop tracks `time.monotonic()` against the cap; on exceed it raises `RuntimeError` with an error message naming `reingest.py <run_id>` as the recovery path. Prevents indefinite blocking when the cyberpower OCR runner wedges (e.g., Ollama hang). 120 min provisioned from observed worst case (Greene Chord Chemistry, 110pp = 37 min at ~0.34 sec/pp; 120 covers a 500-page book at 14 sec/page worst).

## Tests
`python3 -m pytest tests/test_pipeline.py tests/test_masters_schema.py -q` → 72/72 pass (71 before + 1 new for `max_wait_minutes` positivity).

## Blast radius
- F1: zero impact on currently-running drain (in-flight books used old code path). Affects only NEW dispatches after redeploy.
- F8: zero impact on running daemon (daemon uses bash `process_one.sh` + OCR runner directly, not `s1_extract.py`). Affects laptop-side `run.py new-run` only.

## Deploy
Already redeployed to cyberpower; daemon will pick up the new `process_one.sh` on its next dispatch (current Greene MCP in flight uses old code; harmless).

Self-Review-Source: /tmp/sr-339.md