### PR TITLE
configs(#386): reconcile 4 stale unpromoted configs

### DIFF
--- a/pipelines/master-distillation/configs/carter-fingerstyle-jazz.toml
+++ b/pipelines/master-distillation/configs/carter-fingerstyle-jazz.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[notes]
+status = "superseded"
+note = "PDF was mislabeled (filename references Bill Carter; actual content is Alan de Mause, Mel Bay's Complete Fingerstyle Jazz Guitar Book). Salvaged under de-mause-fingerstyle-jazz.toml in PR #372 / #360 audit comments. This config remains as audit trail; do not re-dispatch a worker against it."

--- a/pipelines/master-distillation/configs/greene-chord-chemistry.toml
+++ b/pipelines/master-distillation/configs/greene-chord-chemistry.toml
@@ -5,7 +5,7 @@ id = "ted-greene"
 name = "Ted Greene"
 
 [work]
-id = "chord-chemistry"
+id = "greene-chord-chemistry"
 title = "Chord Chemistry"
 year = 1971
 instrument_scope = "6-string"

--- a/pipelines/master-distillation/configs/greene-modern-chord-progressions.toml
+++ b/pipelines/master-distillation/configs/greene-modern-chord-progressions.toml
@@ -5,7 +5,7 @@ id = "ted-greene"
 name = "Ted Greene"
 
 [work]
-id = "modern-chord-progressions"
+id = "greene-modern-chord-progressions"
 title = "Modern Chord Progressions — Jazz and Classical Voicings for Guitar"
 year = 1976
 instrument_scope = "6-string"

--- a/pipelines/master-distillation/configs/taylor-complete-method-compilation.toml
+++ b/pipelines/master-distillation/configs/taylor-complete-method-compilation.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[notes]
+status = "blocked-on-source-pdf"
+note = "PDF on disk is a marketplace decoy (Amazon-style listing page captured as 1 page; not the actual book). Surfaced on #360 wave-3 audit. Cannot distill until a real Martin Taylor source PDF is sourced. martin-taylor master entry in masters.json has empty works[] as a placeholder for when this gets unblocked."


### PR DESCRIPTION
Implements #386 acceptance criteria. Two greene configs renamed to match masters.json prefixed work_ids. Carter + Taylor configs annotated with [notes] blocks (superseded / blocked-on-source-pdf). Audit now reports 0 unannotated unpromoted configs. Validator green; no masters.json edits.