### PR TITLE
tooling(voicing-tags)(#395 subtask 2): Tally form builder + pilot-50 payload

### DIFF
--- a/scripts/voicing-tags/tally-form-builder.py
+++ b/scripts/voicing-tags/tally-form-builder.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Build a Tally form for crowdsource voicing-tag review (#395 subtask 2).
+
+Reads:
+  - scripts/voicing-tags/pilot-50.csv (or any CSV with voicing_id +
+    voicing_name + chord_quality + category + agent_proposed_voicingStyle
+    + agent_proposed_playStyle + agent_confidence + agent_reasoning)
+  - scripts/voicing-tags/diagrams/<voicing_id>.png (must exist on the
+    branch that backs the configured image base URL)
+
+Emits:
+  - A Tally form payload JSON (default) — inspect before posting.
+  - Optionally POSTs to https://api.tally.so/v1/forms when --post and
+    TALLY_API_KEY env var are both set.
+
+Form structure (per voicing):
+  1. TITLE  — voicing_name + chord_quality + (agent confidence badge)
+  2. IMAGE  — fretboard PNG, fetched from raw.githubusercontent.com
+  3. TEXT   — "Agent proposed: <vs> | <ps>. Reasoning: <agent_reasoning>"
+  4. MULTIPLE_CHOICE_OPTION × 3 — YES / NO / REFINE (single-select)
+  5. TEXTAREA — "Why are you overriding the agent? (required if NO/REFINE)"
+  6. INPUT_TEXT — "Tags to add (comma-separated, optional)"
+  7. TEXTAREA — "Notes (optional)"
+
+Each voicing's blocks share a single groupUuid so Tally renders them as
+one logical question group.
+
+Why Tally over Google Forms: see ticket #395. Tally's free tier includes
+API access, supports image blocks via URL, and can ingest a full form's
+worth of blocks in a single POST.
+"""
+import argparse
+import csv
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+TALLY_API = "https://api.tally.so/v1/forms"
+DEFAULT_BASE_URL = (
+    "https://raw.githubusercontent.com/"
+    "siege-analytics/musescore4-chord-library-plugin/"
+    "develop/scripts/voicing-tags/diagrams"
+)
+
+
+def new_uuid():
+    return str(uuid.uuid4())
+
+
+def title_block(text, group_uuid=None):
+    uid = new_uuid()
+    return {
+        "uuid": uid,
+        "groupUuid": group_uuid or uid,
+        "type": "TITLE",
+        "title": text,
+    }
+
+
+def image_block(image_url, alt_text, group_uuid):
+    return {
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "IMAGE",
+        "imageUrl": image_url,
+        "altText": alt_text,
+    }
+
+
+def text_block(html, group_uuid):
+    return {
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "TEXT",
+        "html": html,
+    }
+
+
+def multiple_choice_options(labels, group_uuid):
+    blocks = []
+    for i, label in enumerate(labels):
+        blocks.append({
+            "uuid": new_uuid(),
+            "groupUuid": group_uuid,
+            "type": "MULTIPLE_CHOICE_OPTION",
+            "title": label,
+            "isFirstOption": i == 0,
+            "isLastOption": i == len(labels) - 1,
+            "optionIndex": i,
+            "allowMultiple": False,
+        })
+    return blocks
+
+
+def textarea_block(title_text, placeholder, group_uuid, required=False):
+    return {
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "TEXTAREA",
+        "title": title_text,
+        "placeholder": placeholder,
+        "isRequired": required,
+    }
+
+
+def input_text_block(title_text, placeholder, group_uuid):
+    return {
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "INPUT_TEXT",
+        "title": title_text,
+        "placeholder": placeholder,
+        "isRequired": False,
+    }
+
+
+def build_voicing_blocks(row, base_image_url):
+    """Build the per-voicing block group. Returns a list of blocks all
+    sharing one groupUuid so Tally treats them as one page/question.
+    """
+    group_uuid = new_uuid()
+    vid = row["voicing_id"]
+    name = row.get("voicing_name", vid)
+    quality = row.get("chord_quality", "")
+    category = row.get("category", "")
+    vs = row.get("agent_proposed_voicingStyle", "") or "(none)"
+    ps = row.get("agent_proposed_playStyle", "") or "(none)"
+    conf = row.get("agent_confidence", "")
+    reasoning = row.get("agent_reasoning", "")
+
+    title_text = f"{name} — {quality} {category}".strip()
+    image_url = f"{base_image_url}/{vid}.png"
+    reasoning_html = (
+        f"<p><b>Agent proposed:</b><br>"
+        f"voicingStyle: <code>{vs}</code><br>"
+        f"playStyle: <code>{ps}</code><br>"
+        f"confidence: <b>{conf}</b></p>"
+        f"<p><b>Reasoning:</b> {reasoning}</p>"
+    )
+
+    blocks = []
+    blocks.append({
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "TITLE",
+        "title": title_text,
+    })
+    blocks.append(image_block(image_url, f"Fretboard diagram for {name}", group_uuid))
+    blocks.append(text_block(reasoning_html, group_uuid))
+
+    # Verdict question — own groupUuid so options are children of it
+    mc_group = new_uuid()
+    blocks.append({
+        "uuid": new_uuid(),
+        "groupUuid": mc_group,
+        "type": "MULTIPLE_CHOICE",
+        "title": "Do these tags fit this voicing?",
+    })
+    blocks.extend(multiple_choice_options(["YES", "NO", "REFINE"], mc_group))
+
+    # Override reason
+    blocks.append(textarea_block(
+        "If NO or REFINE, why are you overriding the agent?",
+        "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+        new_uuid(),
+    ))
+    # Additions
+    blocks.append(input_text_block(
+        "Tags to add (comma-separated, optional)",
+        "e.g. van-eps, walking-bass",
+        new_uuid(),
+    ))
+    # Notes
+    blocks.append(textarea_block(
+        "Anything else? (optional)",
+        "Free-form notes",
+        new_uuid(),
+    ))
+
+    return blocks
+
+
+def build_form_payload(rows, base_image_url, form_title):
+    blocks = []
+    blocks.append({
+        "uuid": new_uuid(),
+        "groupUuid": new_uuid(),
+        "type": "FORM_TITLE",
+        "title": form_title,
+    })
+    intro_group = new_uuid()
+    blocks.append(text_block(
+        "<p>Thanks for helping. Each page shows one guitar voicing, "
+        "the tags an automated tagger guessed, and a fretboard diagram. "
+        "For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and "
+        "tell us why if you disagree.</p>"
+        "<p>You can skip rows you're unsure about — quality of judgment "
+        "beats coverage.</p>",
+        intro_group,
+    ))
+
+    for row in rows:
+        blocks.extend(build_voicing_blocks(row, base_image_url))
+
+    return {
+        "status": "DRAFT",
+        "blocks": blocks,
+    }
+
+
+def post_to_tally(payload, api_key):
+    import urllib.request
+    req = urllib.request.Request(
+        TALLY_API,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.load(resp)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", default="scripts/voicing-tags/pilot-50.csv")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="if > 0, only build N voicings (test-before-bulk)")
+    ap.add_argument("--out", default="scripts/voicing-tags/tally-form-payload.json")
+    ap.add_argument("--base-image-url", default=DEFAULT_BASE_URL)
+    ap.add_argument("--title", default="Voicing-tag review — pilot (#395)")
+    ap.add_argument("--post", action="store_true",
+                    help="POST to Tally API (requires TALLY_API_KEY env var)")
+    args = ap.parse_args()
+
+    rows = list(csv.DictReader(open(args.csv)))
+    if args.limit > 0:
+        rows = rows[: args.limit]
+    print(f"Building Tally form for {len(rows)} voicings", file=sys.stderr)
+    print(f"Image base URL: {args.base_image_url}", file=sys.stderr)
+
+    payload = build_form_payload(rows, args.base_image_url, args.title)
+    n_blocks = len(payload["blocks"])
+    print(f"Generated {n_blocks} blocks ({n_blocks // len(rows) if rows else 0} per voicing avg)", file=sys.stderr)
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {out}", file=sys.stderr)
+
+    if args.post:
+        api_key = os.environ.get("TALLY_API_KEY")
+        if not api_key:
+            print("ERROR: --post given but TALLY_API_KEY env var not set", file=sys.stderr)
+            sys.exit(2)
+        print(f"POSTing to {TALLY_API}…", file=sys.stderr)
+        try:
+            result = post_to_tally(payload, api_key)
+        except Exception as e:
+            print(f"POST failed: {e}", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/voicing-tags/tally-form-builder.py
+++ b/scripts/voicing-tags/tally-form-builder.py
@@ -37,7 +37,7 @@ import sys
 import uuid
 from pathlib import Path
 
-TALLY_API = "https://api.tally.so/v1/forms"
+TALLY_API = "https://api.tally.so/forms"
 DEFAULT_BASE_URL = (
     "https://raw.githubusercontent.com/"
     "siege-analytics/musescore4-chord-library-plugin/"
@@ -49,71 +49,82 @@ def new_uuid():
     return str(uuid.uuid4())
 
 
-def title_block(text, group_uuid=None):
-    uid = new_uuid()
-    return {
-        "uuid": uid,
-        "groupUuid": group_uuid or uid,
-        "type": "TITLE",
-        "title": text,
-    }
-
-
-def image_block(image_url, alt_text, group_uuid):
+def _block(block_type, group_uuid, group_type, payload):
     return {
         "uuid": new_uuid(),
         "groupUuid": group_uuid,
-        "type": "IMAGE",
-        "imageUrl": image_url,
-        "altText": alt_text,
+        "groupType": group_type,
+        "type": block_type,
+        "payload": payload,
     }
 
 
-def text_block(html, group_uuid):
-    return {
-        "uuid": new_uuid(),
-        "groupUuid": group_uuid,
-        "type": "TEXT",
-        "html": html,
-    }
+def form_title_block(text):
+    g = new_uuid()
+    return [
+        _block("FORM_TITLE", g, "TEXT", {"html": text, "title": text}),
+    ]
 
 
-def multiple_choice_options(labels, group_uuid):
-    blocks = []
-    for i, label in enumerate(labels):
-        blocks.append({
-            "uuid": new_uuid(),
-            "groupUuid": group_uuid,
-            "type": "MULTIPLE_CHOICE_OPTION",
-            "title": label,
-            "isFirstOption": i == 0,
-            "isLastOption": i == len(labels) - 1,
-            "optionIndex": i,
-            "allowMultiple": False,
-        })
+def text_paragraph(html):
+    g = new_uuid()
+    return [_block("TEXT", g, "TEXT", {"html": html})]
+
+
+def heading_block(text):
+    """Standalone TITLE block at top level (not a question label)."""
+    g = new_uuid()
+    return [_block("TITLE", g, "TITLE", {"html": text})]
+
+
+def image_question_group(image_url, alt_text):
+    """IMAGE block alone — guess at payload shape from earlier doc sample."""
+    g = new_uuid()
+    return [_block("IMAGE", g, "IMAGE", {
+        "images": [{"url": image_url, "name": alt_text}],
+    })]
+
+
+def _label(text):
+    """Standalone label block — its own groupUuid per Tally's validator."""
+    g = new_uuid()
+    return _block("TITLE", g, "QUESTION", {"html": text})
+
+
+def multiple_choice_question(label_html, options):
+    """Label (own groupUuid) + N MULTIPLE_CHOICE_OPTION blocks sharing
+    groupUuid with groupType=MULTIPLE_CHOICE."""
+    blocks = [_label(label_html)]
+    g = new_uuid()
+    n = len(options)
+    for i, opt in enumerate(options):
+        blocks.append(_block("MULTIPLE_CHOICE_OPTION", g, "MULTIPLE_CHOICE", {
+            "text": opt,
+            "index": i,
+            "isFirst": i == 0,
+            "isLast": i == n - 1,
+        }))
     return blocks
 
 
-def textarea_block(title_text, placeholder, group_uuid, required=False):
-    return {
-        "uuid": new_uuid(),
-        "groupUuid": group_uuid,
-        "type": "TEXTAREA",
-        "title": title_text,
-        "placeholder": placeholder,
-        "isRequired": required,
-    }
+def textarea_question(label_html, placeholder="", required=False):
+    return [
+        _label(label_html),
+        _block("TEXTAREA", new_uuid(), "TEXTAREA", {
+            "isRequired": required,
+            "placeholder": placeholder,
+        }),
+    ]
 
 
-def input_text_block(title_text, placeholder, group_uuid):
-    return {
-        "uuid": new_uuid(),
-        "groupUuid": group_uuid,
-        "type": "INPUT_TEXT",
-        "title": title_text,
-        "placeholder": placeholder,
-        "isRequired": False,
-    }
+def input_text_question(label_html, placeholder=""):
+    return [
+        _label(label_html),
+        _block("INPUT_TEXT", new_uuid(), "INPUT_TEXT", {
+            "isRequired": False,
+            "placeholder": placeholder,
+        }),
+    ]
 
 
 def build_voicing_blocks(row, base_image_url):
@@ -141,64 +152,38 @@ def build_voicing_blocks(row, base_image_url):
     )
 
     blocks = []
-    blocks.append({
-        "uuid": new_uuid(),
-        "groupUuid": group_uuid,
-        "type": "TITLE",
-        "title": title_text,
-    })
-    blocks.append(image_block(image_url, f"Fretboard diagram for {name}", group_uuid))
-    blocks.append(text_block(reasoning_html, group_uuid))
-
-    # Verdict question — own groupUuid so options are children of it
-    mc_group = new_uuid()
-    blocks.append({
-        "uuid": new_uuid(),
-        "groupUuid": mc_group,
-        "type": "MULTIPLE_CHOICE",
-        "title": "Do these tags fit this voicing?",
-    })
-    blocks.extend(multiple_choice_options(["YES", "NO", "REFINE"], mc_group))
-
-    # Override reason
-    blocks.append(textarea_block(
+    blocks.extend(heading_block(title_text))
+    blocks.extend(image_question_group(image_url, f"Fretboard diagram for {name}"))
+    blocks.extend(text_paragraph(reasoning_html))
+    blocks.extend(multiple_choice_question(
+        "Do these tags fit this voicing?",
+        ["YES", "NO", "REFINE"],
+    ))
+    blocks.extend(textarea_question(
         "If NO or REFINE, why are you overriding the agent?",
-        "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-        new_uuid(),
+        placeholder="e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary",
     ))
-    # Additions
-    blocks.append(input_text_block(
+    blocks.extend(input_text_question(
         "Tags to add (comma-separated, optional)",
-        "e.g. van-eps, walking-bass",
-        new_uuid(),
+        placeholder="e.g. van-eps, walking-bass",
     ))
-    # Notes
-    blocks.append(textarea_block(
+    blocks.extend(textarea_question(
         "Anything else? (optional)",
-        "Free-form notes",
-        new_uuid(),
+        placeholder="Free-form notes",
     ))
-
     return blocks
 
 
 def build_form_payload(rows, base_image_url, form_title):
     blocks = []
-    blocks.append({
-        "uuid": new_uuid(),
-        "groupUuid": new_uuid(),
-        "type": "FORM_TITLE",
-        "title": form_title,
-    })
-    intro_group = new_uuid()
-    blocks.append(text_block(
+    blocks.extend(form_title_block(form_title))
+    blocks.extend(text_paragraph(
         "<p>Thanks for helping. Each page shows one guitar voicing, "
         "the tags an automated tagger guessed, and a fretboard diagram. "
         "For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and "
         "tell us why if you disagree.</p>"
         "<p>You can skip rows you're unsure about — quality of judgment "
-        "beats coverage.</p>",
-        intro_group,
+        "beats coverage.</p>"
     ))
 
     for row in rows:
@@ -212,17 +197,24 @@ def build_form_payload(rows, base_image_url, form_title):
 
 def post_to_tally(payload, api_key):
     import urllib.request
+    import urllib.error
     req = urllib.request.Request(
         TALLY_API,
         data=json.dumps(payload).encode("utf-8"),
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "voicing-tag-form-builder/1.0 (#395; curl-equivalent)",
         },
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:
-        return json.load(resp)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {e.code} from Tally: {body}") from None
 
 
 def main():

--- a/scripts/voicing-tags/tally-form-payload.json
+++ b/scripts/voicing-tags/tally-form-payload.json
@@ -2,3966 +2,6723 @@
   "status": "DRAFT",
   "blocks": [
     {
-      "uuid": "0c40ffc6-1a00-4117-b478-9e6f1caaa343",
-      "groupUuid": "5ad255f4-137b-4801-a41f-ecad2e0aee6f",
+      "uuid": "c17c7151-3a07-4e35-9f79-c06549118f33",
+      "groupUuid": "69dc2fa3-e054-4524-822e-0cd63a1bf36b",
+      "groupType": "TEXT",
       "type": "FORM_TITLE",
-      "title": "Voicing-tag review \u2014 pilot (#395)"
+      "payload": {
+        "html": "Voicing-tag review \u2014 pilot (#395)",
+        "title": "Voicing-tag review \u2014 pilot (#395)"
+      }
     },
     {
-      "uuid": "26dab5d8-6313-4d74-85b3-772079e16755",
-      "groupUuid": "bb8443cf-8cd3-4535-9969-a0b78d3c6c70",
+      "uuid": "7de2305b-89bb-4ca1-adac-2b8b199d5d0c",
+      "groupUuid": "8bcde888-b172-48ea-9de5-2b4d097fece1",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p>Thanks for helping. Each page shows one guitar voicing, the tags an automated tagger guessed, and a fretboard diagram. For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and tell us why if you disagree.</p><p>You can skip rows you're unsure about \u2014 quality of judgment beats coverage.</p>"
+      "payload": {
+        "html": "<p>Thanks for helping. Each page shows one guitar voicing, the tags an automated tagger guessed, and a fretboard diagram. For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and tell us why if you disagree.</p><p>You can skip rows you're unsure about \u2014 quality of judgment beats coverage.</p>"
+      }
     },
     {
-      "uuid": "9241de52-fc7f-4cdb-9211-44a352ea9473",
-      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "uuid": "e708be0c-df81-4be9-9a43-9e38d5c38035",
+      "groupUuid": "185ee2dd-09fa-47ad-a1e5-2d5e3a5a9d05",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+      "payload": {
+        "html": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+      }
     },
     {
-      "uuid": "dc805d9c-f12a-4cd0-bb0a-96a737192bf4",
-      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "uuid": "dc62ff74-2377-497a-b948-e3d2ba553587",
+      "groupUuid": "d66b2b16-5e1f-493a-8ad3-3282e41fc076",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm6-altered-6str-26.png",
-      "altText": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm6-altered-6str-26.png",
+            "name": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "0cd2e828-7a1a-4aad-bdf0-c1342f93053c",
-      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "uuid": "3b0bad58-ae10-46a8-9231-37b36037c95f",
+      "groupUuid": "1e7258f9-519e-4180-81ef-6a85d5e43d93",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
     },
     {
-      "uuid": "aba40be8-ef7c-4f72-a19e-c839babadc36",
-      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "c276313e-3365-4b6b-a86e-ffeace37aef0",
-      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "cde62618-2e0b-4506-9218-560b1f8e1c4c",
-      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "cce314ce-4bf2-41c3-b690-ecd4ab26c1c1",
-      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "507599b0-4ac3-468d-a828-a812ab6e7aeb",
-      "groupUuid": "677dd3ef-f4f6-473f-a2ba-4cd0ad6d371d",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "36bb211a-6f5f-4f84-bab9-bdd6c5d97315",
-      "groupUuid": "f692a045-b69a-4b3c-8c64-c815edf9b12e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "43750726-e587-4dfc-af1d-4a7e22316c71",
-      "groupUuid": "38dc92e6-84d7-455f-b95c-454c321b8294",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "b81149e9-98d4-451b-9e6e-470d9b3298b6",
-      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
+      "uuid": "aa3d985f-b82e-4310-942c-e21475b3f712",
+      "groupUuid": "153ab8ce-5b02-4276-b942-8abcb4cb7a4f",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "b33a0941-181c-4446-9044-dd1f37f4510c",
-      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-b7top-6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
-    },
-    {
-      "uuid": "7ff0b510-8117-4651-b924-8855d0b76000",
-      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "aaf62e08-cbef-4ae2-a19a-4fc201bbd960",
-      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "73735b80-d45b-42ab-ad2b-71db51c9d090",
-      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "uuid": "41b7c8cc-5195-4bae-ac04-a86f0fe7358d",
+      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "e63c7c64-599a-4cb4-b5cd-aa0a21e60d24",
-      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "uuid": "783a6712-c91a-42fe-861b-d0de06a90a78",
+      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "044f3136-1539-4013-948c-a87a9a1865f2",
-      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "uuid": "626c210b-ccfd-43f0-ba0d-570a531021ca",
+      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "4e16c380-eef5-4dff-b023-7fc5b6835b46",
-      "groupUuid": "1946ffb0-fbc8-40be-b957-a7238a66222d",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "993eaaaf-0d00-4f46-9255-8f6e07287542",
-      "groupUuid": "a3fc5d7f-030a-4237-94a2-9f055d66287e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "19918d02-5ac8-409e-b10b-9410208bd07b",
-      "groupUuid": "4d29dada-99fe-4a57-a7dc-1956ac17dd74",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "e9a35697-b5bc-4071-a88a-df3701c66118",
-      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
+      "uuid": "3c08057c-696b-48f3-92bf-67eee81b367d",
+      "groupUuid": "2044bd93-fb09-434a-944e-797dd3faf3bc",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "e14033c6-c87f-4694-9932-f352983075e8",
-      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "3602578f-3a3c-456d-ad70-3714d2396a1a",
-      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "da50f515-049a-43c7-92c5-efdec5b10eb6",
-      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "f0837946-b10e-4264-8976-ae62ebea4437",
-      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4b40c83f-bc5b-429f-bb9f-4e77d9df707f",
-      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "47d507fc-dfb2-437c-b169-2e8760d2d9ce",
-      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "cfec88fc-6226-4415-937b-ec972ec850f9",
-      "groupUuid": "1d455bb0-2faf-48b6-801b-0f1c110d399d",
+      "uuid": "a88b4e00-d8fe-434c-bc52-8f24bb2e50fe",
+      "groupUuid": "7db9487d-2302-4499-b833-7ef6e01a4e2c",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "44dc0684-2355-4b04-a25b-d6889e439434",
-      "groupUuid": "621f4055-e3c7-42b7-b0f4-6375d71a94fe",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "c82acce8-7a53-45b3-830e-f0f752c114bd",
-      "groupUuid": "549c1800-e651-47f9-8b2d-e92720221343",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d623267c-2e53-4ca9-8393-cd8a00494f84",
-      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
+      "uuid": "5d475e15-f266-44d5-811b-69db07274452",
+      "groupUuid": "3facb47e-6256-48a9-a97a-1d952c3aca6a",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "674edda9-0685-416b-a744-2f139ff95ce5",
-      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
-    },
-    {
-      "uuid": "83d0188b-794a-4f1e-bb4f-5e0198997eb1",
-      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "9f4e6e20-a201-401c-9ea3-9cd7160b7788",
-      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "12f6ddbb-8ec7-4464-b54d-79cfd4b120e9",
-      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "7692d7a8-8a36-41c8-87fc-2fcbea480154",
-      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "df880eac-acdb-40ff-8c80-6b249517c682",
-      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4fb33aa3-2f3a-4be1-8bc2-b09c208d719a",
-      "groupUuid": "1e25d394-3c6a-4327-abbf-5e66c4d1bc2c",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "6120424f-3421-40a6-ab42-617129671e72",
-      "groupUuid": "325f949c-43e0-4bab-9c5e-d37cfc3d0a68",
+      "uuid": "60bbe785-4b24-4301-9dcc-bb8d18ce0a02",
+      "groupUuid": "588fef02-c764-4a61-8cae-9caf000ecb07",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "02d5f65d-214d-4cc3-8928-4d8ca58e325c",
-      "groupUuid": "73eedec6-6374-4303-94bd-cb7ea0de0a05",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d9b9fa2f-d441-4170-8b24-5c2a5ceac914",
-      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
+      "uuid": "4d346cb4-8168-4de0-961b-ffe7000f8fcc",
+      "groupUuid": "114050b7-52f0-43da-bc48-fcbd19340aa0",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "0f151d90-b230-4f1c-afd7-0f986d3cb9c3",
-      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm6-extended-6str-18.png",
-      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
-    },
-    {
-      "uuid": "b92969c0-4c68-4560-aad7-2c67f030903d",
-      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "d7518955-34ea-4e91-848e-3549e3c45494",
-      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "5d634695-898c-455e-8820-eb9781920511",
-      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "ec7bc0a2-7c93-4f38-a2d1-008c4f5efe9b",
-      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "2818e5e9-24ec-469d-b75b-5bf5116812c9",
-      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "dc9c0357-688f-46bd-8d3a-92460b314b86",
-      "groupUuid": "6e34fcbf-61db-4924-a1e5-f6e060cdfa24",
+      "uuid": "a9986592-9c23-49c3-8049-58b2cb7179de",
+      "groupUuid": "aade363d-86c0-43fc-8a5f-8f903213dd5a",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "ae9df3f3-569a-4d51-993c-3e0211a6cb08",
-      "groupUuid": "07c8d9ee-b308-4b59-be74-099a82233a1d",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "d670a294-2cd0-4d9f-a48c-e33c093af389",
-      "groupUuid": "5b3b5f20-bc44-44fb-af5b-a4727d560abc",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "695504ff-fe66-4ff3-860f-c18aa79aeda2",
-      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "uuid": "0809a00e-1017-4bea-badb-a43463b530c8",
+      "groupUuid": "4a7aab67-9ef8-4257-8867-ddc0715e45a4",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 Fret 1 \u2014 Extended \u2014 dim7 extended"
+      "payload": {
+        "html": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
     },
     {
-      "uuid": "b89c4975-1397-433d-92c3-534093bec121",
-      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "uuid": "895dbd4b-2655-4b05-bb7c-68daa8e1801e",
+      "groupUuid": "7d860845-1557-44d7-84ef-48c795e79304",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f1-6.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 Fret 1 \u2014 Extended"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-b7top-6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
+          }
+        ]
+      }
     },
     {
-      "uuid": "ba421523-b5ff-4ce4-84f6-2432701fcf91",
-      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "uuid": "63c18e6e-e112-4998-990a-fd13934b867d",
+      "groupUuid": "3525c243-ee3c-4133-aac5-45fe66910321",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
     },
     {
-      "uuid": "119ddde1-4405-4bb4-8e5b-f21c5ad03db1",
-      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "f703cb9a-8b97-4860-bf9f-bd7d83a71ac3",
-      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "f4b97315-44ca-46dc-9701-2b3c6a0e81ba",
-      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "5ed591f4-2876-4caf-9fa2-7b56a15364e6",
-      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "8d261219-166f-4322-9230-3b4906771830",
-      "groupUuid": "a8554d70-bf68-4e08-b36f-981f3376163b",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "16b8bede-afa0-40ad-bb78-a478a02b9d0c",
-      "groupUuid": "540d1d0d-4f73-42bc-9d18-de52e997dd6e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "4eb07632-c246-4c22-bdd0-eed37c281c87",
-      "groupUuid": "ca48c3a2-348b-49a6-814b-0f7fd1b36a14",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "3ed6cf37-7722-419b-98b5-3f273a97d65e",
-      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
+      "uuid": "6e9f3d10-0a04-4d69-9030-8f734132f64b",
+      "groupUuid": "0a46e748-625f-4625-a745-7afcb63bd253",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "6158986a-8a6a-4701-9704-db21c063144e",
-      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-a-lower-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)"
-    },
-    {
-      "uuid": "272b0e56-33a3-4e92-8ce3-950939119b4b",
-      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "4a5c9659-83b1-4930-b544-0b18b3c6b405",
-      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "c53b33b3-8c71-4eb3-817e-97fd4c96a243",
-      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "uuid": "37653bea-172b-46eb-9490-22856b795f25",
+      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "5ad782f0-69d8-4c73-9db9-6074f153c18c",
-      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "uuid": "ee9dd13e-bb85-48d2-8599-818a6997134e",
+      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "ddaeeb75-0cae-4972-956e-256dbd006b82",
-      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "uuid": "bccf4890-d142-4f99-b47c-753499c2b48b",
+      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "42a239cf-056c-48db-b2e5-b15e5e55b0d9",
-      "groupUuid": "cf6a7974-e1d6-4354-aa60-2fd0f27db53f",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "d59aa06b-9be3-4915-9216-a8bd7255b9d1",
-      "groupUuid": "cf4f405f-055b-433c-bfb2-8f1200c69918",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "86e84ea6-dc7b-435a-a782-b7fb591cdd1f",
-      "groupUuid": "e15a78e0-dd90-409c-8176-257ad0ded7ed",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d7227947-3055-4572-8a21-1fce6fef0cb1",
-      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
+      "uuid": "8edb0fd8-af80-4440-b80f-a289d60fc7d8",
+      "groupUuid": "ceb9688f-fa85-4315-a87e-0fa81e83a8b9",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "cb58c681-06bd-4cba-b4d7-ad7d5fea29ec",
-      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cm7-shell-7str-7.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
-    },
-    {
-      "uuid": "44b2afbe-e3c3-40c3-b8c3-c92be82e523f",
-      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "535987ed-808c-431c-91b1-c54980c24466",
-      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "ced810e1-5775-483e-8696-2e543a2af3f7",
-      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d19f10f2-9760-4069-ae66-b68a63e330cf",
-      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "bddeb376-3d80-4d3a-a577-13abb27627f6",
-      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "50b3cfa7-066d-4a68-9c56-7ff929bf948b",
-      "groupUuid": "afedb3de-4462-4f86-abe5-1a60f27278b2",
+      "uuid": "1fa34444-b550-4358-930a-231babd5b10b",
+      "groupUuid": "26101f69-48d1-49ac-8ab0-4b1cc1a233ca",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "4767d72e-aeeb-4235-a434-7e2e66af7153",
-      "groupUuid": "83aac471-159c-4dc9-9ece-adde8d7a2c76",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "b24bc649-ad86-48b5-9639-5c7156e4a10c",
-      "groupUuid": "f0d91a60-1f33-46b9-80cc-947bef0bc3ef",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f7b27ddb-c0aa-46e6-8593-280e1675474d",
-      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
+      "uuid": "b8b1ba98-229d-4168-8e14-ded5138c630d",
+      "groupUuid": "6ffe6ae9-ae08-44e2-9592-0c9fbf3a187f",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "bd0d4fad-fba8-4166-8562-c177b5a1fc40",
-      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-shell-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
-    },
-    {
-      "uuid": "6f49deaf-8cd4-4568-9f0b-82760a8b44b9",
-      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "dffc6c87-be39-4d41-8863-4df66aaef04b",
-      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "fbe87aa5-8334-41f3-9319-3fa07517a7d7",
-      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "3d8b6cdc-651b-420d-9e96-8cbdb31c3a94",
-      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "6a24fa95-cbd7-4a71-b91d-3f3501084ef4",
-      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "1ce6263e-7fe3-480a-a77c-4b497cc5f674",
-      "groupUuid": "5b2ccbb8-eda6-4f1a-a8de-17a97ba4f5cb",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "cf720845-3261-479f-9568-fa0004867578",
-      "groupUuid": "db87245e-a283-45e8-ba06-686ad7d360c9",
+      "uuid": "00b37e34-8461-4f90-beea-36afc9b36106",
+      "groupUuid": "bd1598d2-25ba-4165-a646-2a05048fbe0a",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "266b9f0c-7137-4592-90eb-a4190d30f8ff",
-      "groupUuid": "ebd60563-9f12-4c68-aaa2-53c22c0c43c0",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "b8f3f244-3bb5-42c8-b03c-3bbba68d4e2e",
-      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
+      "uuid": "63685a43-b228-4765-85e0-e4d63e820522",
+      "groupUuid": "276040ec-f53c-4a50-9fa4-8b59a6ccb29b",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "238c34ae-1e30-45e5-833d-a99749787b0b",
-      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-shell-a-6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
-    },
-    {
-      "uuid": "dec52203-ca80-4a6d-bbb0-13941d649cb1",
-      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
-    },
-    {
-      "uuid": "41af78e2-3154-41de-8207-83d1d6308230",
-      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "bf6471a7-29d6-4500-96be-605cf9bf9d8a",
-      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9939690b-7ffd-4a5f-99b0-4e17cca54efa",
-      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d59178b6-88a9-468c-9bb0-20ce9fef35a8",
-      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "672a1490-97f5-43c3-96ee-db7b8f2fe6ed",
-      "groupUuid": "f3855be6-6472-46fd-a5cb-9d5a90372c7e",
+      "uuid": "caffc9c2-9298-47b2-bcb3-ef4c2c4fbc5a",
+      "groupUuid": "e9b7ef65-c708-4bb9-acce-34a21c5ac0c2",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "a2cbf463-8f4d-4542-a45b-d33860f384fb",
-      "groupUuid": "7a52c501-ba1a-4e56-89cd-e273c769d906",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "cb48ed2d-098f-4e1a-8d78-c656b04b7198",
-      "groupUuid": "a1766295-c960-4ca9-accb-47d8e6adc940",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "2653e49a-4c56-4a8e-ac09-2159f8f4312b",
-      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "uuid": "718adc69-8c3d-430c-a9d8-dd2a507c03df",
+      "groupUuid": "88639cfa-9e0d-428b-9436-045172f9830e",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+      "payload": {
+        "html": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+      }
     },
     {
-      "uuid": "e75225a4-902b-48e0-9d12-d7a5ede1c5e4",
-      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "uuid": "680360bd-feb4-4193-8f6c-b094b6168737",
+      "groupUuid": "70613098-8e77-45a8-8ad2-f03af35c6796",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm7-altered-7str-28.png",
-      "altText": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-drop3-7str-7.png",
+            "name": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
     },
     {
-      "uuid": "7f94485b-3d7b-46a9-b67a-1c76b1be1525",
-      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "uuid": "8ee74da5-60da-436f-8a1c-7c0dd5b5ac27",
+      "groupUuid": "f1ee4ec0-3712-4bb7-bb3d-519cfb291733",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
     },
     {
-      "uuid": "468aff08-f935-4120-beff-af4eb0c91780",
-      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "a088afa7-3e2f-4614-a956-32406ccc3818",
-      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "5a2ef048-5882-4f6e-90e6-6455df3aece8",
-      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "a6da2fa9-d5e0-499f-894b-786cc9ff3552",
-      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b3845bf1-b9f9-42a4-b780-3b09506a8293",
-      "groupUuid": "3e144962-4441-4929-a8e8-12a858d7c437",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "3fb309b3-1766-4b24-8bde-7c13c7a9c8fd",
-      "groupUuid": "de0c1dcb-fdb9-4c56-9ce1-860298823093",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "b5a4d9cd-3da4-46cb-a3ff-08592b6aa664",
-      "groupUuid": "44480b32-565c-49e6-8c9d-cfc0ef4c8e0f",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "9dfd6b20-f093-49b8-aa1f-c4d679f2c4c9",
-      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
+      "uuid": "463dffa5-f9ba-4d36-a5aa-42b21a757a19",
+      "groupUuid": "d520cdc7-022b-4040-9180-4fa1cb2a75e2",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "306f6597-a7a0-4aad-ab21-4009faec9d7d",
-      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-1top-6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
-    },
-    {
-      "uuid": "5fd86c89-a22b-40f6-a55c-4b6ee6761ff5",
-      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "9f6c92b4-4290-41b9-89b2-8288f74a0e06",
-      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "6ce1f6a8-11ea-4bb0-b67c-59dade51ef09",
-      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "uuid": "987b7787-7c00-4f73-88aa-4dc13ca91fc7",
+      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "db59a909-6b0f-45b6-89a0-38cdd9d01596",
-      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "uuid": "546c353c-7024-48d3-8a16-30b08adba53a",
+      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "ffe8cfd4-201d-4616-830f-4803aa355885",
-      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "uuid": "25cf7acd-734b-4b50-a88c-0a73029128ac",
+      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "78649e80-b8de-4ffe-82ef-5ba1131a420e",
-      "groupUuid": "19c40bf5-de9a-4e46-850b-07e12e7b1f23",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "9b8d3c02-fd04-4214-b71c-9157fc2c9df5",
-      "groupUuid": "e34cd2fe-a1b9-40cb-a3a8-fe404cd75129",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "5ad343cf-d67d-45e1-8d69-3c4042a6309f",
-      "groupUuid": "ba698029-c5a7-4732-ac17-c047c6c85ded",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "ce603121-719e-4b9b-ae71-cc4bd0b7ef4d",
-      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
+      "uuid": "ccc38e85-6f30-49ff-8fae-a07c114cd5d4",
+      "groupUuid": "30f1beb0-4c88-4678-8d67-57cb9fe704a5",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "22ba7a9c-10ed-4dd8-b794-d7019b5ede40",
-      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "9fadad97-39ad-46fa-95e9-f802c4dc5446",
-      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "758a0092-68ca-4689-b8ef-1ccc1a7ef461",
-      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "96bf288f-baed-4024-8a37-17d75412a4e1",
-      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c6bed596-04d4-4854-973c-c4a20aaaa1d6",
-      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "a73b5af3-32d9-46a5-8199-40ea2f70eef8",
-      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "46d17dc0-54c2-47e8-9b98-e42503641b21",
-      "groupUuid": "256613fd-cc0d-42a6-805e-b7705fc8ca9d",
+      "uuid": "93c3a405-efa3-4fa9-b8dd-49a7fe597496",
+      "groupUuid": "4f507a25-452b-40a4-b831-4b44a205b346",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "6d8b58c6-5d03-40bb-9e83-94eec8753e3c",
-      "groupUuid": "d1b90612-d158-4c31-8fd9-f3851376310f",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "4084b415-d7fd-4a18-b715-5ac409594cec",
-      "groupUuid": "57c01c7c-867c-41b9-8417-eec93b149293",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "1a26360b-1423-4f4e-b959-f39bb07a8777",
-      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
+      "uuid": "0d6dd99b-31bb-42b0-94fa-d5f7886e334f",
+      "groupUuid": "cf54d67b-7ef0-4a37-b469-417166f918fe",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "f61607ed-71e5-42a2-b82c-34bd5725ed12",
-      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7-cm7.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
-    },
-    {
-      "uuid": "514ca0e1-aa11-4447-a183-2de4f481b8de",
-      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "e83b024a-d3cf-4a23-9215-51cba6a9de41",
-      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "92034c6d-4bf5-431f-9a65-687008a124e0",
-      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "19e7b88c-6b13-4749-9fc1-a50652aa07f7",
-      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c7f752fb-ae98-4ccd-bf62-08d5138e6d6b",
-      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "eee36fce-70e4-47b0-aa03-1fbfca9d63c2",
-      "groupUuid": "ba98e64e-6811-43c0-804a-0bafa794d717",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "85e0c33b-738c-4490-927d-95a14ec67118",
-      "groupUuid": "0f572aed-dda4-4fdd-958a-8cddc3708405",
+      "uuid": "311e7c1b-a886-42be-9ee2-11d986236a66",
+      "groupUuid": "e6e23ce8-0300-49f9-a656-df89bf022624",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "5836d893-eceb-4781-af39-d2d9c2343d8c",
-      "groupUuid": "73e6b5a8-ea0c-427e-b71a-80288d3e4d47",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "9dee9dd0-73d6-452a-89d2-eb22b76ad557",
-      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
+      "uuid": "504ca601-e8e3-4909-be3c-43a37d41b3c5",
+      "groupUuid": "81a81198-1b37-4736-be1c-14520a86037f",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "7fb6ff38-679c-49d1-9479-91674f373188",
-      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm7-extended-7str-20.png",
-      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
-    },
-    {
-      "uuid": "b3b8ed71-44e7-489b-a859-65415ca3ba57",
-      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "7f20d579-c15d-42e4-9e10-bc7c698a9336",
-      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "d1be8de4-64ef-4c4a-935b-52fc58d95258",
-      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "75adba5a-7b10-4099-a4f4-1fb5d7a863e2",
-      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "7db93cfa-0dad-42ae-b55c-1bc7f4250751",
-      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "3737a7b7-73e0-4522-95d2-0a4f0bfedb52",
-      "groupUuid": "06430510-b8a8-4e9e-8aad-ae340fa05fa5",
+      "uuid": "d852f95e-28df-4a28-b455-90742f16dff5",
+      "groupUuid": "b9834b22-cfe8-4daa-b412-3fcb28645b0b",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "62b4e713-1f3c-4920-9207-9cab68aeb6b8",
-      "groupUuid": "90ed6530-e271-433e-b0c3-57310244a028",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "08194532-6766-4082-932f-dbe4c7c66ce7",
-      "groupUuid": "346fa57d-0169-4616-aedc-72eeb4a467a9",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d1affda3-23e9-4c34-bca8-8f7e5ea48bb4",
-      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "uuid": "679140f0-2c70-4178-869c-61d6d806811a",
+      "groupUuid": "3c70610c-e845-46b6-b241-98bd1d35ef22",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 Fret 2 \u2014 Extended \u2014 dim7 extended"
+      "payload": {
+        "html": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      }
     },
     {
-      "uuid": "f6d544d7-68ed-4a9b-91ea-9d1aab1853a1",
-      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "uuid": "deec93d1-343f-45b6-adc0-43430e4e6252",
+      "groupUuid": "cee5869b-a606-456d-8d96-4d1c148be007",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f2-6.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 Fret 2 \u2014 Extended"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "80a5ed0c-b51a-46d0-a89f-3d29be79c17b",
-      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "uuid": "5e566df4-26e3-481b-89ed-b7aa9f54bb66",
+      "groupUuid": "4292f591-c12e-49c9-b9c9-b93cb05c29ff",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
     },
     {
-      "uuid": "58d87b5e-3350-4a44-a5ac-464f2dd4b2f8",
-      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "74053019-0275-4507-8281-85bd6990e505",
-      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c9cef4ec-befb-49d0-ada9-1aadaffe75fc",
-      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "ac6c7670-b30b-4f87-9a7a-c9445e0c57a9",
-      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "f1c78e68-b04f-4a67-8f67-ee8b359612cd",
-      "groupUuid": "f3c604fa-b10f-47fc-976c-c74ca440a6c0",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "9fddc19c-d293-4044-9d8f-22524727d472",
-      "groupUuid": "0ab467c8-ebf2-476a-9564-2d103fda0b64",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "43761be2-2fcb-4ace-bb1c-a6b16bf0dba4",
-      "groupUuid": "463e2215-01ef-4836-ae6d-7086246bc0e8",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "ac4a4660-c429-46d6-9776-120962abd35e",
-      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
+      "uuid": "a9e16249-c732-4308-a902-4d779e7bec90",
+      "groupUuid": "dac109a2-a0fd-4a16-b8ca-a4514e5253bc",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "0d399ea8-14e7-401d-a8b6-2eea507a3973",
-      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-bb-lower-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)"
-    },
-    {
-      "uuid": "c29eda75-55e3-4849-a413-3c24b74b471a",
-      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "26add9fc-3ebe-4cd8-8c1e-091311e029a4",
-      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "a5cdbf0d-1721-48f1-b725-388b4bd725d3",
-      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "uuid": "5d49aeca-94cd-4995-b34e-af6b8c20d664",
+      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "bfe9f8c3-42a0-4033-9c59-f876c3b1da2f",
-      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "uuid": "037f8957-e62f-486f-8618-32d0b5a9d141",
+      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "290131d3-efb2-4a56-bf01-f762eddc8b8f",
-      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "uuid": "1bc93c39-4a01-4df3-98c9-6aa9a41439d9",
+      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "173c54b7-62fd-4d13-981e-05ff8caade56",
-      "groupUuid": "e755dc00-f6a9-4216-8161-e4c908c80ea1",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "465be447-c7b1-418b-ba7d-3a9aec00d77e",
-      "groupUuid": "c8eed5c3-b81f-4aa1-9587-77c4379d1974",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "b65aa45c-4883-428b-8780-d8d07d7a749b",
-      "groupUuid": "77047e7d-c861-4cbc-8339-745a383e93a5",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "b0722b10-45ce-4f7c-bbd9-b51b3203354f",
-      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
+      "uuid": "f76ef314-2c6a-47ca-aeb5-e6780ec8cb7a",
+      "groupUuid": "901da8eb-286f-4d10-862b-fefc0366f6ed",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "1644577f-7c71-49fc-8775-7c1e50be98db",
-      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cv7-shell-7str-7.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
-    },
-    {
-      "uuid": "e05e6245-2813-497c-b0a8-73c25755d512",
-      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "af4c00c0-eee4-4e5a-b51c-b26982990cc6",
-      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "dc3c6c77-19a2-4625-af62-ba78a9e37ebb",
-      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9569ee20-d8fa-4a0b-84fb-be7cda1c1068",
-      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "00ac7444-7879-4fcd-9a34-992ea8b74bb7",
-      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "37c0136b-dd1e-4e74-949f-3e291f3ec45e",
-      "groupUuid": "83cf3ca3-3e91-4d67-a6ad-027028e09503",
+      "uuid": "c05735a9-8cc4-4154-9e10-c189a29d8578",
+      "groupUuid": "9ae42de2-1d92-49dd-85f2-4643cc3a6704",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "580ccacd-1b6b-4874-b876-f89bf5314b5e",
-      "groupUuid": "38daf8f1-5cc5-4268-92f2-baffcc3ea956",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "c42092fc-6d05-49b6-8928-3cf4e14c875c",
-      "groupUuid": "12e80f5c-683c-48ca-a852-0b50ac12f47c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "25b333c3-8e90-4af1-b427-dd0ef0ddf0f9",
-      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
+      "uuid": "e66c1d01-87b2-40c9-b33e-710db68de1a8",
+      "groupUuid": "74bbb138-690a-4686-9ec0-d0e5c3415ec9",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "572c2907-8d76-4862-aded-2b42248cf01f",
-      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "a2362c3b-2f8b-4a69-9bef-eb358b320e6f",
-      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "26501dc4-c8a9-474d-99a9-9d4bd4a6c9fa",
-      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "8ac30034-24e8-4ca8-bacd-2eec398f9ad5",
-      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "03958566-7afe-423b-ab51-71ce3c52bb72",
-      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c553c45d-dba3-4cde-b40b-e03731284b74",
-      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "1c26c729-91ff-4371-bb38-e54e5babdcd8",
-      "groupUuid": "87fc2670-6f51-4dd1-99b1-34ce6e17396a",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "80082bf4-3cdc-49fd-a5d4-3cb9c2f22396",
-      "groupUuid": "d118f94c-4aff-43ab-af17-88da156eb0c7",
+      "uuid": "247ebd00-66c2-493f-ad0d-36a934a7e874",
+      "groupUuid": "c55eafcd-8e52-4215-85b7-a8e477d9c19f",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "f0fb50ce-6209-4839-8cb5-14cb9f6978ef",
-      "groupUuid": "fd02e2bf-1d66-4af0-b01b-13cf40d7b820",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "218f2455-426d-4d7a-b5b3-abf2c694cc34",
-      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
+      "uuid": "e79214e8-e3b7-4f78-8371-77756d0585e8",
+      "groupUuid": "6e6f80c7-fad3-430b-8b67-529d89ad2cfd",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "d56b4f09-b1ff-4672-b6e4-368177288b15",
-      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "e81efed4-181d-4b51-9550-2f27148986d7",
-      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
-    },
-    {
-      "uuid": "2f6de2b4-8ab8-471a-be27-ec6e089776ed",
-      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "2388035c-1837-402b-ac80-0dc8e04ad28c",
-      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e97a07a6-73cb-478b-9681-91041c818a24",
-      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "868e817a-22a9-4b4d-b073-46d7ba6c52dc",
-      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "953e2a01-9fe4-4d80-821a-de1ad9f56adb",
-      "groupUuid": "a0b5ad15-b8f8-4fc5-bffb-bf0d78ecb828",
+      "uuid": "a9e820d3-92de-4482-b5cd-e14693c2794c",
+      "groupUuid": "31a5bc42-2c6a-4f33-aabf-b17491396876",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "7e8e64dc-4c18-4393-bfb2-93e6978ab071",
-      "groupUuid": "121c37f2-8225-4d96-87a0-a5a60a2fdff9",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "98b547b4-1ed9-4978-b379-bb513363fa0e",
-      "groupUuid": "0c0786ca-e812-47db-837f-1ba8c7e18d48",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "5fee96fa-3c66-4aa8-a2e7-23637bcafb5f",
-      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "uuid": "035cc6e5-62fc-4437-8de1-3d28798026d0",
+      "groupUuid": "f98a49f9-a848-4d45-9f38-f76518261678",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+      "payload": {
+        "html": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+      }
     },
     {
-      "uuid": "02c5a1d5-72e3-4cb0-9cfc-1b9e2c22dc85",
-      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "uuid": "8b5d6a62-56e1-4f1f-9dfc-2794cb07a31e",
+      "groupUuid": "05992a9e-18bf-4c08-ac76-72f9f07719f5",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv6-altered-6str-25.png",
-      "altText": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm6-extended-6str-18.png",
+            "name": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "3eb31a58-b3e9-41f4-b2b8-78a033bd3635",
-      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "uuid": "47a44bd6-90bf-4de8-9798-b25eeabf2d62",
+      "groupUuid": "a239e8b2-f4b4-48de-82be-263dcb950bb4",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
     },
     {
-      "uuid": "bfcf5fb0-ac5d-4b77-be0d-d783236a5384",
-      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "01e00aec-3975-44e0-8df0-1a9e6c9bddc1",
-      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "3454ed97-3866-4f18-951f-0c7a6e234e9b",
-      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "51979008-ab50-4d44-ac6f-634ca67271ae",
-      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4f1ed7bf-47ba-4565-9465-9a347df68e2b",
-      "groupUuid": "3d9c15ff-49b7-4060-95a2-9b9e3a3b348e",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "ee61bd1b-6cb0-4861-920f-9543dcb25c1c",
-      "groupUuid": "88ae5c0e-351a-4832-8ab1-a32ea885b46c",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "cd04e6eb-198b-4e69-809f-d6d71aa3fd8d",
-      "groupUuid": "f3c355bf-b0c2-4d12-9de2-a48f4158a81d",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "aa4bc9b2-9edd-4ef0-8bc9-78d3829d8989",
-      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
+      "uuid": "c6c18aff-7994-4e36-bcb9-363ba552ea56",
+      "groupUuid": "b33aead4-2996-439a-bc03-4b62d650c7fc",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 10 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "fe37c064-df7e-42f6-9e85-adcc0f26b671",
-      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-3rdtop-6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 10 \u2014 Drop 2"
-    },
-    {
-      "uuid": "55f3ca6e-5dd0-4169-8424-245d645e8c51",
-      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "053e9051-065c-4048-b39f-07bff28b2356",
-      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "f3703285-12c0-42e1-aa78-3d189f9f021c",
-      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "uuid": "d9346948-6d48-4450-916d-b151c2437aa9",
+      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "1a71ac8b-f6b7-41a5-8623-7470f6483179",
-      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "uuid": "3cddb499-91ff-42ad-a9d2-c33fb422b4fc",
+      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "b23ac411-d4b6-48ff-a63e-9bfc1067819f",
-      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "uuid": "f1685d30-8ff2-4eb5-ac2f-05206da87ec2",
+      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "f3d0d16d-9df3-4a3c-b062-a847eef9adcb",
-      "groupUuid": "2a2263f1-2a9a-48e7-8895-e0b95ba43f46",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "ee8cac93-a3ed-4899-be30-249fac034e8c",
-      "groupUuid": "d554026a-d61f-463f-88ec-ec5b9808aa9e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "d49bf708-025a-443e-b4a4-2df946f8b171",
-      "groupUuid": "9f76d292-acdb-45c4-962b-402504a9992e",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "cd991eb3-4641-433d-8dab-53b2116d12c0",
-      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
+      "uuid": "e8e1b026-d536-4f2b-bc14-6a488883857c",
+      "groupUuid": "45884610-ed72-408f-bf7d-e5aa8a419ce6",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "71ad91ae-db35-403f-beee-be1facc72f4d",
-      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cm7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "bbd78b2b-f732-4590-a04e-aa3e1a286c37",
-      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "c80ee2ba-16d3-4809-b9da-23294752bd6e",
-      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "18fdc133-6c06-44bc-bcd4-d6c9ead77ccd",
-      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c02f7dad-b635-4473-8bdd-71974a21c436",
-      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9d9ee1e2-0a6a-4596-a249-1123738d7891",
-      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b8c225ac-e10b-4ac0-8e33-61037de956cc",
-      "groupUuid": "29067ecf-ea88-4196-b2f4-65b4be7f8b0f",
+      "uuid": "2ffb381c-3b2f-4d81-a7e0-ededcfefc7f9",
+      "groupUuid": "eabf8079-da96-4c29-b9a1-8984cfd14c2f",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "fdf79f25-c6c3-4b3e-9584-f630b08c4053",
-      "groupUuid": "f3b8ac56-d172-4510-845d-3c779dca0c67",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "32622073-0ce3-42cb-a8c2-0f2fc25536e4",
-      "groupUuid": "a722cb93-4b42-4d61-9615-14e11fc28908",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "79378017-4799-492d-8bf6-88f5a601db0d",
-      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
+      "uuid": "1aa74f40-1259-43e6-96de-c0ebed692502",
+      "groupUuid": "8ff480e6-670e-42e1-a55c-f121c149fca2",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "357581d8-af4a-426d-a6f4-3dadf6017898",
-      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
-    },
-    {
-      "uuid": "7aa20b82-16b0-4f8c-971b-c89532ebd85e",
-      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "8fc6fcdc-3793-43c6-9f72-3fd3a693eec8",
-      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "b4ab1445-d527-4e46-a8c1-5002b555a863",
-      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "313a9187-a1af-4418-b554-d5a568f368ed",
-      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "52701873-33af-4436-9866-e7eff38fabbb",
-      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b517b4de-3e03-4a48-a3bd-ead6a92c5199",
-      "groupUuid": "7aa19bfe-c3f8-47a4-bb48-8caf30d811c4",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "768499da-5202-4c93-b246-c6e314bf40eb",
-      "groupUuid": "ab950fc0-a516-4914-b8e8-1f1fdf5229a6",
+      "uuid": "cc1909df-f87a-41c1-8560-210516248cfe",
+      "groupUuid": "c26c42df-dcb7-4915-a0fe-0b28a002558c",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "59065509-8749-4c5a-9931-00a5f5e866a8",
-      "groupUuid": "81c458a6-dc42-4c7d-856b-90b460ad9e76",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "37348e24-94be-4039-9020-1eeb41a1d1a7",
-      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
+      "uuid": "cadc1e19-6f5a-4334-ac8a-cbff2e7a1d72",
+      "groupUuid": "7b5390b5-18dc-46ae-8488-b1705833771d",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "0689e9be-85e2-40f6-8760-d0e5e16f9d91",
-      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv6-extended-6str-17.png",
-      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
-    },
-    {
-      "uuid": "c6e37d0c-6ba7-4f30-bf83-0c59c60bce24",
-      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "5e08bfd0-7fda-4c7e-996b-3ee0ad14ea3d",
-      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "664b46ed-4d48-4f04-aff7-480861e2084d",
-      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "08c5c8ac-539d-4c73-9f7a-a56091f792a6",
-      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "88e876cb-f615-4de0-80bb-879c596e37e7",
-      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "80200bcc-db9c-4979-9dee-5a41cc893cb3",
-      "groupUuid": "c993170b-6c46-46f7-b599-0005632d9bb5",
+      "uuid": "db97d3fa-e3ff-43d7-aadc-ed6c2f5da52b",
+      "groupUuid": "5cfd369a-8ede-48d9-a998-2eb61b01b755",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "c4089129-2330-4ee7-a686-8c5f946bf465",
-      "groupUuid": "bd0ad227-8a09-4fb8-a08c-ba170daa4c60",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "ccb9ac4d-2313-4fb0-a1da-9e7aa7c7e84e",
-      "groupUuid": "8707d525-da19-4a7e-9855-767f161e2fcb",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f814c69b-9c38-4893-93b0-ce13c9309fb7",
-      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "uuid": "2d87a481-071f-4e31-b44e-446c8910cab8",
+      "groupUuid": "e004f887-d34d-4271-90c6-50b918503108",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13 \u2014 Fret 2 \u2014 Extended \u2014 dom13 extended"
+      "payload": {
+        "html": "Cdim7 \u2014 Fret 1 \u2014 Extended \u2014 dim7 extended"
+      }
     },
     {
-      "uuid": "e74633fc-1384-489c-b6d3-e22fd4cb97f5",
-      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "uuid": "d72750d0-9987-4d78-9658-56e1c0d49659",
+      "groupUuid": "78ca0ee2-8a00-409c-8913-3fb15e3056d9",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f2-6.png",
-      "altText": "Fretboard diagram for C13 \u2014 Fret 2 \u2014 Extended"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f1-6.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 Fret 1 \u2014 Extended"
+          }
+        ]
+      }
     },
     {
-      "uuid": "63879f62-37cf-40f9-bc45-32a8504c4c06",
-      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "uuid": "1040fc4f-bd60-4c3a-b392-c6971b4f663d",
+      "groupUuid": "c007aeb9-e409-40c4-ad0a-53406534abb0",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
     },
     {
-      "uuid": "1af4c108-e7f0-45e8-8b4f-74d675089089",
-      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "fe9cff38-c532-42fa-8ac7-1b5361bef908",
-      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "0faa4700-c47b-4a0a-930c-8c44adbef5fb",
-      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "7d3958d1-3200-4b90-aa02-25a8fbfb41d6",
-      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4fc9b7af-3033-4e72-a4ee-7b07fd5cfc1a",
-      "groupUuid": "50f1ee99-df58-4b46-9cc6-9cff7655d4ff",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "525ec07b-1296-47dc-b6dc-24d732d442b0",
-      "groupUuid": "e2b59c7f-1414-4629-ba8c-0a61a2983751",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "dad24204-9ece-489d-8951-0f8cbd40e7fb",
-      "groupUuid": "2c944705-dfa0-4755-81a7-42b605c888e4",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "287d459a-d3a8-4c49-8c89-89d19eed6a16",
-      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
+      "uuid": "37ecff1c-2be4-4f85-9e41-6e9297ebc428",
+      "groupUuid": "13b1bcf4-713b-41fd-a4cc-39f7b9b1c722",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "852e1746-4498-4f64-a14d-9da445bb2406",
-      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-d-upper-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)"
-    },
-    {
-      "uuid": "9f483536-442a-4ba1-8658-57f262577804",
-      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "20702ecd-76a1-493d-a309-3a85e58cbcd4",
-      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "0bf4c9b8-45eb-4cab-bfdb-0ddf69022964",
-      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "uuid": "119c6e49-7ce6-467c-8e26-29bca9b2d800",
+      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "89735065-c650-41a8-a979-b436fd0b512e",
-      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "uuid": "62e47d57-c124-41a7-8e12-cb22880f7eb1",
+      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "4c8eb53f-52a6-4681-a02c-e98a1ebf02d2",
-      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "uuid": "f6e7e8f9-03c5-4fd1-9f6a-48e1c07d905f",
+      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "a3ec6e74-e868-44cf-9dd3-90eb47725a34",
-      "groupUuid": "721d69d8-2a4b-46df-a08c-be0eec66d62f",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "8e6857c2-db16-40cf-8c74-9e8278766e95",
-      "groupUuid": "e9a81313-1ee4-454f-a086-29de029a17ef",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "7c6e5af2-6eac-41fc-86e6-afa49b9108fb",
-      "groupUuid": "2057b940-1097-4f10-a217-645885b60ece",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "2f5f7349-db4d-4d88-9eb7-bb59ceda495d",
-      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
+      "uuid": "0bd6800f-d80b-44a2-abd3-a505ed137fef",
+      "groupUuid": "735ca87b-5aef-42d9-ae2a-31bb69868e6b",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "19a34b88-f930-40bc-8559-d5d109b557f7",
-      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-shell-7str-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "6400ba0b-cb7e-49fd-ae7f-43e596a2a58a",
-      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "429df7d8-99a7-4c18-8bb0-b6a3fdcda833",
-      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "d7c14493-3ca8-42be-ad1d-8d8618d4df2e",
-      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "138caade-148b-457a-a1d5-6ad6684c2324",
-      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9daaa065-108a-490c-9877-0a595cdab2b9",
-      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "65720faf-f8ea-496b-802f-2e2603c4e74f",
-      "groupUuid": "6aaca151-acf1-485f-8f7a-51697bde034e",
+      "uuid": "6a94c1cb-a636-4478-89d9-01f07e674a24",
+      "groupUuid": "10df6a53-c15c-4071-b252-db387c07a6a1",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "1f07089b-70cb-4b23-9c8e-36e3c266cba8",
-      "groupUuid": "f58819aa-eb9c-48c8-b6c6-02bd155dd4e1",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "25a5e488-2665-401c-9f0a-e6a9d93991c9",
-      "groupUuid": "79129a45-055f-44a5-9713-55cd722de8e4",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "a8c7de1d-8055-4cd4-b0b7-c8fc59c80a66",
-      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
+      "uuid": "b70c23e7-faa3-4dc2-b4d9-e2d473b63109",
+      "groupUuid": "28d16b5a-ea1b-4b5e-ae58-eeb6bc6d8d14",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "df4381ee-c670-4098-abc7-e751571d2130",
-      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-e-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 E shape \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "09a79f85-14c2-42c2-bb9e-44f22555ffb6",
-      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "07935a10-843c-4516-b0d3-5d28a83c4c96",
-      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "62a30ede-db71-44c0-a422-91778213ec47",
-      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e5060334-2040-4740-989b-31a9d83d859c",
-      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "45307e52-b53f-482a-8242-2f3d85b2cf8d",
-      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "5ed8f79e-8e5f-48aa-bcbb-80bbd8d8fd67",
-      "groupUuid": "44e45643-ba2b-460e-a5af-0b5f481b230c",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "9043978a-52e8-46d6-8dfc-929791ac9e9f",
-      "groupUuid": "4b635864-7a12-44d8-8188-c7e667fa0716",
+      "uuid": "9435aa04-f6f9-40f7-a6e4-25c59ed1c7f2",
+      "groupUuid": "95b0e3a2-44fb-4871-b10c-3771ba7b946c",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "683b5203-49bd-43e9-ae72-a5b86314cce3",
-      "groupUuid": "6c0817b9-b229-47b7-aac1-358f97f9a95c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "ddf17afa-3e2e-438f-89c2-52bd41948660",
-      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
+      "uuid": "645e8a06-a7b7-4bff-a4a5-4c4c4e620e6e",
+      "groupUuid": "e07e1b2d-1288-4d71-a840-3f0cb9464634",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "6bece04b-552b-4ca3-bc0f-23d0886035fa",
-      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-e-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 E shape \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "a1bcc03b-f712-42ba-8bd4-e60db29c8355",
-      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
-    },
-    {
-      "uuid": "612dd531-2dab-4519-b2a5-c8c13a2c3be6",
-      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "2cbd48b3-5ef4-4d35-826c-4aa318b59e49",
-      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9de0323d-51cf-45fe-a0c6-d4910198ba86",
-      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "db4dee78-9973-4363-8166-d160815357b5",
-      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "28370580-8839-44d5-b7c0-a70539b4a479",
-      "groupUuid": "17526745-6ef0-4c7a-940d-d8c2d3702f1b",
+      "uuid": "e20a04dd-0589-469c-a516-5cac0712a388",
+      "groupUuid": "054112d6-605c-4bed-89e1-87aee8692e77",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "5202a849-1275-493d-98e1-f732f185ee9c",
-      "groupUuid": "3e97a0d4-2d45-4ced-8880-21977a4d1e2a",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "b18a1c2e-35ae-436f-aa91-a686b9b98cfe",
-      "groupUuid": "406320bc-47fb-4c27-976f-3019e5770114",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "55fc101c-8701-4c16-9df8-90bbbb612888",
-      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "uuid": "61952ea6-5aec-4675-937b-8f98a3207212",
+      "groupUuid": "b34ec572-0c17-46b5-ac04-acdf273fa073",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+      "payload": {
+        "html": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top) \u2014 quartal quartal"
+      }
     },
     {
-      "uuid": "225c4ec2-a3de-4a21-97bd-5fe2ce0b07a3",
-      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "uuid": "18c452be-aed5-4a5d-bdf2-8275497a5dab",
+      "groupUuid": "2c4fb82f-5fd9-4f83-879f-a13f8f8b0531",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv7-altered-7str-27.png",
-      "altText": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-a-lower-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "5307c100-0703-4206-9c6b-4cd7997e4e65",
-      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "uuid": "bd250145-78f6-4bcc-bccd-03d5079d80c0",
+      "groupUuid": "96fcff66-e167-4ae2-b63e-5f6e9051b2b8",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
     },
     {
-      "uuid": "69af7813-df13-4b7c-8c45-45332945bb4d",
-      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "cfa7ad9d-b53c-42d0-9846-7122c9d91f12",
-      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "bf0afe32-e5d1-40e8-84f8-ccdd83c8432f",
-      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "69b9187c-e97b-4b01-ba06-ed9e4e0f36b5",
-      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4b9bb1da-301a-42e3-b37d-521a99213e6c",
-      "groupUuid": "65ae06b6-32ee-492d-9bf6-e961f654163e",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "0878dafe-5a3d-4fc1-8918-677e110a89df",
-      "groupUuid": "e22d9f40-7c24-4066-9aa2-272e41965ba7",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "9b8f8b51-7fae-4ef5-a71a-82c204d37dd1",
-      "groupUuid": "f80e2dbb-ee70-4244-bbf0-be8cc011df5c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "756a579e-c7a3-4fe7-8dd2-c07c4fd7a357",
-      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
+      "uuid": "c8e5da45-bc8a-47ad-aab1-a284ce183d04",
+      "groupUuid": "8466802c-74f7-48f9-b7c4-b80f7c526725",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "0f0d0d19-dcaf-4dda-a872-6f7429a5bdea",
-      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-b7top-7.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
-    },
-    {
-      "uuid": "9b0b55cb-6266-47c3-b185-b5efd93f6885",
-      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "257c0f14-3f96-4ea1-8ec5-688f517936fb",
-      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "9ecc7cb9-37a8-497a-a08c-83fec03ab998",
-      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "uuid": "286745be-221f-4f7d-917b-d2468a6dc679",
+      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "3b69cc3f-5485-482d-b73f-b8c9902e1868",
-      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "uuid": "813c8172-26d5-430e-9cea-83d86e33ed88",
+      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "be3cb1e3-e149-4ae3-9423-16b55847f728",
-      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "uuid": "0041a32a-23b1-47c3-ab3b-dd10b0d7d290",
+      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "47d2be8c-aaf9-4db0-838e-a26858e19022",
-      "groupUuid": "8588b4a7-9f07-4b39-a36b-139000a4b5c9",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "d07f02ff-032d-4429-8d2a-ffaf64f9df1a",
-      "groupUuid": "e44a6fae-9501-4173-8870-8edb9db83cdf",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "00ba9499-8152-4c07-96e5-3aa18536e552",
-      "groupUuid": "61f00353-0140-4f0a-a81d-91362904983c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "1a4becb8-2da6-4d38-a2ea-11506dc80d2d",
-      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
+      "uuid": "c65b3941-8aba-454a-8838-db8097064e4b",
+      "groupUuid": "0b77379f-ba0c-4a23-9312-95f4e6eb7e71",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "c81e26b7-b508-40f3-8770-9767848e1b85",
-      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cv7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "8e436b8f-89b3-4403-97c6-9e8dc9215101",
-      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "f0835501-3fc1-46f3-9f39-5bb302495558",
-      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "d43785b6-a408-470d-b4d1-2a0d9a0f28c6",
-      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "25e3a1df-edd2-4d1d-8e84-e1ebc2603dc8",
-      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "af916e45-a325-4693-9595-9c147326dc4e",
-      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "40712420-89e4-42ce-adc9-3c5fb2fb5f9b",
-      "groupUuid": "0232f786-4bd7-40ad-99a6-633fed50e3b6",
+      "uuid": "421423da-7ab5-4be4-a7ef-a2f2c1c16e81",
+      "groupUuid": "cf1b6aed-e323-430f-82ee-74ad0bc8755b",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "7bb92140-b87a-4038-bbe3-f07c6d108a8b",
-      "groupUuid": "d085a76f-95e7-4700-9829-3d64ab8c2833",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "1fff0dc6-bb43-4a1c-8ffd-8c9e04ea612d",
-      "groupUuid": "246cd770-7d49-475f-b513-bbdcc3428eda",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "10a01755-b9a5-44bf-9cd9-ad93ea0b778f",
-      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
+      "uuid": "8aab0526-2b62-4253-a29b-8c2b20aa7219",
+      "groupUuid": "80d7a050-ed08-4cc8-99f3-73bb9c370654",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "afed22d5-5d04-4e15-af04-e8b688b1f29a",
-      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
-    },
-    {
-      "uuid": "a01583d0-d549-4c19-8d25-ba25d65775ed",
-      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "37f72730-eed8-48a6-a797-24763cd10c67",
-      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "4300f613-020c-4f77-8031-40d899230210",
-      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "45b1cbfb-6bb3-4f2d-b876-1579d187c592",
-      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "89786d00-9f4d-4dd3-8a2a-49cb8aeef664",
-      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b3c54dfa-2b58-4e21-9c0d-4193f5ca3fc7",
-      "groupUuid": "17b19449-821f-4d31-8b2c-df636a63422f",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "475f341c-c6af-4c15-959c-9f63f5d038cf",
-      "groupUuid": "bfe4bd45-c721-45b2-9075-664747f06a79",
+      "uuid": "e609d1eb-f9d4-4a6e-b43d-598625089e84",
+      "groupUuid": "18315ff8-5d1f-48f3-a592-fb32f81a2cca",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "71dfb8df-045d-4125-a828-38f3d2e4423f",
-      "groupUuid": "41725abb-1ae3-4920-b756-3d0f43cc040b",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "9eab1645-b716-4e7e-a702-fcb84de8dfe5",
-      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
+      "uuid": "c794f07d-958d-4206-bf15-d87e28da2375",
+      "groupUuid": "28ad471a-691b-4b49-902a-343a9473533d",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "bc99c817-cd82-40ac-b188-71e155c72b89",
-      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv7-extended-7str-19.png",
-      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
-    },
-    {
-      "uuid": "72dca44d-e96b-4284-87e7-0dce4ed789df",
-      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "315fbc82-9b46-4370-a5a6-62d2ef82e2c7",
-      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "d5287e6e-78af-465e-a8aa-661c94c65444",
-      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d59e31ea-505c-40c8-ae88-204c2105ed5a",
-      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "7688b107-d174-4c47-8144-3fcdfa7f2a60",
-      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d7d82079-eb70-4801-8cbf-529563c06934",
-      "groupUuid": "89687b3c-6893-40e7-b888-5d1b3fb7d0aa",
+      "uuid": "72467557-82b3-4083-8c71-3e38d0dc1d6d",
+      "groupUuid": "7610a85a-4b2c-414e-8901-daec52a0d87b",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "23f6cec6-c94a-4b71-89c5-6ee06fc9137e",
-      "groupUuid": "e88ea530-3fdd-4208-a376-0deb3df5cb4b",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "32961283-b398-4699-9793-aa6fc2614b2e",
-      "groupUuid": "d9df36d4-ce88-4d58-ae93-a79b1c41c024",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d4d45bf6-69e9-4722-abad-4ef6025810fa",
-      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "uuid": "8bafcd5b-8104-4f15-8351-991f43b719ce",
+      "groupUuid": "99c15a84-eaee-4ac8-ae09-a5a3cb7426a2",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13 \u2014 Fret 3 \u2014 Extended \u2014 dom13 extended"
+      "payload": {
+        "html": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+      }
     },
     {
-      "uuid": "e5bbedc2-6f77-440f-bfbb-4223483139d0",
-      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "uuid": "60b4e7f2-6011-4c59-adb7-fa49c75d9132",
+      "groupUuid": "5f106e89-fe0c-425f-8b6e-3e07ac0735b7",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f3-6.png",
-      "altText": "Fretboard diagram for C13 \u2014 Fret 3 \u2014 Extended"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cm7-shell-7str-7.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "435b816f-db94-490b-83ce-ace6384f6ef0",
-      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "uuid": "df729659-9594-492c-8144-79d7a855b0ca",
+      "groupUuid": "775c6291-42c4-4090-82bd-8510587d1d1e",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
     },
     {
-      "uuid": "3dd0a387-2b13-47ca-bcf9-75b06ee75368",
-      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "40363cc8-555e-4b5d-8cba-155be8b2f752",
-      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b1b5343a-370d-4670-b6ec-0fe3fd327137",
-      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "2df8188d-7a70-4a67-afaa-a9d5bf31db4d",
-      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "67a9cc3f-43b2-4c0c-b177-2f96ab7d4235",
-      "groupUuid": "6dc237a9-744d-4698-bd3b-9669cfe28656",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "5c18081d-bb05-4618-8fae-5afc1bdc1908",
-      "groupUuid": "2cfefaf0-17f2-49b1-9237-9f4d06d62162",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "6d91a078-d6dc-4460-9176-6f15604d4fb0",
-      "groupUuid": "ee729eb0-04be-4a38-bec7-fbb386c2304c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "349d4223-46cb-44ba-8a9f-59710dad5cc3",
-      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
+      "uuid": "b7f8195d-f38b-4ac7-8315-f2afed5a501c",
+      "groupUuid": "8f87f86d-dcbe-43d5-a3df-a16a46d22fbb",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "7ea93e42-9c49-475a-943b-0e5466a37c1a",
-      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-eb-upper-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)"
-    },
-    {
-      "uuid": "57e01598-fc07-470e-b763-b8a8bee9c78d",
-      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "1badea63-dd8a-429b-bf9d-fd1a96f192ef",
-      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "c5f012fa-7c0a-44ed-b556-6d085672ec66",
-      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "uuid": "0556b2ec-ac28-4685-947a-7c5a50f26368",
+      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "15ad7860-7a0a-4909-be67-e7aa6d44b8b1",
-      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "uuid": "c32a27a2-4dd1-4c75-9a62-35f028521f61",
+      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "48b8b349-6c90-41dc-8b80-cc8abd9909d3",
-      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "uuid": "eaf3670a-b430-4594-b32a-075c37055808",
+      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "36d8e845-5f1b-4ced-9eb1-436a47bca1b5",
-      "groupUuid": "6cfe9126-1606-4b5f-a422-b54bd7076f24",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "98a0ba9c-dc2e-4831-83f3-1db98b064a67",
-      "groupUuid": "4fac16d7-af2d-4e0f-88e8-5a1364088e87",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "f7fe6c29-9e1e-419d-9161-2212964f8878",
-      "groupUuid": "8d04dbd4-c630-4a76-b317-0f500114e7a2",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "a8af50d0-b2aa-4731-990f-054ebcf1e200",
-      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
+      "uuid": "b24fd514-0b57-401f-bbaa-bc51f89f8417",
+      "groupUuid": "5b255bfa-dc4e-4cc9-8697-334530110bc2",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "1a30ba61-c119-42da-a74f-94534db0d8fe",
-      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-shell-7str-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "2df31218-1523-46d5-9ac5-31589035069b",
-      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "a31b42d3-ead4-491f-a6b4-a8f633da745e",
-      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "2721f571-fb44-4c31-b854-211b584bfbe9",
-      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "6714b741-fef1-49fc-a892-5a2c33c9a8ed",
-      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "318312f3-0e78-4cc7-b9fd-1c34e26f78ff",
-      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "1cde45b7-d3c4-49e0-bd66-46ad507fd896",
-      "groupUuid": "93ff54b3-557e-4b31-b3c7-49d1d2c0a8b0",
+      "uuid": "1a3a40a3-0965-4851-9dec-0bec4972e6e8",
+      "groupUuid": "db3fa69d-0d95-4bca-935d-29e5c00a75e6",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "acb9a0c1-bb65-4915-88f2-7917890a5e51",
-      "groupUuid": "9cb5784d-9dcc-4497-ae75-456c6e828d17",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "50913830-61fa-4b29-a7ce-1ccb3a17d1ca",
-      "groupUuid": "c5d1a5f6-16e9-41cc-81db-654c443dfc1e",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f1f281a8-b398-4002-9133-38c89a3e1901",
-      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
+      "uuid": "031d2805-d5f7-4fb3-a5be-ae10036fdf2d",
+      "groupUuid": "9947610a-e4a1-406c-a185-72a41a86f9ba",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 D shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "a791522d-bb38-4c66-b054-eec7501626b7",
-      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-d-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 D shape \u2014 Shell (b7 on top)"
-    },
-    {
-      "uuid": "5c19fd15-54cf-47e6-bbe7-6ec44a15776b",
-      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "7fb3b944-4033-403a-b048-cb8f67669611",
-      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "c51b1f91-0396-43da-b85b-20ac42b53756",
-      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "910f95a2-0645-4ea3-ad26-1b87c342e0df",
-      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e3cba564-26fd-4702-b974-ad4119fbb697",
-      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "2f970bdc-7421-4271-8e6b-4e5f5d99478c",
-      "groupUuid": "97abf557-f69d-4eed-8752-e6d5bc7f49dc",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "59bb51aa-3344-4128-833e-1a4f0627d826",
-      "groupUuid": "02805b15-8376-4944-8eb0-0126064d12cc",
+      "uuid": "8c5bd1e0-3e4a-4c1a-9f8b-2661a767c0e1",
+      "groupUuid": "46828fb5-b3f3-461d-bcf0-a968acadbb2b",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "de0caac2-88ce-4335-ab18-a863c7cb3a43",
-      "groupUuid": "8ee6a9e9-000b-4e7f-b938-399c34327d16",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "57ddf894-e162-40fd-8932-4e7c1d99c637",
-      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
+      "uuid": "214df08a-62d4-48da-b49b-2fc99e1c5386",
+      "groupUuid": "f9805e8c-4d2f-4fe3-8453-5935a5a7344c",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 D shape \u2014 Shell (7th on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "370376e1-0abf-4824-b180-0a19926e1ba8",
-      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-d-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 D shape \u2014 Shell (7th on top)"
-    },
-    {
-      "uuid": "e8a1d145-f376-4486-a9d5-4a92a0092725",
-      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
-    },
-    {
-      "uuid": "a2f88aeb-ade1-459e-9c83-73b77273fd5d",
-      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "fb240565-9ff7-4cb9-824e-7818248d5795",
-      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e2b83d70-ac2e-46e3-be9b-8ed24ea2f532",
-      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9f26087c-5275-49a0-a64a-fe1badd1c767",
-      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "67303188-7c3a-4b95-986c-88ff11aed4d6",
-      "groupUuid": "854a2b1e-0497-4962-8b3c-13eba5364ccf",
+      "uuid": "db3ac9d6-b1d1-413c-8bc0-05633d80497a",
+      "groupUuid": "a7eb3f8f-e0c0-4bfa-b111-9f326a33cc18",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "0a4d24fb-cfba-4678-9bff-f3c6c0982b00",
-      "groupUuid": "31773d14-1762-4025-a789-f3e8f5f45ff0",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "e76ef653-ac42-4a2e-b9af-63d47b92fc07",
-      "groupUuid": "c67b9065-d279-4c43-9ffa-bffdcacfc14f",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "55ff35da-e6cc-4590-aeb5-da21d1f41cea",
-      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "uuid": "c08e230a-e488-4aa1-87a7-0dcdd119c775",
+      "groupUuid": "86d511e3-4219-4e72-945c-2a52e5d7367b",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top) \u2014 13sharp9 altered"
+      "payload": {
+        "html": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      }
     },
     {
-      "uuid": "f31fc6e6-57e8-43df-bd32-e1bbaf8bd299",
-      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "uuid": "e07388e7-6b87-4d70-8e72-49e8903d61bf",
+      "groupUuid": "64c00ed2-982c-464e-9476-20d2c1426f20",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13s9-cm6-altered-6str-30.png",
-      "altText": "Fretboard diagram for C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-shell-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "3de586ac-bb54-482f-81f5-a5c90c1dab40",
-      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "uuid": "1b309670-7488-487d-b10f-6f8c07b48044",
+      "groupUuid": "5ceb96b4-bc2f-4a39-9e80-a97e919d0892",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
     },
     {
-      "uuid": "51afdcd3-f827-4b56-81ab-8aa435dd3bc6",
-      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "966e9a29-d96f-438c-8985-48c3ecfb59f7",
-      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "318db960-f91f-42b2-ae76-5d4496a266e2",
-      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d5d03872-4935-4e18-a990-ae78428d7683",
-      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c34cd776-ecc8-4ced-a35b-71fee5efc8dd",
-      "groupUuid": "05026a47-7afb-4335-9864-eedcd0dd85fd",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "9ea0f0dd-ef10-4cd8-a138-71efb2b4a707",
-      "groupUuid": "9d66a7df-2adf-4416-b000-89bfa73539e7",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "48edbc7e-1512-4a86-83da-3da2158322c5",
-      "groupUuid": "7f94e18e-bd3c-472f-a29c-6836b2819852",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "1bb91d0a-0083-4add-8a82-75841f77e46b",
-      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
+      "uuid": "9afc4cc7-85e6-4fd5-a32c-fb5223e0a65f",
+      "groupUuid": "4b81a4ec-0ad8-4902-ac10-e2835cfc2a68",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "ebfd9b59-b554-447b-bb5f-2e948769234c",
-      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-1top-7.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
-    },
-    {
-      "uuid": "b6d8fcb0-0cd0-4490-aa26-b120722e18c9",
-      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "89f25c3b-39ca-401c-8244-70aaef21f609",
-      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "23dc80aa-429e-42fd-a82c-13b213cbf4a6",
-      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "uuid": "64d42eaf-2cf4-46c9-acb1-f16d1b0fb26a",
+      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "c6a2cac3-3b11-451c-9b97-f733ec701b37",
-      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "uuid": "158a2ae7-b7fd-46de-a29d-869809427091",
+      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "dee6c2a6-6fd3-4b8b-b82d-268b0e349641",
-      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "uuid": "30300d85-a73c-4f20-9e7b-2a596be8e184",
+      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "0ff19939-5921-4ddf-96c0-6bf44c064010",
-      "groupUuid": "bbdd8101-74d8-40fe-9300-f97c24891c81",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "0fff037d-aa78-4ff1-a2d9-d26313bac4fc",
-      "groupUuid": "7264e2a1-4d35-460c-ad2c-c76245623720",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "052e861d-a856-48a6-b4a7-fd1e5f620843",
-      "groupUuid": "66397392-ef3d-4818-b037-a58658984d04",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "bb078603-99ab-4b09-8a20-26dd2a2ae617",
-      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
+      "uuid": "17487e39-3810-4f7f-b477-270a99126982",
+      "groupUuid": "d98a0d1f-208e-4f1a-8b0f-7fdf9cefa971",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cm7 \u2014 7-str bass \u2014 Drop 3 \u2014 min7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "9eff256a-f236-442a-800a-a61f433fd2cc",
-      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cm7-cm7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for Cm7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "96039c62-7fd2-414d-a7c1-263e8b017923",
-      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "5dd8dfca-8359-4532-b9a7-c0bc10878038",
-      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "af97a963-cc8f-459f-880a-fb6a32136ec0",
-      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "73cf399e-2093-4181-82a6-ab3dc34389ad",
-      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "bdf628a4-ebf9-4709-8ccb-ec73f7da31f9",
-      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d22c13ac-6625-45b7-b9b5-a39631b99321",
-      "groupUuid": "97b6fa6e-23ee-4df7-93af-898ff48bff90",
+      "uuid": "6695aa21-9707-4027-9a6a-8ebb736cb1ce",
+      "groupUuid": "ba049432-c710-4eef-bfc3-9ad813498c06",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "5694c323-053d-42ff-ad2a-6c0c3120fdde",
-      "groupUuid": "3833a370-ecbc-4a05-9c94-b827e0581c19",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "c2cd7c84-84db-40eb-b623-f68dafbc048b",
-      "groupUuid": "a3638690-425c-4a40-9dc4-23d08d81f8ca",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d74d77b1-d65c-4f35-96f0-e8617990c98b",
-      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
+      "uuid": "387a5c91-bf49-4241-8cdd-e695e2efc5c4",
+      "groupUuid": "3f385118-9272-40bd-8d79-c98e49bbc65a",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 A shape \u2014 Drop 3 (5th on top) \u2014 dom7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "94daab2a-285b-4688-bdb4-d8bb7a95b673",
-      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-drop3-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Drop 3 (5th on top)"
-    },
-    {
-      "uuid": "9f8e435a-4da8-4fb7-ab7f-0805503281df",
-      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "4c183f33-d0b5-4d56-993b-bb7375d7170f",
-      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "9f889f66-1487-43cc-b310-1b30181baabc",
-      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "5a21fe6c-b3f1-45aa-8406-8abf01564119",
-      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "29aba4c0-e17e-45e7-b362-a1884499db61",
-      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "60638d71-0c04-4ede-a21a-736c9c464445",
-      "groupUuid": "a322ee8e-004e-4146-ab83-a2228ba2ece4",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "4294161a-59f0-479f-a619-187caa4ab548",
-      "groupUuid": "11a419b7-b92b-43d1-ac66-109b698b227c",
+      "uuid": "b737857d-6156-4406-a330-69b393632fa1",
+      "groupUuid": "9f984b7e-5e27-438e-b1a2-3689dffa00a7",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "fd299442-d19c-4275-932a-e927c9deb998",
-      "groupUuid": "6ae51c8a-47b8-41c7-9d9f-ceb4fb574f85",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "89c9e374-85a8-494a-a573-c89617f637e0",
-      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
+      "uuid": "50aeada4-3017-4f27-8a51-b19d516cd109",
+      "groupUuid": "9590e54a-47d7-435d-b059-c493df2fc35b",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top) \u2014 9sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "eeccf321-f1b0-4667-a99e-0bbd2deb620f",
-      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c9sus4-cm6-extended-6str-14.png",
-      "altText": "Fretboard diagram for C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)"
-    },
-    {
-      "uuid": "21d02841-96e2-4919-bd3d-ba3fc9edd74c",
-      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "c2091452-d196-4764-8f77-ee6527ffa1f6",
-      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "7ceb6c55-6bc0-4ce3-9fc3-97cce28a9974",
-      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4cddba25-8e5d-4095-a0b7-c4937e1ce638",
-      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "a7581be4-8d50-4107-9367-83903e8b8e2c",
-      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "77bc03e1-825a-4f8b-890b-a2ed51f33813",
-      "groupUuid": "2dec5983-cebe-4201-a82a-781381fe1e0b",
+      "uuid": "ac0f4fe5-175a-4b72-a5ae-76f410078ea4",
+      "groupUuid": "f6bc64a8-fb8e-4345-86b8-553434c923fc",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "dc050f9a-c1e0-43b3-9b28-c5d4f4793758",
-      "groupUuid": "5b9812c3-0950-49ef-a462-f71088084739",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "7cd14cc7-e44a-4651-9742-3b0b814c5d4f",
-      "groupUuid": "d6da7167-93dc-4896-acf5-f622ee9bc3a6",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f0b9028b-5ad3-410f-97da-3e114c6c6119",
-      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "uuid": "af7445cd-fe22-42f6-98a0-7175e380dc61",
+      "groupUuid": "8af6a962-8266-4551-9189-003be2b665f7",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top) \u2014 dom7b13 extended"
+      "payload": {
+        "html": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+      }
     },
     {
-      "uuid": "eae8bc8d-6163-44ae-bdc7-747a1d3b2d31",
-      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "uuid": "c71180b7-6b4a-4c05-bc30-5ca75d4bfeeb",
+      "groupUuid": "c5c3df91-2ce3-4cb6-96ee-eab0bd18b33d",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7b13-ext-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-shell-a-6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "7cca705d-bc30-4f8d-a5d8-a728f0435c49",
-      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "uuid": "c9236a8c-187d-4b5a-8ec5-ebe4023e4604",
+      "groupUuid": "16403e79-f89a-4469-9167-648715f0f33a",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
     },
     {
-      "uuid": "066e0ac9-79a8-47e4-99de-fcdd39957a54",
-      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "8290f569-c603-4349-a66e-d83540e44dd5",
-      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e62efc35-3621-4d70-aed5-9540406d00e3",
-      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "20210696-5cdb-4431-93d0-e98ce5871b52",
-      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "bfdb7ecd-a7b8-43b2-9a5c-56e973f64624",
-      "groupUuid": "295e9bb8-0425-476c-b893-884976c376ea",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "5d970d2e-1248-4799-8781-582989375347",
-      "groupUuid": "962bb09a-4e29-4f38-9105-01dbc3751b49",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "a0176b80-da31-4dfe-9ca1-5e9efb97b580",
-      "groupUuid": "857b0d05-c085-43f5-bc33-8ea8d607a412",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f6e09cbe-fa2a-4300-bdb6-eaf8104ec617",
-      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
+      "uuid": "b7d246c7-ffce-4723-aebb-04165860afc4",
+      "groupUuid": "788ee4a0-6822-4a56-81e3-b79a34ed3e05",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "e424249b-2889-40d0-8280-cb6846a8bbe1",
-      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-f-upper-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)"
-    },
-    {
-      "uuid": "2b1b3df5-994f-46f8-b3f9-c902d254b9ae",
-      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "4e0ddd14-be3c-4c1a-a36a-76834993a806",
-      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "7b8284c7-a120-4c17-a25f-00dd19e1a9c3",
-      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "uuid": "cff13637-f050-4853-8b81-a3e3903311aa",
+      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "dce3d3e7-feb1-4b52-80ab-58f0201facc9",
-      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "uuid": "be20e88e-1703-473a-b677-4820515829be",
+      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "177066ed-0d9e-4cc9-bab1-196512fe288c",
-      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "uuid": "6b3bd45b-8746-486a-99dd-1cc9b92b11dd",
+      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "6dadb013-12d1-44f1-99c1-1860e23078ea",
-      "groupUuid": "b3b89b5f-0f52-44b0-92eb-e9b06f02a05f",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "b3096b33-a3f8-45a7-9611-91a7c3aa08b7",
-      "groupUuid": "69a8ddd3-1957-435a-b8f3-36b318446f75",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "3d08e72c-1f48-4e76-b91d-7b6c17588640",
-      "groupUuid": "6d4ba774-ecb7-4745-a646-afff792d5703",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "0ac282fe-52b0-4a61-b4b3-50ba88890517",
-      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
+      "uuid": "c2768bfc-c8d0-4707-befa-220edeecb04e",
+      "groupUuid": "9b203b7c-3162-4cc3-8840-5b9d7fc2031b",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7alt \u2014 7-str root \u2014 Shell (b5 on top) \u2014 dom7alt shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "4f33ff9b-383a-4f0f-ab90-3f3dce62faf3",
-      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7alt-cm7-shell-7str-7.png",
-      "altText": "Fretboard diagram for C7alt \u2014 7-str root \u2014 Shell (b5 on top)"
-    },
-    {
-      "uuid": "96e071db-45a4-4673-bbd3-d3058410f08c",
-      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "563310c4-7939-48c6-a5ba-c46de7ddea93",
-      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "5a307b16-7c57-4bfa-8bb6-8e4897f38d65",
-      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "2c61c1db-9bbf-4659-ac58-8783a0d0e580",
-      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "444c15cb-4d39-4bb4-abf6-070161509dbc",
-      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "0ab5fdf8-5931-4854-8615-71fa50b626b0",
-      "groupUuid": "1d3cc254-8140-4fce-8ec0-c5f884045c71",
+      "uuid": "8a6f3e0b-9cf6-4532-9189-46499547fdf8",
+      "groupUuid": "36f7b4ee-636e-4b8b-b52c-e918f1c33280",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "26f5688f-36c9-498e-80cb-5d4f582b8704",
-      "groupUuid": "cc5f4a7f-ecf5-487b-8798-a034c989977e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "67fd6f51-1033-4aa3-8eb8-f79d3cf51ba3",
-      "groupUuid": "cf44c64b-26d2-4851-8794-0702d3a2a80d",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "351364c5-da6d-4dfa-8fc1-08aeb0d86399",
-      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
+      "uuid": "1ee6011f-1cf2-43a8-a4b5-6ebb03f8dfdd",
+      "groupUuid": "fe1de755-99da-4f20-bd47-2db0d39536c0",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "df5d4ab1-4ee3-4da5-8dbe-fb6321768188",
-      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-cm7-shell-a-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
-    },
-    {
-      "uuid": "b66636e0-b7ff-4bd3-95e3-8e3f6876cfeb",
-      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "fb9d3e57-222f-4862-8a29-09bf660dd362",
-      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "71307d7d-e1fe-4c91-adbb-368b26a067ec",
-      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "3167fdb3-7106-48fa-9d15-65008e4ebad0",
-      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "eca4e1a3-3fe9-4c13-9d0a-7a149433d71a",
-      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "65eea098-1c44-4fb1-939a-6c4bfae76b4e",
-      "groupUuid": "0a2bad26-e332-492b-bc27-088b56835ca5",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "5fa0158c-6fcc-49a2-bfed-19a2d6b11064",
-      "groupUuid": "16432b0c-c374-4f2d-8961-b6dfb2c3dc1e",
+      "uuid": "59efa150-d7b9-49ec-9734-e3f483d736c5",
+      "groupUuid": "c51a5577-eed0-48cc-b547-f475f4f4856e",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "e23ef9dd-6bda-464e-8750-a9b0a81ce335",
-      "groupUuid": "bac8e138-b707-4423-b670-a0fa10a35997",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "4c8617b1-d6f8-471d-a7f3-9e0740063e20",
-      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "uuid": "3a2ce510-23ee-4fa2-b157-ac9e3eb5d12a",
+      "groupUuid": "b8983597-2e6f-4b5e-9bac-9b6326552378",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "e2cc6918-3d7f-4cc3-9371-da81ebdb2641",
-      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "uuid": "2c5c09cb-29d2-4b12-9a53-db18dc20dd45",
+      "groupUuid": "a9bb102e-a117-497f-80ac-aa1c728ad64a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "364916f4-6640-4fba-9cd3-61fad453336b",
+      "groupUuid": "6686e695-0d43-4736-aec0-6bfeb93ec335",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+      }
+    },
+    {
+      "uuid": "43be26ad-41a7-4268-9912-de0bd35d57c9",
+      "groupUuid": "8ba589ee-c31d-47de-9159-c8374a286816",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-shell-a-7.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm7-altered-7str-28.png",
+            "name": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "252ffc5d-6b99-48a6-9c23-a48214d45681",
-      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "uuid": "858d0998-3777-4d00-8714-343209e699a1",
+      "groupUuid": "c7f95bba-fc45-4865-9390-731cd312d26f",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
     },
     {
-      "uuid": "2b1cfa5e-365a-49a1-98fc-ace303c311e3",
-      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
+      "uuid": "125e34aa-beff-42c1-a674-bf298a891468",
+      "groupUuid": "64bd1225-6184-47d3-a99c-e72b2f431aac",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "b665bf70-684f-4bb4-a1ab-c4124faf410c",
-      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "uuid": "1ba5a201-6a48-4ae6-b0b6-ec51358fbf75",
+      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "f9ba926f-0e0f-40dc-ad64-79c09c6cd6e3",
-      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "uuid": "ec0ce49f-83d2-43bf-9077-cda0faf26056",
+      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "6ac32c1f-0364-4b02-98b9-478ebf10ba02",
-      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "uuid": "8059ee76-e4aa-4325-b5b4-05b03bdd9116",
+      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "6892e91e-e4f1-4db5-b954-81b75c53527d",
-      "groupUuid": "7973a3dc-7819-4bbf-9b25-dad30f829a5b",
+      "uuid": "8e779d95-7e5f-4d42-aa88-dfc1edc88b71",
+      "groupUuid": "2d5dce51-8cfe-4bcb-a749-c91fade2a3a9",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "056e214b-ce3b-4e90-b221-194027f38c78",
+      "groupUuid": "8f5ca13e-66b4-4530-b04e-3d41d40bd749",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "637b1619-6712-416d-9822-abee1e3cc5b0",
-      "groupUuid": "96d9c470-e42b-4cb5-801f-fe2975f81cfa",
+      "uuid": "49b3ffb1-db4f-4891-b157-2259e1dc6f84",
+      "groupUuid": "121ba6e7-f041-458f-a217-7b3da91f6614",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "2bb430e5-83d7-429f-95d0-32f5e1ee365f",
+      "groupUuid": "bb2f0756-6681-41b8-b1e6-141ad0db9d38",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "878ddfc6-4203-4d12-805b-8798f1536fc8",
-      "groupUuid": "83fd1c72-079b-407d-baee-6b7f68787902",
+      "uuid": "9f08ba6a-3f41-4675-9d07-a5b367bf9028",
+      "groupUuid": "73552248-eaaa-411f-b865-d29202217009",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "c6f34819-9059-4471-9da5-fd28e2fbae2f",
+      "groupUuid": "26f728f6-b1aa-4f86-848c-ca320bf1a972",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "bacbabc7-e500-4ba5-bbce-2fb90fa052ff",
+      "groupUuid": "57ed6646-e84b-4777-a699-55c49d3ab570",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
+    },
+    {
+      "uuid": "72fa150e-9c05-42b9-9bc9-ab19735a7d0d",
+      "groupUuid": "2df6e4da-4b48-49f4-89d8-9599a7bc49a4",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-1top-6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "d2d4a925-c8b4-4270-99b7-bb02b41153ce",
+      "groupUuid": "b4bc5359-4c42-437e-b2cc-fad13a88757f",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
+    },
+    {
+      "uuid": "87097ed3-07ed-4bc7-b412-5373a3721bcf",
+      "groupUuid": "45cc8e44-8f43-4753-af6f-186fb41384a7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "f31f3753-d786-494f-a44f-a80f5593ff89",
+      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "d8bf5c2a-4c18-409f-96ad-feede953d2a4",
+      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "ee150ab1-69a6-484c-8c07-f968b78db070",
+      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "7be6d845-ce12-4edd-91b4-c163e27eccd6",
+      "groupUuid": "37091098-aa71-4456-9164-51d6375184a6",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "33349f47-8f2a-4d44-9d65-78042848862a",
+      "groupUuid": "07c7f92c-26b2-4f42-904b-4da3e2a74b2f",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "3e6f441f-d15e-4156-8a88-c663a5daccde",
+      "groupUuid": "b818ab42-8697-4767-9741-9c8ec8078c05",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "6c062273-f597-4955-8850-3c6e326076fd",
+      "groupUuid": "076741e9-448d-4ec6-9a24-f41b7caf331b",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "2a7a2134-2f0c-4daf-a655-59cbfc83b675",
+      "groupUuid": "24c191da-1336-485b-a34c-a0663265fef4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "bd858855-9aea-43ab-98cf-72069fb2670c",
+      "groupUuid": "9f56fc2a-16fe-48fa-a987-b395ca7bfc7b",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "395350ff-4e77-421a-88f5-50041b74e431",
+      "groupUuid": "2d55ac60-bf6d-4023-86b3-4c01c442350b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+      }
+    },
+    {
+      "uuid": "36bed446-e649-4571-942a-468ea38eb79c",
+      "groupUuid": "3ccd8f7b-1b74-4a2c-b505-3a097cdc70e9",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-drop3-7str-7.png",
+            "name": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "3dd34ec1-ac17-4fef-b7c8-9a872989f338",
+      "groupUuid": "7067bc97-a469-4c71-b44f-32aafe15b3be",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
+    },
+    {
+      "uuid": "c27f4134-4364-4e1c-8d89-bdb5924e612d",
+      "groupUuid": "032cd38b-01c4-4be4-890f-9f2548a5e16e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "1bbebe7a-f0cb-4667-8b91-be4302a89b74",
+      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "83b5ef31-8d32-4eff-bd2f-a2800d8f4dda",
+      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "33e24eb6-4fe5-4c1c-8fb8-c064c5895d73",
+      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "847c6c84-efb2-4263-a51a-668286bd0bc3",
+      "groupUuid": "11cd35d9-b65f-4274-bb5f-fa5bc8a33091",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "2c4ed1bf-0dc7-418d-a2e3-95d2da96248f",
+      "groupUuid": "2b00b454-fd9c-42db-b174-63d8af6c7576",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "d08145a3-6988-4f96-a99c-92b1c09eb36d",
+      "groupUuid": "ecdc1dd3-39a3-4ebf-9aab-4aa6088a7d0b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "34c7946c-7a8b-4aa2-95ab-4ece4f165df4",
+      "groupUuid": "4ca93864-6e14-4f77-abdb-a61e252e38eb",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "dc61f4bc-0f66-4fca-898e-682ca5620663",
+      "groupUuid": "5a1fbf4e-87d1-41c9-9f96-22f88201fd46",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "cbc90c0e-be83-45f8-b4d8-66a2131dc35e",
+      "groupUuid": "4ba35dbf-6b22-4462-9f33-94566d075ea1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "eb8f091a-3e0f-4f10-a558-5a5550550d9d",
+      "groupUuid": "42a47e21-1d3d-4c93-9f95-aef31d6d3227",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      }
+    },
+    {
+      "uuid": "e2012e24-2a6a-4f6a-82bd-97e1dc956b2e",
+      "groupUuid": "6fae159a-90fd-4022-b930-ce7b6e811c98",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7-cm7.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "c385163f-2747-4a50-aac4-2221de9cc55c",
+      "groupUuid": "01acd642-24ea-4c87-aefb-67814974beb6",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
+    },
+    {
+      "uuid": "ca9510f0-6b01-4bf2-8984-f11755110bdf",
+      "groupUuid": "14d3a75b-5bad-4d2f-8e94-c5f8675a963d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "2d5e63eb-870d-49c5-bf48-c269ee6f3c71",
+      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "0ba4a089-2d97-4a99-8ebc-d4d8f2ac4d01",
+      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "f3983be5-1a07-44a0-b32a-213d0016037b",
+      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "7e254b79-56aa-4382-97ca-979677fce5d1",
+      "groupUuid": "b73c9ef7-6af4-4de8-926a-66fb936f4306",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "c5cfacb3-acb3-4663-bff9-56f274a477b2",
+      "groupUuid": "da55fa5b-8cd9-4000-b07d-6e8dcdbdb418",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a6969fce-963a-4694-825f-ce0be0fca7f4",
+      "groupUuid": "5f97ad96-213d-45c3-a278-315e50415d25",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "39f71d85-2692-41ea-917a-3bfed6e2beec",
+      "groupUuid": "ba3e1a22-bd43-4bba-910f-386973f3824b",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "f1ac6a79-bc8f-4e3e-9ada-837e8074f32e",
+      "groupUuid": "ad47373e-143d-4edc-8a25-b384c6f24c4c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f5d64365-f73c-43a1-9816-1b3cdd641919",
+      "groupUuid": "6d8a08b2-b86d-4fa4-ab4b-66a9d84965a7",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "2386ad47-f646-4df4-a5b7-bd754b9a63b1",
+      "groupUuid": "07fdd513-7c25-4102-a791-8c4e5e3f1cc3",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+      }
+    },
+    {
+      "uuid": "9d1097cf-9cab-49bf-b38f-23295a1183c0",
+      "groupUuid": "ecdf6f82-3b73-4792-b87d-7fec5939d10b",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm7-extended-7str-20.png",
+            "name": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "fd780b1f-71ca-4b0b-a937-28cebbbbe8a0",
+      "groupUuid": "8401947c-d5fc-433e-af40-b93005c2f5c6",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "b7a9a410-9ef2-459c-99ba-830bf7b293c1",
+      "groupUuid": "c9c941e4-3e51-4b77-8ed7-b814c6adb0ab",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "e91bd587-f753-424c-b39c-04634e62e598",
+      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "8cf8eb90-8099-465f-82f3-f34efd5dbf38",
+      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "20432ea0-7521-4eaa-ac59-28d18349286d",
+      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "0bbbec7b-6b67-41be-ad6b-300b8fd6f147",
+      "groupUuid": "8a4d5431-3cde-4009-89bf-f8e006c8a61a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "d95b05b7-ede1-448d-b81b-0e0b513380b7",
+      "groupUuid": "bcd5ab61-79e9-4e2c-8b99-ad9801947db9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "e34b1140-781b-4beb-bc52-aedbda0bbad4",
+      "groupUuid": "9eb1d5ed-4de4-4ea0-9664-d9aa9b43ef92",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "59f73fd7-8958-49fd-9715-95a9deac071a",
+      "groupUuid": "1689d43d-cf2d-4561-a0f8-840b888bdbeb",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "2e077090-e6f4-4953-9187-6c2bfbac1182",
+      "groupUuid": "dc4d2fb5-a2c6-4070-9e21-cc96fe438ae5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "19431104-1401-4404-8024-9ce518f85dc2",
+      "groupUuid": "f995f7ca-a725-4d82-8f8f-2d5fa0fbff83",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "a2088f42-0c93-4bcf-8507-d540f6202798",
+      "groupUuid": "ad22af28-752b-493c-8541-f289e0693140",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 Fret 2 \u2014 Extended \u2014 dim7 extended"
+      }
+    },
+    {
+      "uuid": "b82c7dea-c400-43c8-80e1-e800c71e9c56",
+      "groupUuid": "8d401c75-85e1-49a9-9c80-e3a356b73e4f",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f2-6.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 Fret 2 \u2014 Extended"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "01f760e0-75dc-44e0-8b8b-9f2222bcbef0",
+      "groupUuid": "f363bebf-a0d1-4cfe-961a-f4074cf12b1b",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "f12b60ec-06a2-40de-b372-aed5e396fe9a",
+      "groupUuid": "3ad12243-8d51-4caf-8080-3187d72eadc3",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "91caf4fd-03b5-4b09-baf9-c6daf4152c68",
+      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "6cc72f69-e9b3-4370-96b3-0cdb9f602e72",
+      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "1fefad35-60a3-4bb1-a941-9eca07280f23",
+      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "1fe57405-a3db-4f4b-ba2f-0c083fc0bd78",
+      "groupUuid": "f44b967d-4f1c-412a-9884-7ee5032194c0",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "92ca8ae5-f74e-4172-ab68-003e94d431fa",
+      "groupUuid": "c96d4b7e-c6de-44bc-b57c-6094fd6d6003",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "1a96ab19-164c-41f3-8a27-bae17cf54583",
+      "groupUuid": "791cd7f7-809d-4949-a638-7b7e044c0067",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "8078b616-f1ea-4b40-95ef-7d0b7fee0148",
+      "groupUuid": "516856ed-675c-49b6-aa8c-97de96b47b82",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "18e14fba-4f99-43f6-9273-9b4ce8604733",
+      "groupUuid": "0dda78fa-2a83-4316-888a-920c3312bd68",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "1f4e7e09-8b9b-4830-b3d6-9f163eb4c365",
+      "groupUuid": "5e08d306-480b-4faa-8bdf-49e2d86707d7",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "24cd7e89-3323-43fd-9968-2676b7ce4ca4",
+      "groupUuid": "0d94fdb5-fdcd-42f8-acc8-c02000f3798b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top) \u2014 quartal quartal"
+      }
+    },
+    {
+      "uuid": "6eec085c-e36e-4d37-a80b-d8f72a213109",
+      "groupUuid": "4e2e2b85-70fa-47a1-b704-671e6897e07c",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-bb-lower-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "485ca974-9f03-4dc0-8704-5b75bdbaaf21",
+      "groupUuid": "dd9cf6f3-d9d6-42d4-a097-c5a52954c6be",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
+    },
+    {
+      "uuid": "60e85e67-2705-4bca-bd26-f6b84a54e789",
+      "groupUuid": "7f9545fb-22ce-4b52-be00-974f49bfe8d5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "842a7d66-3319-48df-9766-8d83c66b26e0",
+      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "9a24876d-00d9-4637-ae0f-1582c7f7e2de",
+      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "f22e81ef-7e97-4c4d-9c9a-36f80e088d71",
+      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "1d79de41-1d0f-4330-ad7f-e7bf9817ad94",
+      "groupUuid": "eaa8c67f-4c8a-4e2d-bb46-68de4f7971e6",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "db82030c-714f-4f51-9a68-32178b7786b0",
+      "groupUuid": "11c29064-6bfb-4553-9a5d-091a8bfb5fcc",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a81aa2fb-8057-4593-a3cd-59b12749a126",
+      "groupUuid": "9217582d-021d-4ca2-bfb4-9480e91458b4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "0ed6226b-68fb-4987-8d2e-03bf60535abd",
+      "groupUuid": "373b2d25-c6dc-432b-ae2b-c1dc5dfe9c20",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "59764e85-e92d-4256-a968-47e0b9abdc87",
+      "groupUuid": "d570c35d-9224-41c6-abd2-f9427724063d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "95ae587a-66f1-4e4b-aa29-01f088c975ce",
+      "groupUuid": "59e51952-a50b-4f7d-b31e-4b319b4912e0",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "cdb7f469-ac55-44a0-a98d-1209d783569c",
+      "groupUuid": "04cd92e7-ca84-4a9d-9f4a-5bb837c87000",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+      }
+    },
+    {
+      "uuid": "7968c5e6-9454-422d-881c-9bcb48f44541",
+      "groupUuid": "03906444-1987-42ca-9d50-dfc9ccedf8c5",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cv7-shell-7str-7.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "2dfa9683-7a57-4df0-8297-aab28da391ab",
+      "groupUuid": "b98531bc-8afc-4f46-9687-4fc9577ed41a",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
+    },
+    {
+      "uuid": "6593c9f9-959a-4fcc-b77f-00c238e4c183",
+      "groupUuid": "9d9260ed-84ed-4902-9e76-e0635efef739",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "2f6e9a03-8290-4a35-aa6b-8b2213fb2c01",
+      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "51af30bb-a2d0-4aaf-ac25-3a02f3246f51",
+      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "0689d5d0-e05e-497c-950f-7d86ede17066",
+      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "a26a7bca-b455-4511-9f75-d54e1e129e95",
+      "groupUuid": "40f147e3-4e83-413d-908b-404a90d12dee",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "2f65b31c-8041-43af-b41e-a01c1081d4d3",
+      "groupUuid": "5564fcb5-1b9d-4433-be7b-6afe27cf4b5e",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a1066c2d-5fa6-4e1b-8376-2087685265f9",
+      "groupUuid": "29266880-501f-4276-9d5c-ed41feb55f80",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "8105c311-2b41-41f8-be8b-524d19ecd5af",
+      "groupUuid": "5232e123-ef2f-4fc1-ad19-d0510756b8fc",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "56cd6e53-74f6-4941-a36c-312cbdcf1bcb",
+      "groupUuid": "7cb121dd-6272-4198-bdcf-fef65968d3d8",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "ec22b29e-c4d4-4758-b426-6287a68abf62",
+      "groupUuid": "76885475-2cbd-4eee-b7bf-d3ec42fbdac1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "97542fc7-dc2a-4c0d-9217-0632886f3399",
+      "groupUuid": "99806d47-05ef-4e66-a2bb-93956edb3860",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "3d42ba86-0f06-4659-b79f-ed4fbb86a25f",
+      "groupUuid": "18fd99d6-d46b-4377-91ba-71ec3144a8ca",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "028bc0d6-8b2c-44cc-89f9-a2519b0e11c3",
+      "groupUuid": "d1a77e28-41a3-49e4-94cf-7877e3481961",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
+    },
+    {
+      "uuid": "446c41ed-6c14-45e1-818b-0a379022c4d3",
+      "groupUuid": "d4498517-480b-4d18-9e1f-a1a9954de13e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "7c3f0def-20e5-4f0f-9fa1-52c10627f648",
+      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "4f81999b-9eea-4565-a5d0-c5cdfbba6e26",
+      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "7027c5d6-700a-4c06-a8b3-636bfd58e4ae",
+      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "c00b4d38-999a-4e7c-b485-c03ad4cc20ab",
+      "groupUuid": "1839f795-b870-4ce4-81c0-9709520805bd",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "a366b613-4538-4bf9-b573-7c9e52f077b3",
+      "groupUuid": "e72d43d3-a1c2-4bb6-9fdd-c609728bc0d8",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "ace3d59b-8640-49d5-a112-51d2e8aea0ce",
+      "groupUuid": "1450147e-d47b-48ac-b591-26603fb3a9ed",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "766b2a9f-caef-42df-84a2-7e0b2929ddc8",
+      "groupUuid": "1173277d-da87-4802-bce1-0e1feff70392",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "1f913598-ebe6-4c12-8bdd-814f1849f8db",
+      "groupUuid": "b1fce695-ff35-4495-bb40-bde7ce4b90d5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f4390c1c-5f1a-4575-b099-39547c4ae0f2",
+      "groupUuid": "dc0d19c5-95b0-4aee-9604-8f25b84029d2",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "c34fe986-2a8c-41f4-bfb4-0dc4c6f71625",
+      "groupUuid": "b76a5ed6-fda2-4819-9a75-ce74fab41c0e",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+      }
+    },
+    {
+      "uuid": "9e9680a7-cb9c-4bd5-b7e4-d59c78df4282",
+      "groupUuid": "15387662-ae3a-49c2-8b3f-032cda808a34",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "70e9cb62-09dd-49cd-bbf1-e9aaf0890b21",
+      "groupUuid": "12dc4260-429b-41f6-a3f0-ce8cfa1132cc",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "46df8fb8-c3b0-4dad-878c-e0846fbd2ce8",
+      "groupUuid": "9b786217-73ca-4e86-81f4-5a65416bb885",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "0faca7ac-eee9-4e52-996f-8363d741a9a5",
+      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "5425416b-4df2-4c41-8646-f8fcd73b52d8",
+      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "335b20b3-0b75-4d8f-8ffa-5955c1584db0",
+      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "facc6555-6aae-4d53-8e27-52fd9b09dc17",
+      "groupUuid": "59c503ff-1ba9-4acc-bba3-30bdeb6b75c6",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "bd0511d7-99b8-41b6-a5f2-5360cd6b061d",
+      "groupUuid": "ad3e0cc4-c72d-4c95-8658-3ed40df2e28a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "d0e91305-0e36-49a1-b902-330157dac4cb",
+      "groupUuid": "dbc5e577-6058-49bb-9049-e578ffde5f4a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "ffbad391-0588-4dd9-bcb5-de36f18085eb",
+      "groupUuid": "c36e9e47-27b8-4355-b507-73cd04fc0751",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "b0a5e0e4-ad87-42df-8552-15f8375b3c55",
+      "groupUuid": "561dec83-47f3-44fb-a63d-4beecada380a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "ff389c8b-f2f6-4a98-9433-5ecd407a70b3",
+      "groupUuid": "a5616ad7-656b-4410-bf39-edd5ed7f6a3c",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "b0b40880-4df3-40e5-8450-2d00b0f66fd3",
+      "groupUuid": "b7e72672-a846-448e-bdc5-932680e8a7ed",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+      }
+    },
+    {
+      "uuid": "a301ef39-9589-4ba9-8895-0a2402a4dc94",
+      "groupUuid": "3c01e147-4e3b-492c-a7ec-9e23a89b1b9d",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv6-altered-6str-25.png",
+            "name": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "3eba18e8-d6c8-411e-8fb7-223af51cc52b",
+      "groupUuid": "1d297042-fb1e-4278-a5c0-5d7068d98d25",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "5ad06abf-91d3-457e-a165-c3d8b27ddb93",
+      "groupUuid": "439ee468-68d1-4677-9a07-7a0adaa3affe",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "1a5cc9ff-41d3-42c8-afc7-13b002bdee9c",
+      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "b8045ee2-30f9-4c3d-9960-b63b11069385",
+      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "bb11463b-bf24-4beb-ad86-ee33aefc0d63",
+      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "c8b3833d-8d9a-4287-bf20-222d855c3ed5",
+      "groupUuid": "25b69437-e1e0-44c7-927b-33bd108ac673",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "eec1dbff-bafc-471a-8f0f-407f1ea8d950",
+      "groupUuid": "18d2b1c1-efc2-4290-bc97-bd98abd62d07",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "cffd5cca-b889-46e4-846f-ed84bdd1206d",
+      "groupUuid": "7d90260c-526a-426d-9235-0c7b6fa8bdcc",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "f419a0a3-ae58-4ef6-aa80-98333e3a8a75",
+      "groupUuid": "9475d7d3-e926-4564-8a3b-84a54c065427",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "5c9139e6-3d51-4aab-9599-bb5e60efd7cd",
+      "groupUuid": "f6e050df-a299-4d71-ae00-373df1097c01",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "65edf093-5b14-409d-b95a-daeb83eab607",
+      "groupUuid": "664f2a99-e6df-422e-bf47-5e99dbf7f77d",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "6f65ce58-3d54-48b4-b68f-9bb0b4654c35",
+      "groupUuid": "f8011239-187b-40d1-805f-bca23d8fa0c2",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 Fret 10 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
+    },
+    {
+      "uuid": "d762a9c5-1337-4b84-b635-e38c9dd9a8bc",
+      "groupUuid": "db78fd9b-d2ee-4867-93cf-aebe83256aaf",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-3rdtop-6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 10 \u2014 Drop 2"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "eb53ae35-f2d5-4f49-87a6-e0159f007b6b",
+      "groupUuid": "ae5ac7e6-7c50-4a99-b5a9-13c395358f51",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
+    },
+    {
+      "uuid": "7406cb91-4dc2-4467-942b-ada6623e2aaa",
+      "groupUuid": "35120bdc-9128-4dbe-a6c6-7d56d4dedcfb",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d8c52a1c-7e88-4402-b2cd-650f5388958c",
+      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "6267fce0-eca1-4f04-a658-3b6ea395b6a2",
+      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "1d348a9e-db1f-4d71-b433-8c8632501d6e",
+      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "31baae57-01a9-4843-90df-169fecbca050",
+      "groupUuid": "d54657c6-c10c-4d91-8abb-ef00af1b1b3e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "9fc09ab8-44a2-4992-bb14-b58784ac4f97",
+      "groupUuid": "0fbb3c17-0632-4e4f-ae60-8216d95d4225",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "2b840ead-ff72-443d-a71f-0fe738526c12",
+      "groupUuid": "f807440c-522d-4f3d-9a16-a62669f9802e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "1cf9e8ca-5a02-451d-81cd-db907d331da9",
+      "groupUuid": "a4113acc-9e41-4a32-9794-3e205af26744",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "01674b4e-fd9e-405e-a9c7-a62b21c90c7c",
+      "groupUuid": "c85b0803-fa8e-4d5c-a492-82b87440a775",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "358b08fc-3e65-4854-a720-c8371f2eae18",
+      "groupUuid": "06a9ca64-7107-4268-8906-2f68568414e5",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "40ea7dc3-afd4-4717-9b33-c3ab6e029397",
+      "groupUuid": "b03263b1-9f4f-461a-bc79-1672f70baa2b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+      }
+    },
+    {
+      "uuid": "5fd1800b-0cd7-4b20-a2be-d55fd574989a",
+      "groupUuid": "093b9e1f-1960-4ee1-a3cd-ae59b4061899",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cm7-drop3-7str-7.png",
+            "name": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "f8a694e6-ddab-4ac4-89fe-f65ef2eff542",
+      "groupUuid": "68013d21-9e0a-4d08-84d5-01cc821eb4dd",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
+    },
+    {
+      "uuid": "e16125b6-c23e-47cd-ab46-46821d7fce8a",
+      "groupUuid": "a58e6227-df03-4f67-b0b2-bc4855f75846",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "2ec4c649-5c54-4df1-8705-b26a4f619b8d",
+      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "286d7697-932a-4ea5-a32c-b1f99c58415b",
+      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "e66bfa0a-2d8e-43f7-a304-0fd076cb932d",
+      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "5ca27f7f-740f-443b-b450-9e400cf7c227",
+      "groupUuid": "83385657-4969-43f2-b2be-d7948f72a1b0",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "09848665-2fe0-4ac2-9d8f-dba6caa496fc",
+      "groupUuid": "8b0e6641-f4b4-4575-9db9-5efec65c09b9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "18b04268-41d4-45d5-80bd-3f73c93facac",
+      "groupUuid": "67206303-fe0e-4f98-b24d-7a97301ae56b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "24218a44-d89d-4cf7-8fe5-8ac05ecff855",
+      "groupUuid": "1d0c88b8-7218-4f68-9fb7-ce35c5fc7460",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "0008d810-79f0-427c-a6f4-efbbbd691f29",
+      "groupUuid": "27d55126-db68-4959-a229-9cb7327a01c5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "49325246-4efa-4eff-a9aa-3fe48c4418b1",
+      "groupUuid": "d89ae9ca-23bd-419d-b4c0-529e24869f9a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "a8e50424-4d9b-453d-8faf-fb64dc5b0bae",
+      "groupUuid": "ea9b7b7f-455a-47fe-aabb-275fdcf3f3bd",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      }
+    },
+    {
+      "uuid": "25ec42d4-8b00-4ad4-8251-985d1e5f7e8b",
+      "groupUuid": "b589ecf8-079c-447e-a94e-7b7c61660abd",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "ecbd9fa1-4200-4dc4-b8ac-fda577d294b5",
+      "groupUuid": "1d92b61f-9f3c-4d15-b13b-de8f0b65435e",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
+    },
+    {
+      "uuid": "c031addd-f433-4bbb-9c49-80dd85c7df55",
+      "groupUuid": "be76b380-67a2-4ad3-bdd1-b1276df1dbcf",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "134f3c12-d6d2-458a-987e-095bac00974e",
+      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "d8c79f6d-cbff-4fcd-a08e-40739c447c29",
+      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "2301c305-f7f9-429e-b2b3-26a766baff4b",
+      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "882c6945-3a7c-4507-bb73-246638f04b2d",
+      "groupUuid": "56237876-f201-4584-a381-feb770ce5bfe",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "c0ac7bc7-2e2d-4422-9e41-f28967201faa",
+      "groupUuid": "f8c62eb6-5d87-466d-9c87-f3de1562d49a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "b8a18b9f-cef2-4eac-9fe2-173481bbdd9e",
+      "groupUuid": "6a46d274-9821-41a8-8e24-5c03f8278ad4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "859738a6-1a71-416e-86c2-f1a7b36ae57a",
+      "groupUuid": "178fcd08-1884-4aad-8ed5-47dea5e9fa51",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "cd14f201-4417-4d90-8479-e17afb72e690",
+      "groupUuid": "88772ef5-4509-4b08-a830-4b323ea02e60",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "dc532975-77bb-421a-b6a8-847d2776f208",
+      "groupUuid": "ab72c037-f486-4f85-b5a8-5fe34681a5c0",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "74167e5c-71fc-421b-8eea-00e1e28a92b7",
+      "groupUuid": "356543ed-0604-4124-9ab0-36dc4539396e",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+      }
+    },
+    {
+      "uuid": "a204fd00-6c97-44d3-ad59-daafd76eaec8",
+      "groupUuid": "36c8bb31-35b4-4491-b35c-c6dd17dd6bea",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv6-extended-6str-17.png",
+            "name": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "b2d42386-47ba-4832-8eeb-1989f85292b4",
+      "groupUuid": "c6405ee1-cd7f-4597-b3bf-d61de14a8735",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "b2e1f7fb-d76a-48b2-a448-62d7c1d2f655",
+      "groupUuid": "b8e07dad-4f00-4a36-b521-a3e5bf1c9457",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "324c53ce-8e9f-4596-bdd2-3b7958adc9b3",
+      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "4f0b19bf-3101-4039-857f-a4516663ba2c",
+      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "f600b772-8982-4f84-a183-76c1f637e4ca",
+      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "31e6ea9e-8382-488d-9389-8778aae24bd1",
+      "groupUuid": "e401fc19-7680-4cd1-bf9b-d05c3d233f8b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "f98087f1-3fa6-4a67-b059-49d7662157c6",
+      "groupUuid": "cf05412a-f69f-43ea-9d03-4b5e6fa6ff2e",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "ea1d6f99-ee22-44d9-a04a-bfa5f74a607c",
+      "groupUuid": "c6015601-295e-488d-9a06-2fabf4d42099",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "3d3ba46d-aa1f-4ecc-af1b-a75f006423af",
+      "groupUuid": "b3b5457f-470c-4073-9880-561027478f63",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "1f6bad36-e009-4549-80f2-c0347e4811f4",
+      "groupUuid": "0afc8213-41eb-41ab-9c2d-f04dd0ce21ef",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "bf3fdab2-3591-4b84-b234-6d436924cba2",
+      "groupUuid": "0b6ecd8c-f2fb-469e-82f6-74eb1b7dc3d9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "cd289504-8d07-457c-a5da-0766bf529421",
+      "groupUuid": "a9ac6ce1-159a-4ea4-9c9d-311af7d3515f",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13 \u2014 Fret 2 \u2014 Extended \u2014 dom13 extended"
+      }
+    },
+    {
+      "uuid": "ec3b14cc-5a6c-4e15-8bc8-dfa365b3a1f6",
+      "groupUuid": "bfbe3a93-2fcd-4824-9b06-f623d6d9a093",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f2-6.png",
+            "name": "Fretboard diagram for C13 \u2014 Fret 2 \u2014 Extended"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "2d60937f-f45a-4b79-a4c9-a167a99f9eed",
+      "groupUuid": "ca92d406-d17d-40d4-8630-f73a2f07925c",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "f489f081-d1d8-4225-8454-20c19da7056e",
+      "groupUuid": "e9859cef-ce34-4346-aceb-9b867ce6883e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "559f7122-c2bd-4333-9be5-02deacceae83",
+      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "e8f75ea0-94d3-4edf-bdc2-bfad3d520b74",
+      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "9f5759d9-1377-4e2b-bc87-96f282b76d00",
+      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "8ba4b10d-a4ae-4bcc-9510-5830a9c95222",
+      "groupUuid": "2fb07289-3432-4f5b-ac8f-bed701a4797f",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "7858929b-2b3c-400a-a95a-236380a49fcf",
+      "groupUuid": "ab7a268f-ef06-491a-9363-270531e71ebb",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "40f172d1-27fc-47df-8677-0fcf0d18ad76",
+      "groupUuid": "d5ac3edf-25de-4e6d-9cb2-b8193b34d84f",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c9c0fb88-7f58-415f-89d0-e9883dd58469",
+      "groupUuid": "f72b6ece-88db-476b-82ac-7042d5121984",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "0f0de67d-f3e8-4d0b-b09b-871b6e658263",
+      "groupUuid": "3d2caec2-6a9a-4ba0-8384-bfda1b583321",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f9276213-f9ea-457c-9c3d-f5da605a27a9",
+      "groupUuid": "32ae7bc2-2dc9-453b-83aa-a280e6104568",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "0c4ab215-9348-4690-8f92-849bbd75deb4",
+      "groupUuid": "2bbdb4bf-4db8-4abb-b9bd-d8416e08e273",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top) \u2014 quartal quartal"
+      }
+    },
+    {
+      "uuid": "bd6db14a-2ace-4a66-9461-dd8e542f3b0f",
+      "groupUuid": "3b4d96a6-2aa3-41d1-9994-00bd5b63a5f2",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-d-upper-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "680215fe-89fd-4a86-a5f8-08c6f9129008",
+      "groupUuid": "3dbdb880-e4fd-4f31-ba9d-93766d87d464",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
+    },
+    {
+      "uuid": "57b828d9-d959-4f2b-98a1-c9decb9b199a",
+      "groupUuid": "5fb037ac-093c-4e9a-b06f-28accec620bd",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d52328e9-50d3-4da1-997d-9eeb38fd709b",
+      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "24d37167-222e-4565-abd1-32d83ef03263",
+      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "92609f60-5586-4b50-bac1-381b023a6f09",
+      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "9bc54bbb-134d-4333-a8cc-ca505afd8715",
+      "groupUuid": "13dc871e-3527-4404-b887-814736e82b67",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "a9e0e86d-c19a-4347-9c41-d7a86a61b63f",
+      "groupUuid": "ec276ed4-4088-42d7-8751-48d41624e4b1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "cf99d63d-170f-4e80-8d94-c76370607ed2",
+      "groupUuid": "319dbc07-e7f1-44e9-ad09-c1e3cd7a98f4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c0359e32-dc9a-4eda-a679-ef237fd833dc",
+      "groupUuid": "41195467-cc3b-4a38-bbe7-54c12e4b65bc",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "83af7353-20b2-4547-ae2c-957ee07d1364",
+      "groupUuid": "8bcdbe96-46c0-4b7e-84f4-ab2a41bbcfba",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "6d545641-675f-4586-af13-b3c32e7b927d",
+      "groupUuid": "de4c5703-5a12-4c75-96ac-50826a39d88d",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "ee12c3e9-3c32-45c3-a70e-29fad99991c1",
+      "groupUuid": "226d6e71-be29-44a4-832c-97108e41a4d5",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "7dc2884e-0b48-4782-ac21-98474e75a06c",
+      "groupUuid": "0a8d5e89-2403-4813-880a-0c1a07ec6e4a",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-shell-7str-7.png",
+            "name": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "93b97553-1a68-4c7d-af6d-e94c2569a4cd",
+      "groupUuid": "3e9e474e-8aa5-48c3-9155-f89a24649b4a",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
+    },
+    {
+      "uuid": "7f340a82-49c1-44f9-b826-309b53206591",
+      "groupUuid": "fbbd04d1-eac8-42ab-acbb-324513a9c69c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "b13c045e-90c6-41e6-8203-743bc0cf22e1",
+      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "b6f2da85-b368-40da-81c6-1f20586a174c",
+      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "330bec35-ae56-4cbc-8d82-5c3301b89836",
+      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "98c0c603-4f03-441f-b34c-95aa75c69283",
+      "groupUuid": "59ebea18-20e9-4d98-aa43-f36cd856418d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "9fbe10c0-92de-42bc-9d9d-9ae4891d219a",
+      "groupUuid": "8f2bddb9-1707-4b75-8a99-b1398518ade9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "4e13e21d-c4db-45e9-b3bf-581fe0232884",
+      "groupUuid": "c1ad8918-e3fa-4162-b073-3b4d2faeee84",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "0ac90f6b-987a-4721-bf4a-8081628361ed",
+      "groupUuid": "ec3f38c5-1c34-488f-b6c7-9de9384d1121",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "2ac12ad7-a39a-41be-8190-73fb37e67a0d",
+      "groupUuid": "48aeeba6-f961-4646-91d6-407761aa24ec",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "e2991fd3-d2be-49dc-9f7c-471b4f3ac750",
+      "groupUuid": "7612d54e-30f7-4fcf-bd6d-4bc7efa46144",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "c0072b81-8945-4d28-a0fe-7b74b16982c7",
+      "groupUuid": "b9d226c1-a57f-4821-9da3-6da597d8289b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "a1eaf00f-98ac-4ce9-907d-49e533bfb15d",
+      "groupUuid": "6f8c1fb3-b5c5-45ff-929d-f6cf558d9023",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-e-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 E shape \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "7d1367cc-1d2a-4cb2-b2c6-0fc601c67c2f",
+      "groupUuid": "0120bf5e-f14e-4d3a-a27a-f2116cbcb8e6",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
+    },
+    {
+      "uuid": "0ae0d8c0-aa2d-476c-88aa-d34bc378b2cc",
+      "groupUuid": "5de08cc4-24f2-4ea9-a8ea-104b1cc519f8",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "2f37fe0b-e292-4d1e-b0b4-8389e7a09029",
+      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "be2b516d-731a-4c7f-b5f2-ce4e21180b42",
+      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "9e42bdee-b5a8-41a8-b75c-065dcb5a2837",
+      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "4968a90d-af2c-4329-9f16-362025f1f9c2",
+      "groupUuid": "a3b87eba-eb75-42f5-bc3e-42b7e8f16d66",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "b776b7bb-5244-45c2-96bb-4ec8b2a41db0",
+      "groupUuid": "75046a8d-0088-4863-afc6-41a84da701a3",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "1e374e73-e6e3-436a-9efc-e18182fa4acd",
+      "groupUuid": "9d873c00-88a5-4995-aa50-cb2ca8066102",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "6bfa5196-7fee-477b-8cd9-22e906f67354",
+      "groupUuid": "3d5efdd6-1537-4280-8b46-362e67dd9412",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "36df90a2-6072-4137-84cd-85aa8d2241ac",
+      "groupUuid": "e6bc6a36-fae7-4106-bde7-c25b2081ddab",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "a3449f55-463d-4011-adac-f99e8894879c",
+      "groupUuid": "cb692162-d741-4723-ba59-d532ef197661",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "76a003d8-7a82-4c35-8a9d-3c1fc5777cfe",
+      "groupUuid": "d9ea7b42-9f35-4833-b334-6c6ac998386c",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+      }
+    },
+    {
+      "uuid": "735d4768-4224-4bdb-b757-7393cc09027b",
+      "groupUuid": "48253422-a5b0-428d-866d-06128391463b",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-e-shape-6-cm6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 E shape \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "7f5c9a3b-9fb9-45b7-b269-aeac14b4ea70",
+      "groupUuid": "c1f4f423-4b6b-459f-b301-cc4de5a2cc94",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "c4663e9f-699e-4a0b-bda0-2ac6522edc8f",
+      "groupUuid": "d05152f0-3d17-44d2-8be2-55bd0c376756",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "ec1d0ce7-5bc8-4633-8afd-f309ee18ab35",
+      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "928bcf15-c92c-46f4-b584-42f98c3b09c2",
+      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "7703379b-7698-42fa-af2e-e3700a4c9ef0",
+      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "b6bcbb45-0bc3-44b7-b3f5-88074f352433",
+      "groupUuid": "24be422c-3d8f-40a8-bfd5-12ff06c85639",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "b55d712d-facd-4374-9610-67d4e6c3d42d",
+      "groupUuid": "4d90ab62-ae16-497a-b5bf-7e4a5a458026",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "f09e722d-0aa8-4a17-bc31-4b21f9b2b7ab",
+      "groupUuid": "8eda2592-73c5-4544-b0c9-814586d43217",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "1562ece9-31bf-4c5e-a6ab-9e0183a15296",
+      "groupUuid": "daa66c77-b9f4-4a97-8a17-ad3cd0b70db2",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "1609b609-312e-4eae-baef-cde68541d506",
+      "groupUuid": "1afca7be-ae91-4103-b0a7-7fea2ff907f7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "53642464-4748-49ae-81fb-5c1409092f0e",
+      "groupUuid": "f7c8b1b9-53f6-4716-9cde-bb662e464bad",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "10d04e92-75e4-4220-97c4-1d0ba2b73381",
+      "groupUuid": "31f47114-36cb-4619-ac3d-0406c68ce935",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+      }
+    },
+    {
+      "uuid": "a2d41cfe-16bc-4706-aab8-c96c849ff2a1",
+      "groupUuid": "3b9f3e3d-a747-44ef-8076-5aaa7e695c4c",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv7-altered-7str-27.png",
+            "name": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "bbc755f1-ae8f-41bc-badb-9a0328c62178",
+      "groupUuid": "8caab9a4-e731-4e2a-88db-56cf8d9efbda",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "b330e663-8d21-44e1-8ab8-b7425776f9d2",
+      "groupUuid": "88d4e4f1-8966-41a4-a346-4ae83b7e4f34",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "3c1f5e1e-5199-4010-a303-26b0e852aa01",
+      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "5e3374c5-1be0-4fed-96ad-9d9b08df5bda",
+      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "2a61edea-62f1-4627-be45-028a0397d189",
+      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "2b746dcd-c854-4c5a-851a-93a515131280",
+      "groupUuid": "61b66e4d-638e-4b74-a40d-979f40628828",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "0041b049-1326-4d67-be24-78ea30cb4c82",
+      "groupUuid": "f52167a9-f5fa-4150-ad55-5d78c6ca59b4",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "c41278c8-ca8c-4493-8c37-edef82b195b8",
+      "groupUuid": "f6ec9c01-9f8c-403d-aec5-32f895d43636",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "f38a3dbe-edf4-40ef-8ef6-acb9fe6ccc43",
+      "groupUuid": "38af79bb-dada-4359-9978-053f858f6ecb",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "4d11da57-9c96-4aa4-90ab-a1b4351c6188",
+      "groupUuid": "3582b87a-1bf0-4314-a139-84d295bfbb96",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "a8a3fb93-b0f1-4c2c-b7ea-7b906b82339f",
+      "groupUuid": "cb745dfa-4047-4b72-b9ee-0fad8734a5f1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "1a60895c-5dea-454a-9b4b-0978a946439c",
+      "groupUuid": "4b781c97-ed6c-472c-afe8-249f17c9977a",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
+    },
+    {
+      "uuid": "83ff6013-d41f-4c22-9e57-0b667f85c468",
+      "groupUuid": "f3e4626e-dfb8-4470-ae24-8137331f845b",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-b7top-7.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "d8d5dc7e-fa19-4da1-8c05-afcd7553deae",
+      "groupUuid": "d38fe8c2-0651-4924-bdb5-be3828bc981e",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
+    },
+    {
+      "uuid": "704e92ef-c7e4-4faa-9578-b5efe718b211",
+      "groupUuid": "3fb55df2-f23d-4c6e-9401-89a7b22a632d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "62e0bab2-efc9-4ef7-9807-19d70fd67fbd",
+      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "48762723-d6ea-4591-aab1-22bc204c3ad9",
+      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "dda979e2-da0b-4b79-be6d-a33e9a3d11df",
+      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "a93284cc-8b00-4f2e-b29e-d167651a0c36",
+      "groupUuid": "b6c0745e-7e20-48ef-8b92-7c72c118551b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "e99c499c-3461-40e4-801a-dd8d15292858",
+      "groupUuid": "3be7be1f-8fb1-40ae-9250-d65e127d5f72",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "710b3691-3e19-418e-852c-90e2d820156b",
+      "groupUuid": "3a8923de-3366-4498-bacc-41a6e3e13291",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "447f8ba8-79d6-4ecd-9b2a-dee4b15671d6",
+      "groupUuid": "75ea663d-1fff-4ef0-8440-f5182edcb820",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "bd6bc455-da4d-45d3-a4a6-73550f2d6fb3",
+      "groupUuid": "d4bf8965-f964-45a5-8073-51a7f1eff855",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "90acc9b8-3b4b-4b2a-8241-dc402a776b6c",
+      "groupUuid": "06c97a8c-9852-4494-ad12-154eb0d3c803",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "7e2c05fb-2b0a-429a-9c0e-a2e684d2f31f",
+      "groupUuid": "99200043-f960-4ca0-8549-287b5c6d851d",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+      }
+    },
+    {
+      "uuid": "c9a1bedc-da64-44b3-9f74-99e943991c9b",
+      "groupUuid": "a75e5e70-fb98-47ad-9537-c75845e080a3",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cv7-drop3-7str-7.png",
+            "name": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "f8a5d71c-6daa-4dfd-addf-29843b73123d",
+      "groupUuid": "ee7414e7-d1ed-41da-bf60-0d404c11ffac",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
+    },
+    {
+      "uuid": "f23a21a4-6213-4b37-a8fa-85cbc53fe85b",
+      "groupUuid": "7b99ad0d-bb17-48ae-af25-c4da47cc030d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d31fd062-0c1c-49e5-95b2-f87e9440f0f6",
+      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "6ecb827f-924c-462f-9409-8b489677e2bc",
+      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "822f52ce-58c7-4a23-88ac-ff8427f1051d",
+      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "4bbcea86-d1a4-4622-869b-5403e8fb6376",
+      "groupUuid": "da7d32fb-8ac9-49d8-9192-a96df3f596ab",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "2269e23c-e57c-4b21-afe9-cf3a627be500",
+      "groupUuid": "7dfb4883-ced5-49da-856a-66ef24005cf2",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "f890183f-b1ba-4b10-8e60-3d600fc14aa6",
+      "groupUuid": "4f3f50e1-232c-4234-a037-fd33f345da99",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "780e39a3-fb2c-429d-8e4d-e610b0857650",
+      "groupUuid": "0aef3d67-a9a4-4b19-b831-8f9478704376",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "0f53e3ec-60f6-43c4-a75e-1862666ef74f",
+      "groupUuid": "4f370fba-3333-4f31-9419-9525aebc115c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "baee42ce-5cf3-4384-99bd-b77024cf06ee",
+      "groupUuid": "6f10d5e8-f4fa-4124-b085-7bbf54a214ba",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "f3985f15-17a3-4a42-b479-098942107e6e",
+      "groupUuid": "6751482b-e9ae-492e-8738-91ca3ac98145",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      }
+    },
+    {
+      "uuid": "4f10d424-353e-4a26-9054-c735d917740a",
+      "groupUuid": "4d9631d2-3f0c-4e08-ae7c-f5c61314d80f",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "b55c3010-0c91-4a5d-b710-7c8ad24b78f0",
+      "groupUuid": "4e5ca35d-b579-4bdb-bff3-0e113e3c94c5",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
+    },
+    {
+      "uuid": "82f4f857-fa33-43be-baf1-fbfc4deb6d16",
+      "groupUuid": "15fe72f9-d7b3-49fa-8bab-eaeedd92d7e1",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "eb2991c2-7fd1-4ee8-822a-6e3e0868c3d9",
+      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "9aaf42b4-91b5-4046-b476-adca1ff38f32",
+      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "31ec2b6e-2038-4072-b831-61efff7a250d",
+      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "52a6fad0-62d7-431c-8e4f-30b1240f08a6",
+      "groupUuid": "cecc01e0-09b5-492e-bc3d-6ae17747db86",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "9e059961-e344-475b-9638-7bab716b21b5",
+      "groupUuid": "c437e3be-5cfb-4d56-80eb-970a547d5407",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "fba2eb5f-ec02-4b1c-b963-57ccc2ace98e",
+      "groupUuid": "4c94d566-75d6-453e-b241-4a540e47a1f9",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "74deaa7b-6fb3-43d2-b8aa-e508089e0cd9",
+      "groupUuid": "2ff2989b-66dc-4fda-b017-ab287a47e417",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "3f27431b-be65-42ec-b1ec-97aa274ee5b6",
+      "groupUuid": "87c264be-e5d7-4fc7-972b-6edec7b062a2",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "9f7c386c-6a52-4df2-b8b0-95270ad3c06a",
+      "groupUuid": "107ce4c4-ff95-4690-8b89-4042cadc02a4",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "540af974-410e-4921-a3fe-c83f7166cdbf",
+      "groupUuid": "f09af9a9-c629-46d3-906f-a35c3c50cd60",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+      }
+    },
+    {
+      "uuid": "eb88a477-f9b7-47c8-8d85-512a9181f05c",
+      "groupUuid": "7edb913e-b507-45d5-9a95-f63422108a3c",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv7-extended-7str-19.png",
+            "name": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "0c70071d-d600-4133-912f-9e6ef3474d55",
+      "groupUuid": "4d9bca08-d6e8-46df-aa05-eb75d454bcda",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "b9e47d34-3123-46c9-a90d-1e72502f5544",
+      "groupUuid": "44249be5-a373-40c3-8566-6a49f744a26c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "a3be660f-fb8c-4b84-bb32-a665ac6298b1",
+      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "32fa9687-60a6-4b5c-b393-94a4199c7921",
+      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "90debe20-30c7-46a5-80e0-3ba839590e07",
+      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "7f812914-2f50-4a68-8f9c-997ef697f08b",
+      "groupUuid": "beb4ba6d-c346-48c1-a37b-8029e06e1b83",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "1bdf0fe8-194d-4e64-b015-8b1f40e3755b",
+      "groupUuid": "c04a8432-db5b-415a-bd9c-e78dc3019458",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "6cb126b1-7c3e-44fa-8f25-2d682a97947b",
+      "groupUuid": "759a00fc-58d8-4de3-9929-488dace52c3a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c2b202ae-dee7-43ff-8f53-ddcd7efec2cf",
+      "groupUuid": "dd854663-508b-4c98-ade6-ce49459b5f5d",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "be128ac4-7163-4062-91dd-59268e3852e4",
+      "groupUuid": "473feb67-5c5d-427a-a1f8-d9205b25c9a4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f05aab3b-9863-4e11-94bf-9d8034322227",
+      "groupUuid": "d278fbb4-4b00-4975-8ffa-1d1c29f3bf60",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "8eb46136-05b0-4cbe-8b65-a3fc31295551",
+      "groupUuid": "ae59d0ec-1f30-4cbf-b4b0-55b49b09bc98",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13 \u2014 Fret 3 \u2014 Extended \u2014 dom13 extended"
+      }
+    },
+    {
+      "uuid": "81f38b43-948c-43be-bf9b-639be6f34ddc",
+      "groupUuid": "dfe387ee-d181-4d99-99e3-14223ce7618d",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f3-6.png",
+            "name": "Fretboard diagram for C13 \u2014 Fret 3 \u2014 Extended"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "d5b18c19-87bd-45e7-9d35-2f55334841ac",
+      "groupUuid": "e6c40021-d763-4c73-94bc-ea82f889de8b",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "ad5748ed-8d62-43cf-b2b6-0e596a559cc6",
+      "groupUuid": "37406597-740e-42c6-8852-4503010b0f4b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "7dd6148a-51a7-4ad1-9c93-357aea06b927",
+      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "6b770d8f-4940-4a87-90c0-d1585d320110",
+      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "32fb6d6c-f0a2-4f49-a985-6f0a73a1ebf4",
+      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "b051be56-d851-489c-b254-1bc8d214485e",
+      "groupUuid": "7eff275c-5e24-44ee-9801-60544dfacc5f",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "1f10520f-7812-43cd-aa4d-3f0753443201",
+      "groupUuid": "593923ee-24f2-4170-bb13-5235a6ee3cde",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "f59ecffe-f7db-465c-a0af-3b46ea3cdb3a",
+      "groupUuid": "82d9ec75-7da2-4d7c-bf9f-d416ba1cf8b3",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "ae08a343-d516-40c8-8a27-03a497f7cd81",
+      "groupUuid": "b35ddb7a-74a1-49a6-97e7-ced3ac2db8a0",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "92ffd682-d5c4-437a-b473-fb3d832a03ce",
+      "groupUuid": "67197438-7292-4f6f-a73b-deae742efb49",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "52fc03ee-4e03-48bb-b03e-09a02df5a8eb",
+      "groupUuid": "cc24b9d2-414b-48e8-811e-d5c7e7787acb",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "232dc08b-e21b-4832-baa8-0d4334e2c940",
+      "groupUuid": "1208053c-0fe5-458b-b8f4-9c96ff340cbf",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top) \u2014 quartal quartal"
+      }
+    },
+    {
+      "uuid": "7ced6855-7a32-4b26-914d-0cf290633dc9",
+      "groupUuid": "dd17e6b2-6d76-4202-99b9-e40c05c2b295",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-eb-upper-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "75f9a1ff-685d-49c4-90be-b2974d139eff",
+      "groupUuid": "bf61dba3-bf9d-44ba-8580-c562eb3cdd6d",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
+    },
+    {
+      "uuid": "d1eb1c91-25e4-4916-be9d-1c5672af1351",
+      "groupUuid": "4313f6ad-2ccb-490d-99bb-a09e923ce2bb",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "5be51fa9-a86b-465c-8b57-a2369a820e1a",
+      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "a6cff27b-bd8d-4f73-8d48-2c382c125ab6",
+      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "e9207b2d-d713-40af-ad56-48d707162750",
+      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "3fa4988a-592a-462d-9c6a-3cb28c03feed",
+      "groupUuid": "de373cf7-139e-4de8-b313-4888045ce285",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "93536e09-3893-49da-9a42-087b5fbcf2cb",
+      "groupUuid": "8bd7de98-a394-4bc2-84f4-e3dbd6112553",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a901dcb8-0ba7-4536-a936-b1c289de65a3",
+      "groupUuid": "0d6495d0-ec2d-40c9-89d1-829c88315ccc",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "bb4d2678-4649-470f-a666-3c6fde16056c",
+      "groupUuid": "9077a51a-aaf9-44c1-b1b9-73dfa113011b",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "938a6718-03b1-48cb-928a-4c54983e416c",
+      "groupUuid": "e57695bd-e4bf-471c-a271-7c243de64ec5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "96fd01b3-c73b-46c3-b78c-46c3bb28c1a6",
+      "groupUuid": "6b8e8866-c830-4fd0-8db9-8b89630f8d45",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "cea78dcd-ad6c-4c46-bf94-066b0c2dfdce",
+      "groupUuid": "9b9475fb-94e8-4403-87ae-d3bf980fe57a",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "84d3aeac-2012-4785-a2fc-7c3bf2ce913d",
+      "groupUuid": "0cdb76d1-34a2-47a2-8329-278eb3362409",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-shell-7str-7.png",
+            "name": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "f9f0b036-a803-40db-8025-1fa52e8d5b63",
+      "groupUuid": "923a07c8-3d95-49d3-a8d7-dc221d32a40c",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
+    },
+    {
+      "uuid": "087450d3-6935-4bd5-a64d-8b7c16289747",
+      "groupUuid": "daffe69e-3ff9-4968-b8e7-aae003b2aa9c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "f449cb68-dfb8-4408-b28f-92d8cada0cea",
+      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "894a3453-d208-4931-a554-57591a446fcf",
+      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "ca281e3d-d0d0-4a18-b8dc-350bcb16d226",
+      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "b09a6df7-8c1e-401c-9e8b-e803ca2cf446",
+      "groupUuid": "ec19f04b-300e-4489-bebc-fdf18535040b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "8fd5435c-825d-4d95-95b7-7b578886aa8f",
+      "groupUuid": "03e64fc3-9939-4d50-ab61-a4a85163299a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "d29c08b2-a484-4c0a-ba83-01ebed8ce627",
+      "groupUuid": "b3322519-6ce4-4912-a7b7-31b2d20bbbe5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "e756a7f9-c7c6-4342-9e25-4632196087b9",
+      "groupUuid": "3cc32e7a-de2e-4b82-8b37-4f5baab45a9e",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "dae1a4ed-e1d2-4d04-b996-cb52d0d42594",
+      "groupUuid": "ddcd106f-e628-46d4-8b27-8b570dd1ccd0",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "9e6de611-1416-4a3e-a99e-0d0c606def9b",
+      "groupUuid": "281f18ee-4fb7-4588-9546-22719cd1b00f",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "cd717f3f-faa5-44a0-ad36-1c706b761423",
+      "groupUuid": "d377f844-bf66-4666-97eb-9bf2903b77fb",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 D shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "3ca55b51-43a4-44e3-9536-5984c1209ea0",
+      "groupUuid": "53ae336f-b6a3-4f65-92b4-e8f98de34c03",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-d-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 D shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "8da1ddab-ccd5-4154-b5e2-70f2cb1682c2",
+      "groupUuid": "d16c0044-51ed-4548-852a-7857261bc1c8",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
+    },
+    {
+      "uuid": "93594701-d01e-4c73-af05-02b4bf954699",
+      "groupUuid": "066f7b3a-4b3a-4b99-b3ce-634cac8793b4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "512230f8-d60a-4c48-a037-28d48477d972",
+      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "3ae0078b-0f6e-4db9-872e-849a66ba5f3a",
+      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "ce58c767-e5b7-4e87-b298-d76b71ac8c63",
+      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "6f4b698a-94ae-411e-8f2f-dc4228d3c08b",
+      "groupUuid": "7078bc81-018d-42ba-9a38-e271a635bcf1",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "c02b42f2-8316-4e55-aa80-50bc8e37c606",
+      "groupUuid": "2fe7776a-81fb-4db4-b3dc-6ad54e7d862c",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "149433a8-0488-4852-9c58-f3319382440b",
+      "groupUuid": "1c846cce-e2f2-4ab0-affa-249ee7d93646",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c1c3d8dc-01f8-42f2-9a05-f79afda31dff",
+      "groupUuid": "f411e5fd-8a11-4399-a85e-ce1706d4ac72",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "2da639b7-5201-4aeb-a02b-d502cbb083c6",
+      "groupUuid": "a1789c38-e83b-4233-894a-a03ce4d23cd1",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f9d6bf4a-29f0-4682-9529-e38f98482d33",
+      "groupUuid": "364bf539-5bae-46a0-95e3-8ad2044d09fb",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "2021dc12-242a-46be-83fa-61d466211dc2",
+      "groupUuid": "e6877e1a-b848-4510-a6cd-d2dc0b630dbd",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 D shape \u2014 Shell (7th on top) \u2014 aug7 shell"
+      }
+    },
+    {
+      "uuid": "c1aa9fdf-d4fe-4f38-b801-e1556765a87a",
+      "groupUuid": "3edc32ee-6213-44da-94a2-45432357837c",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-d-shape-6-cm6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 D shape \u2014 Shell (7th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "926d95e2-26a6-4d1d-83d1-5369c0b188eb",
+      "groupUuid": "4f918e72-b5f1-4adc-9d96-aa43c5a9d147",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "27dcc1a0-a56c-47bf-b91e-84aa2eed5b3f",
+      "groupUuid": "158510f4-95cc-4d1a-93f0-f5fb5e9d9cb7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "ab5147d6-b641-4ce5-90f3-4aa2a10c6aeb",
+      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "5058a6b6-bb41-496f-ae03-7ea4a74d63c5",
+      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "7b51fa6c-b76f-483c-9b5a-50c592b6143b",
+      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "e6f8de25-08ad-443d-9f42-920634082e8c",
+      "groupUuid": "89c8809f-78ba-4e2d-bddd-b092dd3f964c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "5e4272af-121a-4db9-acb2-197cecb063cf",
+      "groupUuid": "3609f407-2939-4cea-9404-2afc7b04ae82",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "c3f6a1d0-df19-4252-aa31-094b4e3180e9",
+      "groupUuid": "c0b3ac45-b745-4b04-bd25-b2848dc84201",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "b73c522e-f4f3-41e9-b15f-b7da5ae20abe",
+      "groupUuid": "f0603486-ae8d-43f8-bd36-0bd1ce7431ed",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "b0e2c8d9-68b2-4264-95f2-9e6a73a237a6",
+      "groupUuid": "62fe6d88-d9cc-4b8a-ba49-ef062ef6f651",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "3dbce3c8-dc32-4a4e-9dc5-761626afac13",
+      "groupUuid": "0d87c0ab-e550-476b-8c07-e3cfbb7aa5c8",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "41b0a43d-31aa-4fa1-b57e-0853bed208cc",
+      "groupUuid": "99e62a30-1633-4f0b-a94a-b0a7aea9fde5",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top) \u2014 13sharp9 altered"
+      }
+    },
+    {
+      "uuid": "25f2a2a0-3588-42ab-8bf4-480edbe93bd7",
+      "groupUuid": "cab433a2-532a-4af0-927a-c84550ece947",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13s9-cm6-altered-6str-30.png",
+            "name": "Fretboard diagram for C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "6ff3fe6e-7685-4c54-80e8-fb223a309b7c",
+      "groupUuid": "eff12890-1016-4151-9c71-0bda6c31e731",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "5753a587-471b-4385-8d2f-cba8ba589e1f",
+      "groupUuid": "a7eb12df-b85d-4562-b780-1ce420c45704",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "707de04a-b69e-4348-859b-fd04c2a23761",
+      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "4f413638-a136-43d2-8741-0e7f0ddd5622",
+      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "8b4e6c46-b7f8-44d6-818b-1ceaaa54deb4",
+      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "3ce28b15-6855-457d-accf-7fe395d0da37",
+      "groupUuid": "b445b2b1-f508-4ed0-be35-2c1a3c9170e9",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "80825f61-a73c-4218-aac2-178f62edc8bf",
+      "groupUuid": "33c5818e-b220-4a32-b1ba-001077adc360",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "d48a17b5-7e42-4ddb-9b69-7aebcba07097",
+      "groupUuid": "3a024948-7ff3-4a7c-acae-3d83b789d6ef",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "d1e0cd31-c521-4035-8f1c-c963a9f08460",
+      "groupUuid": "73babb35-d4d8-427f-b5de-b4da665255ac",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "a5fa787d-12bc-4026-a18e-8894fc2b8b78",
+      "groupUuid": "8b0b0794-96b6-447b-a5a0-a3e6159b495d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "4a0f1b50-0fc9-4184-92d2-5dc0bc2e7a6e",
+      "groupUuid": "7e5dc6e8-e118-419d-bd14-462c9f80a718",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "c8b982c9-fd09-4372-bfc5-f6e1d578d3aa",
+      "groupUuid": "69ed8f67-db9d-4002-8717-1f5f55cca93c",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
+    },
+    {
+      "uuid": "794c961f-11a2-4ce8-9567-767ba2b43a89",
+      "groupUuid": "0142777b-1b49-48d0-af2e-c44120264269",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-1top-7.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "083885a2-e2ab-4975-9479-dcd9397cc2bc",
+      "groupUuid": "304e3561-3b84-4690-9744-98a91a69963d",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
+    },
+    {
+      "uuid": "a7a716f9-177f-41f3-88ba-3d4154b4de24",
+      "groupUuid": "53a8ea44-aab9-488b-91ae-e403c7aa772d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "442b6f97-3f42-4848-a06c-20c98f78f55e",
+      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "cac309a7-e890-489b-90a7-4f72badb91c1",
+      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "b4d9c1a7-495a-4788-b93a-4e3209bb0cb2",
+      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "ca01a32b-fcbb-4c79-9fea-fa831ea56e3f",
+      "groupUuid": "1f7e7811-abd4-45d8-9578-41c231899627",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "ea862316-1d1d-448c-8972-7cfd70df76dd",
+      "groupUuid": "81169a70-ca36-4d81-b148-77791b763e56",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "16c50287-f1cf-4dca-9abf-36ac5f6fc493",
+      "groupUuid": "64fd8989-5e38-474b-90e5-103b04f10585",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "f8ea30e2-a720-44b9-8b8b-d4879dc47d65",
+      "groupUuid": "f57d5297-ae0d-4854-85aa-157474b58422",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "f0cf788b-d59c-4253-b6c4-8be8a8bd663c",
+      "groupUuid": "65b996e6-e67a-4050-848a-1c8d13c99918",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "fd020001-02ee-43f8-b66f-72a31b3c3777",
+      "groupUuid": "1d745433-9aef-4a94-aaec-af8f9f2697f5",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "ec48b201-793a-4178-a26d-4a9fa2164234",
+      "groupUuid": "ed0a27cd-7d4d-482b-9446-fdb21d836820",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cm7 \u2014 7-str bass \u2014 Drop 3 \u2014 min7 drop3"
+      }
+    },
+    {
+      "uuid": "48fde2ab-a67d-4e6a-8acd-813907211270",
+      "groupUuid": "40955f59-19e4-489e-8a39-dcc276780a35",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cm7-cm7-drop3-7str-7.png",
+            "name": "Fretboard diagram for Cm7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "dea4a25e-7a44-4bea-bc7a-174a46aa6d75",
+      "groupUuid": "faa03219-b596-479f-b43a-7c7d10222e18",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
+    },
+    {
+      "uuid": "bc3352d0-aaca-4c0e-a6b7-ac66b85ceb16",
+      "groupUuid": "df831fc6-cf25-4f96-9b72-96263d476886",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "5463eecd-2785-453f-af27-c530d9fa5c4e",
+      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "16e36a87-1303-4637-916b-29fcc64e0309",
+      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "708db57a-03ec-4d25-8b6a-902aa4ccdcba",
+      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "579a0408-69f1-4ff2-8cfe-5c45fdda745f",
+      "groupUuid": "ff455564-ef34-42cc-95ad-ed78e43a9100",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "912a093d-eec0-4070-8249-c65da65b77a0",
+      "groupUuid": "92057cde-3110-4930-910c-ca27fbe1d3a1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "41fd4afe-9468-4ff0-906c-b26917821db1",
+      "groupUuid": "cb9a73cf-e5ee-48f4-bb4a-5e5b88c1c1c2",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c3999127-9d22-41c2-91dc-cffdfc0271f0",
+      "groupUuid": "672bf8f4-b5e4-4444-be7a-82730783ad29",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "ba16aec6-c2bb-4e37-8e37-320a51d9cb0e",
+      "groupUuid": "fb34e7ee-dbf3-4578-a5d9-615106867a20",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "fc6783fd-7245-4f5c-8666-73d071f30dd8",
+      "groupUuid": "6c0fa537-533a-4670-a8a3-d9bd1ddeed02",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "eb0ff792-28ce-4f1a-967d-a64715d78322",
+      "groupUuid": "6cace1be-b0a8-42dd-8e47-3607f526a6bb",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 A shape \u2014 Drop 3 (5th on top) \u2014 dom7 drop3"
+      }
+    },
+    {
+      "uuid": "d52e0a17-f761-4e91-82d6-cc0d10a3853b",
+      "groupUuid": "3096ddf2-30fc-4867-b388-4fa002b737f4",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-drop3-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 A shape \u2014 Drop 3 (5th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "62048a19-a5c1-4707-b407-17c86c5000f5",
+      "groupUuid": "e7f78358-5f0b-4fc6-89b4-874a7aabb276",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
+    },
+    {
+      "uuid": "793e6459-c52b-441c-9a4f-0dfb56341452",
+      "groupUuid": "7ccfb600-41ce-467f-bacd-6d704dd78d15",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "71b77957-a01e-497d-8eb6-19c03b0d702c",
+      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "220961a0-ef40-4ac7-b31c-a1a3c8684276",
+      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "8b17b9f0-8e9b-4825-a6d8-85cab07b28e8",
+      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "31570620-2aff-40ad-ad2b-b74abf0151a9",
+      "groupUuid": "c4f7cc9e-649e-49cf-92de-324a32ccd286",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "b8ffac5d-e4be-4503-af66-d0e30e45d20d",
+      "groupUuid": "c4cdae05-9be5-4405-9f9d-d2655d391463",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a86649b8-fffe-481a-a0f8-b5b2eeec0b3a",
+      "groupUuid": "1c5a4db6-2174-4909-9183-6b27c1df43eb",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "abe91b9b-74ee-474f-aaf3-bea93f7b78c2",
+      "groupUuid": "5543aa1d-ecb5-4be1-875d-23eae751b6e0",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "d8097245-8c03-4154-bdac-18347b862494",
+      "groupUuid": "a65a6137-36b3-4ef1-9249-8e91fd0abb38",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "03ae81fb-03d5-4715-acde-7d4a2148aa63",
+      "groupUuid": "ccad0310-dcf4-461e-8165-6bc3495eade1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "d32baba1-fded-4602-8c9d-a03082c82a52",
+      "groupUuid": "70a76780-2472-424a-b560-3a65f43c1293",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top) \u2014 9sus4 extended"
+      }
+    },
+    {
+      "uuid": "b88949ff-6fa4-45fd-b5e0-52a9f53e8c3f",
+      "groupUuid": "45d0aacf-2677-4476-94ba-b8c71d8914ea",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c9sus4-cm6-extended-6str-14.png",
+            "name": "Fretboard diagram for C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "5766c1e4-de03-4ccd-a045-b91db05965da",
+      "groupUuid": "094c6463-eb9e-4623-821a-dcfc120c87cc",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "8b41de44-8d37-42d3-beba-a37b2e86831f",
+      "groupUuid": "14e9e83e-92de-469a-a596-d3a4da1893b7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "403ad666-dced-4c8c-b6bb-4b6faa0af7cd",
+      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "42958008-56d5-4cee-ae82-4fe42d808868",
+      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "cda9a2c4-2558-466a-880f-111c5721fb51",
+      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "0d82f393-a301-43b6-bd75-94e4ccf9b182",
+      "groupUuid": "f7d7ad39-d707-4d2f-ae05-91a386d15ecf",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "be3618f0-b29c-4f92-992e-8066798e5a84",
+      "groupUuid": "ce3c7d14-09b5-46ab-ac58-2871b1977a81",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "5499bcb9-a4a4-4355-a778-4a58e4d79250",
+      "groupUuid": "6720f043-d16e-4989-87a8-29b908ae5292",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "31698d7a-82dd-4039-b420-9a3f68f5cd8c",
+      "groupUuid": "e6832902-5651-45d8-a6d2-62ef53a4bc86",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "5ba1204c-992a-4a0e-9301-bf118d57c114",
+      "groupUuid": "55a16adb-52f3-47f3-9c33-4551d3a6b4fe",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "1dd35627-74b1-4d9c-9e22-24ff7da1a3c4",
+      "groupUuid": "ef0d6a4e-ec22-422e-9d53-89f3bfbe1196",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "aa96cdf1-75e5-4e8a-b78a-9220d2a469d3",
+      "groupUuid": "00f5fb26-8bfb-48e6-8030-6ffdd3bd572b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top) \u2014 dom7b13 extended"
+      }
+    },
+    {
+      "uuid": "b9c839bd-09dd-4d68-a4eb-b40be3e6fb33",
+      "groupUuid": "b0479704-8274-492d-9ab3-499074c1f75a",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7b13-ext-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "060edd23-ead3-474d-8d0e-aaf1e0daafe4",
+      "groupUuid": "4b445692-fe07-41f9-b1a3-e5f0268862ea",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "c7fec2a0-791d-45ee-8023-20eb47e3550c",
+      "groupUuid": "00d215fe-763f-4ae5-9bfc-1daa2cf41127",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "f7ffe4ac-c58d-46fa-b74c-43d4af6c8375",
+      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "f04043d8-642c-47c8-9fc5-7e37ca0d2e0a",
+      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "63d69419-0396-4276-8756-212468add79f",
+      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "4425e508-2bfb-40ee-ac5b-b66ce2de2e7d",
+      "groupUuid": "6ee257ad-1bb5-447b-8226-5880f13bf38a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "2d106145-5753-4fc0-b8cd-8c3d3025e5a8",
+      "groupUuid": "5fa9c36c-b4ae-467a-b4a0-f7109b4962d2",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "f270534a-fdd3-4a57-9500-1e3259c58a0d",
+      "groupUuid": "f89ba019-40cc-4be0-82a1-5da2faea8099",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "a16d82c2-8165-4805-8595-538c984fd79c",
+      "groupUuid": "bc999126-b5bd-4609-be00-4303cd8e485f",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "80880c81-4fa9-41d7-b811-107a5451bff2",
+      "groupUuid": "7d952d18-574e-4115-bfd2-bb30a0021e22",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "a30a1081-da53-4646-b772-7bbef0cc036c",
+      "groupUuid": "ddd8d6bd-10fa-4ac6-827f-6f392aed859c",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "dafc741d-067b-497c-b8ba-6e0147505e96",
+      "groupUuid": "84bebb52-a6eb-4307-8eb6-eaa523effb67",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top) \u2014 quartal quartal"
+      }
+    },
+    {
+      "uuid": "2a8dfbf5-5a18-4454-9781-00da6835c1b8",
+      "groupUuid": "f625eb4f-6781-4f17-9967-822844c11509",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-f-upper-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "68c5d171-ff8d-4b1b-9d10-a6f0d4b815da",
+      "groupUuid": "81961b0b-7c5e-4d52-87b8-d322c1fd22a7",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
+    },
+    {
+      "uuid": "20bb956a-dcd4-4e3a-8b2d-173db373ec23",
+      "groupUuid": "ce95625b-5a91-452e-ab2d-1b095344d299",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d13ed91c-a069-48f8-8ef6-84949e42bda1",
+      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "677d6370-78c2-4e51-bbae-60e409fc320b",
+      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "846dc22f-f088-451b-8673-a9daebbb804f",
+      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "941db39a-e263-4a5e-a1da-bf4637bf6201",
+      "groupUuid": "3dc76610-b321-43c3-a0b7-a25716bdefc5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "867a5e31-1b80-40e0-9d97-ad69db1924e3",
+      "groupUuid": "9c10db46-d24f-4363-89fd-0ac3302a3ddb",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "49fccdc9-0862-48ab-b544-3efb6470ad6f",
+      "groupUuid": "1c0ae8fc-a778-46c1-bba5-468187a0f6b4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "90e32e8d-e945-467c-b933-8e4cbfd63714",
+      "groupUuid": "0f1b7bd5-f20b-4166-a1e3-a5742c0b3f60",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "5032e9a9-ef6a-420b-bf04-c73511ff758c",
+      "groupUuid": "b10a4af3-7966-43b0-9cdc-73b491a51353",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "c017105a-fba7-4c4b-840e-97ade7c4062e",
+      "groupUuid": "6aec69dd-cd33-402d-9de6-8e67446b367d",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "8894e7a9-3e83-4623-aef7-af290f13221f",
+      "groupUuid": "3daca940-0165-4c4d-82b5-018d40cc8d46",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7alt \u2014 7-str root \u2014 Shell (b5 on top) \u2014 dom7alt shell"
+      }
+    },
+    {
+      "uuid": "a9528c51-32cb-4d6b-9922-e3e25378e4a0",
+      "groupUuid": "26689754-4c0a-4a9c-a19d-c295c61b4430",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7alt-cm7-shell-7str-7.png",
+            "name": "Fretboard diagram for C7alt \u2014 7-str root \u2014 Shell (b5 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "76ccb174-44a8-42fc-8c71-7187b1068fb5",
+      "groupUuid": "60db7725-1db7-4ea8-bae1-a88ad0a7c494",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
+    },
+    {
+      "uuid": "ce58e6c4-d34b-42b8-9e57-ee70ba2313e8",
+      "groupUuid": "82e05010-0657-4d6e-ac0d-b27fe41edbdf",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d7f3f8a1-90a9-4574-a7b3-dea6a999cd7c",
+      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "469e5419-294a-44ea-9035-61c464bd5ea5",
+      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "3fdc5e80-97b1-4998-b27b-19a293c5c1a1",
+      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "553bfe02-104c-4814-889f-873aef992a6b",
+      "groupUuid": "b1b6f7d6-e6d4-4e1c-acea-29fda297c81d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "ad546ec1-7bd8-45ce-8db3-77936b0ea822",
+      "groupUuid": "43689250-2088-4234-add1-e4eb2058eb5b",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "2efde63b-e908-498d-95fb-d6ee0f3c1001",
+      "groupUuid": "c6e37d2f-29aa-4f06-8014-ed6243e492c7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "a6037b8c-0ab6-49c6-aabe-acaf4266d7ff",
+      "groupUuid": "9f0e29b7-b07c-47a7-9f63-cc51d0435c6a",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "bb7907e5-4823-407d-bcfc-3b3dcedd2932",
+      "groupUuid": "210f5c70-daf9-4abf-9810-dbc3d42a6edd",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "8597cb09-98a4-4a1d-b63f-cf7538960e16",
+      "groupUuid": "40f3c065-9b2f-4053-b9ad-8243c64aa0e5",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "89d3d083-65ad-4c9a-bc33-39b3932d18ea",
+      "groupUuid": "e6b6aae4-6774-4cbd-8c04-e52ba39c6654",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "36e9c273-47ca-4480-9421-e69fbd9e875e",
+      "groupUuid": "9911edbb-c657-4cf2-982e-ae85cb6794ac",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-cm7-shell-a-7.png",
+            "name": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "dbb357e6-8270-4fd5-850c-5e159b6f42a8",
+      "groupUuid": "496ebb3c-937a-45ee-a626-4ec5102f337e",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
+    },
+    {
+      "uuid": "89904d62-8d5e-4ecf-8970-1cca3679def9",
+      "groupUuid": "402d42bc-1138-40c6-b801-b502b5bf3ad1",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "338a439c-2cc4-40ad-b1d6-e708f3ba3c8a",
+      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "a4adc444-bb49-423e-88e5-1364f8701c35",
+      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "ba1530c6-58fb-459f-80b4-0974ffa16504",
+      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "240b495f-4b9c-4096-b295-d5d3cf374993",
+      "groupUuid": "43e13724-807e-4ad4-acd7-8381718af026",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "d431f25f-4dda-4db5-9452-d1846a44c287",
+      "groupUuid": "99bc9ec7-21b9-4a6b-a7cb-35354e2cbe41",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "e63c6cab-6f04-4713-81e1-d701b91fe9be",
+      "groupUuid": "0be66d93-3392-41d3-84c0-d9cb5a1cc28b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "10769c3e-1714-48d2-8a99-b4fbc391f8c4",
+      "groupUuid": "4e9d4cd8-1090-4c93-bcfb-548338e40cb8",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "c4c2e72a-e86d-4d8b-9583-be2b8dc3dcad",
+      "groupUuid": "6e67967c-763e-4fe7-92f0-23be8cd63275",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "4757491b-219c-494b-b1ef-6f75b434131a",
+      "groupUuid": "0910252b-baae-44cc-9896-ed56ddb12456",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "d93449f9-e555-48ed-ae35-86f417cc3294",
+      "groupUuid": "d5e0d2ec-5382-4687-86a6-88b9ac5eb4c3",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+      }
+    },
+    {
+      "uuid": "88183b60-65e2-4531-a971-5514fff26ca2",
+      "groupUuid": "228a6546-8b25-4594-b4c8-1da550631d17",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-shell-a-7.png",
+            "name": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "fb995954-0cda-425d-a0f0-ac55dd70452f",
+      "groupUuid": "ed3d795b-5874-43c4-b6ce-6b06e93dbc32",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "31acc926-8a0e-4c2f-b642-a1fdd97c10af",
+      "groupUuid": "19115a2f-b721-424c-9afb-2834529b60f4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "f55434b3-c32f-439a-9499-44649bf72509",
+      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "7ef71fb2-20ba-4a47-bea5-62062abab1df",
+      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "76781cee-6dbc-4ecf-a694-042c8158489b",
+      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "d07776a5-ab12-4e7a-b991-e5e6de76cbc3",
+      "groupUuid": "d99687d9-c635-4e94-913c-8f05ead02104",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "307c543f-4a8d-461a-a9fb-224d4657ff5b",
+      "groupUuid": "ac5df544-8181-4b2a-af27-4e574f1147a9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "bbc0624c-5d3f-403d-a9cc-e9327e5c47b2",
+      "groupUuid": "04f11206-d63f-438a-be95-254918be3f49",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "7b5210cd-5dc4-4967-a03e-6da912cc984f",
+      "groupUuid": "bc11be11-dab2-4fd5-866e-837544208c29",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "ab619562-23cb-4459-90bf-a8f4d9286ec7",
+      "groupUuid": "86ff46cc-b5a9-4651-ba1e-29bdeec8e778",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "24964ea4-d437-49c5-8ab0-060d95a6f20e",
+      "groupUuid": "7c384c12-0fa0-4ea4-999b-8429569afa13",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     }
   ]
 }

--- a/scripts/voicing-tags/tally-form-payload.json
+++ b/scripts/voicing-tags/tally-form-payload.json
@@ -1,0 +1,3967 @@
+{
+  "status": "DRAFT",
+  "blocks": [
+    {
+      "uuid": "0c40ffc6-1a00-4117-b478-9e6f1caaa343",
+      "groupUuid": "5ad255f4-137b-4801-a41f-ecad2e0aee6f",
+      "type": "FORM_TITLE",
+      "title": "Voicing-tag review \u2014 pilot (#395)"
+    },
+    {
+      "uuid": "26dab5d8-6313-4d74-85b3-772079e16755",
+      "groupUuid": "bb8443cf-8cd3-4535-9969-a0b78d3c6c70",
+      "type": "TEXT",
+      "html": "<p>Thanks for helping. Each page shows one guitar voicing, the tags an automated tagger guessed, and a fretboard diagram. For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and tell us why if you disagree.</p><p>You can skip rows you're unsure about \u2014 quality of judgment beats coverage.</p>"
+    },
+    {
+      "uuid": "9241de52-fc7f-4cdb-9211-44a352ea9473",
+      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "type": "TITLE",
+      "title": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+    },
+    {
+      "uuid": "dc805d9c-f12a-4cd0-bb0a-96a737192bf4",
+      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm6-altered-6str-26.png",
+      "altText": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+    },
+    {
+      "uuid": "0cd2e828-7a1a-4aad-bdf0-c1342f93053c",
+      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "aba40be8-ef7c-4f72-a19e-c839babadc36",
+      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "c276313e-3365-4b6b-a86e-ffeace37aef0",
+      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "cde62618-2e0b-4506-9218-560b1f8e1c4c",
+      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "cce314ce-4bf2-41c3-b690-ecd4ab26c1c1",
+      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "507599b0-4ac3-468d-a828-a812ab6e7aeb",
+      "groupUuid": "677dd3ef-f4f6-473f-a2ba-4cd0ad6d371d",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "36bb211a-6f5f-4f84-bab9-bdd6c5d97315",
+      "groupUuid": "f692a045-b69a-4b3c-8c64-c815edf9b12e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "43750726-e587-4dfc-af1d-4a7e22316c71",
+      "groupUuid": "38dc92e6-84d7-455f-b95c-454c321b8294",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "b81149e9-98d4-451b-9e6e-470d9b3298b6",
+      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "b33a0941-181c-4446-9044-dd1f37f4510c",
+      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-b7top-6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
+    },
+    {
+      "uuid": "7ff0b510-8117-4651-b924-8855d0b76000",
+      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "aaf62e08-cbef-4ae2-a19a-4fc201bbd960",
+      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "73735b80-d45b-42ab-ad2b-71db51c9d090",
+      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e63c7c64-599a-4cb4-b5cd-aa0a21e60d24",
+      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "044f3136-1539-4013-948c-a87a9a1865f2",
+      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4e16c380-eef5-4dff-b023-7fc5b6835b46",
+      "groupUuid": "1946ffb0-fbc8-40be-b957-a7238a66222d",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "993eaaaf-0d00-4f46-9255-8f6e07287542",
+      "groupUuid": "a3fc5d7f-030a-4237-94a2-9f055d66287e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "19918d02-5ac8-409e-b10b-9410208bd07b",
+      "groupUuid": "4d29dada-99fe-4a57-a7dc-1956ac17dd74",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "e9a35697-b5bc-4071-a88a-df3701c66118",
+      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
+      "type": "TITLE",
+      "title": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+    },
+    {
+      "uuid": "e14033c6-c87f-4694-9932-f352983075e8",
+      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "3602578f-3a3c-456d-ad70-3714d2396a1a",
+      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "da50f515-049a-43c7-92c5-efdec5b10eb6",
+      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "f0837946-b10e-4264-8976-ae62ebea4437",
+      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4b40c83f-bc5b-429f-bb9f-4e77d9df707f",
+      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "47d507fc-dfb2-437c-b169-2e8760d2d9ce",
+      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "cfec88fc-6226-4415-937b-ec972ec850f9",
+      "groupUuid": "1d455bb0-2faf-48b6-801b-0f1c110d399d",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "44dc0684-2355-4b04-a25b-d6889e439434",
+      "groupUuid": "621f4055-e3c7-42b7-b0f4-6375d71a94fe",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "c82acce8-7a53-45b3-830e-f0f752c114bd",
+      "groupUuid": "549c1800-e651-47f9-8b2d-e92720221343",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d623267c-2e53-4ca9-8393-cd8a00494f84",
+      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+    },
+    {
+      "uuid": "674edda9-0685-416b-a744-2f139ff95ce5",
+      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+    },
+    {
+      "uuid": "83d0188b-794a-4f1e-bb4f-5e0198997eb1",
+      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "9f4e6e20-a201-401c-9ea3-9cd7160b7788",
+      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "12f6ddbb-8ec7-4464-b54d-79cfd4b120e9",
+      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "7692d7a8-8a36-41c8-87fc-2fcbea480154",
+      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "df880eac-acdb-40ff-8c80-6b249517c682",
+      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4fb33aa3-2f3a-4be1-8bc2-b09c208d719a",
+      "groupUuid": "1e25d394-3c6a-4327-abbf-5e66c4d1bc2c",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "6120424f-3421-40a6-ab42-617129671e72",
+      "groupUuid": "325f949c-43e0-4bab-9c5e-d37cfc3d0a68",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "02d5f65d-214d-4cc3-8928-4d8ca58e325c",
+      "groupUuid": "73eedec6-6374-4303-94bd-cb7ea0de0a05",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d9b9fa2f-d441-4170-8b24-5c2a5ceac914",
+      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
+      "type": "TITLE",
+      "title": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+    },
+    {
+      "uuid": "0f151d90-b230-4f1c-afd7-0f986d3cb9c3",
+      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm6-extended-6str-18.png",
+      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
+    },
+    {
+      "uuid": "b92969c0-4c68-4560-aad7-2c67f030903d",
+      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "d7518955-34ea-4e91-848e-3549e3c45494",
+      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "5d634695-898c-455e-8820-eb9781920511",
+      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "ec7bc0a2-7c93-4f38-a2d1-008c4f5efe9b",
+      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "2818e5e9-24ec-469d-b75b-5bf5116812c9",
+      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "dc9c0357-688f-46bd-8d3a-92460b314b86",
+      "groupUuid": "6e34fcbf-61db-4924-a1e5-f6e060cdfa24",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "ae9df3f3-569a-4d51-993c-3e0211a6cb08",
+      "groupUuid": "07c8d9ee-b308-4b59-be74-099a82233a1d",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "d670a294-2cd0-4d9f-a48c-e33c093af389",
+      "groupUuid": "5b3b5f20-bc44-44fb-af5b-a4727d560abc",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "695504ff-fe66-4ff3-860f-c18aa79aeda2",
+      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 Fret 1 \u2014 Extended \u2014 dim7 extended"
+    },
+    {
+      "uuid": "b89c4975-1397-433d-92c3-534093bec121",
+      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f1-6.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 Fret 1 \u2014 Extended"
+    },
+    {
+      "uuid": "ba421523-b5ff-4ce4-84f6-2432701fcf91",
+      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "119ddde1-4405-4bb4-8e5b-f21c5ad03db1",
+      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "f703cb9a-8b97-4860-bf9f-bd7d83a71ac3",
+      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "f4b97315-44ca-46dc-9701-2b3c6a0e81ba",
+      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5ed591f4-2876-4caf-9fa2-7b56a15364e6",
+      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "8d261219-166f-4322-9230-3b4906771830",
+      "groupUuid": "a8554d70-bf68-4e08-b36f-981f3376163b",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "16b8bede-afa0-40ad-bb78-a478a02b9d0c",
+      "groupUuid": "540d1d0d-4f73-42bc-9d18-de52e997dd6e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "4eb07632-c246-4c22-bdd0-eed37c281c87",
+      "groupUuid": "ca48c3a2-348b-49a6-814b-0f7fd1b36a14",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "3ed6cf37-7722-419b-98b5-3f273a97d65e",
+      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "6158986a-8a6a-4701-9704-db21c063144e",
+      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-a-lower-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)"
+    },
+    {
+      "uuid": "272b0e56-33a3-4e92-8ce3-950939119b4b",
+      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "4a5c9659-83b1-4930-b544-0b18b3c6b405",
+      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "c53b33b3-8c71-4eb3-817e-97fd4c96a243",
+      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5ad782f0-69d8-4c73-9db9-6074f153c18c",
+      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "ddaeeb75-0cae-4972-956e-256dbd006b82",
+      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "42a239cf-056c-48db-b2e5-b15e5e55b0d9",
+      "groupUuid": "cf6a7974-e1d6-4354-aa60-2fd0f27db53f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "d59aa06b-9be3-4915-9216-a8bd7255b9d1",
+      "groupUuid": "cf4f405f-055b-433c-bfb2-8f1200c69918",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "86e84ea6-dc7b-435a-a782-b7fb591cdd1f",
+      "groupUuid": "e15a78e0-dd90-409c-8176-257ad0ded7ed",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d7227947-3055-4572-8a21-1fce6fef0cb1",
+      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+    },
+    {
+      "uuid": "cb58c681-06bd-4cba-b4d7-ad7d5fea29ec",
+      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cm7-shell-7str-7.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
+    },
+    {
+      "uuid": "44b2afbe-e3c3-40c3-b8c3-c92be82e523f",
+      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "535987ed-808c-431c-91b1-c54980c24466",
+      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "ced810e1-5775-483e-8696-2e543a2af3f7",
+      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d19f10f2-9760-4069-ae66-b68a63e330cf",
+      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bddeb376-3d80-4d3a-a577-13abb27627f6",
+      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "50b3cfa7-066d-4a68-9c56-7ff929bf948b",
+      "groupUuid": "afedb3de-4462-4f86-abe5-1a60f27278b2",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "4767d72e-aeeb-4235-a434-7e2e66af7153",
+      "groupUuid": "83aac471-159c-4dc9-9ece-adde8d7a2c76",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "b24bc649-ad86-48b5-9639-5c7156e4a10c",
+      "groupUuid": "f0d91a60-1f33-46b9-80cc-947bef0bc3ef",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f7b27ddb-c0aa-46e6-8593-280e1675474d",
+      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
+      "type": "TITLE",
+      "title": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "bd0d4fad-fba8-4166-8562-c177b5a1fc40",
+      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-shell-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "6f49deaf-8cd4-4568-9f0b-82760a8b44b9",
+      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "dffc6c87-be39-4d41-8863-4df66aaef04b",
+      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "fbe87aa5-8334-41f3-9319-3fa07517a7d7",
+      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3d8b6cdc-651b-420d-9e96-8cbdb31c3a94",
+      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6a24fa95-cbd7-4a71-b91d-3f3501084ef4",
+      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "1ce6263e-7fe3-480a-a77c-4b497cc5f674",
+      "groupUuid": "5b2ccbb8-eda6-4f1a-a8de-17a97ba4f5cb",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "cf720845-3261-479f-9568-fa0004867578",
+      "groupUuid": "db87245e-a283-45e8-ba06-686ad7d360c9",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "266b9f0c-7137-4592-90eb-a4190d30f8ff",
+      "groupUuid": "ebd60563-9f12-4c68-aaa2-53c22c0c43c0",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "b8f3f244-3bb5-42c8-b03c-3bbba68d4e2e",
+      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "238c34ae-1e30-45e5-833d-a99749787b0b",
+      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-shell-a-6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "dec52203-ca80-4a6d-bbb0-13941d649cb1",
+      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "41af78e2-3154-41de-8207-83d1d6308230",
+      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "bf6471a7-29d6-4500-96be-605cf9bf9d8a",
+      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9939690b-7ffd-4a5f-99b0-4e17cca54efa",
+      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d59178b6-88a9-468c-9bb0-20ce9fef35a8",
+      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "672a1490-97f5-43c3-96ee-db7b8f2fe6ed",
+      "groupUuid": "f3855be6-6472-46fd-a5cb-9d5a90372c7e",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "a2cbf463-8f4d-4542-a45b-d33860f384fb",
+      "groupUuid": "7a52c501-ba1a-4e56-89cd-e273c769d906",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "cb48ed2d-098f-4e1a-8d78-c656b04b7198",
+      "groupUuid": "a1766295-c960-4ca9-accb-47d8e6adc940",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "2653e49a-4c56-4a8e-ac09-2159f8f4312b",
+      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "type": "TITLE",
+      "title": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+    },
+    {
+      "uuid": "e75225a4-902b-48e0-9d12-d7a5ede1c5e4",
+      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm7-altered-7str-28.png",
+      "altText": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+    },
+    {
+      "uuid": "7f94485b-3d7b-46a9-b67a-1c76b1be1525",
+      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "468aff08-f935-4120-beff-af4eb0c91780",
+      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "a088afa7-3e2f-4614-a956-32406ccc3818",
+      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5a2ef048-5882-4f6e-90e6-6455df3aece8",
+      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "a6da2fa9-d5e0-499f-894b-786cc9ff3552",
+      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b3845bf1-b9f9-42a4-b780-3b09506a8293",
+      "groupUuid": "3e144962-4441-4929-a8e8-12a858d7c437",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "3fb309b3-1766-4b24-8bde-7c13c7a9c8fd",
+      "groupUuid": "de0c1dcb-fdb9-4c56-9ce1-860298823093",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "b5a4d9cd-3da4-46cb-a3ff-08592b6aa664",
+      "groupUuid": "44480b32-565c-49e6-8c9d-cfc0ef4c8e0f",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "9dfd6b20-f093-49b8-aa1f-c4d679f2c4c9",
+      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "306f6597-a7a0-4aad-ab21-4009faec9d7d",
+      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-1top-6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
+    },
+    {
+      "uuid": "5fd86c89-a22b-40f6-a55c-4b6ee6761ff5",
+      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "9f6c92b4-4290-41b9-89b2-8288f74a0e06",
+      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "6ce1f6a8-11ea-4bb0-b67c-59dade51ef09",
+      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "db59a909-6b0f-45b6-89a0-38cdd9d01596",
+      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "ffe8cfd4-201d-4616-830f-4803aa355885",
+      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "78649e80-b8de-4ffe-82ef-5ba1131a420e",
+      "groupUuid": "19c40bf5-de9a-4e46-850b-07e12e7b1f23",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "9b8d3c02-fd04-4214-b71c-9157fc2c9df5",
+      "groupUuid": "e34cd2fe-a1b9-40cb-a3a8-fe404cd75129",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "5ad343cf-d67d-45e1-8d69-3c4042a6309f",
+      "groupUuid": "ba698029-c5a7-4732-ac17-c047c6c85ded",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "ce603121-719e-4b9b-ae71-cc4bd0b7ef4d",
+      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
+      "type": "TITLE",
+      "title": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+    },
+    {
+      "uuid": "22ba7a9c-10ed-4dd8-b794-d7019b5ede40",
+      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "9fadad97-39ad-46fa-95e9-f802c4dc5446",
+      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "758a0092-68ca-4689-b8ef-1ccc1a7ef461",
+      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "96bf288f-baed-4024-8a37-17d75412a4e1",
+      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c6bed596-04d4-4854-973c-c4a20aaaa1d6",
+      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "a73b5af3-32d9-46a5-8199-40ea2f70eef8",
+      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "46d17dc0-54c2-47e8-9b98-e42503641b21",
+      "groupUuid": "256613fd-cc0d-42a6-805e-b7705fc8ca9d",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "6d8b58c6-5d03-40bb-9e83-94eec8753e3c",
+      "groupUuid": "d1b90612-d158-4c31-8fd9-f3851376310f",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "4084b415-d7fd-4a18-b715-5ac409594cec",
+      "groupUuid": "57c01c7c-867c-41b9-8417-eec93b149293",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "1a26360b-1423-4f4e-b959-f39bb07a8777",
+      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+    },
+    {
+      "uuid": "f61607ed-71e5-42a2-b82c-34bd5725ed12",
+      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7-cm7.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+    },
+    {
+      "uuid": "514ca0e1-aa11-4447-a183-2de4f481b8de",
+      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "e83b024a-d3cf-4a23-9215-51cba6a9de41",
+      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "92034c6d-4bf5-431f-9a65-687008a124e0",
+      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "19e7b88c-6b13-4749-9fc1-a50652aa07f7",
+      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c7f752fb-ae98-4ccd-bf62-08d5138e6d6b",
+      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "eee36fce-70e4-47b0-aa03-1fbfca9d63c2",
+      "groupUuid": "ba98e64e-6811-43c0-804a-0bafa794d717",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "85e0c33b-738c-4490-927d-95a14ec67118",
+      "groupUuid": "0f572aed-dda4-4fdd-958a-8cddc3708405",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "5836d893-eceb-4781-af39-d2d9c2343d8c",
+      "groupUuid": "73e6b5a8-ea0c-427e-b71a-80288d3e4d47",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "9dee9dd0-73d6-452a-89d2-eb22b76ad557",
+      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
+      "type": "TITLE",
+      "title": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+    },
+    {
+      "uuid": "7fb6ff38-679c-49d1-9479-91674f373188",
+      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm7-extended-7str-20.png",
+      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
+    },
+    {
+      "uuid": "b3b8ed71-44e7-489b-a859-65415ca3ba57",
+      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "7f20d579-c15d-42e4-9e10-bc7c698a9336",
+      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "d1be8de4-64ef-4c4a-935b-52fc58d95258",
+      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "75adba5a-7b10-4099-a4f4-1fb5d7a863e2",
+      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "7db93cfa-0dad-42ae-b55c-1bc7f4250751",
+      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3737a7b7-73e0-4522-95d2-0a4f0bfedb52",
+      "groupUuid": "06430510-b8a8-4e9e-8aad-ae340fa05fa5",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "62b4e713-1f3c-4920-9207-9cab68aeb6b8",
+      "groupUuid": "90ed6530-e271-433e-b0c3-57310244a028",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "08194532-6766-4082-932f-dbe4c7c66ce7",
+      "groupUuid": "346fa57d-0169-4616-aedc-72eeb4a467a9",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d1affda3-23e9-4c34-bca8-8f7e5ea48bb4",
+      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 Fret 2 \u2014 Extended \u2014 dim7 extended"
+    },
+    {
+      "uuid": "f6d544d7-68ed-4a9b-91ea-9d1aab1853a1",
+      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f2-6.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 Fret 2 \u2014 Extended"
+    },
+    {
+      "uuid": "80a5ed0c-b51a-46d0-a89f-3d29be79c17b",
+      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "58d87b5e-3350-4a44-a5ac-464f2dd4b2f8",
+      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "74053019-0275-4507-8281-85bd6990e505",
+      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c9cef4ec-befb-49d0-ada9-1aadaffe75fc",
+      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "ac6c7670-b30b-4f87-9a7a-c9445e0c57a9",
+      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "f1c78e68-b04f-4a67-8f67-ee8b359612cd",
+      "groupUuid": "f3c604fa-b10f-47fc-976c-c74ca440a6c0",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "9fddc19c-d293-4044-9d8f-22524727d472",
+      "groupUuid": "0ab467c8-ebf2-476a-9564-2d103fda0b64",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "43761be2-2fcb-4ace-bb1c-a6b16bf0dba4",
+      "groupUuid": "463e2215-01ef-4836-ae6d-7086246bc0e8",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "ac4a4660-c429-46d6-9776-120962abd35e",
+      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "0d399ea8-14e7-401d-a8b6-2eea507a3973",
+      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-bb-lower-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)"
+    },
+    {
+      "uuid": "c29eda75-55e3-4849-a413-3c24b74b471a",
+      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "26add9fc-3ebe-4cd8-8c1e-091311e029a4",
+      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "a5cdbf0d-1721-48f1-b725-388b4bd725d3",
+      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bfe9f8c3-42a0-4033-9c59-f876c3b1da2f",
+      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "290131d3-efb2-4a56-bf01-f762eddc8b8f",
+      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "173c54b7-62fd-4d13-981e-05ff8caade56",
+      "groupUuid": "e755dc00-f6a9-4216-8161-e4c908c80ea1",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "465be447-c7b1-418b-ba7d-3a9aec00d77e",
+      "groupUuid": "c8eed5c3-b81f-4aa1-9587-77c4379d1974",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "b65aa45c-4883-428b-8780-d8d07d7a749b",
+      "groupUuid": "77047e7d-c861-4cbc-8339-745a383e93a5",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "b0722b10-45ce-4f7c-bbd9-b51b3203354f",
+      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+    },
+    {
+      "uuid": "1644577f-7c71-49fc-8775-7c1e50be98db",
+      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cv7-shell-7str-7.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
+    },
+    {
+      "uuid": "e05e6245-2813-497c-b0a8-73c25755d512",
+      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "af4c00c0-eee4-4e5a-b51c-b26982990cc6",
+      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "dc3c6c77-19a2-4625-af62-ba78a9e37ebb",
+      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9569ee20-d8fa-4a0b-84fb-be7cda1c1068",
+      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "00ac7444-7879-4fcd-9a34-992ea8b74bb7",
+      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "37c0136b-dd1e-4e74-949f-3e291f3ec45e",
+      "groupUuid": "83cf3ca3-3e91-4d67-a6ad-027028e09503",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "580ccacd-1b6b-4874-b876-f89bf5314b5e",
+      "groupUuid": "38daf8f1-5cc5-4268-92f2-baffcc3ea956",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "c42092fc-6d05-49b6-8928-3cf4e14c875c",
+      "groupUuid": "12e80f5c-683c-48ca-a852-0b50ac12f47c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "25b333c3-8e90-4af1-b427-dd0ef0ddf0f9",
+      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
+      "type": "TITLE",
+      "title": "C7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "572c2907-8d76-4862-aded-2b42248cf01f",
+      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "a2362c3b-2f8b-4a69-9bef-eb358b320e6f",
+      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "26501dc4-c8a9-474d-99a9-9d4bd4a6c9fa",
+      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "8ac30034-24e8-4ca8-bacd-2eec398f9ad5",
+      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "03958566-7afe-423b-ab51-71ce3c52bb72",
+      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c553c45d-dba3-4cde-b40b-e03731284b74",
+      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "1c26c729-91ff-4371-bb38-e54e5babdcd8",
+      "groupUuid": "87fc2670-6f51-4dd1-99b1-34ce6e17396a",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "80082bf4-3cdc-49fd-a5d4-3cb9c2f22396",
+      "groupUuid": "d118f94c-4aff-43ab-af17-88da156eb0c7",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "f0fb50ce-6209-4839-8cb5-14cb9f6978ef",
+      "groupUuid": "fd02e2bf-1d66-4af0-b01b-13cf40d7b820",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "218f2455-426d-4d7a-b5b3-abf2c694cc34",
+      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "d56b4f09-b1ff-4672-b6e4-368177288b15",
+      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "e81efed4-181d-4b51-9550-2f27148986d7",
+      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "2f6de2b4-8ab8-471a-be27-ec6e089776ed",
+      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "2388035c-1837-402b-ac80-0dc8e04ad28c",
+      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e97a07a6-73cb-478b-9681-91041c818a24",
+      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "868e817a-22a9-4b4d-b073-46d7ba6c52dc",
+      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "953e2a01-9fe4-4d80-821a-de1ad9f56adb",
+      "groupUuid": "a0b5ad15-b8f8-4fc5-bffb-bf0d78ecb828",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "7e8e64dc-4c18-4393-bfb2-93e6978ab071",
+      "groupUuid": "121c37f2-8225-4d96-87a0-a5a60a2fdff9",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "98b547b4-1ed9-4978-b379-bb513363fa0e",
+      "groupUuid": "0c0786ca-e812-47db-837f-1ba8c7e18d48",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "5fee96fa-3c66-4aa8-a2e7-23637bcafb5f",
+      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "type": "TITLE",
+      "title": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+    },
+    {
+      "uuid": "02c5a1d5-72e3-4cb0-9cfc-1b9e2c22dc85",
+      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv6-altered-6str-25.png",
+      "altText": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+    },
+    {
+      "uuid": "3eb31a58-b3e9-41f4-b2b8-78a033bd3635",
+      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "bfcf5fb0-ac5d-4b77-be0d-d783236a5384",
+      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "01e00aec-3975-44e0-8df0-1a9e6c9bddc1",
+      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3454ed97-3866-4f18-951f-0c7a6e234e9b",
+      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "51979008-ab50-4d44-ac6f-634ca67271ae",
+      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4f1ed7bf-47ba-4565-9465-9a347df68e2b",
+      "groupUuid": "3d9c15ff-49b7-4060-95a2-9b9e3a3b348e",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "ee61bd1b-6cb0-4861-920f-9543dcb25c1c",
+      "groupUuid": "88ae5c0e-351a-4832-8ab1-a32ea885b46c",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "cd04e6eb-198b-4e69-809f-d6d71aa3fd8d",
+      "groupUuid": "f3c355bf-b0c2-4d12-9de2-a48f4158a81d",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "aa4bc9b2-9edd-4ef0-8bc9-78d3829d8989",
+      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 10 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "fe37c064-df7e-42f6-9e85-adcc0f26b671",
+      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-3rdtop-6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 10 \u2014 Drop 2"
+    },
+    {
+      "uuid": "55f3ca6e-5dd0-4169-8424-245d645e8c51",
+      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "053e9051-065c-4048-b39f-07bff28b2356",
+      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "f3703285-12c0-42e1-aa78-3d189f9f021c",
+      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "1a71ac8b-f6b7-41a5-8623-7470f6483179",
+      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b23ac411-d4b6-48ff-a63e-9bfc1067819f",
+      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "f3d0d16d-9df3-4a3c-b062-a847eef9adcb",
+      "groupUuid": "2a2263f1-2a9a-48e7-8895-e0b95ba43f46",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "ee8cac93-a3ed-4899-be30-249fac034e8c",
+      "groupUuid": "d554026a-d61f-463f-88ec-ec5b9808aa9e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "d49bf708-025a-443e-b4a4-2df946f8b171",
+      "groupUuid": "9f76d292-acdb-45c4-962b-402504a9992e",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "cd991eb3-4641-433d-8dab-53b2116d12c0",
+      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
+      "type": "TITLE",
+      "title": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+    },
+    {
+      "uuid": "71ad91ae-db35-403f-beee-be1facc72f4d",
+      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cm7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "bbd78b2b-f732-4590-a04e-aa3e1a286c37",
+      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "c80ee2ba-16d3-4809-b9da-23294752bd6e",
+      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "18fdc133-6c06-44bc-bcd4-d6c9ead77ccd",
+      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c02f7dad-b635-4473-8bdd-71974a21c436",
+      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9d9ee1e2-0a6a-4596-a249-1123738d7891",
+      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b8c225ac-e10b-4ac0-8e33-61037de956cc",
+      "groupUuid": "29067ecf-ea88-4196-b2f4-65b4be7f8b0f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "fdf79f25-c6c3-4b3e-9584-f630b08c4053",
+      "groupUuid": "f3b8ac56-d172-4510-845d-3c779dca0c67",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "32622073-0ce3-42cb-a8c2-0f2fc25536e4",
+      "groupUuid": "a722cb93-4b42-4d61-9615-14e11fc28908",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "79378017-4799-492d-8bf6-88f5a601db0d",
+      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+    },
+    {
+      "uuid": "357581d8-af4a-426d-a6f4-3dadf6017898",
+      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+    },
+    {
+      "uuid": "7aa20b82-16b0-4f8c-971b-c89532ebd85e",
+      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "8fc6fcdc-3793-43c6-9f72-3fd3a693eec8",
+      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "b4ab1445-d527-4e46-a8c1-5002b555a863",
+      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "313a9187-a1af-4418-b554-d5a568f368ed",
+      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "52701873-33af-4436-9866-e7eff38fabbb",
+      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b517b4de-3e03-4a48-a3bd-ead6a92c5199",
+      "groupUuid": "7aa19bfe-c3f8-47a4-bb48-8caf30d811c4",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "768499da-5202-4c93-b246-c6e314bf40eb",
+      "groupUuid": "ab950fc0-a516-4914-b8e8-1f1fdf5229a6",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "59065509-8749-4c5a-9931-00a5f5e866a8",
+      "groupUuid": "81c458a6-dc42-4c7d-856b-90b460ad9e76",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "37348e24-94be-4039-9020-1eeb41a1d1a7",
+      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
+      "type": "TITLE",
+      "title": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+    },
+    {
+      "uuid": "0689e9be-85e2-40f6-8760-d0e5e16f9d91",
+      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv6-extended-6str-17.png",
+      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
+    },
+    {
+      "uuid": "c6e37d0c-6ba7-4f30-bf83-0c59c60bce24",
+      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "5e08bfd0-7fda-4c7e-996b-3ee0ad14ea3d",
+      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "664b46ed-4d48-4f04-aff7-480861e2084d",
+      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "08c5c8ac-539d-4c73-9f7a-a56091f792a6",
+      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "88e876cb-f615-4de0-80bb-879c596e37e7",
+      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "80200bcc-db9c-4979-9dee-5a41cc893cb3",
+      "groupUuid": "c993170b-6c46-46f7-b599-0005632d9bb5",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "c4089129-2330-4ee7-a686-8c5f946bf465",
+      "groupUuid": "bd0ad227-8a09-4fb8-a08c-ba170daa4c60",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "ccb9ac4d-2313-4fb0-a1da-9e7aa7c7e84e",
+      "groupUuid": "8707d525-da19-4a7e-9855-767f161e2fcb",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f814c69b-9c38-4893-93b0-ce13c9309fb7",
+      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "type": "TITLE",
+      "title": "C13 \u2014 Fret 2 \u2014 Extended \u2014 dom13 extended"
+    },
+    {
+      "uuid": "e74633fc-1384-489c-b6d3-e22fd4cb97f5",
+      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f2-6.png",
+      "altText": "Fretboard diagram for C13 \u2014 Fret 2 \u2014 Extended"
+    },
+    {
+      "uuid": "63879f62-37cf-40f9-bc45-32a8504c4c06",
+      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "1af4c108-e7f0-45e8-8b4f-74d675089089",
+      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "fe9cff38-c532-42fa-8ac7-1b5361bef908",
+      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "0faa4700-c47b-4a0a-930c-8c44adbef5fb",
+      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "7d3958d1-3200-4b90-aa02-25a8fbfb41d6",
+      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4fc9b7af-3033-4e72-a4ee-7b07fd5cfc1a",
+      "groupUuid": "50f1ee99-df58-4b46-9cc6-9cff7655d4ff",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "525ec07b-1296-47dc-b6dc-24d732d442b0",
+      "groupUuid": "e2b59c7f-1414-4629-ba8c-0a61a2983751",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "dad24204-9ece-489d-8951-0f8cbd40e7fb",
+      "groupUuid": "2c944705-dfa0-4755-81a7-42b605c888e4",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "287d459a-d3a8-4c49-8c89-89d19eed6a16",
+      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "852e1746-4498-4f64-a14d-9da445bb2406",
+      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-d-upper-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)"
+    },
+    {
+      "uuid": "9f483536-442a-4ba1-8658-57f262577804",
+      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "20702ecd-76a1-493d-a309-3a85e58cbcd4",
+      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "0bf4c9b8-45eb-4cab-bfdb-0ddf69022964",
+      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "89735065-c650-41a8-a979-b436fd0b512e",
+      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4c8eb53f-52a6-4681-a02c-e98a1ebf02d2",
+      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "a3ec6e74-e868-44cf-9dd3-90eb47725a34",
+      "groupUuid": "721d69d8-2a4b-46df-a08c-be0eec66d62f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "8e6857c2-db16-40cf-8c74-9e8278766e95",
+      "groupUuid": "e9a81313-1ee4-454f-a086-29de029a17ef",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "7c6e5af2-6eac-41fc-86e6-afa49b9108fb",
+      "groupUuid": "2057b940-1097-4f10-a217-645885b60ece",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "2f5f7349-db4d-4d88-9eb7-bb59ceda495d",
+      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
+      "type": "TITLE",
+      "title": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "19a34b88-f930-40bc-8559-d5d109b557f7",
+      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-shell-7str-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "6400ba0b-cb7e-49fd-ae7f-43e596a2a58a",
+      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "429df7d8-99a7-4c18-8bb0-b6a3fdcda833",
+      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "d7c14493-3ca8-42be-ad1d-8d8618d4df2e",
+      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "138caade-148b-457a-a1d5-6ad6684c2324",
+      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9daaa065-108a-490c-9877-0a595cdab2b9",
+      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "65720faf-f8ea-496b-802f-2e2603c4e74f",
+      "groupUuid": "6aaca151-acf1-485f-8f7a-51697bde034e",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "1f07089b-70cb-4b23-9c8e-36e3c266cba8",
+      "groupUuid": "f58819aa-eb9c-48c8-b6c6-02bd155dd4e1",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "25a5e488-2665-401c-9f0a-e6a9d93991c9",
+      "groupUuid": "79129a45-055f-44a5-9713-55cd722de8e4",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "a8c7de1d-8055-4cd4-b0b7-c8fc59c80a66",
+      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
+      "type": "TITLE",
+      "title": "C7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "df4381ee-c670-4098-abc7-e751571d2130",
+      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-e-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 E shape \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "09a79f85-14c2-42c2-bb9e-44f22555ffb6",
+      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "07935a10-843c-4516-b0d3-5d28a83c4c96",
+      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "62a30ede-db71-44c0-a422-91778213ec47",
+      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e5060334-2040-4740-989b-31a9d83d859c",
+      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "45307e52-b53f-482a-8242-2f3d85b2cf8d",
+      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5ed8f79e-8e5f-48aa-bcbb-80bbd8d8fd67",
+      "groupUuid": "44e45643-ba2b-460e-a5af-0b5f481b230c",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "9043978a-52e8-46d6-8dfc-929791ac9e9f",
+      "groupUuid": "4b635864-7a12-44d8-8188-c7e667fa0716",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "683b5203-49bd-43e9-ae72-a5b86314cce3",
+      "groupUuid": "6c0817b9-b229-47b7-aac1-358f97f9a95c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "ddf17afa-3e2e-438f-89c2-52bd41948660",
+      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "6bece04b-552b-4ca3-bc0f-23d0886035fa",
+      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-e-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 E shape \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "a1bcc03b-f712-42ba-8bd4-e60db29c8355",
+      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "612dd531-2dab-4519-b2a5-c8c13a2c3be6",
+      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "2cbd48b3-5ef4-4d35-826c-4aa318b59e49",
+      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9de0323d-51cf-45fe-a0c6-d4910198ba86",
+      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "db4dee78-9973-4363-8166-d160815357b5",
+      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "28370580-8839-44d5-b7c0-a70539b4a479",
+      "groupUuid": "17526745-6ef0-4c7a-940d-d8c2d3702f1b",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5202a849-1275-493d-98e1-f732f185ee9c",
+      "groupUuid": "3e97a0d4-2d45-4ced-8880-21977a4d1e2a",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "b18a1c2e-35ae-436f-aa91-a686b9b98cfe",
+      "groupUuid": "406320bc-47fb-4c27-976f-3019e5770114",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "55fc101c-8701-4c16-9df8-90bbbb612888",
+      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "type": "TITLE",
+      "title": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+    },
+    {
+      "uuid": "225c4ec2-a3de-4a21-97bd-5fe2ce0b07a3",
+      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv7-altered-7str-27.png",
+      "altText": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+    },
+    {
+      "uuid": "5307c100-0703-4206-9c6b-4cd7997e4e65",
+      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "69af7813-df13-4b7c-8c45-45332945bb4d",
+      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "cfa7ad9d-b53c-42d0-9846-7122c9d91f12",
+      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bf0afe32-e5d1-40e8-84f8-ccdd83c8432f",
+      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "69b9187c-e97b-4b01-ba06-ed9e4e0f36b5",
+      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4b9bb1da-301a-42e3-b37d-521a99213e6c",
+      "groupUuid": "65ae06b6-32ee-492d-9bf6-e961f654163e",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "0878dafe-5a3d-4fc1-8918-677e110a89df",
+      "groupUuid": "e22d9f40-7c24-4066-9aa2-272e41965ba7",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "9b8f8b51-7fae-4ef5-a71a-82c204d37dd1",
+      "groupUuid": "f80e2dbb-ee70-4244-bbf0-be8cc011df5c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "756a579e-c7a3-4fe7-8dd2-c07c4fd7a357",
+      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "0f0d0d19-dcaf-4dda-a872-6f7429a5bdea",
+      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-b7top-7.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
+    },
+    {
+      "uuid": "9b0b55cb-6266-47c3-b185-b5efd93f6885",
+      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "257c0f14-3f96-4ea1-8ec5-688f517936fb",
+      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "9ecc7cb9-37a8-497a-a08c-83fec03ab998",
+      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3b69cc3f-5485-482d-b73f-b8c9902e1868",
+      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "be3cb1e3-e149-4ae3-9423-16b55847f728",
+      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "47d2be8c-aaf9-4db0-838e-a26858e19022",
+      "groupUuid": "8588b4a7-9f07-4b39-a36b-139000a4b5c9",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "d07f02ff-032d-4429-8d2a-ffaf64f9df1a",
+      "groupUuid": "e44a6fae-9501-4173-8870-8edb9db83cdf",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "00ba9499-8152-4c07-96e5-3aa18536e552",
+      "groupUuid": "61f00353-0140-4f0a-a81d-91362904983c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "1a4becb8-2da6-4d38-a2ea-11506dc80d2d",
+      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
+      "type": "TITLE",
+      "title": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+    },
+    {
+      "uuid": "c81e26b7-b508-40f3-8770-9767848e1b85",
+      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cv7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "8e436b8f-89b3-4403-97c6-9e8dc9215101",
+      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "f0835501-3fc1-46f3-9f39-5bb302495558",
+      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "d43785b6-a408-470d-b4d1-2a0d9a0f28c6",
+      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "25e3a1df-edd2-4d1d-8e84-e1ebc2603dc8",
+      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "af916e45-a325-4693-9595-9c147326dc4e",
+      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "40712420-89e4-42ce-adc9-3c5fb2fb5f9b",
+      "groupUuid": "0232f786-4bd7-40ad-99a6-633fed50e3b6",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "7bb92140-b87a-4038-bbe3-f07c6d108a8b",
+      "groupUuid": "d085a76f-95e7-4700-9829-3d64ab8c2833",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "1fff0dc6-bb43-4a1c-8ffd-8c9e04ea612d",
+      "groupUuid": "246cd770-7d49-475f-b513-bbdcc3428eda",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "10a01755-b9a5-44bf-9cd9-ad93ea0b778f",
+      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+    },
+    {
+      "uuid": "afed22d5-5d04-4e15-af04-e8b688b1f29a",
+      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+    },
+    {
+      "uuid": "a01583d0-d549-4c19-8d25-ba25d65775ed",
+      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "37f72730-eed8-48a6-a797-24763cd10c67",
+      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "4300f613-020c-4f77-8031-40d899230210",
+      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "45b1cbfb-6bb3-4f2d-b876-1579d187c592",
+      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "89786d00-9f4d-4dd3-8a2a-49cb8aeef664",
+      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b3c54dfa-2b58-4e21-9c0d-4193f5ca3fc7",
+      "groupUuid": "17b19449-821f-4d31-8b2c-df636a63422f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "475f341c-c6af-4c15-959c-9f63f5d038cf",
+      "groupUuid": "bfe4bd45-c721-45b2-9075-664747f06a79",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "71dfb8df-045d-4125-a828-38f3d2e4423f",
+      "groupUuid": "41725abb-1ae3-4920-b756-3d0f43cc040b",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "9eab1645-b716-4e7e-a702-fcb84de8dfe5",
+      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
+      "type": "TITLE",
+      "title": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+    },
+    {
+      "uuid": "bc99c817-cd82-40ac-b188-71e155c72b89",
+      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv7-extended-7str-19.png",
+      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
+    },
+    {
+      "uuid": "72dca44d-e96b-4284-87e7-0dce4ed789df",
+      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "315fbc82-9b46-4370-a5a6-62d2ef82e2c7",
+      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "d5287e6e-78af-465e-a8aa-661c94c65444",
+      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d59e31ea-505c-40c8-ae88-204c2105ed5a",
+      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "7688b107-d174-4c47-8144-3fcdfa7f2a60",
+      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d7d82079-eb70-4801-8cbf-529563c06934",
+      "groupUuid": "89687b3c-6893-40e7-b888-5d1b3fb7d0aa",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "23f6cec6-c94a-4b71-89c5-6ee06fc9137e",
+      "groupUuid": "e88ea530-3fdd-4208-a376-0deb3df5cb4b",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "32961283-b398-4699-9793-aa6fc2614b2e",
+      "groupUuid": "d9df36d4-ce88-4d58-ae93-a79b1c41c024",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d4d45bf6-69e9-4722-abad-4ef6025810fa",
+      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "type": "TITLE",
+      "title": "C13 \u2014 Fret 3 \u2014 Extended \u2014 dom13 extended"
+    },
+    {
+      "uuid": "e5bbedc2-6f77-440f-bfbb-4223483139d0",
+      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f3-6.png",
+      "altText": "Fretboard diagram for C13 \u2014 Fret 3 \u2014 Extended"
+    },
+    {
+      "uuid": "435b816f-db94-490b-83ce-ace6384f6ef0",
+      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "3dd0a387-2b13-47ca-bcf9-75b06ee75368",
+      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "40363cc8-555e-4b5d-8cba-155be8b2f752",
+      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b1b5343a-370d-4670-b6ec-0fe3fd327137",
+      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "2df8188d-7a70-4a67-afaa-a9d5bf31db4d",
+      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "67a9cc3f-43b2-4c0c-b177-2f96ab7d4235",
+      "groupUuid": "6dc237a9-744d-4698-bd3b-9669cfe28656",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5c18081d-bb05-4618-8fae-5afc1bdc1908",
+      "groupUuid": "2cfefaf0-17f2-49b1-9237-9f4d06d62162",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "6d91a078-d6dc-4460-9176-6f15604d4fb0",
+      "groupUuid": "ee729eb0-04be-4a38-bec7-fbb386c2304c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "349d4223-46cb-44ba-8a9f-59710dad5cc3",
+      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "7ea93e42-9c49-475a-943b-0e5466a37c1a",
+      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-eb-upper-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)"
+    },
+    {
+      "uuid": "57e01598-fc07-470e-b763-b8a8bee9c78d",
+      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "1badea63-dd8a-429b-bf9d-fd1a96f192ef",
+      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "c5f012fa-7c0a-44ed-b556-6d085672ec66",
+      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "15ad7860-7a0a-4909-be67-e7aa6d44b8b1",
+      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "48b8b349-6c90-41dc-8b80-cc8abd9909d3",
+      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "36d8e845-5f1b-4ced-9eb1-436a47bca1b5",
+      "groupUuid": "6cfe9126-1606-4b5f-a422-b54bd7076f24",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "98a0ba9c-dc2e-4831-83f3-1db98b064a67",
+      "groupUuid": "4fac16d7-af2d-4e0f-88e8-5a1364088e87",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "f7fe6c29-9e1e-419d-9161-2212964f8878",
+      "groupUuid": "8d04dbd4-c630-4a76-b317-0f500114e7a2",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "a8af50d0-b2aa-4731-990f-054ebcf1e200",
+      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
+      "type": "TITLE",
+      "title": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "1a30ba61-c119-42da-a74f-94534db0d8fe",
+      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-shell-7str-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "2df31218-1523-46d5-9ac5-31589035069b",
+      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "a31b42d3-ead4-491f-a6b4-a8f633da745e",
+      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "2721f571-fb44-4c31-b854-211b584bfbe9",
+      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6714b741-fef1-49fc-a892-5a2c33c9a8ed",
+      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "318312f3-0e78-4cc7-b9fd-1c34e26f78ff",
+      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "1cde45b7-d3c4-49e0-bd66-46ad507fd896",
+      "groupUuid": "93ff54b3-557e-4b31-b3c7-49d1d2c0a8b0",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "acb9a0c1-bb65-4915-88f2-7917890a5e51",
+      "groupUuid": "9cb5784d-9dcc-4497-ae75-456c6e828d17",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "50913830-61fa-4b29-a7ce-1ccb3a17d1ca",
+      "groupUuid": "c5d1a5f6-16e9-41cc-81db-654c443dfc1e",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f1f281a8-b398-4002-9133-38c89a3e1901",
+      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
+      "type": "TITLE",
+      "title": "C7 \u2014 D shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "a791522d-bb38-4c66-b054-eec7501626b7",
+      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-d-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 D shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "5c19fd15-54cf-47e6-bbe7-6ec44a15776b",
+      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "7fb3b944-4033-403a-b048-cb8f67669611",
+      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "c51b1f91-0396-43da-b85b-20ac42b53756",
+      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "910f95a2-0645-4ea3-ad26-1b87c342e0df",
+      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e3cba564-26fd-4702-b974-ad4119fbb697",
+      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "2f970bdc-7421-4271-8e6b-4e5f5d99478c",
+      "groupUuid": "97abf557-f69d-4eed-8752-e6d5bc7f49dc",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "59bb51aa-3344-4128-833e-1a4f0627d826",
+      "groupUuid": "02805b15-8376-4944-8eb0-0126064d12cc",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "de0caac2-88ce-4335-ab18-a863c7cb3a43",
+      "groupUuid": "8ee6a9e9-000b-4e7f-b938-399c34327d16",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "57ddf894-e162-40fd-8932-4e7c1d99c637",
+      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 D shape \u2014 Shell (7th on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "370376e1-0abf-4824-b180-0a19926e1ba8",
+      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-d-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 D shape \u2014 Shell (7th on top)"
+    },
+    {
+      "uuid": "e8a1d145-f376-4486-a9d5-4a92a0092725",
+      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "a2f88aeb-ade1-459e-9c83-73b77273fd5d",
+      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "fb240565-9ff7-4cb9-824e-7818248d5795",
+      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e2b83d70-ac2e-46e3-be9b-8ed24ea2f532",
+      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9f26087c-5275-49a0-a64a-fe1badd1c767",
+      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "67303188-7c3a-4b95-986c-88ff11aed4d6",
+      "groupUuid": "854a2b1e-0497-4962-8b3c-13eba5364ccf",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "0a4d24fb-cfba-4678-9bff-f3c6c0982b00",
+      "groupUuid": "31773d14-1762-4025-a789-f3e8f5f45ff0",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "e76ef653-ac42-4a2e-b9af-63d47b92fc07",
+      "groupUuid": "c67b9065-d279-4c43-9ffa-bffdcacfc14f",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "55ff35da-e6cc-4590-aeb5-da21d1f41cea",
+      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "type": "TITLE",
+      "title": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top) \u2014 13sharp9 altered"
+    },
+    {
+      "uuid": "f31fc6e6-57e8-43df-bd32-e1bbaf8bd299",
+      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13s9-cm6-altered-6str-30.png",
+      "altText": "Fretboard diagram for C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)"
+    },
+    {
+      "uuid": "3de586ac-bb54-482f-81f5-a5c90c1dab40",
+      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "51afdcd3-f827-4b56-81ab-8aa435dd3bc6",
+      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "966e9a29-d96f-438c-8985-48c3ecfb59f7",
+      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "318db960-f91f-42b2-ae76-5d4496a266e2",
+      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d5d03872-4935-4e18-a990-ae78428d7683",
+      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c34cd776-ecc8-4ced-a35b-71fee5efc8dd",
+      "groupUuid": "05026a47-7afb-4335-9864-eedcd0dd85fd",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "9ea0f0dd-ef10-4cd8-a138-71efb2b4a707",
+      "groupUuid": "9d66a7df-2adf-4416-b000-89bfa73539e7",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "48edbc7e-1512-4a86-83da-3da2158322c5",
+      "groupUuid": "7f94e18e-bd3c-472f-a29c-6836b2819852",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "1bb91d0a-0083-4add-8a82-75841f77e46b",
+      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "ebfd9b59-b554-447b-bb5f-2e948769234c",
+      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-1top-7.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
+    },
+    {
+      "uuid": "b6d8fcb0-0cd0-4490-aa26-b120722e18c9",
+      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "89f25c3b-39ca-401c-8244-70aaef21f609",
+      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "23dc80aa-429e-42fd-a82c-13b213cbf4a6",
+      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c6a2cac3-3b11-451c-9b97-f733ec701b37",
+      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "dee6c2a6-6fd3-4b8b-b82d-268b0e349641",
+      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "0ff19939-5921-4ddf-96c0-6bf44c064010",
+      "groupUuid": "bbdd8101-74d8-40fe-9300-f97c24891c81",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "0fff037d-aa78-4ff1-a2d9-d26313bac4fc",
+      "groupUuid": "7264e2a1-4d35-460c-ad2c-c76245623720",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "052e861d-a856-48a6-b4a7-fd1e5f620843",
+      "groupUuid": "66397392-ef3d-4818-b037-a58658984d04",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "bb078603-99ab-4b09-8a20-26dd2a2ae617",
+      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
+      "type": "TITLE",
+      "title": "Cm7 \u2014 7-str bass \u2014 Drop 3 \u2014 min7 drop3"
+    },
+    {
+      "uuid": "9eff256a-f236-442a-800a-a61f433fd2cc",
+      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cm7-cm7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for Cm7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "96039c62-7fd2-414d-a7c1-263e8b017923",
+      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "5dd8dfca-8359-4532-b9a7-c0bc10878038",
+      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "af97a963-cc8f-459f-880a-fb6a32136ec0",
+      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "73cf399e-2093-4181-82a6-ab3dc34389ad",
+      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bdf628a4-ebf9-4709-8ccb-ec73f7da31f9",
+      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d22c13ac-6625-45b7-b9b5-a39631b99321",
+      "groupUuid": "97b6fa6e-23ee-4df7-93af-898ff48bff90",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5694c323-053d-42ff-ad2a-6c0c3120fdde",
+      "groupUuid": "3833a370-ecbc-4a05-9c94-b827e0581c19",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "c2cd7c84-84db-40eb-b623-f68dafbc048b",
+      "groupUuid": "a3638690-425c-4a40-9dc4-23d08d81f8ca",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d74d77b1-d65c-4f35-96f0-e8617990c98b",
+      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
+      "type": "TITLE",
+      "title": "C7 \u2014 A shape \u2014 Drop 3 (5th on top) \u2014 dom7 drop3"
+    },
+    {
+      "uuid": "94daab2a-285b-4688-bdb4-d8bb7a95b673",
+      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-drop3-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Drop 3 (5th on top)"
+    },
+    {
+      "uuid": "9f8e435a-4da8-4fb7-ab7f-0805503281df",
+      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "4c183f33-d0b5-4d56-993b-bb7375d7170f",
+      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "9f889f66-1487-43cc-b310-1b30181baabc",
+      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5a21fe6c-b3f1-45aa-8406-8abf01564119",
+      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "29aba4c0-e17e-45e7-b362-a1884499db61",
+      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "60638d71-0c04-4ede-a21a-736c9c464445",
+      "groupUuid": "a322ee8e-004e-4146-ab83-a2228ba2ece4",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "4294161a-59f0-479f-a619-187caa4ab548",
+      "groupUuid": "11a419b7-b92b-43d1-ac66-109b698b227c",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "fd299442-d19c-4275-932a-e927c9deb998",
+      "groupUuid": "6ae51c8a-47b8-41c7-9d9f-ceb4fb574f85",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "89c9e374-85a8-494a-a573-c89617f637e0",
+      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
+      "type": "TITLE",
+      "title": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top) \u2014 9sus4 extended"
+    },
+    {
+      "uuid": "eeccf321-f1b0-4667-a99e-0bbd2deb620f",
+      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c9sus4-cm6-extended-6str-14.png",
+      "altText": "Fretboard diagram for C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)"
+    },
+    {
+      "uuid": "21d02841-96e2-4919-bd3d-ba3fc9edd74c",
+      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "c2091452-d196-4764-8f77-ee6527ffa1f6",
+      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "7ceb6c55-6bc0-4ce3-9fc3-97cce28a9974",
+      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4cddba25-8e5d-4095-a0b7-c4937e1ce638",
+      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "a7581be4-8d50-4107-9367-83903e8b8e2c",
+      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "77bc03e1-825a-4f8b-890b-a2ed51f33813",
+      "groupUuid": "2dec5983-cebe-4201-a82a-781381fe1e0b",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "dc050f9a-c1e0-43b3-9b28-c5d4f4793758",
+      "groupUuid": "5b9812c3-0950-49ef-a462-f71088084739",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "7cd14cc7-e44a-4651-9742-3b0b814c5d4f",
+      "groupUuid": "d6da7167-93dc-4896-acf5-f622ee9bc3a6",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f0b9028b-5ad3-410f-97da-3e114c6c6119",
+      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "type": "TITLE",
+      "title": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top) \u2014 dom7b13 extended"
+    },
+    {
+      "uuid": "eae8bc8d-6163-44ae-bdc7-747a1d3b2d31",
+      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7b13-ext-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)"
+    },
+    {
+      "uuid": "7cca705d-bc30-4f8d-a5d8-a728f0435c49",
+      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "066e0ac9-79a8-47e4-99de-fcdd39957a54",
+      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "8290f569-c603-4349-a66e-d83540e44dd5",
+      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e62efc35-3621-4d70-aed5-9540406d00e3",
+      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "20210696-5cdb-4431-93d0-e98ce5871b52",
+      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bfdb7ecd-a7b8-43b2-9a5c-56e973f64624",
+      "groupUuid": "295e9bb8-0425-476c-b893-884976c376ea",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5d970d2e-1248-4799-8781-582989375347",
+      "groupUuid": "962bb09a-4e29-4f38-9105-01dbc3751b49",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "a0176b80-da31-4dfe-9ca1-5e9efb97b580",
+      "groupUuid": "857b0d05-c085-43f5-bc33-8ea8d607a412",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f6e09cbe-fa2a-4300-bdb6-eaf8104ec617",
+      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "e424249b-2889-40d0-8280-cb6846a8bbe1",
+      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-f-upper-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)"
+    },
+    {
+      "uuid": "2b1b3df5-994f-46f8-b3f9-c902d254b9ae",
+      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "4e0ddd14-be3c-4c1a-a36a-76834993a806",
+      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "7b8284c7-a120-4c17-a25f-00dd19e1a9c3",
+      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "dce3d3e7-feb1-4b52-80ab-58f0201facc9",
+      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "177066ed-0d9e-4cc9-bab1-196512fe288c",
+      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6dadb013-12d1-44f1-99c1-1860e23078ea",
+      "groupUuid": "b3b89b5f-0f52-44b0-92eb-e9b06f02a05f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "b3096b33-a3f8-45a7-9611-91a7c3aa08b7",
+      "groupUuid": "69a8ddd3-1957-435a-b8f3-36b318446f75",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "3d08e72c-1f48-4e76-b91d-7b6c17588640",
+      "groupUuid": "6d4ba774-ecb7-4745-a646-afff792d5703",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "0ac282fe-52b0-4a61-b4b3-50ba88890517",
+      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
+      "type": "TITLE",
+      "title": "C7alt \u2014 7-str root \u2014 Shell (b5 on top) \u2014 dom7alt shell"
+    },
+    {
+      "uuid": "4f33ff9b-383a-4f0f-ab90-3f3dce62faf3",
+      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7alt-cm7-shell-7str-7.png",
+      "altText": "Fretboard diagram for C7alt \u2014 7-str root \u2014 Shell (b5 on top)"
+    },
+    {
+      "uuid": "96e071db-45a4-4673-bbd3-d3058410f08c",
+      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "563310c4-7939-48c6-a5ba-c46de7ddea93",
+      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "5a307b16-7c57-4bfa-8bb6-8e4897f38d65",
+      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "2c61c1db-9bbf-4659-ac58-8783a0d0e580",
+      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "444c15cb-4d39-4bb4-abf6-070161509dbc",
+      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "0ab5fdf8-5931-4854-8615-71fa50b626b0",
+      "groupUuid": "1d3cc254-8140-4fce-8ec0-c5f884045c71",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "26f5688f-36c9-498e-80cb-5d4f582b8704",
+      "groupUuid": "cc5f4a7f-ecf5-487b-8798-a034c989977e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "67fd6f51-1033-4aa3-8eb8-f79d3cf51ba3",
+      "groupUuid": "cf44c64b-26d2-4851-8794-0702d3a2a80d",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "351364c5-da6d-4dfa-8fc1-08aeb0d86399",
+      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
+      "type": "TITLE",
+      "title": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "df5d4ab1-4ee3-4da5-8dbe-fb6321768188",
+      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-cm7-shell-a-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "b66636e0-b7ff-4bd3-95e3-8e3f6876cfeb",
+      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "fb9d3e57-222f-4862-8a29-09bf660dd362",
+      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "71307d7d-e1fe-4c91-adbb-368b26a067ec",
+      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3167fdb3-7106-48fa-9d15-65008e4ebad0",
+      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "eca4e1a3-3fe9-4c13-9d0a-7a149433d71a",
+      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "65eea098-1c44-4fb1-939a-6c4bfae76b4e",
+      "groupUuid": "0a2bad26-e332-492b-bc27-088b56835ca5",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5fa0158c-6fcc-49a2-bfed-19a2d6b11064",
+      "groupUuid": "16432b0c-c374-4f2d-8961-b6dfb2c3dc1e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "e23ef9dd-6bda-464e-8750-a9b0a81ce335",
+      "groupUuid": "bac8e138-b707-4423-b670-a0fa10a35997",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "4c8617b1-d6f8-471d-a7f3-9e0740063e20",
+      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "e2cc6918-3d7f-4cc3-9371-da81ebdb2641",
+      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-shell-a-7.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "252ffc5d-6b99-48a6-9c23-a48214d45681",
+      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "2b1cfa5e-365a-49a1-98fc-ace303c311e3",
+      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "b665bf70-684f-4bb4-a1ab-c4124faf410c",
+      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "f9ba926f-0e0f-40dc-ad64-79c09c6cd6e3",
+      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6ac32c1f-0364-4b02-98b9-478ebf10ba02",
+      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6892e91e-e4f1-4db5-b954-81b75c53527d",
+      "groupUuid": "7973a3dc-7819-4bbf-9b25-dad30f829a5b",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "637b1619-6712-416d-9822-abee1e3cc5b0",
+      "groupUuid": "96d9c470-e42b-4cb5-801f-fe2975f81cfa",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "878ddfc6-4203-4d12-805b-8798f1536fc8",
+      "groupUuid": "83fd1c72-079b-407d-baee-6b7f68787902",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Subtask 2 of #395 — script that reads `pilot-50.csv` + diagrams (from PR #396) and emits a ready-to-POST **Tally form payload** with 50 voicings × 10 blocks per voicing = 502 blocks total. The form's reviewer UX is one voicing per page: fretboard diagram + agent reasoning + YES/NO/REFINE radio buttons + override-reason text field.

Stacked on **PR #396** (feat/395-fretboard-diagrams-pilot) — this PR's base is that branch since it consumes the diagrams.

## What landed

| File | Purpose |
|---|---|
| `scripts/voicing-tags/tally-form-builder.py` | reads CSV + emits Tally form payload JSON; optional `--post` flag to POST to api.tally.so/v1/forms |
| `scripts/voicing-tags/tally-form-payload.json` | the generated payload for all 50 pilot voicings (502 blocks, 154 KB) |

## Per-voicing block layout

```
TITLE             — "C13b9 — Fret 5 — Altered (6th on top) — 13b9 altered"
IMAGE             — fretboard PNG (raw.githubusercontent.com)
TEXT              — Agent proposed: dirk-laukens, …; confidence: MED; reasoning: …
MULTIPLE_CHOICE   — "Do these tags fit this voicing?"
  ├─ OPTION YES
  ├─ OPTION NO
  └─ OPTION REFINE
TEXTAREA          — "If NO or REFINE, why are you overriding the agent?"
INPUT_TEXT        — "Tags to add (comma-separated, optional)"
TEXTAREA          — "Anything else? (optional)"
```

Question + options share a `groupUuid` (Tally's parent-child convention for multiple-choice). Each voicing's blocks share a separate `groupUuid` so the form renders them as one logical page.

## Image hosting

Image URLs default to:
```
https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/<voicing_id>.png
```

These go live the moment PR #396 lands on develop. The base URL is a `--base-image-url` flag so you can point at a fork or alternate host for testing.

## How to use (after both PRs merge)

```bash
# Generate payload, inspect locally
python3 scripts/voicing-tags/tally-form-builder.py --limit 3

# When ready to POST (requires Tally account + API key)
export TALLY_API_KEY=<your-key>
python3 scripts/voicing-tags/tally-form-builder.py --post --limit 3   # 3-voicing test form
python3 scripts/voicing-tags/tally-form-builder.py --post              # full 50-voicing pilot
```

Tally response includes the new form's URL — share that with reviewers.

## Verification

- [x] **Claim A** (think-gate): pilot-50.csv has 50 voicing_id rows
- [x] **Claim B**: 50 diagram PNGs present on the diagrams branch
- [x] **Test-before-bulk**: 3-voicing payload eyeballed (32 blocks: 1 FORM_TITLE + 1 intro TEXT + 3 × 10 voicing blocks)
- [x] **Scaled to 50**: 502 blocks, structure matches expected (50 IMAGE, 50 MULTIPLE_CHOICE + 150 OPTIONS, etc.)
- [ ] **POST to Tally**: not done in this PR — requires your Tally API key. The payload is structurally validated against the Tally OpenAPI block schemas (TitleBlock, ImageBlock, MultipleChoiceOptionBlock, etc.) but a live POST is the real test.

## Known risk

The MULTIPLE_CHOICE → MULTIPLE_CHOICE_OPTION groupUuid relationship is inferred from the API docs but not POST-verified. If the live POST rejects the schema, a small payload tweak (e.g., the options-share-parent-question-uuid) will fix it. The `--limit 3 --post` step is designed to catch this cheaply before scaling to 50.

## Out of scope

- **Subtask 3** of #395: `tally-ingest.py` — Tally CSV export → row-per-voicing CSV in #393's shape for downstream merge.
- Actually POSTing the form (gated on your Tally API key).
- Custom Tally theming (defaults are fine for the pilot).

## Refs

#395 (parent) · #393 / PR #394 (Sheet variant + pilot CSV substrate) · **PR #396** (diagram renderer — base of this stack) · #389 / PR #390 (proposer) · #391 / PR #392 (master vocab) · #222 (engine consumption) · #275 (EPIC)