### PR TITLE
fix(ci): #343 restore green baseline — corpus-only status + stdin test code + pyguitarpro

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,8 @@ jobs:
           node-version: "20"
 
       - name: Install Python dependencies
-        run: pip install jsonschema pytest
+        # #343: pyguitarpro is required by tests/test_core.py::TestExports::test_gp5_export_runs
+        run: pip install jsonschema pytest pyguitarpro
 
       - name: Verify Node.js available
         run: node --version

--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -1300,7 +1300,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "ted-greene",
@@ -2012,7 +2013,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "joe-pass",
@@ -2759,7 +2761,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "martin-taylor",
@@ -3042,7 +3045,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "wes-montgomery",
@@ -3438,7 +3442,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "lenny-breau",
@@ -3723,7 +3728,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "jim-hall",
@@ -4044,7 +4050,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "johnny-smith",
@@ -4284,7 +4291,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "jody-fisher",
@@ -4425,7 +4433,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "promoted"
     },
     {
       "id": "benson",
@@ -5130,7 +5139,8 @@
           "id": "_placeholder:method-vol-7-ultimate-advanced-blues",
           "title": "The George Benson Method, Vol. 7 — Ultimate Advanced Blues Ideas"
         }
-      ]
+      ],
+      "status": "corpus_only"
     },
     {
       "id": "jimmy-bruno",
@@ -5876,7 +5886,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "corpus_only"
     },
     {
       "id": "peter-bernstein",
@@ -6714,7 +6725,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "corpus_only"
     },
     {
       "id": "mickey-baker",
@@ -7462,7 +7474,8 @@
             }
           ]
         }
-      ]
+      ],
+      "status": "corpus_only"
     }
   ]
 }

--- a/tests/js_runner.js
+++ b/tests/js_runner.js
@@ -21,7 +21,16 @@ if (sepIdx < 0) {
 }
 
 const modulePaths = args.slice(0, sepIdx);
-const testCode = args.slice(sepIdx + 1).join(' ');
+// #343: read test code from stdin when the arg after `--` is `-` (or absent).
+// Passing large test code as a CLI arg hits platform argv limits on Windows
+// (WinError 206) and Linux (E2BIG) when JSON payloads grow.
+let testCode;
+const tail = args.slice(sepIdx + 1);
+if (tail.length === 0 || (tail.length === 1 && tail[0] === '-')) {
+    testCode = fs.readFileSync(0, 'utf8');
+} else {
+    testCode = tail.join(' ');
+}
 
 // Create a sandbox context with common globals
 const sandbox = {

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -39,8 +39,13 @@ def run_js(modules, test_code):
         else:
             mod_paths.append(os.path.join(MODEL_DIR, m))
 
-    cmd = ["node", JS_RUNNER] + mod_paths + ["--", test_code]
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT, timeout=30)
+    # #343: pass test code via stdin to avoid platform argv limits
+    # (Windows WinError 206 / Linux E2BIG) when JSON payloads grow.
+    cmd = ["node", JS_RUNNER] + mod_paths + ["--", "-"]
+    result = subprocess.run(
+        cmd, input=test_code, capture_output=True, text=True,
+        cwd=REPO_ROOT, timeout=30,
+    )
 
     if result.returncode != 0 and not result.stdout.strip():
         return {"pass": False, "results": [], "error": result.stderr or "Node.js failed"}
@@ -1742,22 +1747,25 @@ class TestMastersStore:
 
     def test_loads_repo_masters_json(self):
         # Regression fence: the actual plugin/data/masters.json must parse
-        # and meet the AC (≥ 7 masters, ≥ 1 principle each).
+        # and meet the AC (≥ 7 masters, ≥ 1 principle each PROMOTED master).
+        # Corpus-only masters (status="corpus_only") legitimately have 0
+        # principles per the skip-promotion-but-keep-corpus pattern (#320).
         import json as _json
-        with open(os.path.join(REPO_ROOT, "plugin", "data", "masters.json")) as f:
+        with open(os.path.join(REPO_ROOT, "plugin", "data", "masters.json"), encoding="utf-8") as f:
             data = _json.load(f)
         result = run_js(["MastersStore.js"], f"""
             var s = parseStore({_json.dumps(_json.dumps(data))});
             var c = counts(s);
             _results.push({{ pass: c.masters >= 7, message: "at least 7 masters ("+c.masters+")" }});
             _results.push({{ pass: c.principles >= 7, message: "at least 7 principles ("+c.principles+")" }});
-            // Each master has at least one principle.
+            // Each PROMOTED master has at least one principle.
             for (var i = 0; i < s.masters.length; i++) {{
                 var m = s.masters[i];
+                if (m.status === "corpus_only") continue;
                 var ok = m.principles && m.principles.length > 0;
                 _results.push({{
                     pass: ok,
-                    message: "master " + m.id + " has principles (" + (m.principles ? m.principles.length : 0) + ")"
+                    message: "promoted master " + m.id + " has principles (" + (m.principles ? m.principles.length : 0) + ")"
                 }});
                 if (!ok) _pass = false;
             }}

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -41,10 +41,13 @@ def run_js(modules, test_code):
 
     # #343: pass test code via stdin to avoid platform argv limits
     # (Windows WinError 206 / Linux E2BIG) when JSON payloads grow.
+    # encoding="utf-8" is required because subprocess defaults to
+    # locale.getpreferredencoding() (cp1252 on Windows), which can't
+    # encode characters like → (→) used in test payloads.
     cmd = ["node", JS_RUNNER] + mod_paths + ["--", "-"]
     result = subprocess.run(
         cmd, input=test_code, capture_output=True, text=True,
-        cwd=REPO_ROOT, timeout=30,
+        cwd=REPO_ROOT, timeout=30, encoding="utf-8",
     )
 
     if result.returncode != 0 and not result.stdout.strip():


### PR DESCRIPTION
Closes #343.

Three pre-existing CI failures on develop, surfaced post-#342.

## F1 — `test_loads_repo_masters_json` (all platforms)
Test asserted every master has ≥1 principle, but the skip-promotion-but-keep-corpus pattern (#320) ships 4 corpus-only masters with 0 principles.

**Fix:** Add explicit \`status: "promoted" | "corpus_only"\` field to all 13 masters in masters.json. Test now skips the per-master principles assertion when \`status === "corpus_only"\`. Also opens masters.json with \`encoding="utf-8"\` to fix the Windows \`charmap\` UnicodeDecodeError.

Schema is additive (\`additionalProperties: true\`); existing consumers that ignore \`status\` continue to work. The engine will need this distinction later anyway.

## F2 — `test_curated_shapes_json_matches_runtime_signature` (Windows + Ubuntu)
Test passed a large JSON payload as a subprocess CLI arg, hitting \`WinError 206\` on Windows and \`E2BIG\` on Linux.

**Fix:** \`js_runner.js\` reads test code from stdin when the post-\`--\` arg is \`-\` or absent; \`run_js()\` passes it via \`subprocess.run(input=...)\`. Eliminates argv pressure regardless of payload size; backward-compatible with the inlined CLI-arg call sites still in use elsewhere in the test file.

## F3 — `test_gp5_export_runs` (all platforms)
\`export_gp5.py\` imports \`pyguitarpro\`, but the CI install step was \`pip install jsonschema pytest\` only.

**Fix:** Add \`pyguitarpro\` to the CI install line.

## Tests
\`python3 -m pytest tests/test_js_modules.py tests/test_core.py -q\` → 290/290 pass locally (up from 287/290).
\`python3 -m pytest tests/test_pipeline.py tests/test_masters_schema.py -q\` → 72/72 unchanged.

## Blast radius
- F1: additive schema field, ignored by existing consumers; test logic change is scoped to one test.
- F2: backward-compatible (CLI-arg path still works); test-only infrastructure.
- F3: CI-only; local dev environments unaffected.

Self-Review-Source: /tmp/sr-343.md