### PR TITLE
data(voicings)(#389): first-pass heuristic voicing-tag proposal

### DIFF
--- a/plugin/data/voicings-tag-proposal.json
+++ b/plugin/data/voicings-tag-proposal.json
@@ -1,0 +1,17817 @@
+{
+  "_meta": {
+    "ticket": "#389",
+    "purpose": "v2 heuristic voicing-tag proposal (post hostile review)",
+    "voicings_processed": 820,
+    "voicings_tagged": 484,
+    "max_confidence_distribution": {
+      "HIGH": 34,
+      "MED": 450,
+      "LOW": 0,
+      "NONE": 336
+    },
+    "tag_drift_count": 0,
+    "playstyle_vocab_misses": {
+      "drop2\u2192drop-2": 322,
+      "shell\u2192guide-tones": 270,
+      "shell\u2192guide-tone": 270,
+      "shell\u2192shell": 270,
+      "extended\u2192extended": 84,
+      "extended\u2192extensions": 84,
+      "quartal\u2192quartal": 66,
+      "quartal\u2192fourth-voicings": 66,
+      "altered\u2192altered": 52,
+      "drop3\u2192drop-3": 26
+    },
+    "v2_changes": [
+      "GENERIC_DESCRIPTORS denylist requires master-signal second confirmation",
+      "drop2/drop3 tag normalization",
+      "coverage-marker emits only discriminating tags (no pedagogical-method)",
+      "bernstein-shell restricted to standard 7th qualities"
+    ]
+  },
+  "proposals": [
+    {
+      "voicing_id": "c13b9-cm6-altered-6str-26",
+      "voicing_name": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13b9-cm7-altered-7str-28",
+      "voicing_name": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13b9-cv6-altered-6str-25",
+      "voicing_name": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13b9-cv7-altered-7str-27",
+      "voicing_name": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13s9-cm6-altered-6str-30",
+      "voicing_name": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13s9-cm7-altered-7str-32",
+      "voicing_name": "C13#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13s9-cv6-altered-6str-29",
+      "voicing_name": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13s9-cv7-altered-7str-31",
+      "voicing_name": "C13#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13sus4-cm6-extended-6str-18",
+      "voicing_name": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13sus4-cm7-extended-7str-20",
+      "voicing_name": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13sus4-cv6-extended-6str-17",
+      "voicing_name": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13sus4-cv7-extended-7str-19",
+      "voicing_name": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "13sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5b9-cm6-altered-6str-34",
+      "voicing_name": "C7b5b9 \u2014 Fret 6 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b5b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5b9-cm7-altered-7str-36",
+      "voicing_name": "C7b5b9 \u2014 Fret 2 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b5b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5b9-cv6-altered-6str-33",
+      "voicing_name": "C7b5b9 \u2014 Fret 6 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b5b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5b9-cv7-altered-7str-35",
+      "voicing_name": "C7b5b9 \u2014 Fret 2 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b5b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5s9-cm6-altered-6str-38",
+      "voicing_name": "C7b5#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b5sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5s9-cm7-altered-7str-40",
+      "voicing_name": "C7b5#9 \u2014 Fret 3 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b5sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5s9-cv6-altered-6str-37",
+      "voicing_name": "C7b5#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b5sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5s9-cv7-altered-7str-39",
+      "voicing_name": "C7b5#9 \u2014 Fret 3 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b5sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9sus4-cm6-altered-6str-22",
+      "voicing_name": "C7b9sus4 \u2014 Fret 6 \u2014 Altered (b7 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b9sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9sus4-cm7-altered-7str-24",
+      "voicing_name": "C7b9sus4 \u2014 Fret 1 \u2014 Altered (4th on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b9sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9sus4-cv6-altered-6str-21",
+      "voicing_name": "C7b9sus4 \u2014 Fret 6 \u2014 Altered (b7 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b9sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9sus4-cv7-altered-7str-23",
+      "voicing_name": "C7b9sus4 \u2014 Fret 1 \u2014 Altered (4th on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7b9sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5b9-cm6-altered-6str-42",
+      "voicing_name": "C7#5b9 \u2014 Fret 7 \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7sharp5b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5b9-cm7-altered-7str-44",
+      "voicing_name": "C7#5b9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7sharp5b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5b9-cv6-altered-6str-41",
+      "voicing_name": "C7#5b9 \u2014 Fret 7 \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7sharp5b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5b9-cv7-altered-7str-43",
+      "voicing_name": "C7#5b9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7sharp5b9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5s9-cm6-altered-6str-46",
+      "voicing_name": "C7#5#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7sharp5sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5s9-cm7-altered-7str-48",
+      "voicing_name": "C7#5#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7sharp5sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5s9-cv6-altered-6str-45",
+      "voicing_name": "C7#5#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7sharp5sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5s9-cv7-altered-7str-47",
+      "voicing_name": "C7#5#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "7sharp5sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c9sus4-cm6-extended-6str-14",
+      "voicing_name": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "9sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c9sus4-cm7-extended-7str-16",
+      "voicing_name": "C9sus4 \u2014 Fret 1 \u2014 Extended (4th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "9sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c9sus4-cv6-extended-6str-13",
+      "voicing_name": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "9sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c9sus4-cv7-extended-7str-15",
+      "voicing_name": "C9sus4 \u2014 Fret 1 \u2014 Extended (4th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "9sus4",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cm6-drop2-b7top-6",
+      "voicing_name": "Caug7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cm6-drop2-1top-6",
+      "voicing_name": "Caug7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cm6-drop2-3rdtop-6",
+      "voicing_name": "Caug7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cm6-shell-a-6",
+      "voicing_name": "Caug7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-a-shape-6-cm6",
+      "voicing_name": "Caug7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-e-shape-6-cm6",
+      "voicing_name": "Caug7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-d-shape-6-cm6",
+      "voicing_name": "Caug7 \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-cm7-drop2-b7top-7",
+      "voicing_name": "Caug7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cm7-drop2-1top-7",
+      "voicing_name": "Caug7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cm7-drop2-3rdtop-7",
+      "voicing_name": "Caug7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cm7-shell-a-7",
+      "voicing_name": "Caug7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-a-shape-7-cm7",
+      "voicing_name": "Caug7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-e-shape-7-cm7",
+      "voicing_name": "Caug7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-d-shape-7-cm7",
+      "voicing_name": "Caug7 \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug-chordsdb-f1-6",
+      "voicing_name": "Caug7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug-chordsdb-f3-6",
+      "voicing_name": "Caug7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cv6-drop2-b7top-6",
+      "voicing_name": "Caug7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cv6-drop2-1top-6",
+      "voicing_name": "Caug7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cv6-drop2-3rdtop-6",
+      "voicing_name": "Caug7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cv6-shell-a-6",
+      "voicing_name": "Caug7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-a-shape-6",
+      "voicing_name": "Caug7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-e-shape-6",
+      "voicing_name": "Caug7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-d-shape-6",
+      "voicing_name": "Caug7 \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-cv7-drop2-b7top-7",
+      "voicing_name": "Caug7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cv7-drop2-1top-7",
+      "voicing_name": "Caug7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cv7-drop2-3rdtop-7",
+      "voicing_name": "Caug7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caug7-cv7-shell-a-7",
+      "voicing_name": "Caug7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-a-shape-7",
+      "voicing_name": "Caug7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-e-shape-7",
+      "voicing_name": "Caug7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caug7-shell-d-shape-7",
+      "voicing_name": "Caug7 \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "aug7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-a-shape-6-cm6",
+      "voicing_name": "CaugMaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-e-shape-6-cm6",
+      "voicing_name": "CaugMaj7 \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-cm6-drop2-3rdtop-6",
+      "voicing_name": "CaugMaj7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-shell-a-shape-6-cm6",
+      "voicing_name": "CaugMaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-a-shape-7-cm7",
+      "voicing_name": "CaugMaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-e-shape-7-cm7",
+      "voicing_name": "CaugMaj7 \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-cm7-drop2-3rdtop-7",
+      "voicing_name": "CaugMaj7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-cm7-shell-a-7",
+      "voicing_name": "CaugMaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-a-shape-6",
+      "voicing_name": "CaugMaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-e-shape-6",
+      "voicing_name": "CaugMaj7 \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-d-shape-6",
+      "voicing_name": "CaugMaj7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-shell-a-shape-6",
+      "voicing_name": "CaugMaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-a-shape-7",
+      "voicing_name": "CaugMaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-e-shape-7",
+      "voicing_name": "CaugMaj7 \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-drop2-d-shape-7",
+      "voicing_name": "CaugMaj7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "caugmaj7-shell-a-shape-7",
+      "voicing_name": "CaugMaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "augMaj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-cm6-drop2-b5top-6",
+      "voicing_name": "Cdim7 \u2014 Fret 2 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b5"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-a-shape-6-cm6",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cm6-drop2-bb7top-6",
+      "voicing_name": "Cdim7 \u2014 Fret 4 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-bb7"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cm6-drop2-1top-6",
+      "voicing_name": "Cdim7 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-e-shape-6-cm6",
+      "voicing_name": "Cdim7 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cm6-drop2-b3top-6",
+      "voicing_name": "Cdim7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop3-a-shape-6-cm6",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-shell-a-shape-6-cm6",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-shell-e-shape-6-cm6",
+      "voicing_name": "Cdim7 \u2014 E shape \u2014 Shell (bb7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-cm7-drop2-b5top-7",
+      "voicing_name": "Cdim7 \u2014 Fret 2 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b5",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-a-shape-7-cm7",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cm7-drop2-bb7top-7",
+      "voicing_name": "Cdim7 \u2014 Fret 4 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-bb7",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cm7-drop2-1top-7",
+      "voicing_name": "Cdim7 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-e-shape-7-cm7",
+      "voicing_name": "Cdim7 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cm7-drop2-b3top-7",
+      "voicing_name": "Cdim7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop3-a-shape-7-cm7",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-cm7-shell-7str-7",
+      "voicing_name": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdim7-cm7-shell-a-7",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-shell-e-shape-7",
+      "voicing_name": "Cdim7 \u2014 E shape \u2014 Shell (bb7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim-chordsdb-f1-6",
+      "voicing_name": "Cdim7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cv6-drop2-b5top-6",
+      "voicing_name": "Cdim7 \u2014 Fret 2 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b5"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-a-shape-6",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim-chordsdb-f3-6",
+      "voicing_name": "Cdim7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cv6-drop2-bb7top-6",
+      "voicing_name": "Cdim7 \u2014 Fret 4 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-bb7"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cv6-drop2-1top-6",
+      "voicing_name": "Cdim7 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-e-shape-6",
+      "voicing_name": "Cdim7 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-d-shape-6",
+      "voicing_name": "Cdim7 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop3-a-shape-6",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-chordsdb-f1-6",
+      "voicing_name": "Cdim7 \u2014 Fret 1 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-chordsdb-f2-6",
+      "voicing_name": "Cdim7 \u2014 Fret 2 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-shell-a-shape-6",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-shell-e-shape-6",
+      "voicing_name": "Cdim7 \u2014 E shape \u2014 Shell (bb7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-cv7-drop2-b5top-7",
+      "voicing_name": "Cdim7 \u2014 Fret 2 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b5",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-a-shape-7",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cv7-drop2-bb7top-7",
+      "voicing_name": "Cdim7 \u2014 Fret 4 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-bb7",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-cv7-drop2-1top-7",
+      "voicing_name": "Cdim7 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-e-shape-7",
+      "voicing_name": "Cdim7 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop2-d-shape-7",
+      "voicing_name": "Cdim7 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdim7-drop3-a-shape-7",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-cv7-shell-7str-7",
+      "voicing_name": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdim7-shell-a-shape-7",
+      "voicing_name": "Cdim7 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdim7-shell-e-shape-7-cv7",
+      "voicing_name": "Cdim7 \u2014 E shape \u2014 Shell (bb7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dim7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-drop2-e-shape-6-cm6",
+      "voicing_name": "C13 \u2014 E shape \u2014 Drop 2 (b7 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13-shell-a-shape-6-cm6",
+      "voicing_name": "C13 \u2014 A shape \u2014 Shell (13th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom13-shell-a-shape-6-cm6",
+      "voicing_name": "C13 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-shell-e-shape-6-cm6",
+      "voicing_name": "C13 \u2014 E shape \u2014 Shell (13th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-drop2-e-shape-7-cm7",
+      "voicing_name": "C13 \u2014 E shape \u2014 Drop 2 (b7 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13-shell-a-shape-7-cm7",
+      "voicing_name": "C13 \u2014 A shape \u2014 Shell (13th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom13-cm7-shell-a-7",
+      "voicing_name": "C13 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-shell-e-shape-7-cm7",
+      "voicing_name": "C13 \u2014 E shape \u2014 Shell (13th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-drop2-e-shape-6",
+      "voicing_name": "C13 \u2014 E shape \u2014 Drop 2 (b7 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13-chordsdb-f2-6",
+      "voicing_name": "C13 \u2014 Fret 2 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-chordsdb-f3-6",
+      "voicing_name": "C13 \u2014 Fret 3 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-shell-a-shape-6",
+      "voicing_name": "C13 \u2014 A shape \u2014 Shell (13th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom13-shell-a-shape-6",
+      "voicing_name": "C13 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-shell-e-shape-6",
+      "voicing_name": "C13 \u2014 E shape \u2014 Shell (13th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-drop2-e-shape-7",
+      "voicing_name": "C13 \u2014 E shape \u2014 Drop 2 (b7 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c13-shell-a-shape-7",
+      "voicing_name": "C13 \u2014 A shape \u2014 Shell (13th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom13-shell-a-shape-7",
+      "voicing_name": "C13 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c13-shell-e-shape-7",
+      "voicing_name": "C13 \u2014 E shape \u2014 Shell (13th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7-cm6-drop2-5top-6",
+      "voicing_name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-a-shape-6-cm6",
+      "voicing_name": "C7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cm6-drop2-b7top-6",
+      "voicing_name": "C7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cm6-drop2-1top-6",
+      "voicing_name": "C7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-e-shape-6-cm6",
+      "voicing_name": "C7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cm6-drop2-3top-6",
+      "voicing_name": "C7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop3-a-shape-6-cm6",
+      "voicing_name": "C7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7-shell-a-shape-6-cm6",
+      "voicing_name": "C7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-a-shape-6-cm6",
+      "voicing_name": "C7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-e-shape-6-cm6",
+      "voicing_name": "C7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-d-shape-6-cm6",
+      "voicing_name": "C7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cm7-drop2-5top-7",
+      "voicing_name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-a-shape-7-cm7",
+      "voicing_name": "C7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cm7-drop2-b7top-7",
+      "voicing_name": "C7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cm7-drop2-1top-7",
+      "voicing_name": "C7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-e-shape-7-cm7",
+      "voicing_name": "C7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cm7-drop2-3top-7",
+      "voicing_name": "C7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cm7-drop3-7str-7",
+      "voicing_name": "C7 \u2014 7-str bass \u2014 Drop 3",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "drop-3",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "drop-3",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "c7-drop3-a-shape-7-cm7",
+      "voicing_name": "C7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7-cm7-shell-7str-7",
+      "voicing_name": "C7 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdom7-cm7-shell-a-7",
+      "voicing_name": "C7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-a-shape-7",
+      "voicing_name": "C7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-e-shape-7",
+      "voicing_name": "C7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-d-shape-7-cm7",
+      "voicing_name": "C7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-chordsdb-f1-6",
+      "voicing_name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cv6-drop2-5top-6",
+      "voicing_name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-chordsdb-f3-6",
+      "voicing_name": "C7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-a-shape-6",
+      "voicing_name": "C7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cv6-drop2-b7top-6",
+      "voicing_name": "C7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cv6-drop2-1top-6",
+      "voicing_name": "C7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-e-shape-6",
+      "voicing_name": "C7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-d-shape-6",
+      "voicing_name": "C7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop3-a-shape-6",
+      "voicing_name": "C7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7-shell-a-shape-6",
+      "voicing_name": "C7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-a-shape-6",
+      "voicing_name": "C7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-e-shape-6",
+      "voicing_name": "C7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-d-shape-6",
+      "voicing_name": "C7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cv7-drop2-5top-7",
+      "voicing_name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-a-shape-7",
+      "voicing_name": "C7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cv7-drop2-b7top-7",
+      "voicing_name": "C7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cv7-drop2-1top-7",
+      "voicing_name": "C7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-e-shape-7",
+      "voicing_name": "C7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-drop2-d-shape-7",
+      "voicing_name": "C7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-cv7-drop3-7str-7",
+      "voicing_name": "C7 \u2014 7-str bass \u2014 Drop 3",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "drop-3",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "drop-3",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "c7-drop3-a-shape-7",
+      "voicing_name": "C7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7-cv7-shell-7str-7",
+      "voicing_name": "C7 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdom7-shell-a-shape-7",
+      "voicing_name": "C7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-a-shape-7-cv7",
+      "voicing_name": "C7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-e-shape-7-cv7",
+      "voicing_name": "C7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7-shell-d-shape-7",
+      "voicing_name": "C7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-drop2-a-shape-6-cm6",
+      "voicing_name": "C7alt \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-drop2-e-shape-6-cm6",
+      "voicing_name": "C7alt \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7alt-cm6-drop2-3rdtop-6",
+      "voicing_name": "C7alt \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7alt-shell-a-shape-6-cm6",
+      "voicing_name": "C7alt \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7alt-drop2-a-shape-7-cm7",
+      "voicing_name": "C7alt \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-drop2-e-shape-7-cm7",
+      "voicing_name": "C7alt \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7alt-cm7-drop2-3rdtop-7",
+      "voicing_name": "C7alt \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-cm7-shell-7str-7",
+      "voicing_name": "C7alt \u2014 7-str root \u2014 Shell (b5 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdom7alt-cm7-shell-a-7",
+      "voicing_name": "C7alt \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7alt-drop2-a-shape-6",
+      "voicing_name": "C7alt \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-drop2-e-shape-6",
+      "voicing_name": "C7alt \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-drop2-d-shape-6",
+      "voicing_name": "C7alt \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7alt-shell-a-shape-6",
+      "voicing_name": "C7alt \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7alt-drop2-a-shape-7",
+      "voicing_name": "C7alt \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-drop2-e-shape-7",
+      "voicing_name": "C7alt \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-drop2-d-shape-7",
+      "voicing_name": "C7alt \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7alt-cv7-shell-7str-7",
+      "voicing_name": "C7alt \u2014 7-str root \u2014 Shell (b5 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdom7alt-shell-a-shape-7",
+      "voicing_name": "C7alt \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dom7alt",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b13-cm6-drop2-3rdtop-6",
+      "voicing_name": "Cdom7b13 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b13-ext-a-shape-6-cm6",
+      "voicing_name": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b13-ext-e-shape-6-cm6",
+      "voicing_name": "Cdom7b13 \u2014 E shape \u2014 Extended (b13 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b13-shell-a-shape-6-cm6",
+      "voicing_name": "Cdom7b13 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b13-cm7-drop2-3rdtop-7",
+      "voicing_name": "Cdom7b13 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b13-ext-a-shape-7-cm7",
+      "voicing_name": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b13-ext-e-shape-7-cm7",
+      "voicing_name": "Cdom7b13 \u2014 E shape \u2014 Extended (b13 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b13-cm7-shell-a-7",
+      "voicing_name": "Cdom7b13 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b13-cv6-drop2-3rdtop-6",
+      "voicing_name": "Cdom7b13 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b13-ext-a-shape-6",
+      "voicing_name": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b13-ext-e-shape-6",
+      "voicing_name": "Cdom7b13 \u2014 E shape \u2014 Extended (b13 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b13-shell-a-shape-6",
+      "voicing_name": "Cdom7b13 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b13-cv7-drop2-3rdtop-7",
+      "voicing_name": "Cdom7b13 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b13-ext-a-shape-7",
+      "voicing_name": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b13-ext-e-shape-7",
+      "voicing_name": "Cdom7b13 \u2014 E shape \u2014 Extended (b13 on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b13-shell-a-shape-7",
+      "voicing_name": "Cdom7b13 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dom7b13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b9-altered-a-shape-6-cm6",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-altered-e-shape-6-cm6",
+      "voicing_name": "C7b9 \u2014 E shape \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "laukens-p37"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b9-drop2-a-shape-6-cm6",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Drop 2 (b9 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-cm6-drop2-1top-6",
+      "voicing_name": "C7b9 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-cm6-drop2-b9top-6",
+      "voicing_name": "C7b9 \u2014 Fret 9 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b9"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b9-shell-a-shape-6-cm6",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Shell (b9 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b9-altered-a-shape-7-cm7",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-altered-e-shape-7-cm7",
+      "voicing_name": "C7b9 \u2014 E shape \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "laukens-p37",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b9-drop2-a-shape-7-cm7",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Drop 2 (b9 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-cm7-drop2-1top-7",
+      "voicing_name": "C7b9 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-cm7-drop2-b9top-7",
+      "voicing_name": "C7b9 \u2014 Fret 9 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b9",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-cm7-shell-7str-7",
+      "voicing_name": "C7b9 \u2014 7-str root \u2014 Shell (b9 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdom7b9-cm7-shell-a-7",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Shell (b9 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b9-altered-a-shape-6",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-altered-e-shape-6",
+      "voicing_name": "C7b9 \u2014 E shape \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "laukens-p37"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b9-drop2-a-shape-6",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Drop 2 (b9 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-cv6-drop2-1top-6",
+      "voicing_name": "C7b9 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b9-drop2-d-shape-6",
+      "voicing_name": "C7b9 \u2014 D shape \u2014 Drop 2 (b9 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-chordsdb-f2-6",
+      "voicing_name": "C7b9 \u2014 Fret 2 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b9-chordsdb-f6-6",
+      "voicing_name": "C7b9 \u2014 Fret 6 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7b9-shell-a-shape-6",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Shell (b9 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b9-altered-a-shape-7",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-altered-e-shape-7",
+      "voicing_name": "C7b9 \u2014 E shape \u2014 Altered (b9 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "laukens-p37",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b9-drop2-a-shape-7",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Drop 2 (b9 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-cv7-drop2-1top-7",
+      "voicing_name": "C7b9 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b9-drop2-d-shape-7",
+      "voicing_name": "C7b9 \u2014 D shape \u2014 Drop 2 (b9 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b9-cv7-shell-7str-7",
+      "voicing_name": "C7b9 \u2014 7-str root \u2014 Shell (b9 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdom7b9-shell-a-shape-7",
+      "voicing_name": "C7b9 \u2014 A shape \u2014 Shell (b9 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dom7b9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b5-drop2-a-shape-6-cm6",
+      "voicing_name": "C7b5 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5-drop2-e-shape-6-cm6",
+      "voicing_name": "C7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b5-cm6-drop2-3rdtop-6",
+      "voicing_name": "C7b5 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b5-shell-a-shape-6-cm6",
+      "voicing_name": "C7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b5-drop2-a-shape-7-cm7",
+      "voicing_name": "C7b5 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5-drop2-e-shape-7-cm7",
+      "voicing_name": "C7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b5-cm7-drop2-3rdtop-7",
+      "voicing_name": "C7b5 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b5-cm7-shell-a-7",
+      "voicing_name": "C7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b5-chordsdb-f1-6",
+      "voicing_name": "C7b5 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5-drop2-a-shape-6",
+      "voicing_name": "C7b5 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5-drop2-e-shape-6",
+      "voicing_name": "C7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5-drop2-d-shape-6",
+      "voicing_name": "C7b5 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b5-shell-a-shape-6",
+      "voicing_name": "C7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7b5-drop2-a-shape-7",
+      "voicing_name": "C7b5 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5-drop2-e-shape-7",
+      "voicing_name": "C7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7b5-drop2-d-shape-7",
+      "voicing_name": "C7b5 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7b5-shell-a-shape-7",
+      "voicing_name": "C7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dom7flat5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7s11-cm6-drop2-3rdtop-6",
+      "voicing_name": "Cdom7sharp11 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s11-ext-a-shape-6-cm6",
+      "voicing_name": "Cdom7sharp11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s11-ext-e-shape-6-cm6",
+      "voicing_name": "Cdom7sharp11 \u2014 E shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7s11-shell-a-shape-6-cm6",
+      "voicing_name": "Cdom7sharp11 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7s11-cm7-drop2-3rdtop-7",
+      "voicing_name": "Cdom7sharp11 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s11-ext-a-shape-7-cm7",
+      "voicing_name": "Cdom7sharp11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s11-ext-e-shape-7-cm7",
+      "voicing_name": "Cdom7sharp11 \u2014 E shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7s11-cm7-shell-a-7",
+      "voicing_name": "Cdom7sharp11 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7s11-cv6-drop2-3rdtop-6",
+      "voicing_name": "Cdom7sharp11 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s11-ext-a-shape-6",
+      "voicing_name": "Cdom7sharp11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s11-ext-e-shape-6",
+      "voicing_name": "Cdom7sharp11 \u2014 E shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7s11-shell-a-shape-6",
+      "voicing_name": "Cdom7sharp11 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7s11-cv7-drop2-3rdtop-7",
+      "voicing_name": "Cdom7sharp11 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s11-ext-a-shape-7",
+      "voicing_name": "Cdom7sharp11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s11-ext-e-shape-7",
+      "voicing_name": "Cdom7sharp11 \u2014 E shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom7s11-shell-a-shape-7",
+      "voicing_name": "Cdom7sharp11 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s5-altered-a-shape-6-cm6",
+      "voicing_name": "C7#5 \u2014 A shape \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5-altered-e-shape-6-cm6",
+      "voicing_name": "C7#5 \u2014 E shape \u2014 Altered (#5 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7s5-cm6-drop2-3rdtop-6",
+      "voicing_name": "C7#5 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7s5-shell-a-shape-6-cm6",
+      "voicing_name": "C7#5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s5-altered-a-shape-7-cm7",
+      "voicing_name": "C7#5 \u2014 A shape \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5-altered-e-shape-7-cm7",
+      "voicing_name": "C7#5 \u2014 E shape \u2014 Altered (#5 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7s5-cm7-drop2-3rdtop-7",
+      "voicing_name": "C7#5 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5-cm7-shell-7str-7",
+      "voicing_name": "C7#5 \u2014 7-str root \u2014 Shell (#5 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdom7s5-cm7-shell-a-7",
+      "voicing_name": "C7#5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s5-altered-a-shape-6",
+      "voicing_name": "C7#5 \u2014 A shape \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "a-string-root"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5-altered-e-shape-6",
+      "voicing_name": "C7#5 \u2014 E shape \u2014 Altered (#5 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "e-string-root"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5-drop2-d-shape-6",
+      "voicing_name": "C7#5 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom7s5-shell-a-shape-6",
+      "voicing_name": "C7#5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s5-altered-a-shape-7",
+      "voicing_name": "C7#5 \u2014 A shape \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5-altered-e-shape-7",
+      "voicing_name": "C7#5 \u2014 E shape \u2014 Altered (#5 on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5-drop2-d-shape-7",
+      "voicing_name": "C7#5 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s5-cv7-shell-7str-7",
+      "voicing_name": "C7#5 \u2014 7-str root \u2014 Shell (#5 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cdom7s5-shell-a-shape-7",
+      "voicing_name": "C7#5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "dom7sharp5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c7s9-cm6-altered-6str-6",
+      "voicing_name": "C7#9 \u2014 Fret 5 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "dom7sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s9-cm7-altered-7str-8",
+      "voicing_name": "C7#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "dom7sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s9-cv6-altered-6str-5",
+      "voicing_name": "C7#9 \u2014 Fret 5 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "dom7sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s9-chordsdb-f2-6",
+      "voicing_name": "C7#9 \u2014 Fret 2 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom7sharp9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s9-chordsdb-f3-6",
+      "voicing_name": "C7#9 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom7sharp9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c7s9-cv7-altered-7str-7",
+      "voicing_name": "C7#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "dom7sharp9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cdom9-drop2-d-shape-6-cm6",
+      "voicing_name": "C9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c9-extended-e-shape-6-cm6",
+      "voicing_name": "C9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-shell-a-shape-6-cm6",
+      "voicing_name": "C9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-shell-e-shape-6-cm6",
+      "voicing_name": "C9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom9-drop2-d-shape-7-cm7",
+      "voicing_name": "C9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c9-extended-e-shape-7-cm7",
+      "voicing_name": "C9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-cm7-shell-7str-7",
+      "voicing_name": "C9 \u2014 7-str root \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "c9-shell-a-shape-7-cm7",
+      "voicing_name": "C9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-shell-e-shape-7-cm7",
+      "voicing_name": "C9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom9-drop2-d-shape-6",
+      "voicing_name": "C9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c9-chordsdb-f2-1",
+      "voicing_name": "C9 \u2014 Fret 2 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-chordsdb-f2-6",
+      "voicing_name": "C9 \u2014 Fret 2 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-extended-e-shape-6",
+      "voicing_name": "C9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-shell-a-shape-6",
+      "voicing_name": "C9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-shell-e-shape-6",
+      "voicing_name": "C9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cdom9-drop2-d-shape-7",
+      "voicing_name": "C9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c9-extended-e-shape-7",
+      "voicing_name": "C9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-cv7-shell-7str-7",
+      "voicing_name": "C9 \u2014 7-str root \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "c9-shell-a-shape-7",
+      "voicing_name": "C9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c9-shell-e-shape-7",
+      "voicing_name": "C9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "dom9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj13-ext-e-shape-6-cm6",
+      "voicing_name": "Cmaj13 \u2014 E shape \u2014 Extended (13th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "maj13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj13-shell-a-shape-6-cm6",
+      "voicing_name": "Cmaj13 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj13-ext-e-shape-7-cm7",
+      "voicing_name": "Cmaj13 \u2014 E shape \u2014 Extended (13th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj13-cm7-shell-a-7",
+      "voicing_name": "Cmaj13 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj13-ext-e-shape-6",
+      "voicing_name": "Cmaj13 \u2014 E shape \u2014 Extended (13th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "maj13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj13-shell-a-shape-6",
+      "voicing_name": "Cmaj13 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj13-ext-e-shape-7",
+      "voicing_name": "Cmaj13 \u2014 E shape \u2014 Extended (13th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj13-shell-a-shape-7",
+      "voicing_name": "Cmaj13 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "maj13",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-drop2-a-shape-6-cm6",
+      "voicing_name": "C6 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cm6-drop2-5top-6",
+      "voicing_name": "C6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cm6-drop2-6top-6",
+      "voicing_name": "C6 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-6th"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cm6-drop2-1top-6",
+      "voicing_name": "C6 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-drop2-e-shape-6-cm6",
+      "voicing_name": "C6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj6-cm6-drop2-3rdtop-6",
+      "voicing_name": "C6 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-shell-a-shape-6-cm6",
+      "voicing_name": "C6 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj6-shell-a-shape-6-cm6",
+      "voicing_name": "C6 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-e-shape-6-cm6",
+      "voicing_name": "C6 \u2014 E shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-d-shape-6-cm6",
+      "voicing_name": "C6 \u2014 D shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-drop2-a-shape-7-cm7",
+      "voicing_name": "C6 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cm7-drop2-5top-7",
+      "voicing_name": "C6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cm7-drop2-7top-7",
+      "voicing_name": "C6 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-6th",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cm7-drop2-1top-7",
+      "voicing_name": "C6 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-drop2-e-shape-7-cm7",
+      "voicing_name": "C6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj6-cm7-drop2-3rdtop-7",
+      "voicing_name": "C6 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cm7-shell-7str-7",
+      "voicing_name": "C6 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "c6-shell-a-shape-7-cm7",
+      "voicing_name": "C6 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj6-cm7-shell-a-7",
+      "voicing_name": "C6 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-e-shape-7-cm7",
+      "voicing_name": "C6 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-e-shape-7",
+      "voicing_name": "C6 \u2014 E shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-d-shape-7-cm7",
+      "voicing_name": "C6 \u2014 D shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-drop2-a-shape-6",
+      "voicing_name": "C6 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cv6-drop2-5top-6",
+      "voicing_name": "C6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cv6-drop2-6top-6",
+      "voicing_name": "C6 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-6th"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cv6-drop2-1top-6",
+      "voicing_name": "C6 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-drop2-e-shape-6",
+      "voicing_name": "C6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-drop2-d-shape-6",
+      "voicing_name": "C6 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-chordsdb-f1-6",
+      "voicing_name": "C6 \u2014 Fret 1 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-chordsdb-f3-6",
+      "voicing_name": "C6 \u2014 Fret 3 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-a-shape-6",
+      "voicing_name": "C6 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj6-shell-a-shape-6",
+      "voicing_name": "C6 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-e-shape-6",
+      "voicing_name": "C6 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-e-shape-6-cv6",
+      "voicing_name": "C6 \u2014 E shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-d-shape-6",
+      "voicing_name": "C6 \u2014 D shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-drop2-a-shape-7",
+      "voicing_name": "C6 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cv7-drop2-5top-7",
+      "voicing_name": "C6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cv7-drop2-6top-7",
+      "voicing_name": "C6 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-6th",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cv7-drop2-1top-7",
+      "voicing_name": "C6 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-drop2-e-shape-7",
+      "voicing_name": "C6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-drop2-d-shape-7",
+      "voicing_name": "C6 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c6-cv7-shell-7str-7",
+      "voicing_name": "C6 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "c6-shell-a-shape-7",
+      "voicing_name": "C6 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj6-shell-a-shape-7",
+      "voicing_name": "C6 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-e-shape-7-cv7",
+      "voicing_name": "C6 \u2014 E shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c6-shell-d-shape-7",
+      "voicing_name": "C6 \u2014 D shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj69-drop2-d-shape-6-cm6",
+      "voicing_name": "Cmaj69 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c69-ext-a-shape-6-cm6",
+      "voicing_name": "Cmaj69 \u2014 A shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c69-ext-e-shape-6-cm6",
+      "voicing_name": "Cmaj69 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj69-drop2-a-shape-7",
+      "voicing_name": "Cmaj69 \u2014 A shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj69-drop2-d-shape-7-cm7",
+      "voicing_name": "Cmaj69 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c69-ext-e-shape-7-cm7",
+      "voicing_name": "Cmaj69 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj69-drop2-d-shape-6",
+      "voicing_name": "Cmaj69 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c69-chordsdb-f2-6",
+      "voicing_name": "Cmaj69 \u2014 Fret 2 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c69-ext-a-shape-6",
+      "voicing_name": "Cmaj69 \u2014 A shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c69-chordsdb-f3-6",
+      "voicing_name": "Cmaj69 \u2014 Fret 3 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c69-ext-e-shape-6",
+      "voicing_name": "Cmaj69 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj69-drop2-d-shape-7",
+      "voicing_name": "Cmaj69 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c69-ext-a-shape-7",
+      "voicing_name": "Cmaj69 \u2014 A shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c69-ext-e-shape-7",
+      "voicing_name": "Cmaj69 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj69",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7-cm6-drop2-5top-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-a-shape-6-cm6",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cm6-drop2-7top-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-7th"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cm6-drop2-1top-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-e-shape-6-cm6",
+      "voicing_name": "Cmaj7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cm6-drop2-3top-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop3-a-shape-6-cm6",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7-cm6-shell-a-6",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-a-shape-6-cm6",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-e-shape-6-cm6",
+      "voicing_name": "Cmaj7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-d-shape-6-cm6",
+      "voicing_name": "Cmaj7 \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cm7-drop2-5top-7",
+      "voicing_name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-a-shape-7-cm7",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cm7-drop2-7top-7",
+      "voicing_name": "Cmaj7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-7th",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cm7-drop2-1top-7",
+      "voicing_name": "Cmaj7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-e-shape-7-cm7",
+      "voicing_name": "Cmaj7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cm7-drop2-3top-7",
+      "voicing_name": "Cmaj7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cm7-drop3-7str-7",
+      "voicing_name": "Cmaj7 \u2014 7-str bass \u2014 Drop 3",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "drop-3",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "drop-3",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmaj7-drop3-a-shape-7-cm7",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7-cm7-shell-7str-7",
+      "voicing_name": "Cmaj7 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmaj7-cm7-shell-a-7",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-a-shape-7",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-e-shape-7",
+      "voicing_name": "Cmaj7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-d-shape-7-cm7",
+      "voicing_name": "Cmaj7 \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cv6-drop2-5top-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmajor-chordsdb-f1-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-chordsdb-f2-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 2 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-chordsdb-f3-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-a-shape-6",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmajor-chordsdb-f3-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cv6-drop2-7top-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-7th"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cv6-drop2-1top-6",
+      "voicing_name": "Cmaj7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-e-shape-6",
+      "voicing_name": "Cmaj7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-d-shape-6",
+      "voicing_name": "Cmaj7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop3-a-shape-6",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7-cv6-shell-a-6",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-a-shape-6",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-e-shape-6",
+      "voicing_name": "Cmaj7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-d-shape-6",
+      "voicing_name": "Cmaj7 \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cv7-drop2-5top-7",
+      "voicing_name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-a-shape-7",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cv7-drop2-7top-7",
+      "voicing_name": "Cmaj7 \u2014 Fret 5 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-7th",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cv7-drop2-1top-7",
+      "voicing_name": "Cmaj7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-e-shape-7",
+      "voicing_name": "Cmaj7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-drop2-d-shape-7",
+      "voicing_name": "Cmaj7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-cv7-drop3-7str-7",
+      "voicing_name": "Cmaj7 \u2014 7-str bass \u2014 Drop 3",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "drop-3",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "drop-3",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmaj7-drop3-a-shape-7",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7-cv7-shell-7str-7",
+      "voicing_name": "Cmaj7 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmaj7-cv7-shell-a-7",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-a-shape-7-cv7",
+      "voicing_name": "Cmaj7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-e-shape-7-cv7",
+      "voicing_name": "Cmaj7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7-shell-d-shape-7",
+      "voicing_name": "Cmaj7 \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='maj7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7s11-cm6-drop2-3rdtop-6",
+      "voicing_name": "Cmaj7#11 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7s11-ext-a-shape-6-cm6",
+      "voicing_name": "Cmaj7#11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7s11-shell-a-shape-6-cm6",
+      "voicing_name": "Cmaj7#11 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7s11-cm7-drop2-3rdtop-7",
+      "voicing_name": "Cmaj7#11 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7s11-ext-a-shape-7-cm7",
+      "voicing_name": "Cmaj7#11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7s11-cm7-shell-a-7",
+      "voicing_name": "Cmaj7#11 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7s11-cv6-drop2-3rdtop-6",
+      "voicing_name": "Cmaj7#11 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7s11-ext-a-shape-6",
+      "voicing_name": "Cmaj7#11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7s11-shell-a-shape-6",
+      "voicing_name": "Cmaj7#11 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7s11-cv7-drop2-3rdtop-7",
+      "voicing_name": "Cmaj7#11 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-3rd",
+        "7-string"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7s11-ext-a-shape-7",
+      "voicing_name": "Cmaj7#11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7s11-shell-a-shape-7",
+      "voicing_name": "Cmaj7#11 \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "maj7sharp11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj7s5-cm6-altered-6str-2",
+      "voicing_name": "Cmaj7#5 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "maj7sharp5",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7s5-cm7-altered-7str-4",
+      "voicing_name": "Cmaj7#5 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "maj7sharp5",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7s5-cv6-altered-6str-1",
+      "voicing_name": "Cmaj7#5 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "maj7sharp5",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj7s5-cv7-altered-7str-3",
+      "voicing_name": "Cmaj7#5 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "existing_category": "altered",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "maj7sharp5",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [
+        "altered-dominant"
+      ],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        },
+        {
+          "tag": "altered-dominant",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='altered'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj9-drop2-d-shape-6-cm6",
+      "voicing_name": "Cmaj9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj9-extended-e-shape-6-cm6",
+      "voicing_name": "Cmaj9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-shell-a-shape-6-cm6",
+      "voicing_name": "Cmaj9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-shell-e-shape-6-cm6",
+      "voicing_name": "Cmaj9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-drop2-d-shape-7-cm7",
+      "voicing_name": "Cmaj9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj9-extended-e-shape-7-cm7",
+      "voicing_name": "Cmaj9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-cm7-shell-7str-7",
+      "voicing_name": "Cmaj9 \u2014 7-str root \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmaj9-shell-a-shape-7-cm7",
+      "voicing_name": "Cmaj9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-shell-e-shape-7-cm7",
+      "voicing_name": "Cmaj9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-drop2-d-shape-6",
+      "voicing_name": "Cmaj9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj9-chordsdb-f2-6",
+      "voicing_name": "Cmaj9 \u2014 Fret 2 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-chordsdb-f3-6",
+      "voicing_name": "Cmaj9 \u2014 Fret 3 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-extended-e-shape-6",
+      "voicing_name": "Cmaj9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-shell-a-shape-6",
+      "voicing_name": "Cmaj9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-shell-e-shape-6",
+      "voicing_name": "Cmaj9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-drop2-d-shape-7",
+      "voicing_name": "Cmaj9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmaj9-extended-e-shape-7",
+      "voicing_name": "Cmaj9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-cv7-shell-7str-7",
+      "voicing_name": "Cmaj9 \u2014 7-str root \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmaj9-shell-a-shape-7",
+      "voicing_name": "Cmaj9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmaj9-shell-e-shape-7",
+      "voicing_name": "Cmaj9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "maj9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-a-shape-6-cm6",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-e-shape-6-cm6",
+      "voicing_name": "Cm(maj7) \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin-maj7-cm6-drop2-b3top-6",
+      "voicing_name": "Cm(maj7) \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin-maj7-shell-a-shape-6-cm6",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-a-shape-6-cm6",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-d-shape-6-cm6",
+      "voicing_name": "Cm(maj7) \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-e-shape-6-cm6",
+      "voicing_name": "Cm(maj7) \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-a-shape-7-cm7",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-e-shape-7-cm7",
+      "voicing_name": "Cm(maj7) \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin-maj7-cm7-drop2-b3top-7",
+      "voicing_name": "Cm(maj7) \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin-maj7-cm7-shell-a-7",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-cm7-shell-7str-7",
+      "voicing_name": "Cm(maj7) \u2014 7-str root \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-a-shape-7-cm7",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-d-shape-7-cm7",
+      "voicing_name": "Cm(maj7) \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-e-shape-7-cm7",
+      "voicing_name": "Cm(maj7) \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-a-shape-6",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-e-shape-6",
+      "voicing_name": "Cm(maj7) \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-d-shape-6",
+      "voicing_name": "Cm(maj7) \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin-maj7-shell-a-shape-6",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-a-shape-6",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-d-shape-6",
+      "voicing_name": "Cm(maj7) \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-e-shape-6",
+      "voicing_name": "Cm(maj7) \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-a-shape-7",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-e-shape-7",
+      "voicing_name": "Cm(maj7) \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj7-drop2-d-shape-7",
+      "voicing_name": "Cm(maj7) \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin-maj7-shell-a-shape-7",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-cv7-shell-7str-7",
+      "voicing_name": "Cm(maj7) \u2014 7-str root \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-a-shape-7",
+      "voicing_name": "Cm(maj7) \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-d-shape-7",
+      "voicing_name": "Cm(maj7) \u2014 D shape \u2014 Shell (7th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj7-shell-e-shape-7",
+      "voicing_name": "Cm(maj7) \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min-maj7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmmaj9-cm6-extended-6str-10",
+      "voicing_name": "Cm(maj9) \u2014 Fret 6 \u2014 Extended (7th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "min-maj9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj9-cm7-extended-7str-12",
+      "voicing_name": "Cm(maj9) \u2014 Fret 3 \u2014 Extended (7th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "min-maj9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj9-cv6-extended-6str-9",
+      "voicing_name": "Cm(maj9) \u2014 Fret 6 \u2014 Extended (7th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "min-maj9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmmaj9-cv7-extended-7str-11",
+      "voicing_name": "Cm(maj9) \u2014 Fret 3 \u2014 Extended (7th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "calculated",
+        "laukens-coverage"
+      ],
+      "chord_quality": "min-maj9",
+      "proposed_voicingStyle": [
+        "dirk-laukens",
+        "chord-function-driven",
+        "function-assigned",
+        "substitution-derivation"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "dirk-laukens",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' (id-as-tag)"
+        },
+        {
+          "tag": "chord-function-driven",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'chord-function-driven'"
+        },
+        {
+          "tag": "function-assigned",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'function-assigned'"
+        },
+        {
+          "tag": "substitution-derivation",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "derived from voicing.tags='laukens-coverage' \u2192 master 'dirk-laukens' \u2192 discriminating tag 'substitution-derivation'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm11-ext-a-shape-6-cm6",
+      "voicing_name": "Cmin11 \u2014 A shape \u2014 Extended (11th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm11-ext-e-shape-6-cm6",
+      "voicing_name": "Cmin11 \u2014 E shape \u2014 Extended (11th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm11-ext-a-shape-7-cm7",
+      "voicing_name": "Cmin11 \u2014 A shape \u2014 Extended (11th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm11-ext-e-shape-7-cm7",
+      "voicing_name": "Cmin11 \u2014 E shape \u2014 Extended (11th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin11-cm7-shell-7str-7",
+      "voicing_name": "Cmin11 \u2014 7-str root \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "c11-chordsdb-f1-6",
+      "voicing_name": "Cmin11 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "c11-chordsdb-f3-6",
+      "voicing_name": "Cmin11 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm11-chordsdb-f3-6",
+      "voicing_name": "Cmin11 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm11-chordsdb-f1-6",
+      "voicing_name": "Cmin11 \u2014 Fret 1 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm11-ext-a-shape-6",
+      "voicing_name": "Cmin11 \u2014 A shape \u2014 Extended (11th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm11-ext-e-shape-6",
+      "voicing_name": "Cmin11 \u2014 E shape \u2014 Extended (11th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm11-ext-a-shape-7",
+      "voicing_name": "Cmin11 \u2014 A shape \u2014 Extended (11th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm11-ext-e-shape-7",
+      "voicing_name": "Cmin11 \u2014 E shape \u2014 Extended (11th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "extended",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin11-cv7-shell-7str-7",
+      "voicing_name": "Cmin11 \u2014 7-str root \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min11",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-drop2-a-shape-6-cm6",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cm6-drop2-5top-6",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cm6-drop2-6top-6",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-6th"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cm6-drop2-1top-6",
+      "voicing_name": "Cm6 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-drop2-e-shape-6-cm6",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin6-cm6-drop2-b3top-6",
+      "voicing_name": "Cm6 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin6-shell-a-shape-6-cm6",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-a-shape-6-cm6",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-d-shape-6-cm6",
+      "voicing_name": "Cm6 \u2014 D shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-e-shape-6-cm6",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-drop2-a-shape-7-cm7",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cm7-drop2-5top-7",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cm7-drop2-7top-7",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-6th",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cm7-drop2-1top-7",
+      "voicing_name": "Cm6 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-drop2-e-shape-7-cm7",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin6-cm7-drop2-b3top-7",
+      "voicing_name": "Cm6 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cm7-shell-7str-7",
+      "voicing_name": "Cm6 \u2014 7-str root \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmin6-cm7-shell-a-7",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-a-shape-7-cm7",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-e-shape-7-cm7",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-d-shape-7-cm7",
+      "voicing_name": "Cm6 \u2014 D shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-e-shape-7",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-drop2-a-shape-6",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cv6-drop2-5top-6",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cv6-drop2-6top-6",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-6th"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cv6-drop2-1top-6",
+      "voicing_name": "Cm6 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-drop2-e-shape-6",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-drop2-d-shape-6",
+      "voicing_name": "Cm6 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-chordsdb-f1-6",
+      "voicing_name": "Cm6 \u2014 Fret 1 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-chordsdb-f3-6",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin6-shell-a-shape-6",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-a-shape-6",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-e-shape-6",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-d-shape-6",
+      "voicing_name": "Cm6 \u2014 D shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-e-shape-6-cv6",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-drop2-a-shape-7",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cv7-drop2-5top-7",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cv7-drop2-6top-7",
+      "voicing_name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-6th",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cv7-drop2-1top-7",
+      "voicing_name": "Cm6 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-drop2-e-shape-7",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-drop2-d-shape-7",
+      "voicing_name": "Cm6 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm6-cv7-shell-7str-7",
+      "voicing_name": "Cm6 \u2014 7-str root \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmin6-shell-a-shape-7",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-a-shape-7",
+      "voicing_name": "Cm6 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-d-shape-7",
+      "voicing_name": "Cm6 \u2014 D shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm6-shell-e-shape-7-cv7",
+      "voicing_name": "Cm6 \u2014 E shape \u2014 Shell (6th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min6",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm7-cm6-drop2-5top-6",
+      "voicing_name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cm6-drop2-b7top-6",
+      "voicing_name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-a-shape-6-cm6",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cm6-drop2-1top-6",
+      "voicing_name": "Cm7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-e-shape-6-cm6",
+      "voicing_name": "Cm7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cm6-drop2-b3top-6",
+      "voicing_name": "Cm7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop3-a-shape-6-cm6",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin7-shell-a-shape-6-cm6",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-a-shape-6-cm6",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-d-shape-6-cm6",
+      "voicing_name": "Cm7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-e-shape-6-cm6",
+      "voicing_name": "Cm7 \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cm7-drop2-5top-7",
+      "voicing_name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cm7-drop2-b7top-7",
+      "voicing_name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-a-shape-7-cm7",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cm7-drop2-1top-7",
+      "voicing_name": "Cm7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-e-shape-7-cm7",
+      "voicing_name": "Cm7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cm7-drop2-b3top-7",
+      "voicing_name": "Cm7 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cm7-drop3-7str-7",
+      "voicing_name": "Cm7 \u2014 7-str bass \u2014 Drop 3",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "drop-3",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "drop-3",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cm7-drop3-a-shape-7-cm7",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm7-cm7-shell-7str-7",
+      "voicing_name": "Cm7 \u2014 7-str root \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmin7-cm7-shell-a-7",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-a-shape-7",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-d-shape-7-cm7",
+      "voicing_name": "Cm7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-e-shape-7",
+      "voicing_name": "Cm7 \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-chordsdb-f1-6",
+      "voicing_name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cv6-drop2-5top-6",
+      "voicing_name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cminor-chordsdb-f1-6",
+      "voicing_name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cv6-drop2-b7top-6",
+      "voicing_name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-a-shape-6",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cminor-chordsdb-f3-6",
+      "voicing_name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cv6-drop2-1top-6",
+      "voicing_name": "Cm7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-e-shape-6",
+      "voicing_name": "Cm7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-d-shape-6",
+      "voicing_name": "Cm7 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop3-a-shape-6",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin7-shell-a-shape-6",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-a-shape-6",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-d-shape-6",
+      "voicing_name": "Cm7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-e-shape-6",
+      "voicing_name": "Cm7 \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cv7-drop2-5top-7",
+      "voicing_name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-5th",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cv7-drop2-b7top-7",
+      "voicing_name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-a-shape-7",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cv7-drop2-1top-7",
+      "voicing_name": "Cm7 \u2014 Fret 8 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-e-shape-7",
+      "voicing_name": "Cm7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-drop2-d-shape-7",
+      "voicing_name": "Cm7 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-cv7-drop3-7str-7",
+      "voicing_name": "Cm7 \u2014 7-str bass \u2014 Drop 3",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "drop-3",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "drop-3",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cm7-drop3-a-shape-7",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm7-cv7-shell-7str-7",
+      "voicing_name": "Cm7 \u2014 7-str root \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmin7-shell-a-shape-7",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-a-shape-7-cv7",
+      "voicing_name": "Cm7 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-d-shape-7",
+      "voicing_name": "Cm7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7-shell-e-shape-7-cv7",
+      "voicing_name": "Cm7 \u2014 E shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "guide-tone",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-a-shape-6-cm6",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-cm6-drop2-b7top-6",
+      "voicing_name": "Cm7b5 \u2014 Fret 4 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-cm6-drop2-1top-6",
+      "voicing_name": "Cm7b5 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-e-shape-6-26",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-e-shape-6-cm6",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin7b5-cm6-drop2-b3top-6",
+      "voicing_name": "Cm7b5 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop3-a-shape-6-cm6",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin7b5-shell-a-shape-6-cm6",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-a-shape-6-cm6",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-a",
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-d-shape-6-cm6",
+      "voicing_name": "Cm7b5 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-e-shape-6-cm6",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-a-shape-7-cm7",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-cm7-drop2-b7top-7",
+      "voicing_name": "Cm7b5 \u2014 Fret 4 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-cm7-drop2-1top-7",
+      "voicing_name": "Cm7b5 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-e-shape-6-27",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-e-shape-7-cm7",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin7b5-cm7-drop2-b3top-7",
+      "voicing_name": "Cm7b5 \u2014 Fret 10 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b3",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop3-a-shape-7-cm7",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm7b5-cm7-shell-7str-7",
+      "voicing_name": "Cm7b5 \u2014 7-str root \u2014 Shell (b5 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmin7b5-cm7-shell-a-7",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-a-shape-7-cm7",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-a",
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-d-shape-7-cm7",
+      "voicing_name": "Cm7b5 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-e-shape-7",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-a-shape-6",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-cv6-drop2-b7top-6",
+      "voicing_name": "Cm7b5 \u2014 Fret 4 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-cv6-drop2-1top-6",
+      "voicing_name": "Cm7b5 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-e-shape-6-2",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-e-shape-6",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-d-shape-6",
+      "voicing_name": "Cm7b5 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop3-a-shape-6",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin7b5-shell-a-shape-6",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-a-shape-6",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-a",
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-d-shape-6",
+      "voicing_name": "Cm7b5 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-e-shape-6",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-a-shape-7",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-a",
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-cv7-drop2-b7top-7",
+      "voicing_name": "Cm7b5 \u2014 Fret 4 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-b7",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-cv7-drop2-1top-7",
+      "voicing_name": "Cm7b5 \u2014 Fret 7 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "chord-melody",
+        "melody-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-e-shape-7-2",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-e",
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-e-shape-7",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop2-d-shape-7",
+      "voicing_name": "Cm7b5 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "caged-d",
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-drop3-a-shape-7",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "existing_category": "drop3",
+      "existing_tags": [
+        "drop3",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm7b5-cv7-shell-7str-7",
+      "voicing_name": "Cm7b5 \u2014 7-str root \u2014 Shell (b5 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "cmin7b5-shell-a-shape-7",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-a-shape-7",
+      "voicing_name": "Cm7b5 \u2014 A shape \u2014 Shell (b3 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-a",
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-d-shape-7",
+      "voicing_name": "Cm7b5 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "caged-d",
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm7b5-shell-e-shape-7-cv7",
+      "voicing_name": "Cm7b5 \u2014 E shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min7b5",
+      "proposed_voicingStyle": [
+        "shell"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' + category=shell + quality='min7b5' matches bernstein R-3-7 shell principle"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cmin9-drop2-d-shape-6-cm6",
+      "voicing_name": "Cm9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm9-extended-e-shape-6-cm6",
+      "voicing_name": "Cm9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-shell-a-shape-6-cm6",
+      "voicing_name": "Cm9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-shell-e-shape-6-cm6",
+      "voicing_name": "Cm9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin9-drop2-d-shape-7-cm7",
+      "voicing_name": "Cm9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm9-extended-e-shape-7-cm7",
+      "voicing_name": "Cm9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-shell-a-shape-7-cm7",
+      "voicing_name": "Cm9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-shell-e-shape-7-cm7",
+      "voicing_name": "Cm9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin9-drop2-d-shape-6",
+      "voicing_name": "Cm9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm9-chordsdb-f1-6",
+      "voicing_name": "Cm9 \u2014 Fret 1 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-chordsdb-f3-6",
+      "voicing_name": "Cm9 \u2014 Fret 3 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-extended-e-shape-6",
+      "voicing_name": "Cm9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-shell-a-shape-6",
+      "voicing_name": "Cm9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-shell-e-shape-6",
+      "voicing_name": "Cm9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cmin9-drop2-d-shape-7",
+      "voicing_name": "Cm9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "7-string"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "cm9-extended-e-shape-7",
+      "voicing_name": "Cm9 \u2014 E shape \u2014 Extended (9th on top)",
+      "existing_category": "extended",
+      "existing_tags": [
+        "altered",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-shell-a-shape-7",
+      "voicing_name": "Cm9 \u2014 A shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cm9-shell-e-shape-7",
+      "voicing_name": "Cm9 \u2014 E shape \u2014 Shell (9th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "min9",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-a-lower-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-bb-lower-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-upper-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-upper-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-upper-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-quartal-a-shape-6-cm6",
+      "voicing_name": "Cquartal \u2014 A shape \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "caged-a",
+        "quartal",
+        "stacked-4ths",
+        "dorian"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-lower-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-upper-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-lower-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-a-upper-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-bb-upper-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-lower-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-lower-6-cm6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-quartal-d-shape-6-cm6",
+      "voicing_name": "Cquartal \u2014 D shape \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "caged-d",
+        "quartal",
+        "stacked-4ths",
+        "dorian"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-a-lower-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-bb-lower-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-c-7str-low-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-upper-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-upper-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-7str-low-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-upper-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-quartal-a-shape-7-cm7",
+      "voicing_name": "Cquartal \u2014 A shape \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "caged-a",
+        "quartal",
+        "stacked-4ths",
+        "dorian",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-lower-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-7str-low-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-upper-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-lower-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-7str-low-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-a-upper-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-bb-upper-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-lower-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-7str-low-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-lower-7-cm7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-quartal-d-shape-7-cm7",
+      "voicing_name": "Cquartal \u2014 D shape \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "caged-d",
+        "quartal",
+        "stacked-4ths",
+        "dorian",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-a-lower-6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-bb-lower-6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-upper-6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-upper-6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-upper-6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-quartal-a-shape-6",
+      "voicing_name": "Cquartal \u2014 A shape \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "caged-a",
+        "quartal",
+        "stacked-4ths",
+        "dorian"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-lower-6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-upper-6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-lower-6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-a-upper-6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-bb-upper-6",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-lower-6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-lower-6",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-quartal-d-shape-6",
+      "voicing_name": "Cquartal \u2014 D shape \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "caged-d",
+        "quartal",
+        "stacked-4ths",
+        "dorian"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-a-lower-7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-bb-lower-7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-c-7str-low-7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-upper-7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-upper-7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-7str-low-7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-upper-7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-quartal-a-shape-7",
+      "voicing_name": "Cquartal \u2014 A shape \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "caged-a",
+        "quartal",
+        "stacked-4ths",
+        "dorian",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-d-lower-7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-7str-low-7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-upper-7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-eb-lower-7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-7str-low-7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-a-upper-7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-bb-upper-7",
+      "voicing_name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-1-2-3-4",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-f-lower-7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-7str-low-7",
+      "voicing_name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "7-string",
+        "low-register"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-g-lower-7",
+      "voicing_name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "quartal",
+        "c-dorian",
+        "str-2-3-4-5",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "cquartal-quartal-d-shape-7",
+      "voicing_name": "Cquartal \u2014 D shape \u2014 Quartal (b3 on top)",
+      "existing_category": "quartal",
+      "existing_tags": [
+        "caged-d",
+        "quartal",
+        "stacked-4ths",
+        "dorian",
+        "7-string"
+      ],
+      "chord_quality": "quartal",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-drop2-a-shape-6-cm6",
+      "voicing_name": "Csus2 \u2014 A shape \u2014 Drop 2 (2nd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-drop2-e-shape-6-cm6",
+      "voicing_name": "Csus2 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-drop2-d-shape-6-cm6",
+      "voicing_name": "Csus2 \u2014 D shape \u2014 Drop 2 (2nd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-shell-a-shape-6-cm6",
+      "voicing_name": "Csus2 \u2014 A shape \u2014 Shell (2nd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-d-shape-6-cm6",
+      "voicing_name": "Csus2 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-e-shape-6-cm6",
+      "voicing_name": "Csus2 \u2014 E shape \u2014 Shell (2nd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-drop2-a-shape-7-cm7",
+      "voicing_name": "Csus2 \u2014 A shape \u2014 Drop 2 (2nd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-drop2-e-shape-7-cm7",
+      "voicing_name": "Csus2 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-drop2-d-shape-7-cm7",
+      "voicing_name": "Csus2 \u2014 D shape \u2014 Drop 2 (2nd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-shell-a-shape-7-cm7",
+      "voicing_name": "Csus2 \u2014 A shape \u2014 Shell (2nd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-d-shape-7-cm7",
+      "voicing_name": "Csus2 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-e-shape-7-cm7",
+      "voicing_name": "Csus2 \u2014 E shape \u2014 Shell (2nd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-drop2-a-shape-6",
+      "voicing_name": "Csus2 \u2014 A shape \u2014 Drop 2 (2nd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-drop2-e-shape-6",
+      "voicing_name": "Csus2 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-drop2-d-shape-6",
+      "voicing_name": "Csus2 \u2014 D shape \u2014 Drop 2 (2nd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-chordsdb-f1-6",
+      "voicing_name": "Csus2 \u2014 Fret 1 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-chordsdb-f3-6",
+      "voicing_name": "Csus2 \u2014 Fret 3 \u2014 Extended",
+      "existing_category": "extended",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-a-shape-6",
+      "voicing_name": "Csus2 \u2014 A shape \u2014 Shell (2nd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-d-shape-6",
+      "voicing_name": "Csus2 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-e-shape-6",
+      "voicing_name": "Csus2 \u2014 E shape \u2014 Shell (2nd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-drop2-a-shape-7",
+      "voicing_name": "Csus2 \u2014 A shape \u2014 Drop 2 (2nd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-drop2-e-shape-7",
+      "voicing_name": "Csus2 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-drop2-d-shape-7",
+      "voicing_name": "Csus2 \u2014 D shape \u2014 Drop 2 (2nd on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus2-shell-a-shape-7",
+      "voicing_name": "Csus2 \u2014 A shape \u2014 Shell (2nd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-d-shape-7",
+      "voicing_name": "Csus2 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus2-shell-e-shape-7",
+      "voicing_name": "Csus2 \u2014 E shape \u2014 Shell (2nd on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus2",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-drop2-a-shape-6-cm6",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Drop 2 (4th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-e-shape-6-cm6",
+      "voicing_name": "Csus4 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-d-shape-6-cm6",
+      "voicing_name": "Csus4 \u2014 D shape \u2014 Drop 2 (4th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-cm6-shell-a-6",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-a-shape-6-cm6",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-e-shape-6-cm6",
+      "voicing_name": "Csus4 \u2014 E shape \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-d-shape-6-cm6",
+      "voicing_name": "Csus4 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-drop2-a-shape-7-cm7",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Drop 2 (4th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-e-shape-7-cm7",
+      "voicing_name": "Csus4 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-d-shape-7-cm7",
+      "voicing_name": "Csus4 \u2014 D shape \u2014 Drop 2 (4th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-cm7-shell-7str-7",
+      "voicing_name": "Csus4 \u2014 7-str root \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "csus4-cm7-shell-a-7",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-a-shape-7-cm7",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-e-shape-7-cm7",
+      "voicing_name": "Csus4 \u2014 E shape \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-d-shape-7-cm7",
+      "voicing_name": "Csus4 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-chordsdb-f1-6",
+      "voicing_name": "Csus4 \u2014 Fret 1 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-chordsdb-f3-6",
+      "voicing_name": "Csus4 \u2014 Fret 3 \u2014 Drop 2",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "imported",
+        "chords-db"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-a-shape-6",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Drop 2 (4th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-e-shape-6",
+      "voicing_name": "Csus4 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-d-shape-6",
+      "voicing_name": "Csus4 \u2014 D shape \u2014 Drop 2 (4th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-cv6-shell-a-6",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-a-shape-6",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-e-shape-6",
+      "voicing_name": "Csus4 \u2014 E shape \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-d-shape-6",
+      "voicing_name": "Csus4 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-drop2-a-shape-7",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Drop 2 (4th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-e-shape-7",
+      "voicing_name": "Csus4 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-drop2-d-shape-7",
+      "voicing_name": "Csus4 \u2014 D shape \u2014 Drop 2 (4th on top)",
+      "existing_category": "drop2",
+      "existing_tags": [
+        "drop2",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [
+        "block"
+      ],
+      "rationale": [
+        {
+          "tag": "block",
+          "kind": "playStyle",
+          "confidence": "MED",
+          "reason": "derived from category='drop2'"
+        }
+      ],
+      "max_confidence": "MED"
+    },
+    {
+      "voicing_id": "csus4-cv7-shell-7str-7",
+      "voicing_name": "Csus4 \u2014 7-str root \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string",
+        "van-eps"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [
+        "shell",
+        "van-eps"
+      ],
+      "proposed_playStyle": [],
+      "rationale": [
+        {
+          "tag": "shell",
+          "kind": "voicingStyle",
+          "confidence": "MED",
+          "reason": "existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein']"
+        },
+        {
+          "tag": "van-eps",
+          "kind": "voicingStyle",
+          "confidence": "HIGH",
+          "reason": "existing voicing.tags='van-eps' matches master voicingStyleTag (attributes to ['van-eps'])"
+        }
+      ],
+      "max_confidence": "HIGH"
+    },
+    {
+      "voicing_id": "csus4-cv7-shell-a-7",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-a-shape-7",
+      "voicing_name": "Csus4 \u2014 A shape \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "a-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-e-shape-7",
+      "voicing_name": "Csus4 \u2014 E shape \u2014 Shell (4th on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "e-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    },
+    {
+      "voicing_id": "csus4-shell-d-shape-7",
+      "voicing_name": "Csus4 \u2014 D shape \u2014 Shell (b7 on top)",
+      "existing_category": "shell",
+      "existing_tags": [
+        "shell",
+        "d-string-root",
+        "7-string"
+      ],
+      "chord_quality": "sus4",
+      "proposed_voicingStyle": [],
+      "proposed_playStyle": [],
+      "rationale": [],
+      "max_confidence": "NONE"
+    }
+  ]
+}

--- a/scripts/voicing-tags/propose.py
+++ b/scripts/voicing-tags/propose.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Heuristic voicing-tag proposer for #389 — v2 (post hostile review).
+
+Reads:
+  - plugin/data/voicings.json (820 voicings)
+  - plugin/data/masters.json (master vocab: voicingStyleTags + playStyleTags)
+
+Writes:
+  - plugin/data/voicings-tag-proposal.json — per-voicing candidates + rationale.
+
+Changes from v1 (driven by hostile review):
+  1. GENERIC_DESCRIPTORS denylist — `chord-melody`, `shell`, `block`, `drop-2`,
+     `drop-3` happen to appear in some master's vocab but they are content
+     descriptors, not master attribution. They are only emitted when a SECOND
+     signal (master alias in the same voicing, or category+quality rule)
+     confirms attribution.
+  2. Tag normalization — `drop3`→`drop-3`, `drop2`→`drop-2` applied before
+     vocab lookup so the 20 drop3 voicings are no longer starved.
+  3. Coverage marker no longer emits all 8 canonical tags. Emits ONLY the
+     master_id (if it's in the vocab) and tags that are clearly principle-
+     level descriptors (not pedagogical-method labels).
+  4. Shell-as-bernstein restricted to chord_quality in BERNSTEIN_SHELL_QUALITIES
+     so sus/dim/aug shells don't claim bernstein's R-3-7 attribution.
+  5. Confidence demoted from HIGH to MED for generic-descriptor matches that
+     pass the second-signal check.
+  6. playStyle vocab misses are logged in _meta (was previously silent).
+
+Confidence levels (calibrated):
+  HIGH = tag is an existing voicing.tags entry AND a master-specific (not
+         generic) voicingStyleTag.
+  MED  = derived from -coverage marker, master alias, category rule, or
+         a generic-descriptor passing second-signal check.
+  LOW  = (reserved)
+"""
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+GENERIC_DESCRIPTORS = {
+    "chord-melody", "shell", "block", "drop-2", "drop-3",
+    "sparse", "narrative",
+}
+
+BERNSTEIN_SHELL_QUALITIES = {
+    "maj7", "min7", "m7", "dom7", "7", "m7b5", "min7b5",
+}
+
+TAG_NORMALIZATION = {
+    "drop2": "drop-2",
+    "drop3": "drop-3",
+}
+
+PRINCIPLE_METHOD_TAGS = {
+    "shape-based-pedagogy", "standard-anchored-practice",
+    "named-relation-graph", "moveable-shapes",
+}
+
+
+def normalize_tag(t):
+    return TAG_NORMALIZATION.get(t, t)
+
+
+def load_master_vocabulary(masters_json_path):
+    d = json.load(open(masters_json_path))
+    voicing_tag_to_masters = defaultdict(set)
+    play_tag_to_masters = defaultdict(set)
+    master_canonical_voicing_tags = defaultdict(set)
+    master_ids = set()
+    for m in d["masters"]:
+        master_ids.add(m["id"])
+        for p in m.get("principles", []):
+            for t in p.get("voicingStyleTags", []):
+                voicing_tag_to_masters[t].add(m["id"])
+                master_canonical_voicing_tags[m["id"]].add(t)
+            for t in p.get("playStyleTags", []):
+                play_tag_to_masters[t].add(m["id"])
+    return {
+        "voicing_tag_to_masters": dict(voicing_tag_to_masters),
+        "play_tag_to_masters": dict(play_tag_to_masters),
+        "all_voicing_tags": set(voicing_tag_to_masters.keys()),
+        "all_play_tags": set(play_tag_to_masters.keys()),
+        "master_canonical_voicing_tags": dict(master_canonical_voicing_tags),
+        "master_ids": master_ids,
+    }
+
+
+def discriminating_master_tags(mid, vocab):
+    """Tags this master declares that:
+      - are single-master attributed (only this master uses them)
+      - are NOT pedagogical-method tags (those are too abstract for
+        per-voicing attribution)
+    Returns sorted list.
+    """
+    own = vocab["master_canonical_voicing_tags"].get(mid, set())
+    return sorted(
+        t for t in own
+        if len(vocab["voicing_tag_to_masters"].get(t, set())) == 1
+        and t not in PRINCIPLE_METHOD_TAGS
+    )
+
+
+def build_master_alias_map(vocab):
+    alias_to_master = {}
+    for mid in vocab["master_ids"]:
+        alias_to_master[mid] = mid
+        parts = mid.split("-")
+        alias_to_master.setdefault(parts[-1], mid)
+        if len(parts) >= 2:
+            alias_to_master.setdefault("-".join(parts[-2:]), mid)
+    return alias_to_master
+
+
+def category_to_play_tags(category, master_play_vocab):
+    candidates = {
+        "drop2": ["drop-2", "block"],
+        "drop3": ["drop-3"],
+        "quartal": ["quartal", "fourth-voicings"],
+        "extended": ["extended", "extensions"],
+        "altered": ["altered-dominant", "altered"],
+        "shell": ["guide-tones", "guide-tone", "shell"],
+    }
+    raw = candidates.get(category, [])
+    hits = [c for c in raw if c in master_play_vocab]
+    misses = [c for c in raw if c not in master_play_vocab]
+    return hits, misses
+
+
+def voicing_has_master_signal(voicing, alias_to_master, normalized_tags):
+    """True if the voicing carries any explicit master signal:
+      - a *-coverage marker resolving to a master
+      - an existing tag that is exactly a master_id or surname alias
+    """
+    for t in normalized_tags:
+        if t.endswith("-coverage"):
+            if alias_to_master.get(t[: -len("-coverage")]):
+                return True
+        if alias_to_master.get(t):
+            return True
+    return False
+
+
+def propose_tags_for_voicing(voicing, vocab, alias_to_master, playstyle_misses):
+    voicing_style = []
+    play_style = []
+    rationale = []
+    seen_tags = set()
+    conf_rank = {"HIGH": 3, "MED": 2, "LOW": 1, "NONE": 0}
+    max_conf = "NONE"
+
+    def emit_voicing(tag, conf, reason):
+        nonlocal max_conf
+        if tag in seen_tags or tag not in vocab["all_voicing_tags"]:
+            return
+        seen_tags.add(tag)
+        voicing_style.append(tag)
+        rationale.append({"tag": tag, "kind": "voicingStyle", "confidence": conf, "reason": reason})
+        if conf_rank[conf] > conf_rank[max_conf]:
+            max_conf = conf
+
+    def emit_play(tag, conf, reason):
+        nonlocal max_conf
+        if tag in seen_tags or tag not in vocab["all_play_tags"]:
+            return
+        seen_tags.add(tag)
+        play_style.append(tag)
+        rationale.append({"tag": tag, "kind": "playStyle", "confidence": conf, "reason": reason})
+        if conf_rank[conf] > conf_rank[max_conf]:
+            max_conf = conf
+
+    raw_tags = voicing.get("tags", []) or []
+    normalized_tags = [normalize_tag(t) for t in raw_tags]
+    category = voicing.get("category", "")
+    chord_quality = voicing.get("chord_quality", "")
+
+    has_master_signal = voicing_has_master_signal(voicing, alias_to_master, normalized_tags)
+
+    # Heuristic A: existing tag in master voicing vocab
+    for t in normalized_tags:
+        if t not in vocab["voicing_tag_to_masters"]:
+            continue
+        attributing = sorted(vocab["voicing_tag_to_masters"][t])
+        if t in GENERIC_DESCRIPTORS:
+            # Generic descriptor: needs second signal (master alias present)
+            if not has_master_signal:
+                # Special case: 'shell' tag on shell-category, restricted by quality
+                if t == "shell" and category == "shell" and chord_quality in BERNSTEIN_SHELL_QUALITIES:
+                    emit_voicing(t, "MED",
+                                 f"existing tag {t!r} + category=shell + quality={chord_quality!r} "
+                                 f"matches bernstein R-3-7 shell principle")
+                # Otherwise skip — would mis-attribute
+                continue
+            # Has master signal — emit at MED
+            emit_voicing(t, "MED",
+                         f"existing tag {t!r} (generic descriptor) confirmed by "
+                         f"master signal in same voicing; vocab attributes to {attributing}")
+        else:
+            emit_voicing(t, "HIGH",
+                         f"existing voicing.tags={t!r} matches master voicingStyleTag "
+                         f"(attributes to {attributing})")
+
+    # Heuristic B: -coverage marker → emit master_id tag + discriminating tags
+    for t in normalized_tags:
+        if not t.endswith("-coverage"):
+            continue
+        alias = t[: -len("-coverage")]
+        mid = alias_to_master.get(alias)
+        if not mid:
+            continue
+        # Always try master_id itself (if it's in vocab)
+        if mid in vocab["voicing_tag_to_masters"]:
+            emit_voicing(mid, "MED",
+                         f"derived from voicing.tags={t!r} → master {mid!r} (id-as-tag)")
+        # Plus discriminating tags (excludes pedagogical-method tags)
+        for canonical in discriminating_master_tags(mid, vocab):
+            if canonical == mid:
+                continue
+            emit_voicing(canonical, "MED",
+                         f"derived from voicing.tags={t!r} → master {mid!r} "
+                         f"→ discriminating tag {canonical!r}")
+
+    # Heuristic C: existing tag IS a master alias (e.g. 'van-eps')
+    for t in normalized_tags:
+        mid = alias_to_master.get(t)
+        if not mid:
+            continue
+        if mid in vocab["voicing_tag_to_masters"]:
+            emit_voicing(mid, "HIGH" if t == mid else "MED",
+                         f"voicing.tags={t!r} resolves to master {mid!r} (id-as-tag)")
+        for canonical in discriminating_master_tags(mid, vocab):
+            if canonical in (t, mid):
+                continue
+            emit_voicing(canonical, "MED",
+                         f"voicing.tags={t!r} is alias for master {mid!r} "
+                         f"→ discriminating tag {canonical!r}")
+
+    # Heuristic D: category → playStyle
+    if category:
+        hits, misses = category_to_play_tags(category, vocab["all_play_tags"])
+        for pt in hits:
+            emit_play(pt, "MED", f"derived from category={category!r}")
+        for m in misses:
+            playstyle_misses[(category, m)] += 1
+
+    return {
+        "voicingStyle": voicing_style,
+        "playStyle": play_style,
+        "rationale": rationale,
+        "max_confidence": max_conf,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sample", type=int, default=0)
+    ap.add_argument("--voicings", default="plugin/data/voicings.json")
+    ap.add_argument("--masters", default="plugin/data/masters.json")
+    ap.add_argument("--out", default="plugin/data/voicings-tag-proposal.json")
+    args = ap.parse_args()
+
+    vocab = load_master_vocabulary(args.masters)
+    alias_to_master = build_master_alias_map(vocab)
+
+    print(f"Master vocab: {len(vocab['all_voicing_tags'])} voicingStyleTags, "
+          f"{len(vocab['all_play_tags'])} playStyleTags, "
+          f"{len(alias_to_master)} aliases")
+
+    voicings = json.load(open(args.voicings))["voicings"]
+    if args.sample > 0:
+        voicings = voicings[:args.sample]
+
+    playstyle_misses = Counter()
+    proposals = []
+    conf_counts = {"HIGH": 0, "MED": 0, "LOW": 0, "NONE": 0}
+    tagged_count = 0
+    for v in voicings:
+        prop = propose_tags_for_voicing(v, vocab, alias_to_master, playstyle_misses)
+        if prop["voicingStyle"] or prop["playStyle"]:
+            tagged_count += 1
+        conf_counts[prop["max_confidence"]] += 1
+        proposals.append({
+            "voicing_id": v["id"],
+            "voicing_name": v.get("name", "?"),
+            "existing_category": v.get("category", ""),
+            "existing_tags": v.get("tags", []),
+            "chord_quality": v.get("chord_quality", ""),
+            "proposed_voicingStyle": prop["voicingStyle"],
+            "proposed_playStyle": prop["playStyle"],
+            "rationale": prop["rationale"],
+            "max_confidence": prop["max_confidence"],
+        })
+
+    print(f"\nProcessed {len(voicings)} voicings; {tagged_count} tagged "
+          f"({100*tagged_count/len(voicings):.1f}%)")
+    print(f"Max-confidence distribution: {conf_counts}")
+
+    drift = []
+    for p in proposals:
+        for t in p["proposed_voicingStyle"]:
+            if t not in vocab["all_voicing_tags"]:
+                drift.append(("voicingStyle", p["voicing_id"], t))
+        for t in p["proposed_playStyle"]:
+            if t not in vocab["all_play_tags"]:
+                drift.append(("playStyle", p["voicing_id"], t))
+    if drift:
+        print(f"\n[!] TAG DRIFT: {len(drift)} tags not in master vocab")
+        for kind, vid, t in drift[:5]:
+            print(f"    {vid}: {kind}={t!r}")
+    else:
+        print("\n[✓] No tag drift")
+
+    if playstyle_misses:
+        print(f"\n[i] playStyle category misses (category → candidate not in master vocab):")
+        for (cat, cand), n in playstyle_misses.most_common():
+            print(f"    {cat!r} → {cand!r}: {n} voicings affected")
+
+    out_payload = {
+        "_meta": {
+            "ticket": "#389",
+            "purpose": "v2 heuristic voicing-tag proposal (post hostile review)",
+            "voicings_processed": len(voicings),
+            "voicings_tagged": tagged_count,
+            "max_confidence_distribution": conf_counts,
+            "tag_drift_count": len(drift),
+            "playstyle_vocab_misses": {
+                f"{cat}→{cand}": n
+                for (cat, cand), n in playstyle_misses.most_common()
+            },
+            "v2_changes": [
+                "GENERIC_DESCRIPTORS denylist requires master-signal second confirmation",
+                "drop2/drop3 tag normalization",
+                "coverage-marker emits only discriminating tags (no pedagogical-method)",
+                "bernstein-shell restricted to standard 7th qualities",
+            ],
+        },
+        "proposals": proposals,
+    }
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(out_payload, indent=2) + "\n")
+    print(f"\nWrote {args.out} ({len(proposals)} proposals)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

First-pass deliverable for #389 (Strategy C author-coarse-first). Adds:
- `scripts/voicing-tags/propose.py` — heuristic tagger
- `plugin/data/voicings-tag-proposal.json` — 820 per-voicing tag candidates with rationale + confidence

Does **NOT** modify `voicings.json`. The proposal file is a reviewable artifact for the project-owner curatorial pass.

## Results (820 voicings)

| Metric | Value |
|---|---|
| Tagged | 484 (59.0%) |
| Untagged | 336 (41.0%) |
| Max confidence | 34 HIGH, 450 MED, 336 NONE |
| Tag drift | 0 (every emitted tag is in master vocab) |

**voicingStyle distribution:** shell(92), dirk-laukens(48), chord-function-driven(48), function-assigned(48), substitution-derivation(48), van-eps(34), drop-3(6)

**playStyle distribution:** block(322), altered-dominant(52)

## Algorithm (v2, post hostile review)

- **A**: existing voicing.tags entries that match master voicingStyleTag vocab → emit. Generic descriptors (chord-melody, shell, drop-2, block, ...) require a second master signal in the same voicing to avoid mis-attribution.
- **B**: `<X>-coverage` marker → resolve X to master_id, emit master_id + discriminating (single-master, non-pedagogical) tags.
- **C**: voicing.tags entry IS a master alias → same as B.
- **D**: category → playStyle aliases.

Tag normalization (`drop2`→`drop-2`, `drop3`→`drop-3`) applied before vocab lookup. Every emitted tag is gated on master-vocab membership (zero drift by construction).

## Hostile-review findings applied

A hostile-reviewer subagent ran against the v1 output and surfaced three critical bugs that are now fixed in v2:

1. **`chord-melody` mis-attribution to greg-orourke** — 134 voicings affected in v1. v2 denylists chord-melody as a generic descriptor; emits only when a second master signal is present.
2. **`laukens-coverage` 8-tag explosion** — 48 voicings each got all 8 of dirk-laukens' canonical tags including pedagogical-method labels (`shape-based-pedagogy`, `standard-anchored-practice`, etc.). v2 emits 4 discriminating tags.
3. **`drop3` vs `drop-3` normalization** — v1 starved 20 drop3 voicings. v2 normalizes before lookup.
4. **shell-as-bernstein over-attribution** — v1 tagged sus/dim/aug shells with bernstein's R-3-7 attribution. v2 restricts to `{maj7, min7, m7, dom7, m7b5}`.

## Surfaced findings for follow-up

The proposer logs **playStyle vocab misses** (`_meta.playstyle_vocab_misses`) — categories whose obvious playStyle candidates are NOT declared in any master:

| Category | Missing candidate | Voicings affected |
|---|---|---|
| drop2 | drop-2 | 322 |
| shell | shell / guide-tones | 270 |
| extended | extended / extensions | 84 |
| quartal | quartal / fourth-voicings | 66 |
| drop3 | drop-3 | 26 |

**Recommendation**: file a sibling masters.json ticket to add these as playStyleTags to the relevant masters (e.g., `quartal` → jim-hall's `fourth-stacks-and-open-voicings` principle; `drop-3` → joe-pass / jody-fisher; `drop-2` → joe-pass). This would lift the untagged count substantially.

## Rollback

Delete `plugin/data/voicings-tag-proposal.json`. Zero impact on voicings.json or anything else.

## Testing

```bash
python3 scripts/voicing-tags/propose.py
# Expect: 484 tagged, 0 tag drift, distribution as above
```

## Refs

#389 (this ticket) · #222 (engine consumption) · #223 (engine path) · #275 (EPIC) · #347 (batch-1 source)