### PR TITLE
feat(pipeline): #353 chapter-loop subagent worker — tooling for parallel batch-1 dispatch

### DIFF
--- a/pipelines/master-distillation/queue/MASTER-DISTILLATION-WORKER.md
+++ b/pipelines/master-distillation/queue/MASTER-DISTILLATION-WORKER.md
@@ -1,0 +1,166 @@
+# Master-distillation worker — subagent prompt template
+
+You are a chapter-loop worker for the master-distillation pipeline (#297, #347 batch-1). You will be invoked by the main agent with a `run_id`, `master_id`, `work_id`, and `book_title`. Your job is to drive that one book through Stages 2-4 end-to-end and return a structured report. Stage B (masters.json strengthen + composite STATEMENT updates) is NOT yours — return after s4 acceptance.
+
+## Setup
+
+The pipeline lives on cyberpower at `~/git/siege-analytics/musescore4-chord-library-plugin/`. You will reach it over SSH from this session.
+
+All paths in this prompt are remote (cyberpower) unless prefixed with `/tmp/` (local cyberpower temp) or `local:/tmp/` (your session's local /tmp on the laptop).
+
+## State machine summary
+
+For each run, there are 4 sequential stages: s1 (extract), s2 (chapter quotes), s3 (chapter + book summaries), s4 (systems + statement). Each stage cycles `pending → awaiting-llm → awaiting-review → accepted`. The helper script `chapter_worker_step.py` reports the next action.
+
+You will spend nearly all your time on s2 + s3 + s4. s1 needs only reingest + advance.
+
+## The worker loop
+
+```
+1. Check status:
+   ssh dheerajchand@cyberpower 'cd ~/git/siege-analytics/musescore4-chord-library-plugin && python3 pipelines/master-distillation/queue/chapter_worker_step.py status <RUN_ID>'
+
+2. Parse the JSON output. Cases:
+   a. next_action.kind == "done":
+      Pipeline complete. Return your report and exit.
+   b. next_action.kind == "advance":
+      Stage is awaiting-review. Confirm by checking outputs look reasonable
+      via `chapter_worker_step.py status`, then call:
+      ssh dheerajchand@cyberpower 'cd ~/git/siege-analytics/musescore4-chord-library-plugin && python3 pipelines/master-distillation/queue/chapter_worker_step.py advance <RUN_ID>'
+      Loop back to step 1.
+   c. next_action.kind == "redo":
+      Stage errored. Call:
+      ssh dheerajchand@cyberpower 'cd ~/git/siege-analytics/musescore4-chord-library-plugin && python3 pipelines/master-distillation/queue/chapter_worker_step.py redo <RUN_ID> <stage>'
+      Loop back to step 1.
+   d. next_action.kind == "resume":
+      Run `resume` to get the next request:
+      ssh dheerajchand@cyberpower 'cd ~/git/siege-analytics/musescore4-chord-library-plugin && python3 pipelines/master-distillation/queue/chapter_worker_step.py resume <RUN_ID>'
+      Parse the JSON. If exit_code == 0 and request_path is set:
+        - scp the request to local /tmp/
+        - Read it to get the system_prompt, user_prompt, response_schema, scope, model
+        - Call mcp__session__call_llm with:
+            * `attachments` = [local request path]
+            * `systemPrompt` = the request's system_prompt unchanged
+            * `outputSchema` = the request's response_schema (omit if null)
+            * `prompt` = a brief non-empty instruction like "Process the request file
+              loaded via attachment per the system prompt." (the tool REQUIRES a
+              non-empty `prompt`; passing only systemPrompt+attachments returns
+              InputValidationError)
+            * `model` = the request's `model` field ("sonnet" or "haiku")
+        - Receive the LLM response
+        - VALIDATE FIDELITY (see below) — fix or drop bad quotes
+        - Write response to local /tmp/<scope>.resp.json
+        - scp it back to the matching response path on cyberpower
+        - Loop back to step 1
+
+## Stage 1 special handling
+
+If status reports s1 awaiting-review but no `runs/<RUN_ID>/raw-transcript.txt` exists at the run dir root, that means the bridge created the run dir but reingest.py was never called. Run it first:
+
+```
+ssh dheerajchand@cyberpower 'cd ~/git/siege-analytics/musescore4-chord-library-plugin && python3 pipelines/master-distillation/ocr/reingest.py <RUN_ID>'
+```
+
+Then advance s1.
+
+## Stage 2 — chapter quote extraction (s2-toc, s2-extract-chNN)
+
+- **s2-toc**: small TOC request; output the chapters[] array. Use sonnet.
+- **s2-extract-chNN**: per-chapter quote extraction. Use sonnet.
+
+### Quote-fidelity validation (CRITICAL)
+
+Every `verbatim_quote` in your s2-extract response MUST be an EXACT substring of the request's `user_prompt`. The cyberpower pipeline runs a strict substring check; any drift will mark the stage errored and you'll have to redo it.
+
+After receiving the LLM response, validate locally:
+
+```python
+import json
+req = json.load(open('/tmp/<scope>.req.json'))
+resp = json.load(open('/tmp/<scope>.resp.json'))
+src = req['user_prompt']
+fails = [(i, q['topic']) for i, q in enumerate(resp['quotes']) if q['verbatim_quote'] not in src]
+```
+
+If `fails` is empty, proceed. Otherwise fix.
+
+### Known fidelity failure patterns and fixes
+
+1. **Column-break joining.** OCR has multi-column page layouts. The LLM may join text across the column break with `\n`, but the source has a different break. Fix: locate the failing quote's first ~30 chars in the source via `src.find(...)`, then truncate the quote to the first contiguous chunk (stop at the source's actual break/header).
+
+2. **Curly vs straight apostrophes.** Joe's vs Joe's (U+2019 vs U+0027). Fix: locate the actual character in the source and replace yours with it.
+
+3. **Hallucinated content.** Sometimes the LLM fills in plausible-sounding text that isn't in the source (especially when the OCR has gaps). Verify the quote head appears in source verbatim. If the body wanders away from source, DROP the quote entirely — don't try to fix.
+
+4. **Em-dash variants.** — vs - vs --. Use the source's actual character.
+
+### Max retry budget
+
+For each chapter: max 3 fidelity-fix attempts. If still failing after 3, drop the failing quotes entirely (response with fewer quotes is acceptable; empty quotes[] is valid).
+
+### Chapters with no prose (notation-only)
+
+If a chapter is entirely diagrams/notation (no extractable prose passages), the correct response is `{"quotes": []}`. Don't fabricate to fill the 3-15 quote guideline — sparsity is honest.
+
+## Stage 3 — chapter summaries (s3-chapter-chNN) and book summary (s3-book)
+
+- **s3-chapter-chNN**: per-chapter distillation paragraph. Use haiku. Output text wrapped in `{"text": "..."}`.
+- **s3-book**: book-level distillation, multi-paragraph. Use sonnet. Same `{"text": "..."}` wrapping.
+
+For chapters that had empty quotes[] in s2, the s3 summary should explicitly say "Chapter N contains no load-bearing prose passages — composed entirely of notated [exercises/examples/etc.]."
+
+## Stage 4 — systems (s4-systems) and statement (s4-statement)
+
+- **s4-systems**: 1-4 systems per book, structured JSON output. Use sonnet. Schema is in the request. CRITICAL rules:
+  - Three-segment system ids: `<master_id>:<work_id>:<system-slug>` (kebab-case)
+  - Every traversal_rule and modification_rule MUST have a non-empty `references[]` array with at least one `{chapter_n, topic, quote_excerpt, page?}` pointing back at a real chapter quote from the source
+  - `engine_payload.kind` is EITHER one of the 12 named kinds (PositionContinuity, VoiceMotion, StringSetTransition, SymmetryMovement, FamilyCoherence, SubstitutionExpand, DensityFloor, DensityCeiling, OmissionAllow, ColorToneRequire, NCTHarmonization, TextureCycle) OR `_pending:<kebab-slug>` when no name clearly fits. WHEN IN DOUBT, USE `_pending:` — never stretch a kind name.
+  - Aim for 1-4 systems. One central plus optional smaller ones.
+
+- **s4-statement**: human-readable STATEMENT.md, multi-paragraph markdown. Use sonnet. `{"text": "..."}` wrapping. Cite chapter summaries explicitly. Output must include a `## Pending Work` section listing every `_pending:<kebab>` value from systems and what each signals. Include `## Provenance Notes` naming which chapters didn't yield systems.
+
+## When you're done
+
+Return a structured report to the main agent:
+
+```
+{
+  "run_id": "...",
+  "master_id": "...",
+  "work_id": "...",
+  "outcome": "complete" | "partial" | "failed",
+  "stages": {
+    "s1": "accepted" | "...",
+    "s2": "accepted" | "...",
+    "s3": "accepted" | "...",
+    "s4": "accepted" | "..."
+  },
+  "chapters_extracted": <int>,
+  "chapters_with_quotes": <int>,
+  "chapters_empty": <int>,
+  "fidelity_fixes": <int>,
+  "quotes_dropped": <int>,
+  "systems_count": <int>,
+  "pending_kinds": ["_pending:ear-gate", ...],
+  "derived_paths": {
+    "systems_draft": "plugin/data/masters-corpus/<master>/<work>/derived/systems-draft.json",
+    "statement": "plugin/data/masters-corpus/<master>/<work>/derived/STATEMENT.md",
+    "run_audit": "pipelines/master-distillation/runs/<run_id>/"
+  },
+  "issues": ["any caveats the main agent should know about"]
+}
+```
+
+## What you don't do
+
+- Stage B (editing `plugin/data/masters.json` to add the work/systems): main agent does this with curatorial judgment.
+- Composite STATEMENT.md at master level (e.g. `plugin/data/masters-corpus/<master>/STATEMENT.md`): main agent does this if needed.
+- Opening PRs or committing: main agent handles git operations.
+- Curatorial decisions about which quotes are "really" load-bearing: trust the LLM's selection unless it's clearly hallucinating.
+
+## Safety
+
+- Max 3 fidelity-fix retries per chapter; then drop.
+- If a stage errors twice in a row after redo, report `"outcome": "failed"` with the error message and exit. Don't loop forever.
+- Don't touch any files outside the run dir, `plugin/data/masters-corpus/<master>/<work>/`, and local `/tmp/`.
+- Don't run `git add`, `git commit`, or `git push` — the main agent owns version control.

--- a/pipelines/master-distillation/queue/chapter_worker_step.py
+++ b/pipelines/master-distillation/queue/chapter_worker_step.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Single-step helper for the chapter-loop subagent worker.
+
+Given a run_id, this tool drives one step of the Stages 2-4 dispatch:
+inspecting the current state, advancing where possible, and reporting
+back the next request file path that needs an LLM response.
+
+The subagent loop uses this instead of scraping run.py stdout.
+
+Usage:
+    chapter_worker_step.py status <run_id>
+        -> prints JSON: {state, current_stage, current_status,
+                         next_action}
+        where next_action is one of:
+          - {"kind": "advance"}     stage is awaiting-review; call --advance
+          - {"kind": "respond", "request_path": "...", "model": "..."}
+                                    stage is awaiting-llm; fill response
+          - {"kind": "redo", "stage": "sN"}  stage errored; reset + retry
+          - {"kind": "done"}        run is fully through s4 accepted
+          - {"kind": "blocked", "reason": "..."}
+
+    chapter_worker_step.py advance <run_id>
+        -> calls run.py advance (only if current stage is awaiting-review)
+
+    chapter_worker_step.py resume <run_id>
+        -> calls run.py resume (emits next request file)
+
+    chapter_worker_step.py redo <run_id> <stage>
+        -> calls run.py redo and then resume
+
+Ticket: #353
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNS_DIR = REPO_ROOT / "pipelines" / "master-distillation" / "runs"
+RUN_PY = REPO_ROOT / "pipelines" / "master-distillation" / "run.py"
+
+TERMINAL_OK_STAGES = ("s4",)
+
+
+def load_state(run_id: str) -> dict:
+    state_path = RUNS_DIR / run_id / "stage-state.json"
+    if not state_path.exists():
+        raise SystemExit(f"run dir not found: {state_path.parent}")
+    return json.loads(state_path.read_text())
+
+
+def call_runpy(*args: str) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["python3", str(RUN_PY), *args],
+        capture_output=True, text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def parse_request_path(stdout: str) -> tuple[str | None, str | None]:
+    """Find the 'request:' and 'response:' lines emitted by run.py resume."""
+    req = None
+    scope = None
+    for line in stdout.splitlines():
+        line = line.strip()
+        if line.startswith("request:"):
+            req = line.split("request:", 1)[1].strip()
+        if "[awaiting-llm]" in line and "scope=" in line:
+            try:
+                scope = line.split("scope='", 1)[1].split("'", 1)[0]
+            except IndexError:
+                pass
+    return req, scope
+
+
+def cmd_status(run_id: str) -> dict:
+    state = load_state(run_id)
+    stages = state["stages"]
+    # Find the first non-accepted stage
+    for stage_id in ("s1", "s2", "s3", "s4"):
+        st = stages.get(stage_id, {})
+        status = st.get("status", "pending")
+        if status == "accepted":
+            continue
+        # This is the current frontier stage
+        if status == "pending":
+            # Need to call resume to start it
+            return {"state": "frontier", "current_stage": stage_id, "current_status": status,
+                    "next_action": {"kind": "resume"}}
+        if status == "awaiting-llm":
+            return {"state": "frontier", "current_stage": stage_id, "current_status": status,
+                    "next_action": {"kind": "resume"}}  # resume re-emits the request
+        if status == "awaiting-review":
+            return {"state": "frontier", "current_stage": stage_id, "current_status": status,
+                    "next_action": {"kind": "advance"}}
+        if status == "error":
+            return {"state": "frontier", "current_stage": stage_id, "current_status": status,
+                    "next_action": {"kind": "redo", "stage": stage_id},
+                    "error_message": st.get("error_message")}
+    # All s1-s4 are accepted
+    return {"state": "done", "next_action": {"kind": "done"}}
+
+
+def cmd_resume(run_id: str) -> dict:
+    code, stdout, stderr = call_runpy("resume", run_id)
+    req_path, scope = parse_request_path(stdout)
+    return {
+        "exit_code": code,
+        "stdout_tail": stdout.splitlines()[-5:] if stdout else [],
+        "stderr_tail": stderr.splitlines()[-3:] if stderr else [],
+        "request_path": req_path,
+        "scope": scope,
+    }
+
+
+def cmd_advance(run_id: str) -> dict:
+    code, stdout, stderr = call_runpy("advance", run_id)
+    return {
+        "exit_code": code,
+        "stdout_tail": stdout.splitlines()[-3:] if stdout else [],
+        "stderr_tail": stderr.splitlines()[-3:] if stderr else [],
+    }
+
+
+def cmd_redo(run_id: str, stage: str) -> dict:
+    code, stdout, stderr = call_runpy("redo", run_id, stage)
+    return {
+        "exit_code": code,
+        "stdout_tail": stdout.splitlines()[-3:] if stdout else [],
+        "stderr_tail": stderr.splitlines()[-3:] if stderr else [],
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("status")
+    sp.add_argument("run_id")
+
+    sp = sub.add_parser("resume")
+    sp.add_argument("run_id")
+
+    sp = sub.add_parser("advance")
+    sp.add_argument("run_id")
+
+    sp = sub.add_parser("redo")
+    sp.add_argument("run_id")
+    sp.add_argument("stage")
+
+    args = p.parse_args()
+
+    if args.cmd == "status":
+        out = cmd_status(args.run_id)
+    elif args.cmd == "resume":
+        out = cmd_resume(args.run_id)
+    elif args.cmd == "advance":
+        out = cmd_advance(args.run_id)
+    elif args.cmd == "redo":
+        out = cmd_redo(args.run_id, args.stage)
+    else:
+        return 2
+
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #353.

## Context
PR #352 (joe-pass:guitar-method smoke test under #347) proved the dispatch pattern works end-to-end but exposed the per-book grind cost — ~27 LLM round-trips × ~30 min serial = ~5-9 hours total for 17 remaining batches, all burning main-agent context. This PR is the tool that makes that batch tractable: one subagent per book, isolated context, parallelizable.

## What lands

- **`pipelines/master-distillation/queue/chapter_worker_step.py`** — helper script. Given a `run_id`, reads `stage-state.json`, identifies the frontier stage, and reports the next action (`resume` / `advance` / `redo` / `done`) as JSON. Reduces stdout-scraping in the subagent loop.
- **`pipelines/master-distillation/queue/MASTER-DISTILLATION-WORKER.md`** — comprehensive subagent prompt template. Covers the worker loop, s1 reingest handling, quote-fidelity validation, the 4 known failure patterns and fixes (column-break joins, curly apostrophes, hallucinated content, em-dash variants), max retry budget (3 per chapter), per-stage guidance, and the structured return-report shape.

## Smoke test (rule 4)

Spawned one subagent against `2026-05-28T15-05-20-van-eps-1939-method`:
- s1 reingest + advance ✓
- s2 (3 chapters, 3 fidelity fixes — all classic patterns the worker doc names, 0 dropped) ✓
- s3 (3 chapter summaries + book summary) ✓
- s4 (3 systems with full references, STATEMENT.md with Pending Work section) ✓
- ~21 min wall time, ~128K tokens total — **all isolated in the subagent's context**, not main agent's
- Subagent flagged a real tool-usage issue (call_llm requires non-empty `prompt`) — incorporated into the worker doc before commit

## Division of labor

- **Subagent does:** s2 + s3 + s4 (loop-mechanical, fidelity validation, schema compliance)
- **Main agent does:** Stage B (`masters.json` strengthen with curatorial judgment), composite STATEMENT updates, all git operations

## Side observation for #298

3 of the 4 `_pending:` engine_payload kinds the van-eps subagent flagged were right-hand technique rules (mode-assignment, dynamic-axis, pick-path-modification). Suggests the 12-name enum skews toward fretting/voicing systems and may want expansion to cover picking/articulation cleanly. Flagged for the kinds-formalization workstream.

## Not in this PR

- Van-eps Stage B (the smoke-test derived artifacts will move to a separate van-eps strengthen PR after this merges)
- The 35 other materialized run dirs (those go with their respective per-master PRs)
- Server-side worker daemon — out of scope; the SSH-from-laptop pattern works

## Refs
- #347 (batch-1 umbrella that this unblocks)
- #346 (ingestion bridge, prerequisite)
- PR #352 (smoke test that proved the pattern and exposed the grind cost)
- #298 (engine_payload kinds formalization — see side observation)

Self-Review-Source: /tmp/sr-353.md
