### PR TITLE
data(masters)(#391): add quartal/drop-2/drop-3 playStyleTags to existing principles

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -4630,7 +4630,9 @@
           ],
           "playStyleTags": [
             "block",
-            "sequential"
+            "sequential",
+            "drop-2",
+            "drop-3"
           ],
           "applies_to_modes": [
             "chord-melody",
@@ -7100,10 +7102,12 @@
           "name": "Stacked fourths and open voicings",
           "summary": "Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds — beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top. Hall avoids root-position triads; open voicings with wide intervals between adjacent voices keep the register wide.",
           "voicingStyleTags": [
-            "hall"
+            "hall",
+            "quartal"
           ],
           "playStyleTags": [
-            "block"
+            "block",
+            "quartal"
           ],
           "applies_to_modes": [
             "comping",
@@ -7637,7 +7641,9 @@
             "drop-3"
           ],
           "playStyleTags": [
-            "block"
+            "block",
+            "drop-2",
+            "drop-3"
           ],
           "applies_to_modes": [
             "chord-melody",


### PR DESCRIPTION
## Summary

Three surgical vocab additions to `plugin/data/masters.json` to close the master-side vocabulary gap surfaced by the #389 voicing-tag proposer (PR #390). Each addition is justified by the principle's existing summary/content — this is **not** new content, it's **promoting existing implicit tags to explicit `playStyleTags`** so the engine can use them.

## Diff

| Master | Principle | Field | Added |
|---|---|---|---|
| jim-hall | fourth-stacks-and-open-voicings | voicingStyleTags | `quartal` |
| jim-hall | fourth-stacks-and-open-voicings | playStyleTags | `quartal` |
| joe-pass | drop-2-and-drop-3-chord-melody | playStyleTags | `drop-2`, `drop-3` (already in voicingStyleTags) |
| jody-fisher | pedagogical-voicing-taxonomy | playStyleTags | `drop-2`, `drop-3` (already in voicingStyleTags) |

## Impact on #389 proposer (820 voicings)

Re-running `scripts/voicing-tags/propose.py` (from PR #390) after these edits:

| Metric | Before #391 | After #391 | Delta |
|---|---|---|---|
| Tagged voicings | 484 (59.0%) | 570 (69.5%) | **+86** |
| HIGH confidence | 34 | 100 | **+66** |
| Tag drift | 0 | 0 | — |
| voicingStyleTags vocab | 131 | 132 | +1 (`quartal`) |
| playStyleTags vocab | 162 | 165 | +3 (`drop-2`, `drop-3`, `quartal`) |

`_meta.playstyle_vocab_misses` after this PR no longer reports:
- ~~`drop2 → drop-2: 322`~~
- ~~`drop3 → drop-3: 26`~~
- ~~`quartal → quartal: 66`~~

## Verification

- [x] `scripts/validate.py --target masters`: same 5 pre-existing schema errors as develop (galbraith/bertoncini `_pending:` system ids, aebersold year=None — unrelated to this PR)
- [x] Tag normalization handled: every new tag string uses canonical kebab-case
- [x] Diff is minimal (10 insertions, 4 deletions, multiline-array formatting preserved)
- [x] Re-run of #389 proposer: 0 drift, +86 tagged voicings

## Out of scope

- `extended` / `extensions` — needs curatorial call on which master "owns" extended-chord voicings (V-System? laukens.function-assigned? bernstein.dressing?)
- `shell` playStyleTag for non-7th qualities — proposer correctly under-attributes; needs no change

## Refs

#391 (this ticket) · #389 (parent — surfaced the gap) · PR #390 (the proposer) · #222 (engine consumption) · #275 (EPIC)