### PR TITLE
tooling+content(voicing-tags): consolidated #397 (Tally form) + #399 (data dictionary)

### DIFF
--- a/scripts/voicing-tags/build-data-dictionary.py
+++ b/scripts/voicing-tags/build-data-dictionary.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Build the reviewer-facing data dictionary for #398.
+
+Reads:
+  - plugin/data/voicings.json (for categories)
+  - plugin/data/masters.json (for master + principle summaries)
+  - plugin/data/voicings-tag-proposal.json (to know which tags are
+    actually emitted, so we only define what reviewers will see)
+
+Writes:
+  - scripts/voicing-tags/data-dictionary.md  — human-readable doc
+  - scripts/voicing-tags/data-dictionary.json — same content as
+    structured data so tally-form-builder.py can inject per-voicing
+    glossary snippets into the form.
+
+Sections:
+  A. Voicing categories — hand-written here (not derivable from JSON)
+  B. Masters — one line per master, derived from each master's primary
+     principle summary (since masters.json has no master-level bio yet)
+  C. Tags — one summary per voicingStyleTag actually emitted in the
+     proposal, pulled from the source principle's summary in masters.json
+  D. Confidence levels — boilerplate explanation
+"""
+import argparse
+import json
+import re
+import textwrap
+from collections import OrderedDict
+from pathlib import Path
+
+
+# Section A — voicing category definitions. Hand-written because the
+# categories aren't documented in the JSON. Keep these short and
+# guitarist-friendly.
+CATEGORY_DEFINITIONS = {
+    "drop2": {
+        "title": "Drop-2",
+        "definition": (
+            "A 4-note voicing built by taking a close-position chord and "
+            "dropping the second-highest note an octave."
+        ),
+        "sound": (
+            "The bread-and-butter chord-melody and comping shape — clean, "
+            "balanced, easy to voice-lead. Most jazz chord-solo arrangements "
+            "live here."
+        ),
+        "example": (
+            "The Cm7 shape you'd play across strings 6–3 or 5–2 with the b7 "
+            "on top — the same shapes Joe Pass plays through Autumn Leaves."
+        ),
+    },
+    "drop3": {
+        "title": "Drop-3",
+        "definition": (
+            "Like drop-2, but the THIRD-highest voice is dropped an octave — "
+            "producing a wider, more open spread across the strings."
+        ),
+        "sound": (
+            "Bigger sound, more piano-like. Common when you want a bass note "
+            "to ring under a chord-melody phrase."
+        ),
+        "example": (
+            "The Cm7 voicing with root on the 6th string, skipping the 5th "
+            "string, and the rest of the chord on strings 4–2."
+        ),
+    },
+    "shell": {
+        "title": "Shell voicing",
+        "definition": (
+            "A skeleton voicing — usually just the root, third, and seventh "
+            "(R-3-7) — with no fifth or extensions."
+        ),
+        "sound": (
+            "Minimal, dry, leaves space. Common in bebop comping and as a "
+            "starting point that you 'dress' with extensions and tensions."
+        ),
+        "example": (
+            "Peter Bernstein's go-to comping shape: R-3-7 on strings 6, 4, 3 "
+            "or 5, 3, 2 — under a melody on the top strings."
+        ),
+    },
+    "quartal": {
+        "title": "Quartal voicing",
+        "definition": (
+            "A voicing built by stacking perfect-fourths rather than thirds."
+        ),
+        "sound": (
+            "Open, ambiguous, modern. Doesn't commit to a single tonality — "
+            "perfect for modal contexts and McCoy Tyner / Jim Hall sounds."
+        ),
+        "example": (
+            "Three fourths stacked on the middle strings — works equally well "
+            "as Dm7, G7sus, or Cmaj9 depending on the bass."
+        ),
+    },
+    "extended": {
+        "title": "Extended voicing",
+        "definition": (
+            "A voicing that includes upper-structure extensions: 9th, 11th, "
+            "13th."
+        ),
+        "sound": (
+            "Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 "
+            "vamp; sounds 'wrong' on a country progression."
+        ),
+        "example": (
+            "Cmaj9 with the 9 on top instead of the root — turns a static "
+            "chord into a color."
+        ),
+    },
+    "altered": {
+        "title": "Altered voicing",
+        "definition": (
+            "A dominant-7 voicing with one or more altered tensions: b5, #5, "
+            "b9, #9, #11, b13."
+        ),
+        "sound": (
+            "Tense, leaning hard toward resolution. The Tristano / Coltrane "
+            "language."
+        ),
+        "example": (
+            "G7#9 with the #9 on top, used as the V chord into Cm in a minor "
+            "ii-V-i."
+        ),
+    },
+}
+
+
+# Section D — confidence levels boilerplate
+CONFIDENCE_DESCRIPTIONS = OrderedDict([
+    ("HIGH", (
+        "The voicing's existing tags directly named a master tag, so the "
+        "automated tagger is reasonably sure the attribution is right."
+    )),
+    ("MED", (
+        "The tag was derived: from a 'coverage' marker on the voicing, "
+        "from a master-id alias in the voicing's tags, or from a category "
+        "rule (e.g. category=quartal → quartal + jim-hall). The tagger "
+        "thinks this fits but it's less certain."
+    )),
+    ("NONE", (
+        "The tagger couldn't attribute this voicing to any master with "
+        "confidence and left the voicingStyle blank. These are exactly the "
+        "rows your judgment helps most."
+    )),
+])
+
+
+def shorten(text, max_chars=220):
+    text = (text or "").strip()
+    text = re.sub(r"\s+", " ", text)
+    if len(text) <= max_chars:
+        return text
+    cut = text[: max_chars - 1]
+    last_period = max(cut.rfind(". "), cut.rfind("? "), cut.rfind("! "))
+    if last_period > 0:
+        return cut[: last_period + 1].strip()
+    return cut.rstrip() + "…"
+
+
+def first_principle_summary(master):
+    for p in master.get("principles", []):
+        s = p.get("summary")
+        if s:
+            return p["id"], s
+    return None, None
+
+
+def build_masters_section(masters):
+    """One line per master, pulled from the first principle's summary."""
+    entries = []
+    for m in sorted(masters, key=lambda x: x["id"]):
+        pid, summary = first_principle_summary(m)
+        entries.append({
+            "id": m["id"],
+            "summary": shorten(summary or "(no summary in masters.json)", 240),
+            "source_principle": pid,
+        })
+    return entries
+
+
+def build_tags_section(masters, emitted_tags):
+    """For each tag actually emitted in the proposal, find the principle
+    that declared it and pull that principle's summary."""
+    # Find first principle declaring each tag
+    tag_lookup = {}
+    for m in masters:
+        for p in m.get("principles", []):
+            for t in p.get("voicingStyleTags", []):
+                if t in emitted_tags and t not in tag_lookup:
+                    tag_lookup[t] = {
+                        "tag": t,
+                        "from_master": m["id"],
+                        "from_principle": p.get("id", ""),
+                        "summary": shorten(p.get("summary") or "", 280),
+                    }
+    entries = []
+    for t in sorted(emitted_tags):
+        if t in tag_lookup:
+            entries.append(tag_lookup[t])
+        else:
+            entries.append({
+                "tag": t,
+                "from_master": None,
+                "from_principle": None,
+                "summary": f"(no principle summary found for tag {t!r})",
+            })
+    return entries
+
+
+def emitted_tag_set(proposal):
+    tags = set()
+    for p in proposal["proposals"]:
+        for t in p.get("proposed_voicingStyle", []):
+            tags.add(t)
+    return tags
+
+
+def render_markdown(categories, masters, tags, confidences):
+    out = []
+    out.append("# Voicing data dictionary")
+    out.append("")
+    out.append(
+        "A guide for the #395 voicing-tag review. Defines the **voicing "
+        "categories**, **master tags**, and **principle tags** you'll see "
+        "on the form. Generated from `plugin/data/voicings.json` + "
+        "`plugin/data/masters.json` + the #389 proposer output — keep in "
+        "sync via `scripts/voicing-tags/build-data-dictionary.py`."
+    )
+    out.append("")
+
+    out.append("## A. Voicing categories")
+    out.append("")
+    out.append("Each voicing has one `category` — its broad shape family.")
+    out.append("")
+    for slug, defn in categories.items():
+        out.append(f"### `{slug}` — {defn['title']}")
+        out.append("")
+        out.append(f"**What it is:** {defn['definition']}")
+        out.append("")
+        out.append(f"**What it sounds like:** {defn['sound']}")
+        out.append("")
+        out.append(f"**Example:** {defn['example']}")
+        out.append("")
+
+    out.append("## B. Master tags")
+    out.append("")
+    out.append(
+        "Master tags (`joe-pass`, `van-eps`, `dirk-laukens`, …) mean "
+        "\"voicings in this master's tradition.\" One line per master, "
+        "drawn from each master's primary principle in `masters.json`."
+    )
+    out.append("")
+    for m in masters:
+        out.append(f"- **`{m['id']}`** — {m['summary']}")
+    out.append("")
+
+    out.append("## C. Principle tags")
+    out.append("")
+    out.append(
+        "Principle tags describe a specific way of organizing voicings. "
+        "Pulled from the source principle's `summary` field in "
+        "`masters.json` — only tags the #389 proposer actually emits "
+        "are listed."
+    )
+    out.append("")
+    for t in tags:
+        source = (
+            f"from `{t['from_master']}/{t['from_principle']}`"
+            if t["from_master"] else "no source"
+        )
+        out.append(f"### `{t['tag']}` ({source})")
+        out.append("")
+        out.append(t["summary"])
+        out.append("")
+
+    out.append("## D. Confidence levels")
+    out.append("")
+    out.append(
+        "Each row on the form shows an `agent_confidence` of `HIGH`, "
+        "`MED`, or `NONE`."
+    )
+    out.append("")
+    for level, desc in confidences.items():
+        out.append(f"- **`{level}`** — {desc}")
+    out.append("")
+
+    return "\n".join(out) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--voicings", default="plugin/data/voicings.json")
+    ap.add_argument("--masters", default="plugin/data/masters.json")
+    ap.add_argument(
+        "--proposal", default="plugin/data/voicings-tag-proposal.json"
+    )
+    ap.add_argument("--out-md", default="scripts/voicing-tags/data-dictionary.md")
+    ap.add_argument("--out-json", default="scripts/voicing-tags/data-dictionary.json")
+    args = ap.parse_args()
+
+    masters_raw = json.load(open(args.masters))["masters"]
+    proposal = json.load(open(args.proposal))
+    emitted = emitted_tag_set(proposal)
+
+    masters_section = build_masters_section(masters_raw)
+    tags_section = build_tags_section(masters_raw, emitted)
+    md = render_markdown(
+        CATEGORY_DEFINITIONS, masters_section, tags_section,
+        CONFIDENCE_DESCRIPTIONS,
+    )
+
+    Path(args.out_md).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out_md).write_text(md, encoding="utf-8")
+    print(f"Wrote {args.out_md} ({len(md)} bytes)")
+
+    data = {
+        "categories": CATEGORY_DEFINITIONS,
+        "masters": {m["id"]: m for m in masters_section},
+        "tags": {t["tag"]: t for t in tags_section},
+        "confidences": dict(CONFIDENCE_DESCRIPTIONS),
+    }
+    Path(args.out_json).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {args.out_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/voicing-tags/data-dictionary.json
+++ b/scripts/voicing-tags/data-dictionary.json
@@ -1,0 +1,242 @@
+{
+  "categories": {
+    "drop2": {
+      "title": "Drop-2",
+      "definition": "A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave.",
+      "sound": "The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.",
+      "example": "The Cm7 shape you'd play across strings 6\u20133 or 5\u20132 with the b7 on top \u2014 the same shapes Joe Pass plays through Autumn Leaves."
+    },
+    "drop3": {
+      "title": "Drop-3",
+      "definition": "Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings.",
+      "sound": "Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.",
+      "example": "The Cm7 voicing with root on the 6th string, skipping the 5th string, and the rest of the chord on strings 4\u20132."
+    },
+    "shell": {
+      "title": "Shell voicing",
+      "definition": "A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions.",
+      "sound": "Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.",
+      "example": "Peter Bernstein's go-to comping shape: R-3-7 on strings 6, 4, 3 or 5, 3, 2 \u2014 under a melody on the top strings."
+    },
+    "quartal": {
+      "title": "Quartal voicing",
+      "definition": "A voicing built by stacking perfect-fourths rather than thirds.",
+      "sound": "Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.",
+      "example": "Three fourths stacked on the middle strings \u2014 works equally well as Dm7, G7sus, or Cmaj9 depending on the bass."
+    },
+    "extended": {
+      "title": "Extended voicing",
+      "definition": "A voicing that includes upper-structure extensions: 9th, 11th, 13th.",
+      "sound": "Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.",
+      "example": "Cmaj9 with the 9 on top instead of the root \u2014 turns a static chord into a color."
+    },
+    "altered": {
+      "title": "Altered voicing",
+      "definition": "A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13.",
+      "sound": "Tense, leaning hard toward resolution. The Tristano / Coltrane language.",
+      "example": "G7#9 with the #9 on top, used as the V chord into Cm in a minor ii-V-i."
+    }
+  },
+  "masters": {
+    "alan-de-mause": {
+      "id": "alan-de-mause",
+      "summary": "The book's operative procedure throughout: convert a lead sheet (single-note melody + chord symbols) into a complete solo fingerstyle guitar arrangement.",
+      "source_principle": "lead-sheet-to-solo-conversion"
+    },
+    "barry-galbraith": {
+      "id": "barry-galbraith",
+      "summary": "Galbraith's *Jazz Solo Guitar* anthology teaches by demonstration rather than by prose.",
+      "source_principle": "arrangement-as-curriculum"
+    },
+    "benson": {
+      "id": "benson",
+      "summary": "(no summary in masters.json)",
+      "source_principle": null
+    },
+    "brent-vaartstra": {
+      "id": "brent-vaartstra",
+      "summary": "Vaartstra's procedural method for learning any standard.",
+      "source_principle": "ear-first-list-acquisition"
+    },
+    "dirk-laukens": {
+      "id": "dirk-laukens",
+      "summary": "Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.",
+      "source_principle": "moveable-shape-as-organizing-principle"
+    },
+    "gene-bertoncini": {
+      "id": "gene-bertoncini",
+      "summary": "Bertoncini's *Arrangements for Solo Guitar* teaches by demonstration.",
+      "source_principle": "arrangement-as-curriculum"
+    },
+    "greg-orourke": {
+      "id": "greg-orourke",
+      "summary": "O'Rourke's central operating system. Step 1: pick a suitable tune (ballad-not-bebop selection rule \u2014 slower tempos with longer-held melody notes are practically easier).",
+      "source_principle": "four-step-chord-melody-recipe"
+    },
+    "heussenstamm-silbergleit": {
+      "id": "heussenstamm-silbergleit",
+      "summary": "The book's foundational organizing claim: the ii-V-I progression is not just one progression among many but the IRREDUCIBLE harmonic cell from which all jazz vocabulary \u2014 harmonic, melodic, rhythmic, textural \u2014 radiates.",
+      "source_principle": "ii-v-i-as-irreducible-cell"
+    },
+    "jamey-aebersold": {
+      "id": "jamey-aebersold",
+      "summary": "Aebersold's foundational innovation: a recorded rhythm section supplies tempo, harmony, and feel while the student practices scales, chord-tones, patterns, and improvisation over the same progressions.",
+      "source_principle": "play-along-as-curriculum-engine"
+    },
+    "jens-larsen": {
+      "id": "jens-larsen",
+      "summary": "The improviser does not arpeggiate the root chord; instead they select the substitute arpeggio whose notes maximally overlap the underlying chord's guide tones (3rd and 7th) and color tones (9, 11, 13, altered extensions).",
+      "source_principle": "shared-tone-arpeggio-substitution"
+    },
+    "jerry-bergonzi": {
+      "id": "jerry-bergonzi",
+      "summary": "A fixed group of consecutive notes (2-7 eighth notes, or their triplet/16th equivalents) is shifted systematically across all eight metrical entry points in a 4/4 bar.",
+      "source_principle": "consecutive-note-displacement"
+    },
+    "jerry-coker": {
+      "id": "jerry-coker",
+      "summary": "Coker's foundational thesis (Elements Ch1): the great jazz improvisors share roughly 18 common 'devices' that account for nearly all the language they speak.",
+      "source_principle": "improvisation-as-finite-learnable-language"
+    },
+    "jim-hall": {
+      "id": "jim-hall",
+      "summary": "Hall's comping foundation: 3rd and 7th of the chord on the middle strings, often as two-note voicings or grace-noted into fuller shapes.",
+      "source_principle": "guide-tone-voicings"
+    },
+    "jimmy-bruno": {
+      "id": "jimmy-bruno",
+      "summary": "Bruno's central system. Three rules govern every pick stroke: down-stroke when crossing to a higher string, up-stroke when crossing to a lower string, alternate strokes when staying on one string.",
+      "source_principle": "three-rule-directional-picking"
+    },
+    "jody-fisher": {
+      "id": "jody-fisher",
+      "summary": "Fisher categorizes voicings systematically for teaching: drop-2 (drop the second-from-top from a close-position stack), drop-3 (drop the third-from-top), abbreviated voicings, extended-harmony voicings (9ths/11ths/13ths), altered-chord for\u2026",
+      "source_principle": "pedagogical-voicing-taxonomy"
+    },
+    "joe-pass": {
+      "id": "joe-pass",
+      "summary": "Bass walks on every beat (chord tones, passing notes between chord tones, chord-extension notes, tritone approaches to the root); chord 'stabs' land on off-beats with 2-3 note voicings rather than full block chords.",
+      "source_principle": "walking-bass-plus-chord-stabs"
+    },
+    "johnny-smith": {
+      "id": "johnny-smith",
+      "summary": "Closely-voiced chord-melody \u2014 all four voices within an octave, often within a 4-fret span. Produces a unified vertical sound rather than a wide-spread texture.",
+      "source_principle": "tight-closed-voicings"
+    },
+    "lenny-breau": {
+      "id": "lenny-breau",
+      "summary": "Bass, chord, and melody played simultaneously via fingerstyle, with right-hand finger independence treating each voice on its own timeline.",
+      "source_principle": "three-independent-voices"
+    },
+    "martin-taylor": {
+      "id": "martin-taylor",
+      "summary": "The right-hand thumb alternates between the 6th and 5th strings (or 6th/4th depending on chord) to maintain continuous bass support without interrupting melodic flow.",
+      "source_principle": "alternating-thumb-bass"
+    },
+    "matt-warnock": {
+      "id": "matt-warnock",
+      "summary": "Warnock's *Beginner's Guide* organizes its complete curriculum \u2014 chord vocabulary, comping rhythms, picking technique, chromatic harmony, scale shapes, ornaments, and mixed solo texture \u2014 around ONE harmonic vehicle: the Dm7-G7-Cmaj7 ii V\u2026",
+      "source_principle": "single-ii-v-i-as-unifying-vehicle"
+    },
+    "mickey-baker": {
+      "id": "mickey-baker",
+      "summary": "Baker prunes the guitar's chord universe to 26 essential shapes (Chapter 1), later extended to 30 (Chapter 5), and references every voicing by number rather than by Roman-numeral function.",
+      "source_principle": "numbered-finite-vocabulary-with-transposition-mandate"
+    },
+    "nelson-faria": {
+      "id": "nelson-faria",
+      "summary": "Faria's load-bearing technical architecture across all five Brazilian styles.",
+      "source_principle": "two-layer-thumb-finger-texture"
+    },
+    "pat-martino": {
+      "id": "pat-martino",
+      "summary": "The single governing principle of Linear Expressions. Improvisation is not free melodic invention; the chord encountered selects the line form played. Every melodic decision in the system is downstream of harmonic identification.",
+      "source_principle": "harmonic-structure-dictates-melodic-choice"
+    },
+    "peter-bernstein": {
+      "id": "peter-bernstein",
+      "summary": "Bernstein's load-bearing conceptual frame: improvisation is language use, not scale deployment.",
+      "source_principle": "jazz-as-language-narrative-outranks-correctness"
+    },
+    "randy-felts": {
+      "id": "randy-felts",
+      "summary": "Felts's foundational organizing move: every chord is assigned to one of three functional families \u2014 tonic (I, III, VI), subdominant (II, IV, V7sus4), or dominant (V7, VII-7b5) \u2014 and every substitution operates within or between these famil\u2026",
+      "source_principle": "three-functional-families-as-organizing-axis"
+    },
+    "ted-dunbar": {
+      "id": "ted-dunbar",
+      "summary": "The founding axiom of Dunbar's method, named explicitly in Chapter 1. Every pitch in the chromatic scale exerts a cadential pull toward any active tonal center.",
+      "source_principle": "tonal-gravity-law"
+    },
+    "ted-greene": {
+      "id": "ted-greene",
+      "summary": "Four-note voicings are classified into 14 groups (V-1 through V-14) ordered from most compact to most spread: V-1 is the closest cluster, V-14 the widest, with V-13/V-14 less spread than V-11/V-12.",
+      "source_principle": "v-system-voicing-groups"
+    },
+    "van-eps": {
+      "id": "van-eps",
+      "summary": "Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex.",
+      "source_principle": "harmonized-scale-foundation"
+    },
+    "wes-montgomery": {
+      "id": "wes-montgomery",
+      "summary": "A solo arcs through three distinct textural tiers: single-note lines (statement), parallel octaves (intensification), block-chord harmonization (climax).",
+      "source_principle": "three-tier-chorus-development"
+    }
+  },
+  "tags": {
+    "chord-function-driven": {
+      "tag": "chord-function-driven",
+      "from_master": "dirk-laukens",
+      "from_principle": "function-assigned-vocabulary",
+      "summary": "Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key."
+    },
+    "dirk-laukens": {
+      "tag": "dirk-laukens",
+      "from_master": "dirk-laukens",
+      "from_principle": "moveable-shape-as-organizing-principle",
+      "summary": "Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes."
+    },
+    "drop-3": {
+      "tag": "drop-3",
+      "from_master": "joe-pass",
+      "from_principle": "drop-2-and-drop-3-chord-melody",
+      "summary": "Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle."
+    },
+    "function-assigned": {
+      "tag": "function-assigned",
+      "from_master": "dirk-laukens",
+      "from_principle": "function-assigned-vocabulary",
+      "summary": "Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key."
+    },
+    "quartal": {
+      "tag": "quartal",
+      "from_master": "jim-hall",
+      "from_principle": "fourth-stacks-and-open-voicings",
+      "summary": "Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top."
+    },
+    "shell": {
+      "tag": "shell",
+      "from_master": "peter-bernstein",
+      "from_principle": "dressing-the-notes-comping-aesthetic",
+      "summary": "The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important."
+    },
+    "substitution-derivation": {
+      "tag": "substitution-derivation",
+      "from_master": "dirk-laukens",
+      "from_principle": "substitution-as-derivable-not-memorized",
+      "summary": "Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog."
+    },
+    "van-eps": {
+      "tag": "van-eps",
+      "from_master": "van-eps",
+      "from_principle": "harmonized-scale-foundation",
+      "summary": "Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex."
+    }
+  },
+  "confidences": {
+    "HIGH": "The voicing's existing tags directly named a master tag, so the automated tagger is reasonably sure the attribution is right.",
+    "MED": "The tag was derived: from a 'coverage' marker on the voicing, from a master-id alias in the voicing's tags, or from a category rule (e.g. category=quartal \u2192 quartal + jim-hall). The tagger thinks this fits but it's less certain.",
+    "NONE": "The tagger couldn't attribute this voicing to any master with confidence and left the voicingStyle blank. These are exactly the rows your judgment helps most."
+  }
+}

--- a/scripts/voicing-tags/data-dictionary.md
+++ b/scripts/voicing-tags/data-dictionary.md
@@ -1,0 +1,134 @@
+# Voicing data dictionary
+
+A guide for the #395 voicing-tag review. Defines the **voicing categories**, **master tags**, and **principle tags** you'll see on the form. Generated from `plugin/data/voicings.json` + `plugin/data/masters.json` + the #389 proposer output — keep in sync via `scripts/voicing-tags/build-data-dictionary.py`.
+
+## A. Voicing categories
+
+Each voicing has one `category` — its broad shape family.
+
+### `drop2` — Drop-2
+
+**What it is:** A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave.
+
+**What it sounds like:** The bread-and-butter chord-melody and comping shape — clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.
+
+**Example:** The Cm7 shape you'd play across strings 6–3 or 5–2 with the b7 on top — the same shapes Joe Pass plays through Autumn Leaves.
+
+### `drop3` — Drop-3
+
+**What it is:** Like drop-2, but the THIRD-highest voice is dropped an octave — producing a wider, more open spread across the strings.
+
+**What it sounds like:** Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.
+
+**Example:** The Cm7 voicing with root on the 6th string, skipping the 5th string, and the rest of the chord on strings 4–2.
+
+### `shell` — Shell voicing
+
+**What it is:** A skeleton voicing — usually just the root, third, and seventh (R-3-7) — with no fifth or extensions.
+
+**What it sounds like:** Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.
+
+**Example:** Peter Bernstein's go-to comping shape: R-3-7 on strings 6, 4, 3 or 5, 3, 2 — under a melody on the top strings.
+
+### `quartal` — Quartal voicing
+
+**What it is:** A voicing built by stacking perfect-fourths rather than thirds.
+
+**What it sounds like:** Open, ambiguous, modern. Doesn't commit to a single tonality — perfect for modal contexts and McCoy Tyner / Jim Hall sounds.
+
+**Example:** Three fourths stacked on the middle strings — works equally well as Dm7, G7sus, or Cmaj9 depending on the bass.
+
+### `extended` — Extended voicing
+
+**What it is:** A voicing that includes upper-structure extensions: 9th, 11th, 13th.
+
+**What it sounds like:** Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.
+
+**Example:** Cmaj9 with the 9 on top instead of the root — turns a static chord into a color.
+
+### `altered` — Altered voicing
+
+**What it is:** A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13.
+
+**What it sounds like:** Tense, leaning hard toward resolution. The Tristano / Coltrane language.
+
+**Example:** G7#9 with the #9 on top, used as the V chord into Cm in a minor ii-V-i.
+
+## B. Master tags
+
+Master tags (`joe-pass`, `van-eps`, `dirk-laukens`, …) mean "voicings in this master's tradition." One line per master, drawn from each master's primary principle in `masters.json`.
+
+- **`alan-de-mause`** — The book's operative procedure throughout: convert a lead sheet (single-note melody + chord symbols) into a complete solo fingerstyle guitar arrangement.
+- **`barry-galbraith`** — Galbraith's *Jazz Solo Guitar* anthology teaches by demonstration rather than by prose.
+- **`benson`** — (no summary in masters.json)
+- **`brent-vaartstra`** — Vaartstra's procedural method for learning any standard.
+- **`dirk-laukens`** — Laukens organizes his entire pedagogy — across the beginner method, the chord dictionary, the pattern volume, and the lick anthology — around moveable physical shapes.
+- **`gene-bertoncini`** — Bertoncini's *Arrangements for Solo Guitar* teaches by demonstration.
+- **`greg-orourke`** — O'Rourke's central operating system. Step 1: pick a suitable tune (ballad-not-bebop selection rule — slower tempos with longer-held melody notes are practically easier).
+- **`heussenstamm-silbergleit`** — The book's foundational organizing claim: the ii-V-I progression is not just one progression among many but the IRREDUCIBLE harmonic cell from which all jazz vocabulary — harmonic, melodic, rhythmic, textural — radiates.
+- **`jamey-aebersold`** — Aebersold's foundational innovation: a recorded rhythm section supplies tempo, harmony, and feel while the student practices scales, chord-tones, patterns, and improvisation over the same progressions.
+- **`jens-larsen`** — The improviser does not arpeggiate the root chord; instead they select the substitute arpeggio whose notes maximally overlap the underlying chord's guide tones (3rd and 7th) and color tones (9, 11, 13, altered extensions).
+- **`jerry-bergonzi`** — A fixed group of consecutive notes (2-7 eighth notes, or their triplet/16th equivalents) is shifted systematically across all eight metrical entry points in a 4/4 bar.
+- **`jerry-coker`** — Coker's foundational thesis (Elements Ch1): the great jazz improvisors share roughly 18 common 'devices' that account for nearly all the language they speak.
+- **`jim-hall`** — Hall's comping foundation: 3rd and 7th of the chord on the middle strings, often as two-note voicings or grace-noted into fuller shapes.
+- **`jimmy-bruno`** — Bruno's central system. Three rules govern every pick stroke: down-stroke when crossing to a higher string, up-stroke when crossing to a lower string, alternate strokes when staying on one string.
+- **`jody-fisher`** — Fisher categorizes voicings systematically for teaching: drop-2 (drop the second-from-top from a close-position stack), drop-3 (drop the third-from-top), abbreviated voicings, extended-harmony voicings (9ths/11ths/13ths), altered-chord for…
+- **`joe-pass`** — Bass walks on every beat (chord tones, passing notes between chord tones, chord-extension notes, tritone approaches to the root); chord 'stabs' land on off-beats with 2-3 note voicings rather than full block chords.
+- **`johnny-smith`** — Closely-voiced chord-melody — all four voices within an octave, often within a 4-fret span. Produces a unified vertical sound rather than a wide-spread texture.
+- **`lenny-breau`** — Bass, chord, and melody played simultaneously via fingerstyle, with right-hand finger independence treating each voice on its own timeline.
+- **`martin-taylor`** — The right-hand thumb alternates between the 6th and 5th strings (or 6th/4th depending on chord) to maintain continuous bass support without interrupting melodic flow.
+- **`matt-warnock`** — Warnock's *Beginner's Guide* organizes its complete curriculum — chord vocabulary, comping rhythms, picking technique, chromatic harmony, scale shapes, ornaments, and mixed solo texture — around ONE harmonic vehicle: the Dm7-G7-Cmaj7 ii V…
+- **`mickey-baker`** — Baker prunes the guitar's chord universe to 26 essential shapes (Chapter 1), later extended to 30 (Chapter 5), and references every voicing by number rather than by Roman-numeral function.
+- **`nelson-faria`** — Faria's load-bearing technical architecture across all five Brazilian styles.
+- **`pat-martino`** — The single governing principle of Linear Expressions. Improvisation is not free melodic invention; the chord encountered selects the line form played. Every melodic decision in the system is downstream of harmonic identification.
+- **`peter-bernstein`** — Bernstein's load-bearing conceptual frame: improvisation is language use, not scale deployment.
+- **`randy-felts`** — Felts's foundational organizing move: every chord is assigned to one of three functional families — tonic (I, III, VI), subdominant (II, IV, V7sus4), or dominant (V7, VII-7b5) — and every substitution operates within or between these famil…
+- **`ted-dunbar`** — The founding axiom of Dunbar's method, named explicitly in Chapter 1. Every pitch in the chromatic scale exerts a cadential pull toward any active tonal center.
+- **`ted-greene`** — Four-note voicings are classified into 14 groups (V-1 through V-14) ordered from most compact to most spread: V-1 is the closest cluster, V-14 the widest, with V-13/V-14 less spread than V-11/V-12.
+- **`van-eps`** — Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex.
+- **`wes-montgomery`** — A solo arcs through three distinct textural tiers: single-note lines (statement), parallel octaves (intensification), block-chord harmonization (climax).
+
+## C. Principle tags
+
+Principle tags describe a specific way of organizing voicings. Pulled from the source principle's `summary` field in `masters.json` — only tags the #389 proposer actually emits are listed.
+
+### `chord-function-driven` (from `dirk-laukens/function-assigned-vocabulary`)
+
+Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.
+
+### `dirk-laukens` (from `dirk-laukens/moveable-shape-as-organizing-principle`)
+
+Laukens organizes his entire pedagogy — across the beginner method, the chord dictionary, the pattern volume, and the lick anthology — around moveable physical shapes.
+
+### `drop-3` (from `joe-pass/drop-2-and-drop-3-chord-melody`)
+
+Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.
+
+### `function-assigned` (from `dirk-laukens/function-assigned-vocabulary`)
+
+Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.
+
+### `quartal` (from `jim-hall/fourth-stacks-and-open-voicings`)
+
+Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds — beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.
+
+### `shell` (from `peter-bernstein/dressing-the-notes-comping-aesthetic`)
+
+The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.
+
+### `substitution-derivation` (from `dirk-laukens/substitution-as-derivable-not-memorized`)
+
+Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.
+
+### `van-eps` (from `van-eps/harmonized-scale-foundation`)
+
+Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.
+
+## D. Confidence levels
+
+Each row on the form shows an `agent_confidence` of `HIGH`, `MED`, or `NONE`.
+
+- **`HIGH`** — The voicing's existing tags directly named a master tag, so the automated tagger is reasonably sure the attribution is right.
+- **`MED`** — The tag was derived: from a 'coverage' marker on the voicing, from a master-id alias in the voicing's tags, or from a category rule (e.g. category=quartal → quartal + jim-hall). The tagger thinks this fits but it's less certain.
+- **`NONE`** — The tagger couldn't attribute this voicing to any master with confidence and left the voicingStyle blank. These are exactly the rows your judgment helps most.
+

--- a/scripts/voicing-tags/tally-form-builder.py
+++ b/scripts/voicing-tags/tally-form-builder.py
@@ -137,9 +137,8 @@ def load_dictionary(path):
 
 
 def dictionary_snippet(row, dictionary):
-    """Build an HTML snippet defining the category + each proposed tag,
-    pulled from the data dictionary. Returns '' if no dictionary or
-    nothing to define."""
+    """Build a plain-HTML snippet (only <p>/<b>/<i>/<br> — Tally strips
+    <code>/<ul>/<li>) defining the category + each proposed tag."""
     if not dictionary:
         return ""
     parts = []
@@ -147,7 +146,7 @@ def dictionary_snippet(row, dictionary):
     cat_def = dictionary.get("categories", {}).get(cat)
     if cat_def:
         parts.append(
-            f"<p><b>What's a {cat_def['title']}?</b> {cat_def['definition']} "
+            f"<p><b>{cat_def['title']}:</b> {cat_def['definition']} "
             f"<i>{cat_def['sound']}</i></p>"
         )
     tag_entries = []
@@ -160,13 +159,17 @@ def dictionary_snippet(row, dictionary):
             seen.add(t)
             defn = dictionary.get("tags", {}).get(t)
             if defn:
-                tag_entries.append(f"<li><code>{t}</code> — {defn['summary']}</li>")
+                tag_entries.append(f"• <b>{t}</b> — {defn['summary']}")
                 continue
             mdef = dictionary.get("masters", {}).get(t)
             if mdef:
-                tag_entries.append(f"<li><code>{t}</code> — {mdef['summary']}</li>")
+                tag_entries.append(f"• <b>{t}</b> — {mdef['summary']}")
     if tag_entries:
-        parts.append("<p><b>Tag definitions:</b></p><ul>" + "".join(tag_entries) + "</ul>")
+        parts.append(
+            "<p><b>Tag definitions:</b><br>"
+            + "<br>".join(tag_entries)
+            + "</p>"
+        )
     return "".join(parts)
 
 
@@ -189,8 +192,8 @@ def build_voicing_blocks(row, base_image_url, dictionary=None):
     glossary = dictionary_snippet(row, dictionary)
     reasoning_html = (
         f"<p><b>Agent proposed:</b><br>"
-        f"voicingStyle: <code>{vs}</code><br>"
-        f"playStyle: <code>{ps}</code><br>"
+        f"voicingStyle: {vs}<br>"
+        f"playStyle: {ps}<br>"
         f"confidence: <b>{conf}</b></p>"
         f"<p><b>Reasoning:</b> {reasoning}</p>"
         + glossary

--- a/scripts/voicing-tags/tally-form-builder.py
+++ b/scripts/voicing-tags/tally-form-builder.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Build a Tally form for crowdsource voicing-tag review (#395 subtask 2).
+
+Reads:
+  - scripts/voicing-tags/pilot-50.csv (or any CSV with voicing_id +
+    voicing_name + chord_quality + category + agent_proposed_voicingStyle
+    + agent_proposed_playStyle + agent_confidence + agent_reasoning)
+  - scripts/voicing-tags/diagrams/<voicing_id>.png (must exist on the
+    branch that backs the configured image base URL)
+
+Emits:
+  - A Tally form payload JSON (default) — inspect before posting.
+  - Optionally POSTs to https://api.tally.so/v1/forms when --post and
+    TALLY_API_KEY env var are both set.
+
+Form structure (per voicing):
+  1. TITLE  — voicing_name + chord_quality + (agent confidence badge)
+  2. IMAGE  — fretboard PNG, fetched from raw.githubusercontent.com
+  3. TEXT   — "Agent proposed: <vs> | <ps>. Reasoning: <agent_reasoning>"
+  4. MULTIPLE_CHOICE_OPTION × 3 — YES / NO / REFINE (single-select)
+  5. TEXTAREA — "Why are you overriding the agent? (required if NO/REFINE)"
+  6. INPUT_TEXT — "Tags to add (comma-separated, optional)"
+  7. TEXTAREA — "Notes (optional)"
+
+Each voicing's blocks share a single groupUuid so Tally renders them as
+one logical question group.
+
+Why Tally over Google Forms: see ticket #395. Tally's free tier includes
+API access, supports image blocks via URL, and can ingest a full form's
+worth of blocks in a single POST.
+"""
+import argparse
+import csv
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+TALLY_API = "https://api.tally.so/v1/forms"
+DEFAULT_BASE_URL = (
+    "https://raw.githubusercontent.com/"
+    "siege-analytics/musescore4-chord-library-plugin/"
+    "develop/scripts/voicing-tags/diagrams"
+)
+
+
+def new_uuid():
+    return str(uuid.uuid4())
+
+
+def title_block(text, group_uuid=None):
+    uid = new_uuid()
+    return {
+        "uuid": uid,
+        "groupUuid": group_uuid or uid,
+        "type": "TITLE",
+        "title": text,
+    }
+
+
+def image_block(image_url, alt_text, group_uuid):
+    return {
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "IMAGE",
+        "imageUrl": image_url,
+        "altText": alt_text,
+    }
+
+
+def text_block(html, group_uuid):
+    return {
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "TEXT",
+        "html": html,
+    }
+
+
+def multiple_choice_options(labels, group_uuid):
+    blocks = []
+    for i, label in enumerate(labels):
+        blocks.append({
+            "uuid": new_uuid(),
+            "groupUuid": group_uuid,
+            "type": "MULTIPLE_CHOICE_OPTION",
+            "title": label,
+            "isFirstOption": i == 0,
+            "isLastOption": i == len(labels) - 1,
+            "optionIndex": i,
+            "allowMultiple": False,
+        })
+    return blocks
+
+
+def textarea_block(title_text, placeholder, group_uuid, required=False):
+    return {
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "TEXTAREA",
+        "title": title_text,
+        "placeholder": placeholder,
+        "isRequired": required,
+    }
+
+
+def input_text_block(title_text, placeholder, group_uuid):
+    return {
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "INPUT_TEXT",
+        "title": title_text,
+        "placeholder": placeholder,
+        "isRequired": False,
+    }
+
+
+def build_voicing_blocks(row, base_image_url):
+    """Build the per-voicing block group. Returns a list of blocks all
+    sharing one groupUuid so Tally treats them as one page/question.
+    """
+    group_uuid = new_uuid()
+    vid = row["voicing_id"]
+    name = row.get("voicing_name", vid)
+    quality = row.get("chord_quality", "")
+    category = row.get("category", "")
+    vs = row.get("agent_proposed_voicingStyle", "") or "(none)"
+    ps = row.get("agent_proposed_playStyle", "") or "(none)"
+    conf = row.get("agent_confidence", "")
+    reasoning = row.get("agent_reasoning", "")
+
+    title_text = f"{name} — {quality} {category}".strip()
+    image_url = f"{base_image_url}/{vid}.png"
+    reasoning_html = (
+        f"<p><b>Agent proposed:</b><br>"
+        f"voicingStyle: <code>{vs}</code><br>"
+        f"playStyle: <code>{ps}</code><br>"
+        f"confidence: <b>{conf}</b></p>"
+        f"<p><b>Reasoning:</b> {reasoning}</p>"
+    )
+
+    blocks = []
+    blocks.append({
+        "uuid": new_uuid(),
+        "groupUuid": group_uuid,
+        "type": "TITLE",
+        "title": title_text,
+    })
+    blocks.append(image_block(image_url, f"Fretboard diagram for {name}", group_uuid))
+    blocks.append(text_block(reasoning_html, group_uuid))
+
+    # Verdict question — own groupUuid so options are children of it
+    mc_group = new_uuid()
+    blocks.append({
+        "uuid": new_uuid(),
+        "groupUuid": mc_group,
+        "type": "MULTIPLE_CHOICE",
+        "title": "Do these tags fit this voicing?",
+    })
+    blocks.extend(multiple_choice_options(["YES", "NO", "REFINE"], mc_group))
+
+    # Override reason
+    blocks.append(textarea_block(
+        "If NO or REFINE, why are you overriding the agent?",
+        "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+        new_uuid(),
+    ))
+    # Additions
+    blocks.append(input_text_block(
+        "Tags to add (comma-separated, optional)",
+        "e.g. van-eps, walking-bass",
+        new_uuid(),
+    ))
+    # Notes
+    blocks.append(textarea_block(
+        "Anything else? (optional)",
+        "Free-form notes",
+        new_uuid(),
+    ))
+
+    return blocks
+
+
+def build_form_payload(rows, base_image_url, form_title):
+    blocks = []
+    blocks.append({
+        "uuid": new_uuid(),
+        "groupUuid": new_uuid(),
+        "type": "FORM_TITLE",
+        "title": form_title,
+    })
+    intro_group = new_uuid()
+    blocks.append(text_block(
+        "<p>Thanks for helping. Each page shows one guitar voicing, "
+        "the tags an automated tagger guessed, and a fretboard diagram. "
+        "For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and "
+        "tell us why if you disagree.</p>"
+        "<p>You can skip rows you're unsure about — quality of judgment "
+        "beats coverage.</p>",
+        intro_group,
+    ))
+
+    for row in rows:
+        blocks.extend(build_voicing_blocks(row, base_image_url))
+
+    return {
+        "status": "DRAFT",
+        "blocks": blocks,
+    }
+
+
+def post_to_tally(payload, api_key):
+    import urllib.request
+    req = urllib.request.Request(
+        TALLY_API,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.load(resp)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", default="scripts/voicing-tags/pilot-50.csv")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="if > 0, only build N voicings (test-before-bulk)")
+    ap.add_argument("--out", default="scripts/voicing-tags/tally-form-payload.json")
+    ap.add_argument("--base-image-url", default=DEFAULT_BASE_URL)
+    ap.add_argument("--title", default="Voicing-tag review — pilot (#395)")
+    ap.add_argument("--post", action="store_true",
+                    help="POST to Tally API (requires TALLY_API_KEY env var)")
+    args = ap.parse_args()
+
+    rows = list(csv.DictReader(open(args.csv)))
+    if args.limit > 0:
+        rows = rows[: args.limit]
+    print(f"Building Tally form for {len(rows)} voicings", file=sys.stderr)
+    print(f"Image base URL: {args.base_image_url}", file=sys.stderr)
+
+    payload = build_form_payload(rows, args.base_image_url, args.title)
+    n_blocks = len(payload["blocks"])
+    print(f"Generated {n_blocks} blocks ({n_blocks // len(rows) if rows else 0} per voicing avg)", file=sys.stderr)
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {out}", file=sys.stderr)
+
+    if args.post:
+        api_key = os.environ.get("TALLY_API_KEY")
+        if not api_key:
+            print("ERROR: --post given but TALLY_API_KEY env var not set", file=sys.stderr)
+            sys.exit(2)
+        print(f"POSTing to {TALLY_API}…", file=sys.stderr)
+        try:
+            result = post_to_tally(payload, api_key)
+        except Exception as e:
+            print(f"POST failed: {e}", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/voicing-tags/tally-form-builder.py
+++ b/scripts/voicing-tags/tally-form-builder.py
@@ -127,7 +127,50 @@ def input_text_question(label_html, placeholder=""):
     ]
 
 
-def build_voicing_blocks(row, base_image_url):
+def load_dictionary(path):
+    if not path:
+        return None
+    p = Path(path)
+    if not p.exists():
+        return None
+    return json.load(open(p))
+
+
+def dictionary_snippet(row, dictionary):
+    """Build an HTML snippet defining the category + each proposed tag,
+    pulled from the data dictionary. Returns '' if no dictionary or
+    nothing to define."""
+    if not dictionary:
+        return ""
+    parts = []
+    cat = (row.get("category") or "").strip()
+    cat_def = dictionary.get("categories", {}).get(cat)
+    if cat_def:
+        parts.append(
+            f"<p><b>What's a {cat_def['title']}?</b> {cat_def['definition']} "
+            f"<i>{cat_def['sound']}</i></p>"
+        )
+    tag_entries = []
+    seen = set()
+    for field in ("agent_proposed_voicingStyle", "agent_proposed_playStyle"):
+        raw = row.get(field, "") or ""
+        for t in [s.strip() for s in raw.split(",") if s.strip()]:
+            if t in seen:
+                continue
+            seen.add(t)
+            defn = dictionary.get("tags", {}).get(t)
+            if defn:
+                tag_entries.append(f"<li><code>{t}</code> — {defn['summary']}</li>")
+                continue
+            mdef = dictionary.get("masters", {}).get(t)
+            if mdef:
+                tag_entries.append(f"<li><code>{t}</code> — {mdef['summary']}</li>")
+    if tag_entries:
+        parts.append("<p><b>Tag definitions:</b></p><ul>" + "".join(tag_entries) + "</ul>")
+    return "".join(parts)
+
+
+def build_voicing_blocks(row, base_image_url, dictionary=None):
     """Build the per-voicing block group. Returns a list of blocks all
     sharing one groupUuid so Tally treats them as one page/question.
     """
@@ -143,12 +186,14 @@ def build_voicing_blocks(row, base_image_url):
 
     title_text = f"{name} — {quality} {category}".strip()
     image_url = f"{base_image_url}/{vid}.png"
+    glossary = dictionary_snippet(row, dictionary)
     reasoning_html = (
         f"<p><b>Agent proposed:</b><br>"
         f"voicingStyle: <code>{vs}</code><br>"
         f"playStyle: <code>{ps}</code><br>"
         f"confidence: <b>{conf}</b></p>"
         f"<p><b>Reasoning:</b> {reasoning}</p>"
+        + glossary
     )
 
     blocks = []
@@ -174,7 +219,7 @@ def build_voicing_blocks(row, base_image_url):
     return blocks
 
 
-def build_form_payload(rows, base_image_url, form_title):
+def build_form_payload(rows, base_image_url, form_title, dictionary=None):
     blocks = []
     blocks.extend(form_title_block(form_title))
     blocks.extend(text_paragraph(
@@ -187,7 +232,7 @@ def build_form_payload(rows, base_image_url, form_title):
     ))
 
     for row in rows:
-        blocks.extend(build_voicing_blocks(row, base_image_url))
+        blocks.extend(build_voicing_blocks(row, base_image_url, dictionary))
 
     return {
         "status": "DRAFT",
@@ -227,6 +272,9 @@ def main():
     ap.add_argument("--title", default="Voicing-tag review — pilot (#395)")
     ap.add_argument("--post", action="store_true",
                     help="POST to Tally API (requires TALLY_API_KEY env var)")
+    ap.add_argument("--dictionary",
+                    default="scripts/voicing-tags/data-dictionary.json",
+                    help="data-dictionary JSON for inline tag definitions")
     args = ap.parse_args()
 
     rows = list(csv.DictReader(open(args.csv)))
@@ -235,7 +283,18 @@ def main():
     print(f"Building Tally form for {len(rows)} voicings", file=sys.stderr)
     print(f"Image base URL: {args.base_image_url}", file=sys.stderr)
 
-    payload = build_form_payload(rows, args.base_image_url, args.title)
+    dictionary = load_dictionary(args.dictionary)
+    if dictionary:
+        print(
+            f"Loaded data dictionary from {args.dictionary} "
+            f"({len(dictionary.get('tags', {}))} tags, "
+            f"{len(dictionary.get('categories', {}))} categories)",
+            file=sys.stderr,
+        )
+    else:
+        print(f"NOTE: no dictionary at {args.dictionary} — no inline definitions",
+              file=sys.stderr)
+    payload = build_form_payload(rows, args.base_image_url, args.title, dictionary)
     n_blocks = len(payload["blocks"])
     print(f"Generated {n_blocks} blocks ({n_blocks // len(rows) if rows else 0} per voicing avg)", file=sys.stderr)
 

--- a/scripts/voicing-tags/tally-form-builder.py
+++ b/scripts/voicing-tags/tally-form-builder.py
@@ -37,7 +37,7 @@ import sys
 import uuid
 from pathlib import Path
 
-TALLY_API = "https://api.tally.so/v1/forms"
+TALLY_API = "https://api.tally.so/forms"
 DEFAULT_BASE_URL = (
     "https://raw.githubusercontent.com/"
     "siege-analytics/musescore4-chord-library-plugin/"
@@ -49,71 +49,82 @@ def new_uuid():
     return str(uuid.uuid4())
 
 
-def title_block(text, group_uuid=None):
-    uid = new_uuid()
-    return {
-        "uuid": uid,
-        "groupUuid": group_uuid or uid,
-        "type": "TITLE",
-        "title": text,
-    }
-
-
-def image_block(image_url, alt_text, group_uuid):
+def _block(block_type, group_uuid, group_type, payload):
     return {
         "uuid": new_uuid(),
         "groupUuid": group_uuid,
-        "type": "IMAGE",
-        "imageUrl": image_url,
-        "altText": alt_text,
+        "groupType": group_type,
+        "type": block_type,
+        "payload": payload,
     }
 
 
-def text_block(html, group_uuid):
-    return {
-        "uuid": new_uuid(),
-        "groupUuid": group_uuid,
-        "type": "TEXT",
-        "html": html,
-    }
+def form_title_block(text):
+    g = new_uuid()
+    return [
+        _block("FORM_TITLE", g, "TEXT", {"html": text, "title": text}),
+    ]
 
 
-def multiple_choice_options(labels, group_uuid):
-    blocks = []
-    for i, label in enumerate(labels):
-        blocks.append({
-            "uuid": new_uuid(),
-            "groupUuid": group_uuid,
-            "type": "MULTIPLE_CHOICE_OPTION",
-            "title": label,
-            "isFirstOption": i == 0,
-            "isLastOption": i == len(labels) - 1,
-            "optionIndex": i,
-            "allowMultiple": False,
-        })
+def text_paragraph(html):
+    g = new_uuid()
+    return [_block("TEXT", g, "TEXT", {"html": html})]
+
+
+def heading_block(text):
+    """Standalone TITLE block at top level (not a question label)."""
+    g = new_uuid()
+    return [_block("TITLE", g, "TITLE", {"html": text})]
+
+
+def image_question_group(image_url, alt_text):
+    """IMAGE block alone — guess at payload shape from earlier doc sample."""
+    g = new_uuid()
+    return [_block("IMAGE", g, "IMAGE", {
+        "images": [{"url": image_url, "name": alt_text}],
+    })]
+
+
+def _label(text):
+    """Standalone label block — its own groupUuid per Tally's validator."""
+    g = new_uuid()
+    return _block("TITLE", g, "QUESTION", {"html": text})
+
+
+def multiple_choice_question(label_html, options):
+    """Label (own groupUuid) + N MULTIPLE_CHOICE_OPTION blocks sharing
+    groupUuid with groupType=MULTIPLE_CHOICE."""
+    blocks = [_label(label_html)]
+    g = new_uuid()
+    n = len(options)
+    for i, opt in enumerate(options):
+        blocks.append(_block("MULTIPLE_CHOICE_OPTION", g, "MULTIPLE_CHOICE", {
+            "text": opt,
+            "index": i,
+            "isFirst": i == 0,
+            "isLast": i == n - 1,
+        }))
     return blocks
 
 
-def textarea_block(title_text, placeholder, group_uuid, required=False):
-    return {
-        "uuid": new_uuid(),
-        "groupUuid": group_uuid,
-        "type": "TEXTAREA",
-        "title": title_text,
-        "placeholder": placeholder,
-        "isRequired": required,
-    }
+def textarea_question(label_html, placeholder="", required=False):
+    return [
+        _label(label_html),
+        _block("TEXTAREA", new_uuid(), "TEXTAREA", {
+            "isRequired": required,
+            "placeholder": placeholder,
+        }),
+    ]
 
 
-def input_text_block(title_text, placeholder, group_uuid):
-    return {
-        "uuid": new_uuid(),
-        "groupUuid": group_uuid,
-        "type": "INPUT_TEXT",
-        "title": title_text,
-        "placeholder": placeholder,
-        "isRequired": False,
-    }
+def input_text_question(label_html, placeholder=""):
+    return [
+        _label(label_html),
+        _block("INPUT_TEXT", new_uuid(), "INPUT_TEXT", {
+            "isRequired": False,
+            "placeholder": placeholder,
+        }),
+    ]
 
 
 def build_voicing_blocks(row, base_image_url):
@@ -141,64 +152,38 @@ def build_voicing_blocks(row, base_image_url):
     )
 
     blocks = []
-    blocks.append({
-        "uuid": new_uuid(),
-        "groupUuid": group_uuid,
-        "type": "TITLE",
-        "title": title_text,
-    })
-    blocks.append(image_block(image_url, f"Fretboard diagram for {name}", group_uuid))
-    blocks.append(text_block(reasoning_html, group_uuid))
-
-    # Verdict question — own groupUuid so options are children of it
-    mc_group = new_uuid()
-    blocks.append({
-        "uuid": new_uuid(),
-        "groupUuid": mc_group,
-        "type": "MULTIPLE_CHOICE",
-        "title": "Do these tags fit this voicing?",
-    })
-    blocks.extend(multiple_choice_options(["YES", "NO", "REFINE"], mc_group))
-
-    # Override reason
-    blocks.append(textarea_block(
+    blocks.extend(heading_block(title_text))
+    blocks.extend(image_question_group(image_url, f"Fretboard diagram for {name}"))
+    blocks.extend(text_paragraph(reasoning_html))
+    blocks.extend(multiple_choice_question(
+        "Do these tags fit this voicing?",
+        ["YES", "NO", "REFINE"],
+    ))
+    blocks.extend(textarea_question(
         "If NO or REFINE, why are you overriding the agent?",
-        "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-        new_uuid(),
+        placeholder="e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary",
     ))
-    # Additions
-    blocks.append(input_text_block(
+    blocks.extend(input_text_question(
         "Tags to add (comma-separated, optional)",
-        "e.g. van-eps, walking-bass",
-        new_uuid(),
+        placeholder="e.g. van-eps, walking-bass",
     ))
-    # Notes
-    blocks.append(textarea_block(
+    blocks.extend(textarea_question(
         "Anything else? (optional)",
-        "Free-form notes",
-        new_uuid(),
+        placeholder="Free-form notes",
     ))
-
     return blocks
 
 
 def build_form_payload(rows, base_image_url, form_title):
     blocks = []
-    blocks.append({
-        "uuid": new_uuid(),
-        "groupUuid": new_uuid(),
-        "type": "FORM_TITLE",
-        "title": form_title,
-    })
-    intro_group = new_uuid()
-    blocks.append(text_block(
+    blocks.extend(form_title_block(form_title))
+    blocks.extend(text_paragraph(
         "<p>Thanks for helping. Each page shows one guitar voicing, "
         "the tags an automated tagger guessed, and a fretboard diagram. "
         "For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and "
         "tell us why if you disagree.</p>"
         "<p>You can skip rows you're unsure about — quality of judgment "
-        "beats coverage.</p>",
-        intro_group,
+        "beats coverage.</p>"
     ))
 
     for row in rows:
@@ -212,17 +197,24 @@ def build_form_payload(rows, base_image_url, form_title):
 
 def post_to_tally(payload, api_key):
     import urllib.request
+    import urllib.error
     req = urllib.request.Request(
         TALLY_API,
         data=json.dumps(payload).encode("utf-8"),
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "voicing-tag-form-builder/1.0 (#395; curl-equivalent)",
         },
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:
-        return json.load(resp)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {e.code} from Tally: {body}") from None
 
 
 def main():

--- a/scripts/voicing-tags/tally-form-payload.json
+++ b/scripts/voicing-tags/tally-form-payload.json
@@ -2,3966 +2,6723 @@
   "status": "DRAFT",
   "blocks": [
     {
-      "uuid": "0c40ffc6-1a00-4117-b478-9e6f1caaa343",
-      "groupUuid": "5ad255f4-137b-4801-a41f-ecad2e0aee6f",
+      "uuid": "c17c7151-3a07-4e35-9f79-c06549118f33",
+      "groupUuid": "69dc2fa3-e054-4524-822e-0cd63a1bf36b",
+      "groupType": "TEXT",
       "type": "FORM_TITLE",
-      "title": "Voicing-tag review \u2014 pilot (#395)"
+      "payload": {
+        "html": "Voicing-tag review \u2014 pilot (#395)",
+        "title": "Voicing-tag review \u2014 pilot (#395)"
+      }
     },
     {
-      "uuid": "26dab5d8-6313-4d74-85b3-772079e16755",
-      "groupUuid": "bb8443cf-8cd3-4535-9969-a0b78d3c6c70",
+      "uuid": "7de2305b-89bb-4ca1-adac-2b8b199d5d0c",
+      "groupUuid": "8bcde888-b172-48ea-9de5-2b4d097fece1",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p>Thanks for helping. Each page shows one guitar voicing, the tags an automated tagger guessed, and a fretboard diagram. For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and tell us why if you disagree.</p><p>You can skip rows you're unsure about \u2014 quality of judgment beats coverage.</p>"
+      "payload": {
+        "html": "<p>Thanks for helping. Each page shows one guitar voicing, the tags an automated tagger guessed, and a fretboard diagram. For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and tell us why if you disagree.</p><p>You can skip rows you're unsure about \u2014 quality of judgment beats coverage.</p>"
+      }
     },
     {
-      "uuid": "9241de52-fc7f-4cdb-9211-44a352ea9473",
-      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "uuid": "e708be0c-df81-4be9-9a43-9e38d5c38035",
+      "groupUuid": "185ee2dd-09fa-47ad-a1e5-2d5e3a5a9d05",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+      "payload": {
+        "html": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+      }
     },
     {
-      "uuid": "dc805d9c-f12a-4cd0-bb0a-96a737192bf4",
-      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "uuid": "dc62ff74-2377-497a-b948-e3d2ba553587",
+      "groupUuid": "d66b2b16-5e1f-493a-8ad3-3282e41fc076",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm6-altered-6str-26.png",
-      "altText": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm6-altered-6str-26.png",
+            "name": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "0cd2e828-7a1a-4aad-bdf0-c1342f93053c",
-      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "uuid": "3b0bad58-ae10-46a8-9231-37b36037c95f",
+      "groupUuid": "1e7258f9-519e-4180-81ef-6a85d5e43d93",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
     },
     {
-      "uuid": "aba40be8-ef7c-4f72-a19e-c839babadc36",
-      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "c276313e-3365-4b6b-a86e-ffeace37aef0",
-      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "cde62618-2e0b-4506-9218-560b1f8e1c4c",
-      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "cce314ce-4bf2-41c3-b690-ecd4ab26c1c1",
-      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "507599b0-4ac3-468d-a828-a812ab6e7aeb",
-      "groupUuid": "677dd3ef-f4f6-473f-a2ba-4cd0ad6d371d",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "36bb211a-6f5f-4f84-bab9-bdd6c5d97315",
-      "groupUuid": "f692a045-b69a-4b3c-8c64-c815edf9b12e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "43750726-e587-4dfc-af1d-4a7e22316c71",
-      "groupUuid": "38dc92e6-84d7-455f-b95c-454c321b8294",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "b81149e9-98d4-451b-9e6e-470d9b3298b6",
-      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
+      "uuid": "aa3d985f-b82e-4310-942c-e21475b3f712",
+      "groupUuid": "153ab8ce-5b02-4276-b942-8abcb4cb7a4f",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "b33a0941-181c-4446-9044-dd1f37f4510c",
-      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-b7top-6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
-    },
-    {
-      "uuid": "7ff0b510-8117-4651-b924-8855d0b76000",
-      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "aaf62e08-cbef-4ae2-a19a-4fc201bbd960",
-      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "73735b80-d45b-42ab-ad2b-71db51c9d090",
-      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "uuid": "41b7c8cc-5195-4bae-ac04-a86f0fe7358d",
+      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "e63c7c64-599a-4cb4-b5cd-aa0a21e60d24",
-      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "uuid": "783a6712-c91a-42fe-861b-d0de06a90a78",
+      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "044f3136-1539-4013-948c-a87a9a1865f2",
-      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "uuid": "626c210b-ccfd-43f0-ba0d-570a531021ca",
+      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "4e16c380-eef5-4dff-b023-7fc5b6835b46",
-      "groupUuid": "1946ffb0-fbc8-40be-b957-a7238a66222d",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "993eaaaf-0d00-4f46-9255-8f6e07287542",
-      "groupUuid": "a3fc5d7f-030a-4237-94a2-9f055d66287e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "19918d02-5ac8-409e-b10b-9410208bd07b",
-      "groupUuid": "4d29dada-99fe-4a57-a7dc-1956ac17dd74",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "e9a35697-b5bc-4071-a88a-df3701c66118",
-      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
+      "uuid": "3c08057c-696b-48f3-92bf-67eee81b367d",
+      "groupUuid": "2044bd93-fb09-434a-944e-797dd3faf3bc",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "e14033c6-c87f-4694-9932-f352983075e8",
-      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "3602578f-3a3c-456d-ad70-3714d2396a1a",
-      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "da50f515-049a-43c7-92c5-efdec5b10eb6",
-      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "f0837946-b10e-4264-8976-ae62ebea4437",
-      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4b40c83f-bc5b-429f-bb9f-4e77d9df707f",
-      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "47d507fc-dfb2-437c-b169-2e8760d2d9ce",
-      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "cfec88fc-6226-4415-937b-ec972ec850f9",
-      "groupUuid": "1d455bb0-2faf-48b6-801b-0f1c110d399d",
+      "uuid": "a88b4e00-d8fe-434c-bc52-8f24bb2e50fe",
+      "groupUuid": "7db9487d-2302-4499-b833-7ef6e01a4e2c",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "44dc0684-2355-4b04-a25b-d6889e439434",
-      "groupUuid": "621f4055-e3c7-42b7-b0f4-6375d71a94fe",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "c82acce8-7a53-45b3-830e-f0f752c114bd",
-      "groupUuid": "549c1800-e651-47f9-8b2d-e92720221343",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d623267c-2e53-4ca9-8393-cd8a00494f84",
-      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
+      "uuid": "5d475e15-f266-44d5-811b-69db07274452",
+      "groupUuid": "3facb47e-6256-48a9-a97a-1d952c3aca6a",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "674edda9-0685-416b-a744-2f139ff95ce5",
-      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
-    },
-    {
-      "uuid": "83d0188b-794a-4f1e-bb4f-5e0198997eb1",
-      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "9f4e6e20-a201-401c-9ea3-9cd7160b7788",
-      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "12f6ddbb-8ec7-4464-b54d-79cfd4b120e9",
-      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "7692d7a8-8a36-41c8-87fc-2fcbea480154",
-      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "df880eac-acdb-40ff-8c80-6b249517c682",
-      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4fb33aa3-2f3a-4be1-8bc2-b09c208d719a",
-      "groupUuid": "1e25d394-3c6a-4327-abbf-5e66c4d1bc2c",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "6120424f-3421-40a6-ab42-617129671e72",
-      "groupUuid": "325f949c-43e0-4bab-9c5e-d37cfc3d0a68",
+      "uuid": "60bbe785-4b24-4301-9dcc-bb8d18ce0a02",
+      "groupUuid": "588fef02-c764-4a61-8cae-9caf000ecb07",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "02d5f65d-214d-4cc3-8928-4d8ca58e325c",
-      "groupUuid": "73eedec6-6374-4303-94bd-cb7ea0de0a05",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d9b9fa2f-d441-4170-8b24-5c2a5ceac914",
-      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
+      "uuid": "4d346cb4-8168-4de0-961b-ffe7000f8fcc",
+      "groupUuid": "114050b7-52f0-43da-bc48-fcbd19340aa0",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "0f151d90-b230-4f1c-afd7-0f986d3cb9c3",
-      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm6-extended-6str-18.png",
-      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
-    },
-    {
-      "uuid": "b92969c0-4c68-4560-aad7-2c67f030903d",
-      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "d7518955-34ea-4e91-848e-3549e3c45494",
-      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "5d634695-898c-455e-8820-eb9781920511",
-      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "ec7bc0a2-7c93-4f38-a2d1-008c4f5efe9b",
-      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "2818e5e9-24ec-469d-b75b-5bf5116812c9",
-      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "dc9c0357-688f-46bd-8d3a-92460b314b86",
-      "groupUuid": "6e34fcbf-61db-4924-a1e5-f6e060cdfa24",
+      "uuid": "a9986592-9c23-49c3-8049-58b2cb7179de",
+      "groupUuid": "aade363d-86c0-43fc-8a5f-8f903213dd5a",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "ae9df3f3-569a-4d51-993c-3e0211a6cb08",
-      "groupUuid": "07c8d9ee-b308-4b59-be74-099a82233a1d",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "d670a294-2cd0-4d9f-a48c-e33c093af389",
-      "groupUuid": "5b3b5f20-bc44-44fb-af5b-a4727d560abc",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "695504ff-fe66-4ff3-860f-c18aa79aeda2",
-      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "uuid": "0809a00e-1017-4bea-badb-a43463b530c8",
+      "groupUuid": "4a7aab67-9ef8-4257-8867-ddc0715e45a4",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 Fret 1 \u2014 Extended \u2014 dim7 extended"
+      "payload": {
+        "html": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
     },
     {
-      "uuid": "b89c4975-1397-433d-92c3-534093bec121",
-      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "uuid": "895dbd4b-2655-4b05-bb7c-68daa8e1801e",
+      "groupUuid": "7d860845-1557-44d7-84ef-48c795e79304",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f1-6.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 Fret 1 \u2014 Extended"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-b7top-6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
+          }
+        ]
+      }
     },
     {
-      "uuid": "ba421523-b5ff-4ce4-84f6-2432701fcf91",
-      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "uuid": "63c18e6e-e112-4998-990a-fd13934b867d",
+      "groupUuid": "3525c243-ee3c-4133-aac5-45fe66910321",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
     },
     {
-      "uuid": "119ddde1-4405-4bb4-8e5b-f21c5ad03db1",
-      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "f703cb9a-8b97-4860-bf9f-bd7d83a71ac3",
-      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "f4b97315-44ca-46dc-9701-2b3c6a0e81ba",
-      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "5ed591f4-2876-4caf-9fa2-7b56a15364e6",
-      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "8d261219-166f-4322-9230-3b4906771830",
-      "groupUuid": "a8554d70-bf68-4e08-b36f-981f3376163b",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "16b8bede-afa0-40ad-bb78-a478a02b9d0c",
-      "groupUuid": "540d1d0d-4f73-42bc-9d18-de52e997dd6e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "4eb07632-c246-4c22-bdd0-eed37c281c87",
-      "groupUuid": "ca48c3a2-348b-49a6-814b-0f7fd1b36a14",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "3ed6cf37-7722-419b-98b5-3f273a97d65e",
-      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
+      "uuid": "6e9f3d10-0a04-4d69-9030-8f734132f64b",
+      "groupUuid": "0a46e748-625f-4625-a745-7afcb63bd253",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "6158986a-8a6a-4701-9704-db21c063144e",
-      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-a-lower-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)"
-    },
-    {
-      "uuid": "272b0e56-33a3-4e92-8ce3-950939119b4b",
-      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "4a5c9659-83b1-4930-b544-0b18b3c6b405",
-      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "c53b33b3-8c71-4eb3-817e-97fd4c96a243",
-      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "uuid": "37653bea-172b-46eb-9490-22856b795f25",
+      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "5ad782f0-69d8-4c73-9db9-6074f153c18c",
-      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "uuid": "ee9dd13e-bb85-48d2-8599-818a6997134e",
+      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "ddaeeb75-0cae-4972-956e-256dbd006b82",
-      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "uuid": "bccf4890-d142-4f99-b47c-753499c2b48b",
+      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "42a239cf-056c-48db-b2e5-b15e5e55b0d9",
-      "groupUuid": "cf6a7974-e1d6-4354-aa60-2fd0f27db53f",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "d59aa06b-9be3-4915-9216-a8bd7255b9d1",
-      "groupUuid": "cf4f405f-055b-433c-bfb2-8f1200c69918",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "86e84ea6-dc7b-435a-a782-b7fb591cdd1f",
-      "groupUuid": "e15a78e0-dd90-409c-8176-257ad0ded7ed",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d7227947-3055-4572-8a21-1fce6fef0cb1",
-      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
+      "uuid": "8edb0fd8-af80-4440-b80f-a289d60fc7d8",
+      "groupUuid": "ceb9688f-fa85-4315-a87e-0fa81e83a8b9",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "cb58c681-06bd-4cba-b4d7-ad7d5fea29ec",
-      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cm7-shell-7str-7.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
-    },
-    {
-      "uuid": "44b2afbe-e3c3-40c3-b8c3-c92be82e523f",
-      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "535987ed-808c-431c-91b1-c54980c24466",
-      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "ced810e1-5775-483e-8696-2e543a2af3f7",
-      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d19f10f2-9760-4069-ae66-b68a63e330cf",
-      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "bddeb376-3d80-4d3a-a577-13abb27627f6",
-      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "50b3cfa7-066d-4a68-9c56-7ff929bf948b",
-      "groupUuid": "afedb3de-4462-4f86-abe5-1a60f27278b2",
+      "uuid": "1fa34444-b550-4358-930a-231babd5b10b",
+      "groupUuid": "26101f69-48d1-49ac-8ab0-4b1cc1a233ca",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "4767d72e-aeeb-4235-a434-7e2e66af7153",
-      "groupUuid": "83aac471-159c-4dc9-9ece-adde8d7a2c76",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "b24bc649-ad86-48b5-9639-5c7156e4a10c",
-      "groupUuid": "f0d91a60-1f33-46b9-80cc-947bef0bc3ef",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f7b27ddb-c0aa-46e6-8593-280e1675474d",
-      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
+      "uuid": "b8b1ba98-229d-4168-8e14-ded5138c630d",
+      "groupUuid": "6ffe6ae9-ae08-44e2-9592-0c9fbf3a187f",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "bd0d4fad-fba8-4166-8562-c177b5a1fc40",
-      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-shell-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
-    },
-    {
-      "uuid": "6f49deaf-8cd4-4568-9f0b-82760a8b44b9",
-      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "dffc6c87-be39-4d41-8863-4df66aaef04b",
-      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "fbe87aa5-8334-41f3-9319-3fa07517a7d7",
-      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "3d8b6cdc-651b-420d-9e96-8cbdb31c3a94",
-      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "6a24fa95-cbd7-4a71-b91d-3f3501084ef4",
-      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "1ce6263e-7fe3-480a-a77c-4b497cc5f674",
-      "groupUuid": "5b2ccbb8-eda6-4f1a-a8de-17a97ba4f5cb",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "cf720845-3261-479f-9568-fa0004867578",
-      "groupUuid": "db87245e-a283-45e8-ba06-686ad7d360c9",
+      "uuid": "00b37e34-8461-4f90-beea-36afc9b36106",
+      "groupUuid": "bd1598d2-25ba-4165-a646-2a05048fbe0a",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "266b9f0c-7137-4592-90eb-a4190d30f8ff",
-      "groupUuid": "ebd60563-9f12-4c68-aaa2-53c22c0c43c0",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "b8f3f244-3bb5-42c8-b03c-3bbba68d4e2e",
-      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
+      "uuid": "63685a43-b228-4765-85e0-e4d63e820522",
+      "groupUuid": "276040ec-f53c-4a50-9fa4-8b59a6ccb29b",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "238c34ae-1e30-45e5-833d-a99749787b0b",
-      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-shell-a-6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
-    },
-    {
-      "uuid": "dec52203-ca80-4a6d-bbb0-13941d649cb1",
-      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
-    },
-    {
-      "uuid": "41af78e2-3154-41de-8207-83d1d6308230",
-      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "bf6471a7-29d6-4500-96be-605cf9bf9d8a",
-      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9939690b-7ffd-4a5f-99b0-4e17cca54efa",
-      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d59178b6-88a9-468c-9bb0-20ce9fef35a8",
-      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "672a1490-97f5-43c3-96ee-db7b8f2fe6ed",
-      "groupUuid": "f3855be6-6472-46fd-a5cb-9d5a90372c7e",
+      "uuid": "caffc9c2-9298-47b2-bcb3-ef4c2c4fbc5a",
+      "groupUuid": "e9b7ef65-c708-4bb9-acce-34a21c5ac0c2",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "a2cbf463-8f4d-4542-a45b-d33860f384fb",
-      "groupUuid": "7a52c501-ba1a-4e56-89cd-e273c769d906",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "cb48ed2d-098f-4e1a-8d78-c656b04b7198",
-      "groupUuid": "a1766295-c960-4ca9-accb-47d8e6adc940",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "2653e49a-4c56-4a8e-ac09-2159f8f4312b",
-      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "uuid": "718adc69-8c3d-430c-a9d8-dd2a507c03df",
+      "groupUuid": "88639cfa-9e0d-428b-9436-045172f9830e",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+      "payload": {
+        "html": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+      }
     },
     {
-      "uuid": "e75225a4-902b-48e0-9d12-d7a5ede1c5e4",
-      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "uuid": "680360bd-feb4-4193-8f6c-b094b6168737",
+      "groupUuid": "70613098-8e77-45a8-8ad2-f03af35c6796",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm7-altered-7str-28.png",
-      "altText": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-drop3-7str-7.png",
+            "name": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
     },
     {
-      "uuid": "7f94485b-3d7b-46a9-b67a-1c76b1be1525",
-      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "uuid": "8ee74da5-60da-436f-8a1c-7c0dd5b5ac27",
+      "groupUuid": "f1ee4ec0-3712-4bb7-bb3d-519cfb291733",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
     },
     {
-      "uuid": "468aff08-f935-4120-beff-af4eb0c91780",
-      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "a088afa7-3e2f-4614-a956-32406ccc3818",
-      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "5a2ef048-5882-4f6e-90e6-6455df3aece8",
-      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "a6da2fa9-d5e0-499f-894b-786cc9ff3552",
-      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b3845bf1-b9f9-42a4-b780-3b09506a8293",
-      "groupUuid": "3e144962-4441-4929-a8e8-12a858d7c437",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "3fb309b3-1766-4b24-8bde-7c13c7a9c8fd",
-      "groupUuid": "de0c1dcb-fdb9-4c56-9ce1-860298823093",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "b5a4d9cd-3da4-46cb-a3ff-08592b6aa664",
-      "groupUuid": "44480b32-565c-49e6-8c9d-cfc0ef4c8e0f",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "9dfd6b20-f093-49b8-aa1f-c4d679f2c4c9",
-      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
+      "uuid": "463dffa5-f9ba-4d36-a5aa-42b21a757a19",
+      "groupUuid": "d520cdc7-022b-4040-9180-4fa1cb2a75e2",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "306f6597-a7a0-4aad-ab21-4009faec9d7d",
-      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-1top-6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
-    },
-    {
-      "uuid": "5fd86c89-a22b-40f6-a55c-4b6ee6761ff5",
-      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "9f6c92b4-4290-41b9-89b2-8288f74a0e06",
-      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "6ce1f6a8-11ea-4bb0-b67c-59dade51ef09",
-      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "uuid": "987b7787-7c00-4f73-88aa-4dc13ca91fc7",
+      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "db59a909-6b0f-45b6-89a0-38cdd9d01596",
-      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "uuid": "546c353c-7024-48d3-8a16-30b08adba53a",
+      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "ffe8cfd4-201d-4616-830f-4803aa355885",
-      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "uuid": "25cf7acd-734b-4b50-a88c-0a73029128ac",
+      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "78649e80-b8de-4ffe-82ef-5ba1131a420e",
-      "groupUuid": "19c40bf5-de9a-4e46-850b-07e12e7b1f23",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "9b8d3c02-fd04-4214-b71c-9157fc2c9df5",
-      "groupUuid": "e34cd2fe-a1b9-40cb-a3a8-fe404cd75129",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "5ad343cf-d67d-45e1-8d69-3c4042a6309f",
-      "groupUuid": "ba698029-c5a7-4732-ac17-c047c6c85ded",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "ce603121-719e-4b9b-ae71-cc4bd0b7ef4d",
-      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
+      "uuid": "ccc38e85-6f30-49ff-8fae-a07c114cd5d4",
+      "groupUuid": "30f1beb0-4c88-4678-8d67-57cb9fe704a5",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "22ba7a9c-10ed-4dd8-b794-d7019b5ede40",
-      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "9fadad97-39ad-46fa-95e9-f802c4dc5446",
-      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "758a0092-68ca-4689-b8ef-1ccc1a7ef461",
-      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "96bf288f-baed-4024-8a37-17d75412a4e1",
-      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c6bed596-04d4-4854-973c-c4a20aaaa1d6",
-      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "a73b5af3-32d9-46a5-8199-40ea2f70eef8",
-      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "46d17dc0-54c2-47e8-9b98-e42503641b21",
-      "groupUuid": "256613fd-cc0d-42a6-805e-b7705fc8ca9d",
+      "uuid": "93c3a405-efa3-4fa9-b8dd-49a7fe597496",
+      "groupUuid": "4f507a25-452b-40a4-b831-4b44a205b346",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "6d8b58c6-5d03-40bb-9e83-94eec8753e3c",
-      "groupUuid": "d1b90612-d158-4c31-8fd9-f3851376310f",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "4084b415-d7fd-4a18-b715-5ac409594cec",
-      "groupUuid": "57c01c7c-867c-41b9-8417-eec93b149293",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "1a26360b-1423-4f4e-b959-f39bb07a8777",
-      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
+      "uuid": "0d6dd99b-31bb-42b0-94fa-d5f7886e334f",
+      "groupUuid": "cf54d67b-7ef0-4a37-b469-417166f918fe",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "f61607ed-71e5-42a2-b82c-34bd5725ed12",
-      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7-cm7.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
-    },
-    {
-      "uuid": "514ca0e1-aa11-4447-a183-2de4f481b8de",
-      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "e83b024a-d3cf-4a23-9215-51cba6a9de41",
-      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "92034c6d-4bf5-431f-9a65-687008a124e0",
-      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "19e7b88c-6b13-4749-9fc1-a50652aa07f7",
-      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c7f752fb-ae98-4ccd-bf62-08d5138e6d6b",
-      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "eee36fce-70e4-47b0-aa03-1fbfca9d63c2",
-      "groupUuid": "ba98e64e-6811-43c0-804a-0bafa794d717",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "85e0c33b-738c-4490-927d-95a14ec67118",
-      "groupUuid": "0f572aed-dda4-4fdd-958a-8cddc3708405",
+      "uuid": "311e7c1b-a886-42be-9ee2-11d986236a66",
+      "groupUuid": "e6e23ce8-0300-49f9-a656-df89bf022624",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "5836d893-eceb-4781-af39-d2d9c2343d8c",
-      "groupUuid": "73e6b5a8-ea0c-427e-b71a-80288d3e4d47",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "9dee9dd0-73d6-452a-89d2-eb22b76ad557",
-      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
+      "uuid": "504ca601-e8e3-4909-be3c-43a37d41b3c5",
+      "groupUuid": "81a81198-1b37-4736-be1c-14520a86037f",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "7fb6ff38-679c-49d1-9479-91674f373188",
-      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm7-extended-7str-20.png",
-      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
-    },
-    {
-      "uuid": "b3b8ed71-44e7-489b-a859-65415ca3ba57",
-      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "7f20d579-c15d-42e4-9e10-bc7c698a9336",
-      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "d1be8de4-64ef-4c4a-935b-52fc58d95258",
-      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "75adba5a-7b10-4099-a4f4-1fb5d7a863e2",
-      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "7db93cfa-0dad-42ae-b55c-1bc7f4250751",
-      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "3737a7b7-73e0-4522-95d2-0a4f0bfedb52",
-      "groupUuid": "06430510-b8a8-4e9e-8aad-ae340fa05fa5",
+      "uuid": "d852f95e-28df-4a28-b455-90742f16dff5",
+      "groupUuid": "b9834b22-cfe8-4daa-b412-3fcb28645b0b",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "62b4e713-1f3c-4920-9207-9cab68aeb6b8",
-      "groupUuid": "90ed6530-e271-433e-b0c3-57310244a028",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "08194532-6766-4082-932f-dbe4c7c66ce7",
-      "groupUuid": "346fa57d-0169-4616-aedc-72eeb4a467a9",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d1affda3-23e9-4c34-bca8-8f7e5ea48bb4",
-      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "uuid": "679140f0-2c70-4178-869c-61d6d806811a",
+      "groupUuid": "3c70610c-e845-46b6-b241-98bd1d35ef22",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 Fret 2 \u2014 Extended \u2014 dim7 extended"
+      "payload": {
+        "html": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      }
     },
     {
-      "uuid": "f6d544d7-68ed-4a9b-91ea-9d1aab1853a1",
-      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "uuid": "deec93d1-343f-45b6-adc0-43430e4e6252",
+      "groupUuid": "cee5869b-a606-456d-8d96-4d1c148be007",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f2-6.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 Fret 2 \u2014 Extended"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "80a5ed0c-b51a-46d0-a89f-3d29be79c17b",
-      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "uuid": "5e566df4-26e3-481b-89ed-b7aa9f54bb66",
+      "groupUuid": "4292f591-c12e-49c9-b9c9-b93cb05c29ff",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
     },
     {
-      "uuid": "58d87b5e-3350-4a44-a5ac-464f2dd4b2f8",
-      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "74053019-0275-4507-8281-85bd6990e505",
-      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c9cef4ec-befb-49d0-ada9-1aadaffe75fc",
-      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "ac6c7670-b30b-4f87-9a7a-c9445e0c57a9",
-      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "f1c78e68-b04f-4a67-8f67-ee8b359612cd",
-      "groupUuid": "f3c604fa-b10f-47fc-976c-c74ca440a6c0",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "9fddc19c-d293-4044-9d8f-22524727d472",
-      "groupUuid": "0ab467c8-ebf2-476a-9564-2d103fda0b64",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "43761be2-2fcb-4ace-bb1c-a6b16bf0dba4",
-      "groupUuid": "463e2215-01ef-4836-ae6d-7086246bc0e8",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "ac4a4660-c429-46d6-9776-120962abd35e",
-      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
+      "uuid": "a9e16249-c732-4308-a902-4d779e7bec90",
+      "groupUuid": "dac109a2-a0fd-4a16-b8ca-a4514e5253bc",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "0d399ea8-14e7-401d-a8b6-2eea507a3973",
-      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-bb-lower-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)"
-    },
-    {
-      "uuid": "c29eda75-55e3-4849-a413-3c24b74b471a",
-      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "26add9fc-3ebe-4cd8-8c1e-091311e029a4",
-      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "a5cdbf0d-1721-48f1-b725-388b4bd725d3",
-      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "uuid": "5d49aeca-94cd-4995-b34e-af6b8c20d664",
+      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "bfe9f8c3-42a0-4033-9c59-f876c3b1da2f",
-      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "uuid": "037f8957-e62f-486f-8618-32d0b5a9d141",
+      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "290131d3-efb2-4a56-bf01-f762eddc8b8f",
-      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "uuid": "1bc93c39-4a01-4df3-98c9-6aa9a41439d9",
+      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "173c54b7-62fd-4d13-981e-05ff8caade56",
-      "groupUuid": "e755dc00-f6a9-4216-8161-e4c908c80ea1",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "465be447-c7b1-418b-ba7d-3a9aec00d77e",
-      "groupUuid": "c8eed5c3-b81f-4aa1-9587-77c4379d1974",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "b65aa45c-4883-428b-8780-d8d07d7a749b",
-      "groupUuid": "77047e7d-c861-4cbc-8339-745a383e93a5",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "b0722b10-45ce-4f7c-bbd9-b51b3203354f",
-      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
+      "uuid": "f76ef314-2c6a-47ca-aeb5-e6780ec8cb7a",
+      "groupUuid": "901da8eb-286f-4d10-862b-fefc0366f6ed",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "1644577f-7c71-49fc-8775-7c1e50be98db",
-      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cv7-shell-7str-7.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
-    },
-    {
-      "uuid": "e05e6245-2813-497c-b0a8-73c25755d512",
-      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "af4c00c0-eee4-4e5a-b51c-b26982990cc6",
-      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "dc3c6c77-19a2-4625-af62-ba78a9e37ebb",
-      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9569ee20-d8fa-4a0b-84fb-be7cda1c1068",
-      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "00ac7444-7879-4fcd-9a34-992ea8b74bb7",
-      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "37c0136b-dd1e-4e74-949f-3e291f3ec45e",
-      "groupUuid": "83cf3ca3-3e91-4d67-a6ad-027028e09503",
+      "uuid": "c05735a9-8cc4-4154-9e10-c189a29d8578",
+      "groupUuid": "9ae42de2-1d92-49dd-85f2-4643cc3a6704",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "580ccacd-1b6b-4874-b876-f89bf5314b5e",
-      "groupUuid": "38daf8f1-5cc5-4268-92f2-baffcc3ea956",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "c42092fc-6d05-49b6-8928-3cf4e14c875c",
-      "groupUuid": "12e80f5c-683c-48ca-a852-0b50ac12f47c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "25b333c3-8e90-4af1-b427-dd0ef0ddf0f9",
-      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
+      "uuid": "e66c1d01-87b2-40c9-b33e-710db68de1a8",
+      "groupUuid": "74bbb138-690a-4686-9ec0-d0e5c3415ec9",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "572c2907-8d76-4862-aded-2b42248cf01f",
-      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "a2362c3b-2f8b-4a69-9bef-eb358b320e6f",
-      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "26501dc4-c8a9-474d-99a9-9d4bd4a6c9fa",
-      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "8ac30034-24e8-4ca8-bacd-2eec398f9ad5",
-      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "03958566-7afe-423b-ab51-71ce3c52bb72",
-      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c553c45d-dba3-4cde-b40b-e03731284b74",
-      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "1c26c729-91ff-4371-bb38-e54e5babdcd8",
-      "groupUuid": "87fc2670-6f51-4dd1-99b1-34ce6e17396a",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "80082bf4-3cdc-49fd-a5d4-3cb9c2f22396",
-      "groupUuid": "d118f94c-4aff-43ab-af17-88da156eb0c7",
+      "uuid": "247ebd00-66c2-493f-ad0d-36a934a7e874",
+      "groupUuid": "c55eafcd-8e52-4215-85b7-a8e477d9c19f",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "f0fb50ce-6209-4839-8cb5-14cb9f6978ef",
-      "groupUuid": "fd02e2bf-1d66-4af0-b01b-13cf40d7b820",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "218f2455-426d-4d7a-b5b3-abf2c694cc34",
-      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
+      "uuid": "e79214e8-e3b7-4f78-8371-77756d0585e8",
+      "groupUuid": "6e6f80c7-fad3-430b-8b67-529d89ad2cfd",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "d56b4f09-b1ff-4672-b6e4-368177288b15",
-      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "e81efed4-181d-4b51-9550-2f27148986d7",
-      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
-    },
-    {
-      "uuid": "2f6de2b4-8ab8-471a-be27-ec6e089776ed",
-      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "2388035c-1837-402b-ac80-0dc8e04ad28c",
-      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e97a07a6-73cb-478b-9681-91041c818a24",
-      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "868e817a-22a9-4b4d-b073-46d7ba6c52dc",
-      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "953e2a01-9fe4-4d80-821a-de1ad9f56adb",
-      "groupUuid": "a0b5ad15-b8f8-4fc5-bffb-bf0d78ecb828",
+      "uuid": "a9e820d3-92de-4482-b5cd-e14693c2794c",
+      "groupUuid": "31a5bc42-2c6a-4f33-aabf-b17491396876",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "7e8e64dc-4c18-4393-bfb2-93e6978ab071",
-      "groupUuid": "121c37f2-8225-4d96-87a0-a5a60a2fdff9",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "98b547b4-1ed9-4978-b379-bb513363fa0e",
-      "groupUuid": "0c0786ca-e812-47db-837f-1ba8c7e18d48",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "5fee96fa-3c66-4aa8-a2e7-23637bcafb5f",
-      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "uuid": "035cc6e5-62fc-4437-8de1-3d28798026d0",
+      "groupUuid": "f98a49f9-a848-4d45-9f38-f76518261678",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+      "payload": {
+        "html": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+      }
     },
     {
-      "uuid": "02c5a1d5-72e3-4cb0-9cfc-1b9e2c22dc85",
-      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "uuid": "8b5d6a62-56e1-4f1f-9dfc-2794cb07a31e",
+      "groupUuid": "05992a9e-18bf-4c08-ac76-72f9f07719f5",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv6-altered-6str-25.png",
-      "altText": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm6-extended-6str-18.png",
+            "name": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "3eb31a58-b3e9-41f4-b2b8-78a033bd3635",
-      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "uuid": "47a44bd6-90bf-4de8-9798-b25eeabf2d62",
+      "groupUuid": "a239e8b2-f4b4-48de-82be-263dcb950bb4",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
     },
     {
-      "uuid": "bfcf5fb0-ac5d-4b77-be0d-d783236a5384",
-      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "01e00aec-3975-44e0-8df0-1a9e6c9bddc1",
-      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "3454ed97-3866-4f18-951f-0c7a6e234e9b",
-      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "51979008-ab50-4d44-ac6f-634ca67271ae",
-      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4f1ed7bf-47ba-4565-9465-9a347df68e2b",
-      "groupUuid": "3d9c15ff-49b7-4060-95a2-9b9e3a3b348e",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "ee61bd1b-6cb0-4861-920f-9543dcb25c1c",
-      "groupUuid": "88ae5c0e-351a-4832-8ab1-a32ea885b46c",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "cd04e6eb-198b-4e69-809f-d6d71aa3fd8d",
-      "groupUuid": "f3c355bf-b0c2-4d12-9de2-a48f4158a81d",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "aa4bc9b2-9edd-4ef0-8bc9-78d3829d8989",
-      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
+      "uuid": "c6c18aff-7994-4e36-bcb9-363ba552ea56",
+      "groupUuid": "b33aead4-2996-439a-bc03-4b62d650c7fc",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 10 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "fe37c064-df7e-42f6-9e85-adcc0f26b671",
-      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-3rdtop-6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 10 \u2014 Drop 2"
-    },
-    {
-      "uuid": "55f3ca6e-5dd0-4169-8424-245d645e8c51",
-      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "053e9051-065c-4048-b39f-07bff28b2356",
-      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "f3703285-12c0-42e1-aa78-3d189f9f021c",
-      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "uuid": "d9346948-6d48-4450-916d-b151c2437aa9",
+      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "1a71ac8b-f6b7-41a5-8623-7470f6483179",
-      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "uuid": "3cddb499-91ff-42ad-a9d2-c33fb422b4fc",
+      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "b23ac411-d4b6-48ff-a63e-9bfc1067819f",
-      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "uuid": "f1685d30-8ff2-4eb5-ac2f-05206da87ec2",
+      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "f3d0d16d-9df3-4a3c-b062-a847eef9adcb",
-      "groupUuid": "2a2263f1-2a9a-48e7-8895-e0b95ba43f46",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "ee8cac93-a3ed-4899-be30-249fac034e8c",
-      "groupUuid": "d554026a-d61f-463f-88ec-ec5b9808aa9e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "d49bf708-025a-443e-b4a4-2df946f8b171",
-      "groupUuid": "9f76d292-acdb-45c4-962b-402504a9992e",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "cd991eb3-4641-433d-8dab-53b2116d12c0",
-      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
+      "uuid": "e8e1b026-d536-4f2b-bc14-6a488883857c",
+      "groupUuid": "45884610-ed72-408f-bf7d-e5aa8a419ce6",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "71ad91ae-db35-403f-beee-be1facc72f4d",
-      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cm7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "bbd78b2b-f732-4590-a04e-aa3e1a286c37",
-      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "c80ee2ba-16d3-4809-b9da-23294752bd6e",
-      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "18fdc133-6c06-44bc-bcd4-d6c9ead77ccd",
-      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c02f7dad-b635-4473-8bdd-71974a21c436",
-      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9d9ee1e2-0a6a-4596-a249-1123738d7891",
-      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b8c225ac-e10b-4ac0-8e33-61037de956cc",
-      "groupUuid": "29067ecf-ea88-4196-b2f4-65b4be7f8b0f",
+      "uuid": "2ffb381c-3b2f-4d81-a7e0-ededcfefc7f9",
+      "groupUuid": "eabf8079-da96-4c29-b9a1-8984cfd14c2f",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "fdf79f25-c6c3-4b3e-9584-f630b08c4053",
-      "groupUuid": "f3b8ac56-d172-4510-845d-3c779dca0c67",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "32622073-0ce3-42cb-a8c2-0f2fc25536e4",
-      "groupUuid": "a722cb93-4b42-4d61-9615-14e11fc28908",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "79378017-4799-492d-8bf6-88f5a601db0d",
-      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
+      "uuid": "1aa74f40-1259-43e6-96de-c0ebed692502",
+      "groupUuid": "8ff480e6-670e-42e1-a55c-f121c149fca2",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "357581d8-af4a-426d-a6f4-3dadf6017898",
-      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
-    },
-    {
-      "uuid": "7aa20b82-16b0-4f8c-971b-c89532ebd85e",
-      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "8fc6fcdc-3793-43c6-9f72-3fd3a693eec8",
-      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "b4ab1445-d527-4e46-a8c1-5002b555a863",
-      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "313a9187-a1af-4418-b554-d5a568f368ed",
-      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "52701873-33af-4436-9866-e7eff38fabbb",
-      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b517b4de-3e03-4a48-a3bd-ead6a92c5199",
-      "groupUuid": "7aa19bfe-c3f8-47a4-bb48-8caf30d811c4",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "768499da-5202-4c93-b246-c6e314bf40eb",
-      "groupUuid": "ab950fc0-a516-4914-b8e8-1f1fdf5229a6",
+      "uuid": "cc1909df-f87a-41c1-8560-210516248cfe",
+      "groupUuid": "c26c42df-dcb7-4915-a0fe-0b28a002558c",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "59065509-8749-4c5a-9931-00a5f5e866a8",
-      "groupUuid": "81c458a6-dc42-4c7d-856b-90b460ad9e76",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "37348e24-94be-4039-9020-1eeb41a1d1a7",
-      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
+      "uuid": "cadc1e19-6f5a-4334-ac8a-cbff2e7a1d72",
+      "groupUuid": "7b5390b5-18dc-46ae-8488-b1705833771d",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "0689e9be-85e2-40f6-8760-d0e5e16f9d91",
-      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv6-extended-6str-17.png",
-      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
-    },
-    {
-      "uuid": "c6e37d0c-6ba7-4f30-bf83-0c59c60bce24",
-      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "5e08bfd0-7fda-4c7e-996b-3ee0ad14ea3d",
-      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "664b46ed-4d48-4f04-aff7-480861e2084d",
-      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "08c5c8ac-539d-4c73-9f7a-a56091f792a6",
-      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "88e876cb-f615-4de0-80bb-879c596e37e7",
-      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "80200bcc-db9c-4979-9dee-5a41cc893cb3",
-      "groupUuid": "c993170b-6c46-46f7-b599-0005632d9bb5",
+      "uuid": "db97d3fa-e3ff-43d7-aadc-ed6c2f5da52b",
+      "groupUuid": "5cfd369a-8ede-48d9-a998-2eb61b01b755",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "c4089129-2330-4ee7-a686-8c5f946bf465",
-      "groupUuid": "bd0ad227-8a09-4fb8-a08c-ba170daa4c60",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "ccb9ac4d-2313-4fb0-a1da-9e7aa7c7e84e",
-      "groupUuid": "8707d525-da19-4a7e-9855-767f161e2fcb",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f814c69b-9c38-4893-93b0-ce13c9309fb7",
-      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "uuid": "2d87a481-071f-4e31-b44e-446c8910cab8",
+      "groupUuid": "e004f887-d34d-4271-90c6-50b918503108",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13 \u2014 Fret 2 \u2014 Extended \u2014 dom13 extended"
+      "payload": {
+        "html": "Cdim7 \u2014 Fret 1 \u2014 Extended \u2014 dim7 extended"
+      }
     },
     {
-      "uuid": "e74633fc-1384-489c-b6d3-e22fd4cb97f5",
-      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "uuid": "d72750d0-9987-4d78-9658-56e1c0d49659",
+      "groupUuid": "78ca0ee2-8a00-409c-8913-3fb15e3056d9",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f2-6.png",
-      "altText": "Fretboard diagram for C13 \u2014 Fret 2 \u2014 Extended"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f1-6.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 Fret 1 \u2014 Extended"
+          }
+        ]
+      }
     },
     {
-      "uuid": "63879f62-37cf-40f9-bc45-32a8504c4c06",
-      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "uuid": "1040fc4f-bd60-4c3a-b392-c6971b4f663d",
+      "groupUuid": "c007aeb9-e409-40c4-ad0a-53406534abb0",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
     },
     {
-      "uuid": "1af4c108-e7f0-45e8-8b4f-74d675089089",
-      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "fe9cff38-c532-42fa-8ac7-1b5361bef908",
-      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "0faa4700-c47b-4a0a-930c-8c44adbef5fb",
-      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "7d3958d1-3200-4b90-aa02-25a8fbfb41d6",
-      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4fc9b7af-3033-4e72-a4ee-7b07fd5cfc1a",
-      "groupUuid": "50f1ee99-df58-4b46-9cc6-9cff7655d4ff",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "525ec07b-1296-47dc-b6dc-24d732d442b0",
-      "groupUuid": "e2b59c7f-1414-4629-ba8c-0a61a2983751",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "dad24204-9ece-489d-8951-0f8cbd40e7fb",
-      "groupUuid": "2c944705-dfa0-4755-81a7-42b605c888e4",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "287d459a-d3a8-4c49-8c89-89d19eed6a16",
-      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
+      "uuid": "37ecff1c-2be4-4f85-9e41-6e9297ebc428",
+      "groupUuid": "13b1bcf4-713b-41fd-a4cc-39f7b9b1c722",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "852e1746-4498-4f64-a14d-9da445bb2406",
-      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-d-upper-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)"
-    },
-    {
-      "uuid": "9f483536-442a-4ba1-8658-57f262577804",
-      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "20702ecd-76a1-493d-a309-3a85e58cbcd4",
-      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "0bf4c9b8-45eb-4cab-bfdb-0ddf69022964",
-      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "uuid": "119c6e49-7ce6-467c-8e26-29bca9b2d800",
+      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "89735065-c650-41a8-a979-b436fd0b512e",
-      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "uuid": "62e47d57-c124-41a7-8e12-cb22880f7eb1",
+      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "4c8eb53f-52a6-4681-a02c-e98a1ebf02d2",
-      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "uuid": "f6e7e8f9-03c5-4fd1-9f6a-48e1c07d905f",
+      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "a3ec6e74-e868-44cf-9dd3-90eb47725a34",
-      "groupUuid": "721d69d8-2a4b-46df-a08c-be0eec66d62f",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "8e6857c2-db16-40cf-8c74-9e8278766e95",
-      "groupUuid": "e9a81313-1ee4-454f-a086-29de029a17ef",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "7c6e5af2-6eac-41fc-86e6-afa49b9108fb",
-      "groupUuid": "2057b940-1097-4f10-a217-645885b60ece",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "2f5f7349-db4d-4d88-9eb7-bb59ceda495d",
-      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
+      "uuid": "0bd6800f-d80b-44a2-abd3-a505ed137fef",
+      "groupUuid": "735ca87b-5aef-42d9-ae2a-31bb69868e6b",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "19a34b88-f930-40bc-8559-d5d109b557f7",
-      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-shell-7str-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "6400ba0b-cb7e-49fd-ae7f-43e596a2a58a",
-      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "429df7d8-99a7-4c18-8bb0-b6a3fdcda833",
-      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "d7c14493-3ca8-42be-ad1d-8d8618d4df2e",
-      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "138caade-148b-457a-a1d5-6ad6684c2324",
-      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9daaa065-108a-490c-9877-0a595cdab2b9",
-      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "65720faf-f8ea-496b-802f-2e2603c4e74f",
-      "groupUuid": "6aaca151-acf1-485f-8f7a-51697bde034e",
+      "uuid": "6a94c1cb-a636-4478-89d9-01f07e674a24",
+      "groupUuid": "10df6a53-c15c-4071-b252-db387c07a6a1",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "1f07089b-70cb-4b23-9c8e-36e3c266cba8",
-      "groupUuid": "f58819aa-eb9c-48c8-b6c6-02bd155dd4e1",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "25a5e488-2665-401c-9f0a-e6a9d93991c9",
-      "groupUuid": "79129a45-055f-44a5-9713-55cd722de8e4",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "a8c7de1d-8055-4cd4-b0b7-c8fc59c80a66",
-      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
+      "uuid": "b70c23e7-faa3-4dc2-b4d9-e2d473b63109",
+      "groupUuid": "28d16b5a-ea1b-4b5e-ae58-eeb6bc6d8d14",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "df4381ee-c670-4098-abc7-e751571d2130",
-      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-e-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 E shape \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "09a79f85-14c2-42c2-bb9e-44f22555ffb6",
-      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "07935a10-843c-4516-b0d3-5d28a83c4c96",
-      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "62a30ede-db71-44c0-a422-91778213ec47",
-      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e5060334-2040-4740-989b-31a9d83d859c",
-      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "45307e52-b53f-482a-8242-2f3d85b2cf8d",
-      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "5ed8f79e-8e5f-48aa-bcbb-80bbd8d8fd67",
-      "groupUuid": "44e45643-ba2b-460e-a5af-0b5f481b230c",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "9043978a-52e8-46d6-8dfc-929791ac9e9f",
-      "groupUuid": "4b635864-7a12-44d8-8188-c7e667fa0716",
+      "uuid": "9435aa04-f6f9-40f7-a6e4-25c59ed1c7f2",
+      "groupUuid": "95b0e3a2-44fb-4871-b10c-3771ba7b946c",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "683b5203-49bd-43e9-ae72-a5b86314cce3",
-      "groupUuid": "6c0817b9-b229-47b7-aac1-358f97f9a95c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "ddf17afa-3e2e-438f-89c2-52bd41948660",
-      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
+      "uuid": "645e8a06-a7b7-4bff-a4a5-4c4c4e620e6e",
+      "groupUuid": "e07e1b2d-1288-4d71-a840-3f0cb9464634",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "6bece04b-552b-4ca3-bc0f-23d0886035fa",
-      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-e-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 E shape \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "a1bcc03b-f712-42ba-8bd4-e60db29c8355",
-      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
-    },
-    {
-      "uuid": "612dd531-2dab-4519-b2a5-c8c13a2c3be6",
-      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "2cbd48b3-5ef4-4d35-826c-4aa318b59e49",
-      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9de0323d-51cf-45fe-a0c6-d4910198ba86",
-      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "db4dee78-9973-4363-8166-d160815357b5",
-      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "28370580-8839-44d5-b7c0-a70539b4a479",
-      "groupUuid": "17526745-6ef0-4c7a-940d-d8c2d3702f1b",
+      "uuid": "e20a04dd-0589-469c-a516-5cac0712a388",
+      "groupUuid": "054112d6-605c-4bed-89e1-87aee8692e77",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "5202a849-1275-493d-98e1-f732f185ee9c",
-      "groupUuid": "3e97a0d4-2d45-4ced-8880-21977a4d1e2a",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "b18a1c2e-35ae-436f-aa91-a686b9b98cfe",
-      "groupUuid": "406320bc-47fb-4c27-976f-3019e5770114",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "55fc101c-8701-4c16-9df8-90bbbb612888",
-      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "uuid": "61952ea6-5aec-4675-937b-8f98a3207212",
+      "groupUuid": "b34ec572-0c17-46b5-ac04-acdf273fa073",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+      "payload": {
+        "html": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top) \u2014 quartal quartal"
+      }
     },
     {
-      "uuid": "225c4ec2-a3de-4a21-97bd-5fe2ce0b07a3",
-      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "uuid": "18c452be-aed5-4a5d-bdf2-8275497a5dab",
+      "groupUuid": "2c4fb82f-5fd9-4f83-879f-a13f8f8b0531",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv7-altered-7str-27.png",
-      "altText": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-a-lower-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "5307c100-0703-4206-9c6b-4cd7997e4e65",
-      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "uuid": "bd250145-78f6-4bcc-bccd-03d5079d80c0",
+      "groupUuid": "96fcff66-e167-4ae2-b63e-5f6e9051b2b8",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
     },
     {
-      "uuid": "69af7813-df13-4b7c-8c45-45332945bb4d",
-      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "cfa7ad9d-b53c-42d0-9846-7122c9d91f12",
-      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "bf0afe32-e5d1-40e8-84f8-ccdd83c8432f",
-      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "69b9187c-e97b-4b01-ba06-ed9e4e0f36b5",
-      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4b9bb1da-301a-42e3-b37d-521a99213e6c",
-      "groupUuid": "65ae06b6-32ee-492d-9bf6-e961f654163e",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "0878dafe-5a3d-4fc1-8918-677e110a89df",
-      "groupUuid": "e22d9f40-7c24-4066-9aa2-272e41965ba7",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "9b8f8b51-7fae-4ef5-a71a-82c204d37dd1",
-      "groupUuid": "f80e2dbb-ee70-4244-bbf0-be8cc011df5c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "756a579e-c7a3-4fe7-8dd2-c07c4fd7a357",
-      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
+      "uuid": "c8e5da45-bc8a-47ad-aab1-a284ce183d04",
+      "groupUuid": "8466802c-74f7-48f9-b7c4-b80f7c526725",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "0f0d0d19-dcaf-4dda-a872-6f7429a5bdea",
-      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-b7top-7.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
-    },
-    {
-      "uuid": "9b0b55cb-6266-47c3-b185-b5efd93f6885",
-      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "257c0f14-3f96-4ea1-8ec5-688f517936fb",
-      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "9ecc7cb9-37a8-497a-a08c-83fec03ab998",
-      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "uuid": "286745be-221f-4f7d-917b-d2468a6dc679",
+      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "3b69cc3f-5485-482d-b73f-b8c9902e1868",
-      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "uuid": "813c8172-26d5-430e-9cea-83d86e33ed88",
+      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "be3cb1e3-e149-4ae3-9423-16b55847f728",
-      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "uuid": "0041a32a-23b1-47c3-ab3b-dd10b0d7d290",
+      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "47d2be8c-aaf9-4db0-838e-a26858e19022",
-      "groupUuid": "8588b4a7-9f07-4b39-a36b-139000a4b5c9",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "d07f02ff-032d-4429-8d2a-ffaf64f9df1a",
-      "groupUuid": "e44a6fae-9501-4173-8870-8edb9db83cdf",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "00ba9499-8152-4c07-96e5-3aa18536e552",
-      "groupUuid": "61f00353-0140-4f0a-a81d-91362904983c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "1a4becb8-2da6-4d38-a2ea-11506dc80d2d",
-      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
+      "uuid": "c65b3941-8aba-454a-8838-db8097064e4b",
+      "groupUuid": "0b77379f-ba0c-4a23-9312-95f4e6eb7e71",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "c81e26b7-b508-40f3-8770-9767848e1b85",
-      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cv7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "8e436b8f-89b3-4403-97c6-9e8dc9215101",
-      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "f0835501-3fc1-46f3-9f39-5bb302495558",
-      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "d43785b6-a408-470d-b4d1-2a0d9a0f28c6",
-      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "25e3a1df-edd2-4d1d-8e84-e1ebc2603dc8",
-      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "af916e45-a325-4693-9595-9c147326dc4e",
-      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "40712420-89e4-42ce-adc9-3c5fb2fb5f9b",
-      "groupUuid": "0232f786-4bd7-40ad-99a6-633fed50e3b6",
+      "uuid": "421423da-7ab5-4be4-a7ef-a2f2c1c16e81",
+      "groupUuid": "cf1b6aed-e323-430f-82ee-74ad0bc8755b",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "7bb92140-b87a-4038-bbe3-f07c6d108a8b",
-      "groupUuid": "d085a76f-95e7-4700-9829-3d64ab8c2833",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "1fff0dc6-bb43-4a1c-8ffd-8c9e04ea612d",
-      "groupUuid": "246cd770-7d49-475f-b513-bbdcc3428eda",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "10a01755-b9a5-44bf-9cd9-ad93ea0b778f",
-      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
+      "uuid": "8aab0526-2b62-4253-a29b-8c2b20aa7219",
+      "groupUuid": "80d7a050-ed08-4cc8-99f3-73bb9c370654",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "afed22d5-5d04-4e15-af04-e8b688b1f29a",
-      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7.png",
-      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
-    },
-    {
-      "uuid": "a01583d0-d549-4c19-8d25-ba25d65775ed",
-      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "37f72730-eed8-48a6-a797-24763cd10c67",
-      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "4300f613-020c-4f77-8031-40d899230210",
-      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "45b1cbfb-6bb3-4f2d-b876-1579d187c592",
-      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "89786d00-9f4d-4dd3-8a2a-49cb8aeef664",
-      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b3c54dfa-2b58-4e21-9c0d-4193f5ca3fc7",
-      "groupUuid": "17b19449-821f-4d31-8b2c-df636a63422f",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "475f341c-c6af-4c15-959c-9f63f5d038cf",
-      "groupUuid": "bfe4bd45-c721-45b2-9075-664747f06a79",
+      "uuid": "e609d1eb-f9d4-4a6e-b43d-598625089e84",
+      "groupUuid": "18315ff8-5d1f-48f3-a592-fb32f81a2cca",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "71dfb8df-045d-4125-a828-38f3d2e4423f",
-      "groupUuid": "41725abb-1ae3-4920-b756-3d0f43cc040b",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "9eab1645-b716-4e7e-a702-fcb84de8dfe5",
-      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
+      "uuid": "c794f07d-958d-4206-bf15-d87e28da2375",
+      "groupUuid": "28ad471a-691b-4b49-902a-343a9473533d",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "bc99c817-cd82-40ac-b188-71e155c72b89",
-      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv7-extended-7str-19.png",
-      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
-    },
-    {
-      "uuid": "72dca44d-e96b-4284-87e7-0dce4ed789df",
-      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "315fbc82-9b46-4370-a5a6-62d2ef82e2c7",
-      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "d5287e6e-78af-465e-a8aa-661c94c65444",
-      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d59e31ea-505c-40c8-ae88-204c2105ed5a",
-      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "7688b107-d174-4c47-8144-3fcdfa7f2a60",
-      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d7d82079-eb70-4801-8cbf-529563c06934",
-      "groupUuid": "89687b3c-6893-40e7-b888-5d1b3fb7d0aa",
+      "uuid": "72467557-82b3-4083-8c71-3e38d0dc1d6d",
+      "groupUuid": "7610a85a-4b2c-414e-8901-daec52a0d87b",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "23f6cec6-c94a-4b71-89c5-6ee06fc9137e",
-      "groupUuid": "e88ea530-3fdd-4208-a376-0deb3df5cb4b",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "32961283-b398-4699-9793-aa6fc2614b2e",
-      "groupUuid": "d9df36d4-ce88-4d58-ae93-a79b1c41c024",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d4d45bf6-69e9-4722-abad-4ef6025810fa",
-      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "uuid": "8bafcd5b-8104-4f15-8351-991f43b719ce",
+      "groupUuid": "99c15a84-eaee-4ac8-ae09-a5a3cb7426a2",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13 \u2014 Fret 3 \u2014 Extended \u2014 dom13 extended"
+      "payload": {
+        "html": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+      }
     },
     {
-      "uuid": "e5bbedc2-6f77-440f-bfbb-4223483139d0",
-      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "uuid": "60b4e7f2-6011-4c59-adb7-fa49c75d9132",
+      "groupUuid": "5f106e89-fe0c-425f-8b6e-3e07ac0735b7",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f3-6.png",
-      "altText": "Fretboard diagram for C13 \u2014 Fret 3 \u2014 Extended"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cm7-shell-7str-7.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "435b816f-db94-490b-83ce-ace6384f6ef0",
-      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "uuid": "df729659-9594-492c-8144-79d7a855b0ca",
+      "groupUuid": "775c6291-42c4-4090-82bd-8510587d1d1e",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
     },
     {
-      "uuid": "3dd0a387-2b13-47ca-bcf9-75b06ee75368",
-      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "40363cc8-555e-4b5d-8cba-155be8b2f752",
-      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "b1b5343a-370d-4670-b6ec-0fe3fd327137",
-      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "2df8188d-7a70-4a67-afaa-a9d5bf31db4d",
-      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "67a9cc3f-43b2-4c0c-b177-2f96ab7d4235",
-      "groupUuid": "6dc237a9-744d-4698-bd3b-9669cfe28656",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "5c18081d-bb05-4618-8fae-5afc1bdc1908",
-      "groupUuid": "2cfefaf0-17f2-49b1-9237-9f4d06d62162",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "6d91a078-d6dc-4460-9176-6f15604d4fb0",
-      "groupUuid": "ee729eb0-04be-4a38-bec7-fbb386c2304c",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "349d4223-46cb-44ba-8a9f-59710dad5cc3",
-      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
+      "uuid": "b7f8195d-f38b-4ac7-8315-f2afed5a501c",
+      "groupUuid": "8f87f86d-dcbe-43d5-a3df-a16a46d22fbb",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "7ea93e42-9c49-475a-943b-0e5466a37c1a",
-      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-eb-upper-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)"
-    },
-    {
-      "uuid": "57e01598-fc07-470e-b763-b8a8bee9c78d",
-      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "1badea63-dd8a-429b-bf9d-fd1a96f192ef",
-      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "c5f012fa-7c0a-44ed-b556-6d085672ec66",
-      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "uuid": "0556b2ec-ac28-4685-947a-7c5a50f26368",
+      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "15ad7860-7a0a-4909-be67-e7aa6d44b8b1",
-      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "uuid": "c32a27a2-4dd1-4c75-9a62-35f028521f61",
+      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "48b8b349-6c90-41dc-8b80-cc8abd9909d3",
-      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "uuid": "eaf3670a-b430-4594-b32a-075c37055808",
+      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "36d8e845-5f1b-4ced-9eb1-436a47bca1b5",
-      "groupUuid": "6cfe9126-1606-4b5f-a422-b54bd7076f24",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "98a0ba9c-dc2e-4831-83f3-1db98b064a67",
-      "groupUuid": "4fac16d7-af2d-4e0f-88e8-5a1364088e87",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "f7fe6c29-9e1e-419d-9161-2212964f8878",
-      "groupUuid": "8d04dbd4-c630-4a76-b317-0f500114e7a2",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "a8af50d0-b2aa-4731-990f-054ebcf1e200",
-      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
+      "uuid": "b24fd514-0b57-401f-bbaa-bc51f89f8417",
+      "groupUuid": "5b255bfa-dc4e-4cc9-8697-334530110bc2",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "1a30ba61-c119-42da-a74f-94534db0d8fe",
-      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-shell-7str-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
-    },
-    {
-      "uuid": "2df31218-1523-46d5-9ac5-31589035069b",
-      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "a31b42d3-ead4-491f-a6b4-a8f633da745e",
-      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "2721f571-fb44-4c31-b854-211b584bfbe9",
-      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "6714b741-fef1-49fc-a892-5a2c33c9a8ed",
-      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "318312f3-0e78-4cc7-b9fd-1c34e26f78ff",
-      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "1cde45b7-d3c4-49e0-bd66-46ad507fd896",
-      "groupUuid": "93ff54b3-557e-4b31-b3c7-49d1d2c0a8b0",
+      "uuid": "1a3a40a3-0965-4851-9dec-0bec4972e6e8",
+      "groupUuid": "db3fa69d-0d95-4bca-935d-29e5c00a75e6",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "acb9a0c1-bb65-4915-88f2-7917890a5e51",
-      "groupUuid": "9cb5784d-9dcc-4497-ae75-456c6e828d17",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "50913830-61fa-4b29-a7ce-1ccb3a17d1ca",
-      "groupUuid": "c5d1a5f6-16e9-41cc-81db-654c443dfc1e",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f1f281a8-b398-4002-9133-38c89a3e1901",
-      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
+      "uuid": "031d2805-d5f7-4fb3-a5be-ae10036fdf2d",
+      "groupUuid": "9947610a-e4a1-406c-a185-72a41a86f9ba",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 D shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "a791522d-bb38-4c66-b054-eec7501626b7",
-      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-d-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 D shape \u2014 Shell (b7 on top)"
-    },
-    {
-      "uuid": "5c19fd15-54cf-47e6-bbe7-6ec44a15776b",
-      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "7fb3b944-4033-403a-b048-cb8f67669611",
-      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "c51b1f91-0396-43da-b85b-20ac42b53756",
-      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "910f95a2-0645-4ea3-ad26-1b87c342e0df",
-      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e3cba564-26fd-4702-b974-ad4119fbb697",
-      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "2f970bdc-7421-4271-8e6b-4e5f5d99478c",
-      "groupUuid": "97abf557-f69d-4eed-8752-e6d5bc7f49dc",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "59bb51aa-3344-4128-833e-1a4f0627d826",
-      "groupUuid": "02805b15-8376-4944-8eb0-0126064d12cc",
+      "uuid": "8c5bd1e0-3e4a-4c1a-9f8b-2661a767c0e1",
+      "groupUuid": "46828fb5-b3f3-461d-bcf0-a968acadbb2b",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "de0caac2-88ce-4335-ab18-a863c7cb3a43",
-      "groupUuid": "8ee6a9e9-000b-4e7f-b938-399c34327d16",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "57ddf894-e162-40fd-8932-4e7c1d99c637",
-      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
+      "uuid": "214df08a-62d4-48da-b49b-2fc99e1c5386",
+      "groupUuid": "f9805e8c-4d2f-4fe3-8453-5935a5a7344c",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 D shape \u2014 Shell (7th on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "370376e1-0abf-4824-b180-0a19926e1ba8",
-      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-d-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 D shape \u2014 Shell (7th on top)"
-    },
-    {
-      "uuid": "e8a1d145-f376-4486-a9d5-4a92a0092725",
-      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
-    },
-    {
-      "uuid": "a2f88aeb-ade1-459e-9c83-73b77273fd5d",
-      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "fb240565-9ff7-4cb9-824e-7818248d5795",
-      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e2b83d70-ac2e-46e3-be9b-8ed24ea2f532",
-      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "9f26087c-5275-49a0-a64a-fe1badd1c767",
-      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "67303188-7c3a-4b95-986c-88ff11aed4d6",
-      "groupUuid": "854a2b1e-0497-4962-8b3c-13eba5364ccf",
+      "uuid": "db3ac9d6-b1d1-413c-8bc0-05633d80497a",
+      "groupUuid": "a7eb3f8f-e0c0-4bfa-b111-9f326a33cc18",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "0a4d24fb-cfba-4678-9bff-f3c6c0982b00",
-      "groupUuid": "31773d14-1762-4025-a789-f3e8f5f45ff0",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "e76ef653-ac42-4a2e-b9af-63d47b92fc07",
-      "groupUuid": "c67b9065-d279-4c43-9ffa-bffdcacfc14f",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "55ff35da-e6cc-4590-aeb5-da21d1f41cea",
-      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "uuid": "c08e230a-e488-4aa1-87a7-0dcdd119c775",
+      "groupUuid": "86d511e3-4219-4e72-945c-2a52e5d7367b",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top) \u2014 13sharp9 altered"
+      "payload": {
+        "html": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      }
     },
     {
-      "uuid": "f31fc6e6-57e8-43df-bd32-e1bbaf8bd299",
-      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "uuid": "e07388e7-6b87-4d70-8e72-49e8903d61bf",
+      "groupUuid": "64c00ed2-982c-464e-9476-20d2c1426f20",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13s9-cm6-altered-6str-30.png",
-      "altText": "Fretboard diagram for C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-shell-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "3de586ac-bb54-482f-81f5-a5c90c1dab40",
-      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "uuid": "1b309670-7488-487d-b10f-6f8c07b48044",
+      "groupUuid": "5ceb96b4-bc2f-4a39-9e80-a97e919d0892",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
     },
     {
-      "uuid": "51afdcd3-f827-4b56-81ab-8aa435dd3bc6",
-      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "966e9a29-d96f-438c-8985-48c3ecfb59f7",
-      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "318db960-f91f-42b2-ae76-5d4496a266e2",
-      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d5d03872-4935-4e18-a990-ae78428d7683",
-      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "c34cd776-ecc8-4ced-a35b-71fee5efc8dd",
-      "groupUuid": "05026a47-7afb-4335-9864-eedcd0dd85fd",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "9ea0f0dd-ef10-4cd8-a138-71efb2b4a707",
-      "groupUuid": "9d66a7df-2adf-4416-b000-89bfa73539e7",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "48edbc7e-1512-4a86-83da-3da2158322c5",
-      "groupUuid": "7f94e18e-bd3c-472f-a29c-6836b2819852",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "1bb91d0a-0083-4add-8a82-75841f77e46b",
-      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
+      "uuid": "9afc4cc7-85e6-4fd5-a32c-fb5223e0a65f",
+      "groupUuid": "4b81a4ec-0ad8-4902-ac10-e2835cfc2a68",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "ebfd9b59-b554-447b-bb5f-2e948769234c",
-      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-1top-7.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
-    },
-    {
-      "uuid": "b6d8fcb0-0cd0-4490-aa26-b120722e18c9",
-      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
-    },
-    {
-      "uuid": "89f25c3b-39ca-401c-8244-70aaef21f609",
-      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "23dc80aa-429e-42fd-a82c-13b213cbf4a6",
-      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "uuid": "64d42eaf-2cf4-46c9-acb1-f16d1b0fb26a",
+      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "c6a2cac3-3b11-451c-9b97-f733ec701b37",
-      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "uuid": "158a2ae7-b7fd-46de-a29d-869809427091",
+      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "dee6c2a6-6fd3-4b8b-b82d-268b0e349641",
-      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "uuid": "30300d85-a73c-4f20-9e7b-2a596be8e184",
+      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "0ff19939-5921-4ddf-96c0-6bf44c064010",
-      "groupUuid": "bbdd8101-74d8-40fe-9300-f97c24891c81",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "0fff037d-aa78-4ff1-a2d9-d26313bac4fc",
-      "groupUuid": "7264e2a1-4d35-460c-ad2c-c76245623720",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "052e861d-a856-48a6-b4a7-fd1e5f620843",
-      "groupUuid": "66397392-ef3d-4818-b037-a58658984d04",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "bb078603-99ab-4b09-8a20-26dd2a2ae617",
-      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
+      "uuid": "17487e39-3810-4f7f-b477-270a99126982",
+      "groupUuid": "d98a0d1f-208e-4f1a-8b0f-7fdf9cefa971",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cm7 \u2014 7-str bass \u2014 Drop 3 \u2014 min7 drop3"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "9eff256a-f236-442a-800a-a61f433fd2cc",
-      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cm7-cm7-drop3-7str-7.png",
-      "altText": "Fretboard diagram for Cm7 \u2014 7-str bass \u2014 Drop 3"
-    },
-    {
-      "uuid": "96039c62-7fd2-414d-a7c1-263e8b017923",
-      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
-    },
-    {
-      "uuid": "5dd8dfca-8359-4532-b9a7-c0bc10878038",
-      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "af97a963-cc8f-459f-880a-fb6a32136ec0",
-      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "73cf399e-2093-4181-82a6-ab3dc34389ad",
-      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "bdf628a4-ebf9-4709-8ccb-ec73f7da31f9",
-      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "d22c13ac-6625-45b7-b9b5-a39631b99321",
-      "groupUuid": "97b6fa6e-23ee-4df7-93af-898ff48bff90",
+      "uuid": "6695aa21-9707-4027-9a6a-8ebb736cb1ce",
+      "groupUuid": "ba049432-c710-4eef-bfc3-9ad813498c06",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "5694c323-053d-42ff-ad2a-6c0c3120fdde",
-      "groupUuid": "3833a370-ecbc-4a05-9c94-b827e0581c19",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "c2cd7c84-84db-40eb-b623-f68dafbc048b",
-      "groupUuid": "a3638690-425c-4a40-9dc4-23d08d81f8ca",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "d74d77b1-d65c-4f35-96f0-e8617990c98b",
-      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
+      "uuid": "387a5c91-bf49-4241-8cdd-e695e2efc5c4",
+      "groupUuid": "3f385118-9272-40bd-8d79-c98e49bbc65a",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 A shape \u2014 Drop 3 (5th on top) \u2014 dom7 drop3"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "94daab2a-285b-4688-bdb4-d8bb7a95b673",
-      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-drop3-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Drop 3 (5th on top)"
-    },
-    {
-      "uuid": "9f8e435a-4da8-4fb7-ab7f-0805503281df",
-      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
-    },
-    {
-      "uuid": "4c183f33-d0b5-4d56-993b-bb7375d7170f",
-      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "9f889f66-1487-43cc-b310-1b30181baabc",
-      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "5a21fe6c-b3f1-45aa-8406-8abf01564119",
-      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "29aba4c0-e17e-45e7-b362-a1884499db61",
-      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "60638d71-0c04-4ede-a21a-736c9c464445",
-      "groupUuid": "a322ee8e-004e-4146-ab83-a2228ba2ece4",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "4294161a-59f0-479f-a619-187caa4ab548",
-      "groupUuid": "11a419b7-b92b-43d1-ac66-109b698b227c",
+      "uuid": "b737857d-6156-4406-a330-69b393632fa1",
+      "groupUuid": "9f984b7e-5e27-438e-b1a2-3689dffa00a7",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "fd299442-d19c-4275-932a-e927c9deb998",
-      "groupUuid": "6ae51c8a-47b8-41c7-9d9f-ceb4fb574f85",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "89c9e374-85a8-494a-a573-c89617f637e0",
-      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
+      "uuid": "50aeada4-3017-4f27-8a51-b19d516cd109",
+      "groupUuid": "9590e54a-47d7-435d-b059-c493df2fc35b",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top) \u2014 9sus4 extended"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "eeccf321-f1b0-4667-a99e-0bbd2deb620f",
-      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c9sus4-cm6-extended-6str-14.png",
-      "altText": "Fretboard diagram for C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)"
-    },
-    {
-      "uuid": "21d02841-96e2-4919-bd3d-ba3fc9edd74c",
-      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
-    },
-    {
-      "uuid": "c2091452-d196-4764-8f77-ee6527ffa1f6",
-      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "7ceb6c55-6bc0-4ce3-9fc3-97cce28a9974",
-      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "4cddba25-8e5d-4095-a0b7-c4937e1ce638",
-      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "a7581be4-8d50-4107-9367-83903e8b8e2c",
-      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "77bc03e1-825a-4f8b-890b-a2ed51f33813",
-      "groupUuid": "2dec5983-cebe-4201-a82a-781381fe1e0b",
+      "uuid": "ac0f4fe5-175a-4b72-a5ae-76f410078ea4",
+      "groupUuid": "f6bc64a8-fb8e-4345-86b8-553434c923fc",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     },
     {
-      "uuid": "dc050f9a-c1e0-43b3-9b28-c5d4f4793758",
-      "groupUuid": "5b9812c3-0950-49ef-a462-f71088084739",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "7cd14cc7-e44a-4651-9742-3b0b814c5d4f",
-      "groupUuid": "d6da7167-93dc-4896-acf5-f622ee9bc3a6",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f0b9028b-5ad3-410f-97da-3e114c6c6119",
-      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "uuid": "af7445cd-fe22-42f6-98a0-7175e380dc61",
+      "groupUuid": "8af6a962-8266-4551-9189-003be2b665f7",
+      "groupType": "TITLE",
       "type": "TITLE",
-      "title": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top) \u2014 dom7b13 extended"
+      "payload": {
+        "html": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+      }
     },
     {
-      "uuid": "eae8bc8d-6163-44ae-bdc7-747a1d3b2d31",
-      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "uuid": "c71180b7-6b4a-4c05-bc30-5ca75d4bfeeb",
+      "groupUuid": "c5c3df91-2ce3-4cb6-96ee-eab0bd18b33d",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7b13-ext-a-shape-6-cm6.png",
-      "altText": "Fretboard diagram for Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-shell-a-6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "7cca705d-bc30-4f8d-a5d8-a728f0435c49",
-      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "uuid": "c9236a8c-187d-4b5a-8ec5-ebe4023e4604",
+      "groupUuid": "16403e79-f89a-4469-9167-648715f0f33a",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
     },
     {
-      "uuid": "066e0ac9-79a8-47e4-99de-fcdd39957a54",
-      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "8290f569-c603-4349-a66e-d83540e44dd5",
-      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "e62efc35-3621-4d70-aed5-9540406d00e3",
-      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "20210696-5cdb-4431-93d0-e98ce5871b52",
-      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "bfdb7ecd-a7b8-43b2-9a5c-56e973f64624",
-      "groupUuid": "295e9bb8-0425-476c-b893-884976c376ea",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "5d970d2e-1248-4799-8781-582989375347",
-      "groupUuid": "962bb09a-4e29-4f38-9105-01dbc3751b49",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "a0176b80-da31-4dfe-9ca1-5e9efb97b580",
-      "groupUuid": "857b0d05-c085-43f5-bc33-8ea8d607a412",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "f6e09cbe-fa2a-4300-bdb6-eaf8104ec617",
-      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
+      "uuid": "b7d246c7-ffce-4723-aebb-04165860afc4",
+      "groupUuid": "788ee4a0-6822-4a56-81e3-b79a34ed3e05",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top) \u2014 quartal quartal"
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "e424249b-2889-40d0-8280-cb6846a8bbe1",
-      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-f-upper-6-cm6.png",
-      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)"
-    },
-    {
-      "uuid": "2b1b3df5-994f-46f8-b3f9-c902d254b9ae",
-      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
-    },
-    {
-      "uuid": "4e0ddd14-be3c-4c1a-a36a-76834993a806",
-      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "7b8284c7-a120-4c17-a25f-00dd19e1a9c3",
-      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "uuid": "cff13637-f050-4853-8b81-a3e3903311aa",
+      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "dce3d3e7-feb1-4b52-80ab-58f0201facc9",
-      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "uuid": "be20e88e-1703-473a-b677-4820515829be",
+      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "177066ed-0d9e-4cc9-bab1-196512fe288c",
-      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "uuid": "6b3bd45b-8746-486a-99dd-1cc9b92b11dd",
+      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "6dadb013-12d1-44f1-99c1-1860e23078ea",
-      "groupUuid": "b3b89b5f-0f52-44b0-92eb-e9b06f02a05f",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "b3096b33-a3f8-45a7-9611-91a7c3aa08b7",
-      "groupUuid": "69a8ddd3-1957-435a-b8f3-36b318446f75",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "3d08e72c-1f48-4e76-b91d-7b6c17588640",
-      "groupUuid": "6d4ba774-ecb7-4745-a646-afff792d5703",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "0ac282fe-52b0-4a61-b4b3-50ba88890517",
-      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
+      "uuid": "c2768bfc-c8d0-4707-befa-220edeecb04e",
+      "groupUuid": "9b203b7c-3162-4cc3-8840-5b9d7fc2031b",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7alt \u2014 7-str root \u2014 Shell (b5 on top) \u2014 dom7alt shell"
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
     },
     {
-      "uuid": "4f33ff9b-383a-4f0f-ab90-3f3dce62faf3",
-      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7alt-cm7-shell-7str-7.png",
-      "altText": "Fretboard diagram for C7alt \u2014 7-str root \u2014 Shell (b5 on top)"
-    },
-    {
-      "uuid": "96e071db-45a4-4673-bbd3-d3058410f08c",
-      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
-    },
-    {
-      "uuid": "563310c4-7939-48c6-a5ba-c46de7ddea93",
-      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "5a307b16-7c57-4bfa-8bb6-8e4897f38d65",
-      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "2c61c1db-9bbf-4659-ac58-8783a0d0e580",
-      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "444c15cb-4d39-4bb4-abf6-070161509dbc",
-      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "0ab5fdf8-5931-4854-8615-71fa50b626b0",
-      "groupUuid": "1d3cc254-8140-4fce-8ec0-c5f884045c71",
+      "uuid": "8a6f3e0b-9cf6-4532-9189-46499547fdf8",
+      "groupUuid": "36f7b4ee-636e-4b8b-b52c-e918f1c33280",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "26f5688f-36c9-498e-80cb-5d4f582b8704",
-      "groupUuid": "cc5f4a7f-ecf5-487b-8798-a034c989977e",
-      "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
-    },
-    {
-      "uuid": "67fd6f51-1033-4aa3-8eb8-f79d3cf51ba3",
-      "groupUuid": "cf44c64b-26d2-4851-8794-0702d3a2a80d",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "351364c5-da6d-4dfa-8fc1-08aeb0d86399",
-      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
+      "uuid": "1ee6011f-1cf2-43a8-a4b5-6ebb03f8dfdd",
+      "groupUuid": "fe1de755-99da-4f20-bd47-2db0d39536c0",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
     },
     {
-      "uuid": "df5d4ab1-4ee3-4da5-8dbe-fb6321768188",
-      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
-      "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-cm7-shell-a-7.png",
-      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
-    },
-    {
-      "uuid": "b66636e0-b7ff-4bd3-95e3-8e3f6876cfeb",
-      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
-      "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
-    },
-    {
-      "uuid": "fb9d3e57-222f-4862-8a29-09bf660dd362",
-      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
-    },
-    {
-      "uuid": "71307d7d-e1fe-4c91-adbb-368b26a067ec",
-      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "3167fdb3-7106-48fa-9d15-65008e4ebad0",
-      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "eca4e1a3-3fe9-4c13-9d0a-7a149433d71a",
-      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
-      "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
-    },
-    {
-      "uuid": "65eea098-1c44-4fb1-939a-6c4bfae76b4e",
-      "groupUuid": "0a2bad26-e332-492b-bc27-088b56835ca5",
-      "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
-    },
-    {
-      "uuid": "5fa0158c-6fcc-49a2-bfed-19a2d6b11064",
-      "groupUuid": "16432b0c-c374-4f2d-8961-b6dfb2c3dc1e",
+      "uuid": "59efa150-d7b9-49ec-9734-e3f483d736c5",
+      "groupUuid": "c51a5577-eed0-48cc-b547-f475f4f4856e",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "e23ef9dd-6bda-464e-8750-a9b0a81ce335",
-      "groupUuid": "bac8e138-b707-4423-b670-a0fa10a35997",
-      "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
-    },
-    {
-      "uuid": "4c8617b1-d6f8-471d-a7f3-9e0740063e20",
-      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "uuid": "3a2ce510-23ee-4fa2-b157-ac9e3eb5d12a",
+      "groupUuid": "b8983597-2e6f-4b5e-9bac-9b6326552378",
+      "groupType": "QUESTION",
       "type": "TITLE",
-      "title": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
     },
     {
-      "uuid": "e2cc6918-3d7f-4cc3-9371-da81ebdb2641",
-      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "uuid": "2c5c09cb-29d2-4b12-9a53-db18dc20dd45",
+      "groupUuid": "a9bb102e-a117-497f-80ac-aa1c728ad64a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "364916f4-6640-4fba-9cd3-61fad453336b",
+      "groupUuid": "6686e695-0d43-4736-aec0-6bfeb93ec335",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+      }
+    },
+    {
+      "uuid": "43be26ad-41a7-4268-9912-de0bd35d57c9",
+      "groupUuid": "8ba589ee-c31d-47de-9159-c8374a286816",
+      "groupType": "IMAGE",
       "type": "IMAGE",
-      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-shell-a-7.png",
-      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm7-altered-7str-28.png",
+            "name": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+          }
+        ]
+      }
     },
     {
-      "uuid": "252ffc5d-6b99-48a6-9c23-a48214d45681",
-      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "uuid": "858d0998-3777-4d00-8714-343209e699a1",
+      "groupUuid": "c7f95bba-fc45-4865-9390-731cd312d26f",
+      "groupType": "TEXT",
       "type": "TEXT",
-      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
     },
     {
-      "uuid": "2b1cfa5e-365a-49a1-98fc-ace303c311e3",
-      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
-      "type": "MULTIPLE_CHOICE",
-      "title": "Do these tags fit this voicing?"
+      "uuid": "125e34aa-beff-42c1-a674-bf298a891468",
+      "groupUuid": "64bd1225-6184-47d3-a99c-e72b2f431aac",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
     },
     {
-      "uuid": "b665bf70-684f-4bb4-a1ab-c4124faf410c",
-      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "uuid": "1ba5a201-6a48-4ae6-b0b6-ec51358fbf75",
+      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "YES",
-      "isFirstOption": true,
-      "isLastOption": false,
-      "optionIndex": 0,
-      "allowMultiple": false
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
     },
     {
-      "uuid": "f9ba926f-0e0f-40dc-ad64-79c09c6cd6e3",
-      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "uuid": "ec0ce49f-83d2-43bf-9077-cda0faf26056",
+      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "NO",
-      "isFirstOption": false,
-      "isLastOption": false,
-      "optionIndex": 1,
-      "allowMultiple": false
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
     },
     {
-      "uuid": "6ac32c1f-0364-4b02-98b9-478ebf10ba02",
-      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "uuid": "8059ee76-e4aa-4325-b5b4-05b03bdd9116",
+      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
-      "title": "REFINE",
-      "isFirstOption": false,
-      "isLastOption": true,
-      "optionIndex": 2,
-      "allowMultiple": false
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
     },
     {
-      "uuid": "6892e91e-e4f1-4db5-b954-81b75c53527d",
-      "groupUuid": "7973a3dc-7819-4bbf-9b25-dad30f829a5b",
+      "uuid": "8e779d95-7e5f-4d42-aa88-dfc1edc88b71",
+      "groupUuid": "2d5dce51-8cfe-4bcb-a749-c91fade2a3a9",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "056e214b-ce3b-4e90-b221-194027f38c78",
+      "groupUuid": "8f5ca13e-66b4-4530-b04e-3d41d40bd749",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "If NO or REFINE, why are you overriding the agent?",
-      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
     },
     {
-      "uuid": "637b1619-6712-416d-9822-abee1e3cc5b0",
-      "groupUuid": "96d9c470-e42b-4cb5-801f-fe2975f81cfa",
+      "uuid": "49b3ffb1-db4f-4891-b157-2259e1dc6f84",
+      "groupUuid": "121ba6e7-f041-458f-a217-7b3da91f6614",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "2bb430e5-83d7-429f-95d0-32f5e1ee365f",
+      "groupUuid": "bb2f0756-6681-41b8-b1e6-141ad0db9d38",
+      "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
-      "title": "Tags to add (comma-separated, optional)",
-      "placeholder": "e.g. van-eps, walking-bass",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
     },
     {
-      "uuid": "878ddfc6-4203-4d12-805b-8798f1536fc8",
-      "groupUuid": "83fd1c72-079b-407d-baee-6b7f68787902",
+      "uuid": "9f08ba6a-3f41-4675-9d07-a5b367bf9028",
+      "groupUuid": "73552248-eaaa-411f-b865-d29202217009",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "c6f34819-9059-4471-9da5-fd28e2fbae2f",
+      "groupUuid": "26f728f6-b1aa-4f86-848c-ca320bf1a972",
+      "groupType": "TEXTAREA",
       "type": "TEXTAREA",
-      "title": "Anything else? (optional)",
-      "placeholder": "Free-form notes",
-      "isRequired": false
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "bacbabc7-e500-4ba5-bbce-2fb90fa052ff",
+      "groupUuid": "57ed6646-e84b-4777-a699-55c49d3ab570",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
+    },
+    {
+      "uuid": "72fa150e-9c05-42b9-9bc9-ab19735a7d0d",
+      "groupUuid": "2df6e4da-4b48-49f4-89d8-9599a7bc49a4",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-1top-6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "d2d4a925-c8b4-4270-99b7-bb02b41153ce",
+      "groupUuid": "b4bc5359-4c42-437e-b2cc-fad13a88757f",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
+    },
+    {
+      "uuid": "87097ed3-07ed-4bc7-b412-5373a3721bcf",
+      "groupUuid": "45cc8e44-8f43-4753-af6f-186fb41384a7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "f31f3753-d786-494f-a44f-a80f5593ff89",
+      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "d8bf5c2a-4c18-409f-96ad-feede953d2a4",
+      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "ee150ab1-69a6-484c-8c07-f968b78db070",
+      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "7be6d845-ce12-4edd-91b4-c163e27eccd6",
+      "groupUuid": "37091098-aa71-4456-9164-51d6375184a6",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "33349f47-8f2a-4d44-9d65-78042848862a",
+      "groupUuid": "07c7f92c-26b2-4f42-904b-4da3e2a74b2f",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "3e6f441f-d15e-4156-8a88-c663a5daccde",
+      "groupUuid": "b818ab42-8697-4767-9741-9c8ec8078c05",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "6c062273-f597-4955-8850-3c6e326076fd",
+      "groupUuid": "076741e9-448d-4ec6-9a24-f41b7caf331b",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "2a7a2134-2f0c-4daf-a655-59cbfc83b675",
+      "groupUuid": "24c191da-1336-485b-a34c-a0663265fef4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "bd858855-9aea-43ab-98cf-72069fb2670c",
+      "groupUuid": "9f56fc2a-16fe-48fa-a987-b395ca7bfc7b",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "395350ff-4e77-421a-88f5-50041b74e431",
+      "groupUuid": "2d55ac60-bf6d-4023-86b3-4c01c442350b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+      }
+    },
+    {
+      "uuid": "36bed446-e649-4571-942a-468ea38eb79c",
+      "groupUuid": "3ccd8f7b-1b74-4a2c-b505-3a097cdc70e9",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-drop3-7str-7.png",
+            "name": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "3dd34ec1-ac17-4fef-b7c8-9a872989f338",
+      "groupUuid": "7067bc97-a469-4c71-b44f-32aafe15b3be",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
+    },
+    {
+      "uuid": "c27f4134-4364-4e1c-8d89-bdb5924e612d",
+      "groupUuid": "032cd38b-01c4-4be4-890f-9f2548a5e16e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "1bbebe7a-f0cb-4667-8b91-be4302a89b74",
+      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "83b5ef31-8d32-4eff-bd2f-a2800d8f4dda",
+      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "33e24eb6-4fe5-4c1c-8fb8-c064c5895d73",
+      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "847c6c84-efb2-4263-a51a-668286bd0bc3",
+      "groupUuid": "11cd35d9-b65f-4274-bb5f-fa5bc8a33091",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "2c4ed1bf-0dc7-418d-a2e3-95d2da96248f",
+      "groupUuid": "2b00b454-fd9c-42db-b174-63d8af6c7576",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "d08145a3-6988-4f96-a99c-92b1c09eb36d",
+      "groupUuid": "ecdc1dd3-39a3-4ebf-9aab-4aa6088a7d0b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "34c7946c-7a8b-4aa2-95ab-4ece4f165df4",
+      "groupUuid": "4ca93864-6e14-4f77-abdb-a61e252e38eb",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "dc61f4bc-0f66-4fca-898e-682ca5620663",
+      "groupUuid": "5a1fbf4e-87d1-41c9-9f96-22f88201fd46",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "cbc90c0e-be83-45f8-b4d8-66a2131dc35e",
+      "groupUuid": "4ba35dbf-6b22-4462-9f33-94566d075ea1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "eb8f091a-3e0f-4f10-a558-5a5550550d9d",
+      "groupUuid": "42a47e21-1d3d-4c93-9f95-aef31d6d3227",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      }
+    },
+    {
+      "uuid": "e2012e24-2a6a-4f6a-82bd-97e1dc956b2e",
+      "groupUuid": "6fae159a-90fd-4022-b930-ce7b6e811c98",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7-cm7.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "c385163f-2747-4a50-aac4-2221de9cc55c",
+      "groupUuid": "01acd642-24ea-4c87-aefb-67814974beb6",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
+    },
+    {
+      "uuid": "ca9510f0-6b01-4bf2-8984-f11755110bdf",
+      "groupUuid": "14d3a75b-5bad-4d2f-8e94-c5f8675a963d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "2d5e63eb-870d-49c5-bf48-c269ee6f3c71",
+      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "0ba4a089-2d97-4a99-8ebc-d4d8f2ac4d01",
+      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "f3983be5-1a07-44a0-b32a-213d0016037b",
+      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "7e254b79-56aa-4382-97ca-979677fce5d1",
+      "groupUuid": "b73c9ef7-6af4-4de8-926a-66fb936f4306",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "c5cfacb3-acb3-4663-bff9-56f274a477b2",
+      "groupUuid": "da55fa5b-8cd9-4000-b07d-6e8dcdbdb418",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a6969fce-963a-4694-825f-ce0be0fca7f4",
+      "groupUuid": "5f97ad96-213d-45c3-a278-315e50415d25",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "39f71d85-2692-41ea-917a-3bfed6e2beec",
+      "groupUuid": "ba3e1a22-bd43-4bba-910f-386973f3824b",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "f1ac6a79-bc8f-4e3e-9ada-837e8074f32e",
+      "groupUuid": "ad47373e-143d-4edc-8a25-b384c6f24c4c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f5d64365-f73c-43a1-9816-1b3cdd641919",
+      "groupUuid": "6d8a08b2-b86d-4fa4-ab4b-66a9d84965a7",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "2386ad47-f646-4df4-a5b7-bd754b9a63b1",
+      "groupUuid": "07fdd513-7c25-4102-a791-8c4e5e3f1cc3",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+      }
+    },
+    {
+      "uuid": "9d1097cf-9cab-49bf-b38f-23295a1183c0",
+      "groupUuid": "ecdf6f82-3b73-4792-b87d-7fec5939d10b",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm7-extended-7str-20.png",
+            "name": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "fd780b1f-71ca-4b0b-a937-28cebbbbe8a0",
+      "groupUuid": "8401947c-d5fc-433e-af40-b93005c2f5c6",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "b7a9a410-9ef2-459c-99ba-830bf7b293c1",
+      "groupUuid": "c9c941e4-3e51-4b77-8ed7-b814c6adb0ab",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "e91bd587-f753-424c-b39c-04634e62e598",
+      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "8cf8eb90-8099-465f-82f3-f34efd5dbf38",
+      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "20432ea0-7521-4eaa-ac59-28d18349286d",
+      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "0bbbec7b-6b67-41be-ad6b-300b8fd6f147",
+      "groupUuid": "8a4d5431-3cde-4009-89bf-f8e006c8a61a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "d95b05b7-ede1-448d-b81b-0e0b513380b7",
+      "groupUuid": "bcd5ab61-79e9-4e2c-8b99-ad9801947db9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "e34b1140-781b-4beb-bc52-aedbda0bbad4",
+      "groupUuid": "9eb1d5ed-4de4-4ea0-9664-d9aa9b43ef92",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "59f73fd7-8958-49fd-9715-95a9deac071a",
+      "groupUuid": "1689d43d-cf2d-4561-a0f8-840b888bdbeb",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "2e077090-e6f4-4953-9187-6c2bfbac1182",
+      "groupUuid": "dc4d2fb5-a2c6-4070-9e21-cc96fe438ae5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "19431104-1401-4404-8024-9ce518f85dc2",
+      "groupUuid": "f995f7ca-a725-4d82-8f8f-2d5fa0fbff83",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "a2088f42-0c93-4bcf-8507-d540f6202798",
+      "groupUuid": "ad22af28-752b-493c-8541-f289e0693140",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 Fret 2 \u2014 Extended \u2014 dim7 extended"
+      }
+    },
+    {
+      "uuid": "b82c7dea-c400-43c8-80e1-e800c71e9c56",
+      "groupUuid": "8d401c75-85e1-49a9-9c80-e3a356b73e4f",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f2-6.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 Fret 2 \u2014 Extended"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "01f760e0-75dc-44e0-8b8b-9f2222bcbef0",
+      "groupUuid": "f363bebf-a0d1-4cfe-961a-f4074cf12b1b",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "f12b60ec-06a2-40de-b372-aed5e396fe9a",
+      "groupUuid": "3ad12243-8d51-4caf-8080-3187d72eadc3",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "91caf4fd-03b5-4b09-baf9-c6daf4152c68",
+      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "6cc72f69-e9b3-4370-96b3-0cdb9f602e72",
+      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "1fefad35-60a3-4bb1-a941-9eca07280f23",
+      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "1fe57405-a3db-4f4b-ba2f-0c083fc0bd78",
+      "groupUuid": "f44b967d-4f1c-412a-9884-7ee5032194c0",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "92ca8ae5-f74e-4172-ab68-003e94d431fa",
+      "groupUuid": "c96d4b7e-c6de-44bc-b57c-6094fd6d6003",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "1a96ab19-164c-41f3-8a27-bae17cf54583",
+      "groupUuid": "791cd7f7-809d-4949-a638-7b7e044c0067",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "8078b616-f1ea-4b40-95ef-7d0b7fee0148",
+      "groupUuid": "516856ed-675c-49b6-aa8c-97de96b47b82",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "18e14fba-4f99-43f6-9273-9b4ce8604733",
+      "groupUuid": "0dda78fa-2a83-4316-888a-920c3312bd68",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "1f4e7e09-8b9b-4830-b3d6-9f163eb4c365",
+      "groupUuid": "5e08d306-480b-4faa-8bdf-49e2d86707d7",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "24cd7e89-3323-43fd-9968-2676b7ce4ca4",
+      "groupUuid": "0d94fdb5-fdcd-42f8-acc8-c02000f3798b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top) \u2014 quartal quartal"
+      }
+    },
+    {
+      "uuid": "6eec085c-e36e-4d37-a80b-d8f72a213109",
+      "groupUuid": "4e2e2b85-70fa-47a1-b704-671e6897e07c",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-bb-lower-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "485ca974-9f03-4dc0-8704-5b75bdbaaf21",
+      "groupUuid": "dd9cf6f3-d9d6-42d4-a097-c5a52954c6be",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
+    },
+    {
+      "uuid": "60e85e67-2705-4bca-bd26-f6b84a54e789",
+      "groupUuid": "7f9545fb-22ce-4b52-be00-974f49bfe8d5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "842a7d66-3319-48df-9766-8d83c66b26e0",
+      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "9a24876d-00d9-4637-ae0f-1582c7f7e2de",
+      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "f22e81ef-7e97-4c4d-9c9a-36f80e088d71",
+      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "1d79de41-1d0f-4330-ad7f-e7bf9817ad94",
+      "groupUuid": "eaa8c67f-4c8a-4e2d-bb46-68de4f7971e6",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "db82030c-714f-4f51-9a68-32178b7786b0",
+      "groupUuid": "11c29064-6bfb-4553-9a5d-091a8bfb5fcc",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a81aa2fb-8057-4593-a3cd-59b12749a126",
+      "groupUuid": "9217582d-021d-4ca2-bfb4-9480e91458b4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "0ed6226b-68fb-4987-8d2e-03bf60535abd",
+      "groupUuid": "373b2d25-c6dc-432b-ae2b-c1dc5dfe9c20",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "59764e85-e92d-4256-a968-47e0b9abdc87",
+      "groupUuid": "d570c35d-9224-41c6-abd2-f9427724063d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "95ae587a-66f1-4e4b-aa29-01f088c975ce",
+      "groupUuid": "59e51952-a50b-4f7d-b31e-4b319b4912e0",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "cdb7f469-ac55-44a0-a98d-1209d783569c",
+      "groupUuid": "04cd92e7-ca84-4a9d-9f4a-5bb837c87000",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+      }
+    },
+    {
+      "uuid": "7968c5e6-9454-422d-881c-9bcb48f44541",
+      "groupUuid": "03906444-1987-42ca-9d50-dfc9ccedf8c5",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cv7-shell-7str-7.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "2dfa9683-7a57-4df0-8297-aab28da391ab",
+      "groupUuid": "b98531bc-8afc-4f46-9687-4fc9577ed41a",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
+    },
+    {
+      "uuid": "6593c9f9-959a-4fcc-b77f-00c238e4c183",
+      "groupUuid": "9d9260ed-84ed-4902-9e76-e0635efef739",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "2f6e9a03-8290-4a35-aa6b-8b2213fb2c01",
+      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "51af30bb-a2d0-4aaf-ac25-3a02f3246f51",
+      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "0689d5d0-e05e-497c-950f-7d86ede17066",
+      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "a26a7bca-b455-4511-9f75-d54e1e129e95",
+      "groupUuid": "40f147e3-4e83-413d-908b-404a90d12dee",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "2f65b31c-8041-43af-b41e-a01c1081d4d3",
+      "groupUuid": "5564fcb5-1b9d-4433-be7b-6afe27cf4b5e",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a1066c2d-5fa6-4e1b-8376-2087685265f9",
+      "groupUuid": "29266880-501f-4276-9d5c-ed41feb55f80",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "8105c311-2b41-41f8-be8b-524d19ecd5af",
+      "groupUuid": "5232e123-ef2f-4fc1-ad19-d0510756b8fc",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "56cd6e53-74f6-4941-a36c-312cbdcf1bcb",
+      "groupUuid": "7cb121dd-6272-4198-bdcf-fef65968d3d8",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "ec22b29e-c4d4-4758-b426-6287a68abf62",
+      "groupUuid": "76885475-2cbd-4eee-b7bf-d3ec42fbdac1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "97542fc7-dc2a-4c0d-9217-0632886f3399",
+      "groupUuid": "99806d47-05ef-4e66-a2bb-93956edb3860",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "3d42ba86-0f06-4659-b79f-ed4fbb86a25f",
+      "groupUuid": "18fd99d6-d46b-4377-91ba-71ec3144a8ca",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "028bc0d6-8b2c-44cc-89f9-a2519b0e11c3",
+      "groupUuid": "d1a77e28-41a3-49e4-94cf-7877e3481961",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
+    },
+    {
+      "uuid": "446c41ed-6c14-45e1-818b-0a379022c4d3",
+      "groupUuid": "d4498517-480b-4d18-9e1f-a1a9954de13e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "7c3f0def-20e5-4f0f-9fa1-52c10627f648",
+      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "4f81999b-9eea-4565-a5d0-c5cdfbba6e26",
+      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "7027c5d6-700a-4c06-a8b3-636bfd58e4ae",
+      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "c00b4d38-999a-4e7c-b485-c03ad4cc20ab",
+      "groupUuid": "1839f795-b870-4ce4-81c0-9709520805bd",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "a366b613-4538-4bf9-b573-7c9e52f077b3",
+      "groupUuid": "e72d43d3-a1c2-4bb6-9fdd-c609728bc0d8",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "ace3d59b-8640-49d5-a112-51d2e8aea0ce",
+      "groupUuid": "1450147e-d47b-48ac-b591-26603fb3a9ed",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "766b2a9f-caef-42df-84a2-7e0b2929ddc8",
+      "groupUuid": "1173277d-da87-4802-bce1-0e1feff70392",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "1f913598-ebe6-4c12-8bdd-814f1849f8db",
+      "groupUuid": "b1fce695-ff35-4495-bb40-bde7ce4b90d5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f4390c1c-5f1a-4575-b099-39547c4ae0f2",
+      "groupUuid": "dc0d19c5-95b0-4aee-9604-8f25b84029d2",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "c34fe986-2a8c-41f4-bfb4-0dc4c6f71625",
+      "groupUuid": "b76a5ed6-fda2-4819-9a75-ce74fab41c0e",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+      }
+    },
+    {
+      "uuid": "9e9680a7-cb9c-4bd5-b7e4-d59c78df4282",
+      "groupUuid": "15387662-ae3a-49c2-8b3f-032cda808a34",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "70e9cb62-09dd-49cd-bbf1-e9aaf0890b21",
+      "groupUuid": "12dc4260-429b-41f6-a3f0-ce8cfa1132cc",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "46df8fb8-c3b0-4dad-878c-e0846fbd2ce8",
+      "groupUuid": "9b786217-73ca-4e86-81f4-5a65416bb885",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "0faca7ac-eee9-4e52-996f-8363d741a9a5",
+      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "5425416b-4df2-4c41-8646-f8fcd73b52d8",
+      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "335b20b3-0b75-4d8f-8ffa-5955c1584db0",
+      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "facc6555-6aae-4d53-8e27-52fd9b09dc17",
+      "groupUuid": "59c503ff-1ba9-4acc-bba3-30bdeb6b75c6",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "bd0511d7-99b8-41b6-a5f2-5360cd6b061d",
+      "groupUuid": "ad3e0cc4-c72d-4c95-8658-3ed40df2e28a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "d0e91305-0e36-49a1-b902-330157dac4cb",
+      "groupUuid": "dbc5e577-6058-49bb-9049-e578ffde5f4a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "ffbad391-0588-4dd9-bcb5-de36f18085eb",
+      "groupUuid": "c36e9e47-27b8-4355-b507-73cd04fc0751",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "b0a5e0e4-ad87-42df-8552-15f8375b3c55",
+      "groupUuid": "561dec83-47f3-44fb-a63d-4beecada380a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "ff389c8b-f2f6-4a98-9433-5ecd407a70b3",
+      "groupUuid": "a5616ad7-656b-4410-bf39-edd5ed7f6a3c",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "b0b40880-4df3-40e5-8450-2d00b0f66fd3",
+      "groupUuid": "b7e72672-a846-448e-bdc5-932680e8a7ed",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+      }
+    },
+    {
+      "uuid": "a301ef39-9589-4ba9-8895-0a2402a4dc94",
+      "groupUuid": "3c01e147-4e3b-492c-a7ec-9e23a89b1b9d",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv6-altered-6str-25.png",
+            "name": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "3eba18e8-d6c8-411e-8fb7-223af51cc52b",
+      "groupUuid": "1d297042-fb1e-4278-a5c0-5d7068d98d25",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "5ad06abf-91d3-457e-a165-c3d8b27ddb93",
+      "groupUuid": "439ee468-68d1-4677-9a07-7a0adaa3affe",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "1a5cc9ff-41d3-42c8-afc7-13b002bdee9c",
+      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "b8045ee2-30f9-4c3d-9960-b63b11069385",
+      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "bb11463b-bf24-4beb-ad86-ee33aefc0d63",
+      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "c8b3833d-8d9a-4287-bf20-222d855c3ed5",
+      "groupUuid": "25b69437-e1e0-44c7-927b-33bd108ac673",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "eec1dbff-bafc-471a-8f0f-407f1ea8d950",
+      "groupUuid": "18d2b1c1-efc2-4290-bc97-bd98abd62d07",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "cffd5cca-b889-46e4-846f-ed84bdd1206d",
+      "groupUuid": "7d90260c-526a-426d-9235-0c7b6fa8bdcc",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "f419a0a3-ae58-4ef6-aa80-98333e3a8a75",
+      "groupUuid": "9475d7d3-e926-4564-8a3b-84a54c065427",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "5c9139e6-3d51-4aab-9599-bb5e60efd7cd",
+      "groupUuid": "f6e050df-a299-4d71-ae00-373df1097c01",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "65edf093-5b14-409d-b95a-daeb83eab607",
+      "groupUuid": "664f2a99-e6df-422e-bf47-5e99dbf7f77d",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "6f65ce58-3d54-48b4-b68f-9bb0b4654c35",
+      "groupUuid": "f8011239-187b-40d1-805f-bca23d8fa0c2",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 Fret 10 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
+    },
+    {
+      "uuid": "d762a9c5-1337-4b84-b635-e38c9dd9a8bc",
+      "groupUuid": "db78fd9b-d2ee-4867-93cf-aebe83256aaf",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-3rdtop-6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 10 \u2014 Drop 2"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "eb53ae35-f2d5-4f49-87a6-e0159f007b6b",
+      "groupUuid": "ae5ac7e6-7c50-4a99-b5a9-13c395358f51",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
+    },
+    {
+      "uuid": "7406cb91-4dc2-4467-942b-ada6623e2aaa",
+      "groupUuid": "35120bdc-9128-4dbe-a6c6-7d56d4dedcfb",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d8c52a1c-7e88-4402-b2cd-650f5388958c",
+      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "6267fce0-eca1-4f04-a658-3b6ea395b6a2",
+      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "1d348a9e-db1f-4d71-b433-8c8632501d6e",
+      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "31baae57-01a9-4843-90df-169fecbca050",
+      "groupUuid": "d54657c6-c10c-4d91-8abb-ef00af1b1b3e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "9fc09ab8-44a2-4992-bb14-b58784ac4f97",
+      "groupUuid": "0fbb3c17-0632-4e4f-ae60-8216d95d4225",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "2b840ead-ff72-443d-a71f-0fe738526c12",
+      "groupUuid": "f807440c-522d-4f3d-9a16-a62669f9802e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "1cf9e8ca-5a02-451d-81cd-db907d331da9",
+      "groupUuid": "a4113acc-9e41-4a32-9794-3e205af26744",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "01674b4e-fd9e-405e-a9c7-a62b21c90c7c",
+      "groupUuid": "c85b0803-fa8e-4d5c-a492-82b87440a775",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "358b08fc-3e65-4854-a720-c8371f2eae18",
+      "groupUuid": "06a9ca64-7107-4268-8906-2f68568414e5",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "40ea7dc3-afd4-4717-9b33-c3ab6e029397",
+      "groupUuid": "b03263b1-9f4f-461a-bc79-1672f70baa2b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+      }
+    },
+    {
+      "uuid": "5fd1800b-0cd7-4b20-a2be-d55fd574989a",
+      "groupUuid": "093b9e1f-1960-4ee1-a3cd-ae59b4061899",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cm7-drop3-7str-7.png",
+            "name": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "f8a694e6-ddab-4ac4-89fe-f65ef2eff542",
+      "groupUuid": "68013d21-9e0a-4d08-84d5-01cc821eb4dd",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
+    },
+    {
+      "uuid": "e16125b6-c23e-47cd-ab46-46821d7fce8a",
+      "groupUuid": "a58e6227-df03-4f67-b0b2-bc4855f75846",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "2ec4c649-5c54-4df1-8705-b26a4f619b8d",
+      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "286d7697-932a-4ea5-a32c-b1f99c58415b",
+      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "e66bfa0a-2d8e-43f7-a304-0fd076cb932d",
+      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "5ca27f7f-740f-443b-b450-9e400cf7c227",
+      "groupUuid": "83385657-4969-43f2-b2be-d7948f72a1b0",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "09848665-2fe0-4ac2-9d8f-dba6caa496fc",
+      "groupUuid": "8b0e6641-f4b4-4575-9db9-5efec65c09b9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "18b04268-41d4-45d5-80bd-3f73c93facac",
+      "groupUuid": "67206303-fe0e-4f98-b24d-7a97301ae56b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "24218a44-d89d-4cf7-8fe5-8ac05ecff855",
+      "groupUuid": "1d0c88b8-7218-4f68-9fb7-ce35c5fc7460",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "0008d810-79f0-427c-a6f4-efbbbd691f29",
+      "groupUuid": "27d55126-db68-4959-a229-9cb7327a01c5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "49325246-4efa-4eff-a9aa-3fe48c4418b1",
+      "groupUuid": "d89ae9ca-23bd-419d-b4c0-529e24869f9a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "a8e50424-4d9b-453d-8faf-fb64dc5b0bae",
+      "groupUuid": "ea9b7b7f-455a-47fe-aabb-275fdcf3f3bd",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      }
+    },
+    {
+      "uuid": "25ec42d4-8b00-4ad4-8251-985d1e5f7e8b",
+      "groupUuid": "b589ecf8-079c-447e-a94e-7b7c61660abd",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "ecbd9fa1-4200-4dc4-b8ac-fda577d294b5",
+      "groupUuid": "1d92b61f-9f3c-4d15-b13b-de8f0b65435e",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
+    },
+    {
+      "uuid": "c031addd-f433-4bbb-9c49-80dd85c7df55",
+      "groupUuid": "be76b380-67a2-4ad3-bdd1-b1276df1dbcf",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "134f3c12-d6d2-458a-987e-095bac00974e",
+      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "d8c79f6d-cbff-4fcd-a08e-40739c447c29",
+      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "2301c305-f7f9-429e-b2b3-26a766baff4b",
+      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "882c6945-3a7c-4507-bb73-246638f04b2d",
+      "groupUuid": "56237876-f201-4584-a381-feb770ce5bfe",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "c0ac7bc7-2e2d-4422-9e41-f28967201faa",
+      "groupUuid": "f8c62eb6-5d87-466d-9c87-f3de1562d49a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "b8a18b9f-cef2-4eac-9fe2-173481bbdd9e",
+      "groupUuid": "6a46d274-9821-41a8-8e24-5c03f8278ad4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "859738a6-1a71-416e-86c2-f1a7b36ae57a",
+      "groupUuid": "178fcd08-1884-4aad-8ed5-47dea5e9fa51",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "cd14f201-4417-4d90-8479-e17afb72e690",
+      "groupUuid": "88772ef5-4509-4b08-a830-4b323ea02e60",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "dc532975-77bb-421a-b6a8-847d2776f208",
+      "groupUuid": "ab72c037-f486-4f85-b5a8-5fe34681a5c0",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "74167e5c-71fc-421b-8eea-00e1e28a92b7",
+      "groupUuid": "356543ed-0604-4124-9ab0-36dc4539396e",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+      }
+    },
+    {
+      "uuid": "a204fd00-6c97-44d3-ad59-daafd76eaec8",
+      "groupUuid": "36c8bb31-35b4-4491-b35c-c6dd17dd6bea",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv6-extended-6str-17.png",
+            "name": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "b2d42386-47ba-4832-8eeb-1989f85292b4",
+      "groupUuid": "c6405ee1-cd7f-4597-b3bf-d61de14a8735",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "b2e1f7fb-d76a-48b2-a448-62d7c1d2f655",
+      "groupUuid": "b8e07dad-4f00-4a36-b521-a3e5bf1c9457",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "324c53ce-8e9f-4596-bdd2-3b7958adc9b3",
+      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "4f0b19bf-3101-4039-857f-a4516663ba2c",
+      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "f600b772-8982-4f84-a183-76c1f637e4ca",
+      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "31e6ea9e-8382-488d-9389-8778aae24bd1",
+      "groupUuid": "e401fc19-7680-4cd1-bf9b-d05c3d233f8b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "f98087f1-3fa6-4a67-b059-49d7662157c6",
+      "groupUuid": "cf05412a-f69f-43ea-9d03-4b5e6fa6ff2e",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "ea1d6f99-ee22-44d9-a04a-bfa5f74a607c",
+      "groupUuid": "c6015601-295e-488d-9a06-2fabf4d42099",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "3d3ba46d-aa1f-4ecc-af1b-a75f006423af",
+      "groupUuid": "b3b5457f-470c-4073-9880-561027478f63",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "1f6bad36-e009-4549-80f2-c0347e4811f4",
+      "groupUuid": "0afc8213-41eb-41ab-9c2d-f04dd0ce21ef",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "bf3fdab2-3591-4b84-b234-6d436924cba2",
+      "groupUuid": "0b6ecd8c-f2fb-469e-82f6-74eb1b7dc3d9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "cd289504-8d07-457c-a5da-0766bf529421",
+      "groupUuid": "a9ac6ce1-159a-4ea4-9c9d-311af7d3515f",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13 \u2014 Fret 2 \u2014 Extended \u2014 dom13 extended"
+      }
+    },
+    {
+      "uuid": "ec3b14cc-5a6c-4e15-8bc8-dfa365b3a1f6",
+      "groupUuid": "bfbe3a93-2fcd-4824-9b06-f623d6d9a093",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f2-6.png",
+            "name": "Fretboard diagram for C13 \u2014 Fret 2 \u2014 Extended"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "2d60937f-f45a-4b79-a4c9-a167a99f9eed",
+      "groupUuid": "ca92d406-d17d-40d4-8630-f73a2f07925c",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "f489f081-d1d8-4225-8454-20c19da7056e",
+      "groupUuid": "e9859cef-ce34-4346-aceb-9b867ce6883e",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "559f7122-c2bd-4333-9be5-02deacceae83",
+      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "e8f75ea0-94d3-4edf-bdc2-bfad3d520b74",
+      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "9f5759d9-1377-4e2b-bc87-96f282b76d00",
+      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "8ba4b10d-a4ae-4bcc-9510-5830a9c95222",
+      "groupUuid": "2fb07289-3432-4f5b-ac8f-bed701a4797f",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "7858929b-2b3c-400a-a95a-236380a49fcf",
+      "groupUuid": "ab7a268f-ef06-491a-9363-270531e71ebb",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "40f172d1-27fc-47df-8677-0fcf0d18ad76",
+      "groupUuid": "d5ac3edf-25de-4e6d-9cb2-b8193b34d84f",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c9c0fb88-7f58-415f-89d0-e9883dd58469",
+      "groupUuid": "f72b6ece-88db-476b-82ac-7042d5121984",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "0f0de67d-f3e8-4d0b-b09b-871b6e658263",
+      "groupUuid": "3d2caec2-6a9a-4ba0-8384-bfda1b583321",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f9276213-f9ea-457c-9c3d-f5da605a27a9",
+      "groupUuid": "32ae7bc2-2dc9-453b-83aa-a280e6104568",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "0c4ab215-9348-4690-8f92-849bbd75deb4",
+      "groupUuid": "2bbdb4bf-4db8-4abb-b9bd-d8416e08e273",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top) \u2014 quartal quartal"
+      }
+    },
+    {
+      "uuid": "bd6db14a-2ace-4a66-9461-dd8e542f3b0f",
+      "groupUuid": "3b4d96a6-2aa3-41d1-9994-00bd5b63a5f2",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-d-upper-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "680215fe-89fd-4a86-a5f8-08c6f9129008",
+      "groupUuid": "3dbdb880-e4fd-4f31-ba9d-93766d87d464",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
+    },
+    {
+      "uuid": "57b828d9-d959-4f2b-98a1-c9decb9b199a",
+      "groupUuid": "5fb037ac-093c-4e9a-b06f-28accec620bd",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d52328e9-50d3-4da1-997d-9eeb38fd709b",
+      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "24d37167-222e-4565-abd1-32d83ef03263",
+      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "92609f60-5586-4b50-bac1-381b023a6f09",
+      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "9bc54bbb-134d-4333-a8cc-ca505afd8715",
+      "groupUuid": "13dc871e-3527-4404-b887-814736e82b67",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "a9e0e86d-c19a-4347-9c41-d7a86a61b63f",
+      "groupUuid": "ec276ed4-4088-42d7-8751-48d41624e4b1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "cf99d63d-170f-4e80-8d94-c76370607ed2",
+      "groupUuid": "319dbc07-e7f1-44e9-ad09-c1e3cd7a98f4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c0359e32-dc9a-4eda-a679-ef237fd833dc",
+      "groupUuid": "41195467-cc3b-4a38-bbe7-54c12e4b65bc",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "83af7353-20b2-4547-ae2c-957ee07d1364",
+      "groupUuid": "8bcdbe96-46c0-4b7e-84f4-ab2a41bbcfba",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "6d545641-675f-4586-af13-b3c32e7b927d",
+      "groupUuid": "de4c5703-5a12-4c75-96ac-50826a39d88d",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "ee12c3e9-3c32-45c3-a70e-29fad99991c1",
+      "groupUuid": "226d6e71-be29-44a4-832c-97108e41a4d5",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "7dc2884e-0b48-4782-ac21-98474e75a06c",
+      "groupUuid": "0a8d5e89-2403-4813-880a-0c1a07ec6e4a",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-shell-7str-7.png",
+            "name": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "93b97553-1a68-4c7d-af6d-e94c2569a4cd",
+      "groupUuid": "3e9e474e-8aa5-48c3-9155-f89a24649b4a",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
+    },
+    {
+      "uuid": "7f340a82-49c1-44f9-b826-309b53206591",
+      "groupUuid": "fbbd04d1-eac8-42ab-acbb-324513a9c69c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "b13c045e-90c6-41e6-8203-743bc0cf22e1",
+      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "b6f2da85-b368-40da-81c6-1f20586a174c",
+      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "330bec35-ae56-4cbc-8d82-5c3301b89836",
+      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "98c0c603-4f03-441f-b34c-95aa75c69283",
+      "groupUuid": "59ebea18-20e9-4d98-aa43-f36cd856418d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "9fbe10c0-92de-42bc-9d9d-9ae4891d219a",
+      "groupUuid": "8f2bddb9-1707-4b75-8a99-b1398518ade9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "4e13e21d-c4db-45e9-b3bf-581fe0232884",
+      "groupUuid": "c1ad8918-e3fa-4162-b073-3b4d2faeee84",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "0ac90f6b-987a-4721-bf4a-8081628361ed",
+      "groupUuid": "ec3f38c5-1c34-488f-b6c7-9de9384d1121",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "2ac12ad7-a39a-41be-8190-73fb37e67a0d",
+      "groupUuid": "48aeeba6-f961-4646-91d6-407761aa24ec",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "e2991fd3-d2be-49dc-9f7c-471b4f3ac750",
+      "groupUuid": "7612d54e-30f7-4fcf-bd6d-4bc7efa46144",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "c0072b81-8945-4d28-a0fe-7b74b16982c7",
+      "groupUuid": "b9d226c1-a57f-4821-9da3-6da597d8289b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "a1eaf00f-98ac-4ce9-907d-49e533bfb15d",
+      "groupUuid": "6f8c1fb3-b5c5-45ff-929d-f6cf558d9023",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-e-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 E shape \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "7d1367cc-1d2a-4cb2-b2c6-0fc601c67c2f",
+      "groupUuid": "0120bf5e-f14e-4d3a-a27a-f2116cbcb8e6",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
+    },
+    {
+      "uuid": "0ae0d8c0-aa2d-476c-88aa-d34bc378b2cc",
+      "groupUuid": "5de08cc4-24f2-4ea9-a8ea-104b1cc519f8",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "2f37fe0b-e292-4d1e-b0b4-8389e7a09029",
+      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "be2b516d-731a-4c7f-b5f2-ce4e21180b42",
+      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "9e42bdee-b5a8-41a8-b75c-065dcb5a2837",
+      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "4968a90d-af2c-4329-9f16-362025f1f9c2",
+      "groupUuid": "a3b87eba-eb75-42f5-bc3e-42b7e8f16d66",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "b776b7bb-5244-45c2-96bb-4ec8b2a41db0",
+      "groupUuid": "75046a8d-0088-4863-afc6-41a84da701a3",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "1e374e73-e6e3-436a-9efc-e18182fa4acd",
+      "groupUuid": "9d873c00-88a5-4995-aa50-cb2ca8066102",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "6bfa5196-7fee-477b-8cd9-22e906f67354",
+      "groupUuid": "3d5efdd6-1537-4280-8b46-362e67dd9412",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "36df90a2-6072-4137-84cd-85aa8d2241ac",
+      "groupUuid": "e6bc6a36-fae7-4106-bde7-c25b2081ddab",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "a3449f55-463d-4011-adac-f99e8894879c",
+      "groupUuid": "cb692162-d741-4723-ba59-d532ef197661",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "76a003d8-7a82-4c35-8a9d-3c1fc5777cfe",
+      "groupUuid": "d9ea7b42-9f35-4833-b334-6c6ac998386c",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+      }
+    },
+    {
+      "uuid": "735d4768-4224-4bdb-b757-7393cc09027b",
+      "groupUuid": "48253422-a5b0-428d-866d-06128391463b",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-e-shape-6-cm6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 E shape \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "7f5c9a3b-9fb9-45b7-b269-aeac14b4ea70",
+      "groupUuid": "c1f4f423-4b6b-459f-b301-cc4de5a2cc94",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "c4663e9f-699e-4a0b-bda0-2ac6522edc8f",
+      "groupUuid": "d05152f0-3d17-44d2-8be2-55bd0c376756",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "ec1d0ce7-5bc8-4633-8afd-f309ee18ab35",
+      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "928bcf15-c92c-46f4-b584-42f98c3b09c2",
+      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "7703379b-7698-42fa-af2e-e3700a4c9ef0",
+      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "b6bcbb45-0bc3-44b7-b3f5-88074f352433",
+      "groupUuid": "24be422c-3d8f-40a8-bfd5-12ff06c85639",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "b55d712d-facd-4374-9610-67d4e6c3d42d",
+      "groupUuid": "4d90ab62-ae16-497a-b5bf-7e4a5a458026",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "f09e722d-0aa8-4a17-bc31-4b21f9b2b7ab",
+      "groupUuid": "8eda2592-73c5-4544-b0c9-814586d43217",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "1562ece9-31bf-4c5e-a6ab-9e0183a15296",
+      "groupUuid": "daa66c77-b9f4-4a97-8a17-ad3cd0b70db2",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "1609b609-312e-4eae-baef-cde68541d506",
+      "groupUuid": "1afca7be-ae91-4103-b0a7-7fea2ff907f7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "53642464-4748-49ae-81fb-5c1409092f0e",
+      "groupUuid": "f7c8b1b9-53f6-4716-9cde-bb662e464bad",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "10d04e92-75e4-4220-97c4-1d0ba2b73381",
+      "groupUuid": "31f47114-36cb-4619-ac3d-0406c68ce935",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+      }
+    },
+    {
+      "uuid": "a2d41cfe-16bc-4706-aab8-c96c849ff2a1",
+      "groupUuid": "3b9f3e3d-a747-44ef-8076-5aaa7e695c4c",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv7-altered-7str-27.png",
+            "name": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "bbc755f1-ae8f-41bc-badb-9a0328c62178",
+      "groupUuid": "8caab9a4-e731-4e2a-88db-56cf8d9efbda",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "b330e663-8d21-44e1-8ab8-b7425776f9d2",
+      "groupUuid": "88d4e4f1-8966-41a4-a346-4ae83b7e4f34",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "3c1f5e1e-5199-4010-a303-26b0e852aa01",
+      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "5e3374c5-1be0-4fed-96ad-9d9b08df5bda",
+      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "2a61edea-62f1-4627-be45-028a0397d189",
+      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "2b746dcd-c854-4c5a-851a-93a515131280",
+      "groupUuid": "61b66e4d-638e-4b74-a40d-979f40628828",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "0041b049-1326-4d67-be24-78ea30cb4c82",
+      "groupUuid": "f52167a9-f5fa-4150-ad55-5d78c6ca59b4",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "c41278c8-ca8c-4493-8c37-edef82b195b8",
+      "groupUuid": "f6ec9c01-9f8c-403d-aec5-32f895d43636",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "f38a3dbe-edf4-40ef-8ef6-acb9fe6ccc43",
+      "groupUuid": "38af79bb-dada-4359-9978-053f858f6ecb",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "4d11da57-9c96-4aa4-90ab-a1b4351c6188",
+      "groupUuid": "3582b87a-1bf0-4314-a139-84d295bfbb96",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "a8a3fb93-b0f1-4c2c-b7ea-7b906b82339f",
+      "groupUuid": "cb745dfa-4047-4b72-b9ee-0fad8734a5f1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "1a60895c-5dea-454a-9b4b-0978a946439c",
+      "groupUuid": "4b781c97-ed6c-472c-afe8-249f17c9977a",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
+    },
+    {
+      "uuid": "83ff6013-d41f-4c22-9e57-0b667f85c468",
+      "groupUuid": "f3e4626e-dfb8-4470-ae24-8137331f845b",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-b7top-7.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "d8d5dc7e-fa19-4da1-8c05-afcd7553deae",
+      "groupUuid": "d38fe8c2-0651-4924-bdb5-be3828bc981e",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
+    },
+    {
+      "uuid": "704e92ef-c7e4-4faa-9578-b5efe718b211",
+      "groupUuid": "3fb55df2-f23d-4c6e-9401-89a7b22a632d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "62e0bab2-efc9-4ef7-9807-19d70fd67fbd",
+      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "48762723-d6ea-4591-aab1-22bc204c3ad9",
+      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "dda979e2-da0b-4b79-be6d-a33e9a3d11df",
+      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "a93284cc-8b00-4f2e-b29e-d167651a0c36",
+      "groupUuid": "b6c0745e-7e20-48ef-8b92-7c72c118551b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "e99c499c-3461-40e4-801a-dd8d15292858",
+      "groupUuid": "3be7be1f-8fb1-40ae-9250-d65e127d5f72",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "710b3691-3e19-418e-852c-90e2d820156b",
+      "groupUuid": "3a8923de-3366-4498-bacc-41a6e3e13291",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "447f8ba8-79d6-4ecd-9b2a-dee4b15671d6",
+      "groupUuid": "75ea663d-1fff-4ef0-8440-f5182edcb820",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "bd6bc455-da4d-45d3-a4a6-73550f2d6fb3",
+      "groupUuid": "d4bf8965-f964-45a5-8073-51a7f1eff855",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "90acc9b8-3b4b-4b2a-8241-dc402a776b6c",
+      "groupUuid": "06c97a8c-9852-4494-ad12-154eb0d3c803",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "7e2c05fb-2b0a-429a-9c0e-a2e684d2f31f",
+      "groupUuid": "99200043-f960-4ca0-8549-287b5c6d851d",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+      }
+    },
+    {
+      "uuid": "c9a1bedc-da64-44b3-9f74-99e943991c9b",
+      "groupUuid": "a75e5e70-fb98-47ad-9537-c75845e080a3",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cv7-drop3-7str-7.png",
+            "name": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "f8a5d71c-6daa-4dfd-addf-29843b73123d",
+      "groupUuid": "ee7414e7-d1ed-41da-bf60-0d404c11ffac",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
+    },
+    {
+      "uuid": "f23a21a4-6213-4b37-a8fa-85cbc53fe85b",
+      "groupUuid": "7b99ad0d-bb17-48ae-af25-c4da47cc030d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d31fd062-0c1c-49e5-95b2-f87e9440f0f6",
+      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "6ecb827f-924c-462f-9409-8b489677e2bc",
+      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "822f52ce-58c7-4a23-88ac-ff8427f1051d",
+      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "4bbcea86-d1a4-4622-869b-5403e8fb6376",
+      "groupUuid": "da7d32fb-8ac9-49d8-9192-a96df3f596ab",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "2269e23c-e57c-4b21-afe9-cf3a627be500",
+      "groupUuid": "7dfb4883-ced5-49da-856a-66ef24005cf2",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "f890183f-b1ba-4b10-8e60-3d600fc14aa6",
+      "groupUuid": "4f3f50e1-232c-4234-a037-fd33f345da99",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "780e39a3-fb2c-429d-8e4d-e610b0857650",
+      "groupUuid": "0aef3d67-a9a4-4b19-b831-8f9478704376",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "0f53e3ec-60f6-43c4-a75e-1862666ef74f",
+      "groupUuid": "4f370fba-3333-4f31-9419-9525aebc115c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "baee42ce-5cf3-4384-99bd-b77024cf06ee",
+      "groupUuid": "6f10d5e8-f4fa-4124-b085-7bbf54a214ba",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "f3985f15-17a3-4a42-b479-098942107e6e",
+      "groupUuid": "6751482b-e9ae-492e-8738-91ca3ac98145",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+      }
+    },
+    {
+      "uuid": "4f10d424-353e-4a26-9054-c735d917740a",
+      "groupUuid": "4d9631d2-3f0c-4e08-ae7c-f5c61314d80f",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7.png",
+            "name": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "b55c3010-0c91-4a5d-b710-7c8ad24b78f0",
+      "groupUuid": "4e5ca35d-b579-4bdb-bff3-0e113e3c94c5",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
+    },
+    {
+      "uuid": "82f4f857-fa33-43be-baf1-fbfc4deb6d16",
+      "groupUuid": "15fe72f9-d7b3-49fa-8bab-eaeedd92d7e1",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "eb2991c2-7fd1-4ee8-822a-6e3e0868c3d9",
+      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "9aaf42b4-91b5-4046-b476-adca1ff38f32",
+      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "31ec2b6e-2038-4072-b831-61efff7a250d",
+      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "52a6fad0-62d7-431c-8e4f-30b1240f08a6",
+      "groupUuid": "cecc01e0-09b5-492e-bc3d-6ae17747db86",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "9e059961-e344-475b-9638-7bab716b21b5",
+      "groupUuid": "c437e3be-5cfb-4d56-80eb-970a547d5407",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "fba2eb5f-ec02-4b1c-b963-57ccc2ace98e",
+      "groupUuid": "4c94d566-75d6-453e-b241-4a540e47a1f9",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "74deaa7b-6fb3-43d2-b8aa-e508089e0cd9",
+      "groupUuid": "2ff2989b-66dc-4fda-b017-ab287a47e417",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "3f27431b-be65-42ec-b1ec-97aa274ee5b6",
+      "groupUuid": "87c264be-e5d7-4fc7-972b-6edec7b062a2",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "9f7c386c-6a52-4df2-b8b0-95270ad3c06a",
+      "groupUuid": "107ce4c4-ff95-4690-8b89-4042cadc02a4",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "540af974-410e-4921-a3fe-c83f7166cdbf",
+      "groupUuid": "f09af9a9-c629-46d3-906f-a35c3c50cd60",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+      }
+    },
+    {
+      "uuid": "eb88a477-f9b7-47c8-8d85-512a9181f05c",
+      "groupUuid": "7edb913e-b507-45d5-9a95-f63422108a3c",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv7-extended-7str-19.png",
+            "name": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "0c70071d-d600-4133-912f-9e6ef3474d55",
+      "groupUuid": "4d9bca08-d6e8-46df-aa05-eb75d454bcda",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "b9e47d34-3123-46c9-a90d-1e72502f5544",
+      "groupUuid": "44249be5-a373-40c3-8566-6a49f744a26c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "a3be660f-fb8c-4b84-bb32-a665ac6298b1",
+      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "32fa9687-60a6-4b5c-b393-94a4199c7921",
+      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "90debe20-30c7-46a5-80e0-3ba839590e07",
+      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "7f812914-2f50-4a68-8f9c-997ef697f08b",
+      "groupUuid": "beb4ba6d-c346-48c1-a37b-8029e06e1b83",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "1bdf0fe8-194d-4e64-b015-8b1f40e3755b",
+      "groupUuid": "c04a8432-db5b-415a-bd9c-e78dc3019458",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "6cb126b1-7c3e-44fa-8f25-2d682a97947b",
+      "groupUuid": "759a00fc-58d8-4de3-9929-488dace52c3a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c2b202ae-dee7-43ff-8f53-ddcd7efec2cf",
+      "groupUuid": "dd854663-508b-4c98-ade6-ce49459b5f5d",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "be128ac4-7163-4062-91dd-59268e3852e4",
+      "groupUuid": "473feb67-5c5d-427a-a1f8-d9205b25c9a4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f05aab3b-9863-4e11-94bf-9d8034322227",
+      "groupUuid": "d278fbb4-4b00-4975-8ffa-1d1c29f3bf60",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "8eb46136-05b0-4cbe-8b65-a3fc31295551",
+      "groupUuid": "ae59d0ec-1f30-4cbf-b4b0-55b49b09bc98",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13 \u2014 Fret 3 \u2014 Extended \u2014 dom13 extended"
+      }
+    },
+    {
+      "uuid": "81f38b43-948c-43be-bf9b-639be6f34ddc",
+      "groupUuid": "dfe387ee-d181-4d99-99e3-14223ce7618d",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f3-6.png",
+            "name": "Fretboard diagram for C13 \u2014 Fret 3 \u2014 Extended"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "d5b18c19-87bd-45e7-9d35-2f55334841ac",
+      "groupUuid": "e6c40021-d763-4c73-94bc-ea82f889de8b",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "ad5748ed-8d62-43cf-b2b6-0e596a559cc6",
+      "groupUuid": "37406597-740e-42c6-8852-4503010b0f4b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "7dd6148a-51a7-4ad1-9c93-357aea06b927",
+      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "6b770d8f-4940-4a87-90c0-d1585d320110",
+      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "32fb6d6c-f0a2-4f49-a985-6f0a73a1ebf4",
+      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "b051be56-d851-489c-b254-1bc8d214485e",
+      "groupUuid": "7eff275c-5e24-44ee-9801-60544dfacc5f",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "1f10520f-7812-43cd-aa4d-3f0753443201",
+      "groupUuid": "593923ee-24f2-4170-bb13-5235a6ee3cde",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "f59ecffe-f7db-465c-a0af-3b46ea3cdb3a",
+      "groupUuid": "82d9ec75-7da2-4d7c-bf9f-d416ba1cf8b3",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "ae08a343-d516-40c8-8a27-03a497f7cd81",
+      "groupUuid": "b35ddb7a-74a1-49a6-97e7-ced3ac2db8a0",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "92ffd682-d5c4-437a-b473-fb3d832a03ce",
+      "groupUuid": "67197438-7292-4f6f-a73b-deae742efb49",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "52fc03ee-4e03-48bb-b03e-09a02df5a8eb",
+      "groupUuid": "cc24b9d2-414b-48e8-811e-d5c7e7787acb",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "232dc08b-e21b-4832-baa8-0d4334e2c940",
+      "groupUuid": "1208053c-0fe5-458b-b8f4-9c96ff340cbf",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top) \u2014 quartal quartal"
+      }
+    },
+    {
+      "uuid": "7ced6855-7a32-4b26-914d-0cf290633dc9",
+      "groupUuid": "dd17e6b2-6d76-4202-99b9-e40c05c2b295",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-eb-upper-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "75f9a1ff-685d-49c4-90be-b2974d139eff",
+      "groupUuid": "bf61dba3-bf9d-44ba-8580-c562eb3cdd6d",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
+    },
+    {
+      "uuid": "d1eb1c91-25e4-4916-be9d-1c5672af1351",
+      "groupUuid": "4313f6ad-2ccb-490d-99bb-a09e923ce2bb",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "5be51fa9-a86b-465c-8b57-a2369a820e1a",
+      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "a6cff27b-bd8d-4f73-8d48-2c382c125ab6",
+      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "e9207b2d-d713-40af-ad56-48d707162750",
+      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "3fa4988a-592a-462d-9c6a-3cb28c03feed",
+      "groupUuid": "de373cf7-139e-4de8-b313-4888045ce285",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "93536e09-3893-49da-9a42-087b5fbcf2cb",
+      "groupUuid": "8bd7de98-a394-4bc2-84f4-e3dbd6112553",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a901dcb8-0ba7-4536-a936-b1c289de65a3",
+      "groupUuid": "0d6495d0-ec2d-40c9-89d1-829c88315ccc",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "bb4d2678-4649-470f-a666-3c6fde16056c",
+      "groupUuid": "9077a51a-aaf9-44c1-b1b9-73dfa113011b",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "938a6718-03b1-48cb-928a-4c54983e416c",
+      "groupUuid": "e57695bd-e4bf-471c-a271-7c243de64ec5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "96fd01b3-c73b-46c3-b78c-46c3bb28c1a6",
+      "groupUuid": "6b8e8866-c830-4fd0-8db9-8b89630f8d45",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "cea78dcd-ad6c-4c46-bf94-066b0c2dfdce",
+      "groupUuid": "9b9475fb-94e8-4403-87ae-d3bf980fe57a",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "84d3aeac-2012-4785-a2fc-7c3bf2ce913d",
+      "groupUuid": "0cdb76d1-34a2-47a2-8329-278eb3362409",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-shell-7str-7.png",
+            "name": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "f9f0b036-a803-40db-8025-1fa52e8d5b63",
+      "groupUuid": "923a07c8-3d95-49d3-a8d7-dc221d32a40c",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
+    },
+    {
+      "uuid": "087450d3-6935-4bd5-a64d-8b7c16289747",
+      "groupUuid": "daffe69e-3ff9-4968-b8e7-aae003b2aa9c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "f449cb68-dfb8-4408-b28f-92d8cada0cea",
+      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "894a3453-d208-4931-a554-57591a446fcf",
+      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "ca281e3d-d0d0-4a18-b8dc-350bcb16d226",
+      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "b09a6df7-8c1e-401c-9e8b-e803ca2cf446",
+      "groupUuid": "ec19f04b-300e-4489-bebc-fdf18535040b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "8fd5435c-825d-4d95-95b7-7b578886aa8f",
+      "groupUuid": "03e64fc3-9939-4d50-ab61-a4a85163299a",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "d29c08b2-a484-4c0a-ba83-01ebed8ce627",
+      "groupUuid": "b3322519-6ce4-4912-a7b7-31b2d20bbbe5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "e756a7f9-c7c6-4342-9e25-4632196087b9",
+      "groupUuid": "3cc32e7a-de2e-4b82-8b37-4f5baab45a9e",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "dae1a4ed-e1d2-4d04-b996-cb52d0d42594",
+      "groupUuid": "ddcd106f-e628-46d4-8b27-8b570dd1ccd0",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "9e6de611-1416-4a3e-a99e-0d0c606def9b",
+      "groupUuid": "281f18ee-4fb7-4588-9546-22719cd1b00f",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "cd717f3f-faa5-44a0-ad36-1c706b761423",
+      "groupUuid": "d377f844-bf66-4666-97eb-9bf2903b77fb",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 D shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "3ca55b51-43a4-44e3-9536-5984c1209ea0",
+      "groupUuid": "53ae336f-b6a3-4f65-92b4-e8f98de34c03",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-d-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 D shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "8da1ddab-ccd5-4154-b5e2-70f2cb1682c2",
+      "groupUuid": "d16c0044-51ed-4548-852a-7857261bc1c8",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
+    },
+    {
+      "uuid": "93594701-d01e-4c73-af05-02b4bf954699",
+      "groupUuid": "066f7b3a-4b3a-4b99-b3ce-634cac8793b4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "512230f8-d60a-4c48-a037-28d48477d972",
+      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "3ae0078b-0f6e-4db9-872e-849a66ba5f3a",
+      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "ce58c767-e5b7-4e87-b298-d76b71ac8c63",
+      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "6f4b698a-94ae-411e-8f2f-dc4228d3c08b",
+      "groupUuid": "7078bc81-018d-42ba-9a38-e271a635bcf1",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "c02b42f2-8316-4e55-aa80-50bc8e37c606",
+      "groupUuid": "2fe7776a-81fb-4db4-b3dc-6ad54e7d862c",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "149433a8-0488-4852-9c58-f3319382440b",
+      "groupUuid": "1c846cce-e2f2-4ab0-affa-249ee7d93646",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c1c3d8dc-01f8-42f2-9a05-f79afda31dff",
+      "groupUuid": "f411e5fd-8a11-4399-a85e-ce1706d4ac72",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "2da639b7-5201-4aeb-a02b-d502cbb083c6",
+      "groupUuid": "a1789c38-e83b-4233-894a-a03ce4d23cd1",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "f9d6bf4a-29f0-4682-9529-e38f98482d33",
+      "groupUuid": "364bf539-5bae-46a0-95e3-8ad2044d09fb",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "2021dc12-242a-46be-83fa-61d466211dc2",
+      "groupUuid": "e6877e1a-b848-4510-a6cd-d2dc0b630dbd",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 D shape \u2014 Shell (7th on top) \u2014 aug7 shell"
+      }
+    },
+    {
+      "uuid": "c1aa9fdf-d4fe-4f38-b801-e1556765a87a",
+      "groupUuid": "3edc32ee-6213-44da-94a2-45432357837c",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-d-shape-6-cm6.png",
+            "name": "Fretboard diagram for Caug7 \u2014 D shape \u2014 Shell (7th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "926d95e2-26a6-4d1d-83d1-5369c0b188eb",
+      "groupUuid": "4f918e72-b5f1-4adc-9d96-aa43c5a9d147",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "27dcc1a0-a56c-47bf-b91e-84aa2eed5b3f",
+      "groupUuid": "158510f4-95cc-4d1a-93f0-f5fb5e9d9cb7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "ab5147d6-b641-4ce5-90f3-4aa2a10c6aeb",
+      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "5058a6b6-bb41-496f-ae03-7ea4a74d63c5",
+      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "7b51fa6c-b76f-483c-9b5a-50c592b6143b",
+      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "e6f8de25-08ad-443d-9f42-920634082e8c",
+      "groupUuid": "89c8809f-78ba-4e2d-bddd-b092dd3f964c",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "5e4272af-121a-4db9-acb2-197cecb063cf",
+      "groupUuid": "3609f407-2939-4cea-9404-2afc7b04ae82",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "c3f6a1d0-df19-4252-aa31-094b4e3180e9",
+      "groupUuid": "c0b3ac45-b745-4b04-bd25-b2848dc84201",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "b73c522e-f4f3-41e9-b15f-b7da5ae20abe",
+      "groupUuid": "f0603486-ae8d-43f8-bd36-0bd1ce7431ed",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "b0e2c8d9-68b2-4264-95f2-9e6a73a237a6",
+      "groupUuid": "62fe6d88-d9cc-4b8a-ba49-ef062ef6f651",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "3dbce3c8-dc32-4a4e-9dc5-761626afac13",
+      "groupUuid": "0d87c0ab-e550-476b-8c07-e3cfbb7aa5c8",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "41b0a43d-31aa-4fa1-b57e-0853bed208cc",
+      "groupUuid": "99e62a30-1633-4f0b-a94a-b0a7aea9fde5",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top) \u2014 13sharp9 altered"
+      }
+    },
+    {
+      "uuid": "25f2a2a0-3588-42ab-8bf4-480edbe93bd7",
+      "groupUuid": "cab433a2-532a-4af0-927a-c84550ece947",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13s9-cm6-altered-6str-30.png",
+            "name": "Fretboard diagram for C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "6ff3fe6e-7685-4c54-80e8-fb223a309b7c",
+      "groupUuid": "eff12890-1016-4151-9c71-0bda6c31e731",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "5753a587-471b-4385-8d2f-cba8ba589e1f",
+      "groupUuid": "a7eb12df-b85d-4562-b780-1ce420c45704",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "707de04a-b69e-4348-859b-fd04c2a23761",
+      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "4f413638-a136-43d2-8741-0e7f0ddd5622",
+      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "8b4e6c46-b7f8-44d6-818b-1ceaaa54deb4",
+      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "3ce28b15-6855-457d-accf-7fe395d0da37",
+      "groupUuid": "b445b2b1-f508-4ed0-be35-2c1a3c9170e9",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "80825f61-a73c-4218-aac2-178f62edc8bf",
+      "groupUuid": "33c5818e-b220-4a32-b1ba-001077adc360",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "d48a17b5-7e42-4ddb-9b69-7aebcba07097",
+      "groupUuid": "3a024948-7ff3-4a7c-acae-3d83b789d6ef",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "d1e0cd31-c521-4035-8f1c-c963a9f08460",
+      "groupUuid": "73babb35-d4d8-427f-b5de-b4da665255ac",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "a5fa787d-12bc-4026-a18e-8894fc2b8b78",
+      "groupUuid": "8b0b0794-96b6-447b-a5a0-a3e6159b495d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "4a0f1b50-0fc9-4184-92d2-5dc0bc2e7a6e",
+      "groupUuid": "7e5dc6e8-e118-419d-bd14-462c9f80a718",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "c8b982c9-fd09-4372-bfc5-f6e1d578d3aa",
+      "groupUuid": "69ed8f67-db9d-4002-8717-1f5f55cca93c",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+      }
+    },
+    {
+      "uuid": "794c961f-11a2-4ce8-9567-767ba2b43a89",
+      "groupUuid": "0142777b-1b49-48d0-af2e-c44120264269",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-1top-7.png",
+            "name": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "083885a2-e2ab-4975-9479-dcd9397cc2bc",
+      "groupUuid": "304e3561-3b84-4690-9744-98a91a69963d",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+      }
+    },
+    {
+      "uuid": "a7a716f9-177f-41f3-88ba-3d4154b4de24",
+      "groupUuid": "53a8ea44-aab9-488b-91ae-e403c7aa772d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "442b6f97-3f42-4848-a06c-20c98f78f55e",
+      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "cac309a7-e890-489b-90a7-4f72badb91c1",
+      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "b4d9c1a7-495a-4788-b93a-4e3209bb0cb2",
+      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "ca01a32b-fcbb-4c79-9fea-fa831ea56e3f",
+      "groupUuid": "1f7e7811-abd4-45d8-9578-41c231899627",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "ea862316-1d1d-448c-8972-7cfd70df76dd",
+      "groupUuid": "81169a70-ca36-4d81-b148-77791b763e56",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "16c50287-f1cf-4dca-9abf-36ac5f6fc493",
+      "groupUuid": "64fd8989-5e38-474b-90e5-103b04f10585",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "f8ea30e2-a720-44b9-8b8b-d4879dc47d65",
+      "groupUuid": "f57d5297-ae0d-4854-85aa-157474b58422",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "f0cf788b-d59c-4253-b6c4-8be8a8bd663c",
+      "groupUuid": "65b996e6-e67a-4050-848a-1c8d13c99918",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "fd020001-02ee-43f8-b66f-72a31b3c3777",
+      "groupUuid": "1d745433-9aef-4a94-aaec-af8f9f2697f5",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "ec48b201-793a-4178-a26d-4a9fa2164234",
+      "groupUuid": "ed0a27cd-7d4d-482b-9446-fdb21d836820",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cm7 \u2014 7-str bass \u2014 Drop 3 \u2014 min7 drop3"
+      }
+    },
+    {
+      "uuid": "48fde2ab-a67d-4e6a-8acd-813907211270",
+      "groupUuid": "40955f59-19e4-489e-8a39-dcc276780a35",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cm7-cm7-drop3-7str-7.png",
+            "name": "Fretboard diagram for Cm7 \u2014 7-str bass \u2014 Drop 3"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "dea4a25e-7a44-4bea-bc7a-174a46aa6d75",
+      "groupUuid": "faa03219-b596-479f-b43a-7c7d10222e18",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+      }
+    },
+    {
+      "uuid": "bc3352d0-aaca-4c0e-a6b7-ac66b85ceb16",
+      "groupUuid": "df831fc6-cf25-4f96-9b72-96263d476886",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "5463eecd-2785-453f-af27-c530d9fa5c4e",
+      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "16e36a87-1303-4637-916b-29fcc64e0309",
+      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "708db57a-03ec-4d25-8b6a-902aa4ccdcba",
+      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "579a0408-69f1-4ff2-8cfe-5c45fdda745f",
+      "groupUuid": "ff455564-ef34-42cc-95ad-ed78e43a9100",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "912a093d-eec0-4070-8249-c65da65b77a0",
+      "groupUuid": "92057cde-3110-4930-910c-ca27fbe1d3a1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "41fd4afe-9468-4ff0-906c-b26917821db1",
+      "groupUuid": "cb9a73cf-e5ee-48f4-bb4a-5e5b88c1c1c2",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "c3999127-9d22-41c2-91dc-cffdfc0271f0",
+      "groupUuid": "672bf8f4-b5e4-4444-be7a-82730783ad29",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "ba16aec6-c2bb-4e37-8e37-320a51d9cb0e",
+      "groupUuid": "fb34e7ee-dbf3-4578-a5d9-615106867a20",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "fc6783fd-7245-4f5c-8666-73d071f30dd8",
+      "groupUuid": "6c0fa537-533a-4670-a8a3-d9bd1ddeed02",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "eb0ff792-28ce-4f1a-967d-a64715d78322",
+      "groupUuid": "6cace1be-b0a8-42dd-8e47-3607f526a6bb",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 A shape \u2014 Drop 3 (5th on top) \u2014 dom7 drop3"
+      }
+    },
+    {
+      "uuid": "d52e0a17-f761-4e91-82d6-cc0d10a3853b",
+      "groupUuid": "3096ddf2-30fc-4867-b388-4fa002b737f4",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-drop3-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for C7 \u2014 A shape \u2014 Drop 3 (5th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "62048a19-a5c1-4707-b407-17c86c5000f5",
+      "groupUuid": "e7f78358-5f0b-4fc6-89b4-874a7aabb276",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+      }
+    },
+    {
+      "uuid": "793e6459-c52b-441c-9a4f-0dfb56341452",
+      "groupUuid": "7ccfb600-41ce-467f-bacd-6d704dd78d15",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "71b77957-a01e-497d-8eb6-19c03b0d702c",
+      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "220961a0-ef40-4ac7-b31c-a1a3c8684276",
+      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "8b17b9f0-8e9b-4825-a6d8-85cab07b28e8",
+      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "31570620-2aff-40ad-ad2b-b74abf0151a9",
+      "groupUuid": "c4f7cc9e-649e-49cf-92de-324a32ccd286",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "b8ffac5d-e4be-4503-af66-d0e30e45d20d",
+      "groupUuid": "c4cdae05-9be5-4405-9f9d-d2655d391463",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "a86649b8-fffe-481a-a0f8-b5b2eeec0b3a",
+      "groupUuid": "1c5a4db6-2174-4909-9183-6b27c1df43eb",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "abe91b9b-74ee-474f-aaf3-bea93f7b78c2",
+      "groupUuid": "5543aa1d-ecb5-4be1-875d-23eae751b6e0",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "d8097245-8c03-4154-bdac-18347b862494",
+      "groupUuid": "a65a6137-36b3-4ef1-9249-8e91fd0abb38",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "03ae81fb-03d5-4715-acde-7d4a2148aa63",
+      "groupUuid": "ccad0310-dcf4-461e-8165-6bc3495eade1",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "d32baba1-fded-4602-8c9d-a03082c82a52",
+      "groupUuid": "70a76780-2472-424a-b560-3a65f43c1293",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top) \u2014 9sus4 extended"
+      }
+    },
+    {
+      "uuid": "b88949ff-6fa4-45fd-b5e0-52a9f53e8c3f",
+      "groupUuid": "45d0aacf-2677-4476-94ba-b8c71d8914ea",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c9sus4-cm6-extended-6str-14.png",
+            "name": "Fretboard diagram for C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "5766c1e4-de03-4ccd-a045-b91db05965da",
+      "groupUuid": "094c6463-eb9e-4623-821a-dcfc120c87cc",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+      }
+    },
+    {
+      "uuid": "8b41de44-8d37-42d3-beba-a37b2e86831f",
+      "groupUuid": "14e9e83e-92de-469a-a596-d3a4da1893b7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "403ad666-dced-4c8c-b6bb-4b6faa0af7cd",
+      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "42958008-56d5-4cee-ae82-4fe42d808868",
+      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "cda9a2c4-2558-466a-880f-111c5721fb51",
+      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "0d82f393-a301-43b6-bd75-94e4ccf9b182",
+      "groupUuid": "f7d7ad39-d707-4d2f-ae05-91a386d15ecf",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "be3618f0-b29c-4f92-992e-8066798e5a84",
+      "groupUuid": "ce3c7d14-09b5-46ab-ac58-2871b1977a81",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "5499bcb9-a4a4-4355-a778-4a58e4d79250",
+      "groupUuid": "6720f043-d16e-4989-87a8-29b908ae5292",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "31698d7a-82dd-4039-b420-9a3f68f5cd8c",
+      "groupUuid": "e6832902-5651-45d8-a6d2-62ef53a4bc86",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "5ba1204c-992a-4a0e-9301-bf118d57c114",
+      "groupUuid": "55a16adb-52f3-47f3-9c33-4551d3a6b4fe",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "1dd35627-74b1-4d9c-9e22-24ff7da1a3c4",
+      "groupUuid": "ef0d6a4e-ec22-422e-9d53-89f3bfbe1196",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "aa96cdf1-75e5-4e8a-b78a-9220d2a469d3",
+      "groupUuid": "00f5fb26-8bfb-48e6-8030-6ffdd3bd572b",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top) \u2014 dom7b13 extended"
+      }
+    },
+    {
+      "uuid": "b9c839bd-09dd-4d68-a4eb-b40be3e6fb33",
+      "groupUuid": "b0479704-8274-492d-9ab3-499074c1f75a",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7b13-ext-a-shape-6-cm6.png",
+            "name": "Fretboard diagram for Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "060edd23-ead3-474d-8d0e-aaf1e0daafe4",
+      "groupUuid": "4b445692-fe07-41f9-b1a3-e5f0268862ea",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "c7fec2a0-791d-45ee-8023-20eb47e3550c",
+      "groupUuid": "00d215fe-763f-4ae5-9bfc-1daa2cf41127",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "f7ffe4ac-c58d-46fa-b74c-43d4af6c8375",
+      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "f04043d8-642c-47c8-9fc5-7e37ca0d2e0a",
+      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "63d69419-0396-4276-8756-212468add79f",
+      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "4425e508-2bfb-40ee-ac5b-b66ce2de2e7d",
+      "groupUuid": "6ee257ad-1bb5-447b-8226-5880f13bf38a",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "2d106145-5753-4fc0-b8cd-8c3d3025e5a8",
+      "groupUuid": "5fa9c36c-b4ae-467a-b4a0-f7109b4962d2",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "f270534a-fdd3-4a57-9500-1e3259c58a0d",
+      "groupUuid": "f89ba019-40cc-4be0-82a1-5da2faea8099",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "a16d82c2-8165-4805-8595-538c984fd79c",
+      "groupUuid": "bc999126-b5bd-4609-be00-4303cd8e485f",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "80880c81-4fa9-41d7-b811-107a5451bff2",
+      "groupUuid": "7d952d18-574e-4115-bfd2-bb30a0021e22",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "a30a1081-da53-4646-b772-7bbef0cc036c",
+      "groupUuid": "ddd8d6bd-10fa-4ac6-827f-6f392aed859c",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "dafc741d-067b-497c-b8ba-6e0147505e96",
+      "groupUuid": "84bebb52-a6eb-4307-8eb6-eaa523effb67",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top) \u2014 quartal quartal"
+      }
+    },
+    {
+      "uuid": "2a8dfbf5-5a18-4454-9781-00da6835c1b8",
+      "groupUuid": "f625eb4f-6781-4f17-9967-822844c11509",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-f-upper-6-cm6.png",
+            "name": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "68c5d171-ff8d-4b1b-9d10-a6f0d4b815da",
+      "groupUuid": "81961b0b-7c5e-4d52-87b8-d322c1fd22a7",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+      }
+    },
+    {
+      "uuid": "20bb956a-dcd4-4e3a-8b2d-173db373ec23",
+      "groupUuid": "ce95625b-5a91-452e-ab2d-1b095344d299",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d13ed91c-a069-48f8-8ef6-84949e42bda1",
+      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "677d6370-78c2-4e51-bbae-60e409fc320b",
+      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "846dc22f-f088-451b-8673-a9daebbb804f",
+      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "941db39a-e263-4a5e-a1da-bf4637bf6201",
+      "groupUuid": "3dc76610-b321-43c3-a0b7-a25716bdefc5",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "867a5e31-1b80-40e0-9d97-ad69db1924e3",
+      "groupUuid": "9c10db46-d24f-4363-89fd-0ac3302a3ddb",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "49fccdc9-0862-48ab-b544-3efb6470ad6f",
+      "groupUuid": "1c0ae8fc-a778-46c1-bba5-468187a0f6b4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "90e32e8d-e945-467c-b933-8e4cbfd63714",
+      "groupUuid": "0f1b7bd5-f20b-4166-a1e3-a5742c0b3f60",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "5032e9a9-ef6a-420b-bf04-c73511ff758c",
+      "groupUuid": "b10a4af3-7966-43b0-9cdc-73b491a51353",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "c017105a-fba7-4c4b-840e-97ade7c4062e",
+      "groupUuid": "6aec69dd-cd33-402d-9de6-8e67446b367d",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "8894e7a9-3e83-4623-aef7-af290f13221f",
+      "groupUuid": "3daca940-0165-4c4d-82b5-018d40cc8d46",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7alt \u2014 7-str root \u2014 Shell (b5 on top) \u2014 dom7alt shell"
+      }
+    },
+    {
+      "uuid": "a9528c51-32cb-4d6b-9922-e3e25378e4a0",
+      "groupUuid": "26689754-4c0a-4a9c-a19d-c295c61b4430",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7alt-cm7-shell-7str-7.png",
+            "name": "Fretboard diagram for C7alt \u2014 7-str root \u2014 Shell (b5 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "76ccb174-44a8-42fc-8c71-7187b1068fb5",
+      "groupUuid": "60db7725-1db7-4ea8-bae1-a88ad0a7c494",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+      }
+    },
+    {
+      "uuid": "ce58e6c4-d34b-42b8-9e57-ee70ba2313e8",
+      "groupUuid": "82e05010-0657-4d6e-ac0d-b27fe41edbdf",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "d7f3f8a1-90a9-4574-a7b3-dea6a999cd7c",
+      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "469e5419-294a-44ea-9035-61c464bd5ea5",
+      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "3fdc5e80-97b1-4998-b27b-19a293c5c1a1",
+      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "553bfe02-104c-4814-889f-873aef992a6b",
+      "groupUuid": "b1b6f7d6-e6d4-4e1c-acea-29fda297c81d",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "ad546ec1-7bd8-45ce-8db3-77936b0ea822",
+      "groupUuid": "43689250-2088-4234-add1-e4eb2058eb5b",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "2efde63b-e908-498d-95fb-d6ee0f3c1001",
+      "groupUuid": "c6e37d2f-29aa-4f06-8014-ed6243e492c7",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "a6037b8c-0ab6-49c6-aabe-acaf4266d7ff",
+      "groupUuid": "9f0e29b7-b07c-47a7-9f63-cc51d0435c6a",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "bb7907e5-4823-407d-bcfc-3b3dcedd2932",
+      "groupUuid": "210f5c70-daf9-4abf-9810-dbc3d42a6edd",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "8597cb09-98a4-4a1d-b63f-cf7538960e16",
+      "groupUuid": "40f3c065-9b2f-4053-b9ad-8243c64aa0e5",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "89d3d083-65ad-4c9a-bc33-39b3932d18ea",
+      "groupUuid": "e6b6aae4-6774-4cbd-8c04-e52ba39c6654",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+      }
+    },
+    {
+      "uuid": "36e9c273-47ca-4480-9421-e69fbd9e875e",
+      "groupUuid": "9911edbb-c657-4cf2-982e-ae85cb6794ac",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-cm7-shell-a-7.png",
+            "name": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "dbb357e6-8270-4fd5-850c-5e159b6f42a8",
+      "groupUuid": "496ebb3c-937a-45ee-a626-4ec5102f337e",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+      }
+    },
+    {
+      "uuid": "89904d62-8d5e-4ecf-8970-1cca3679def9",
+      "groupUuid": "402d42bc-1138-40c6-b801-b502b5bf3ad1",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "338a439c-2cc4-40ad-b1d6-e708f3ba3c8a",
+      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "a4adc444-bb49-423e-88e5-1364f8701c35",
+      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "ba1530c6-58fb-459f-80b4-0974ffa16504",
+      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "240b495f-4b9c-4096-b295-d5d3cf374993",
+      "groupUuid": "43e13724-807e-4ad4-acd7-8381718af026",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "d431f25f-4dda-4db5-9452-d1846a44c287",
+      "groupUuid": "99bc9ec7-21b9-4a6b-a7cb-35354e2cbe41",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "e63c6cab-6f04-4713-81e1-d701b91fe9be",
+      "groupUuid": "0be66d93-3392-41d3-84c0-d9cb5a1cc28b",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "10769c3e-1714-48d2-8a99-b4fbc391f8c4",
+      "groupUuid": "4e9d4cd8-1090-4c93-bcfb-548338e40cb8",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "c4c2e72a-e86d-4d8b-9583-be2b8dc3dcad",
+      "groupUuid": "6e67967c-763e-4fe7-92f0-23be8cd63275",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "4757491b-219c-494b-b1ef-6f75b434131a",
+      "groupUuid": "0910252b-baae-44cc-9896-ed56ddb12456",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
+    },
+    {
+      "uuid": "d93449f9-e555-48ed-ae35-86f417cc3294",
+      "groupUuid": "d5e0d2ec-5382-4687-86a6-88b9ac5eb4c3",
+      "groupType": "TITLE",
+      "type": "TITLE",
+      "payload": {
+        "html": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+      }
+    },
+    {
+      "uuid": "88183b60-65e2-4531-a971-5514fff26ca2",
+      "groupUuid": "228a6546-8b25-4594-b4c8-1da550631d17",
+      "groupType": "IMAGE",
+      "type": "IMAGE",
+      "payload": {
+        "images": [
+          {
+            "url": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-shell-a-7.png",
+            "name": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "fb995954-0cda-425d-a0f0-ac55dd70452f",
+      "groupUuid": "ed3d795b-5874-43c4-b6ce-6b06e93dbc32",
+      "groupType": "TEXT",
+      "type": "TEXT",
+      "payload": {
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+      }
+    },
+    {
+      "uuid": "31acc926-8a0e-4c2f-b642-a1fdd97c10af",
+      "groupUuid": "19115a2f-b721-424c-9afb-2834529b60f4",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Do these tags fit this voicing?"
+      }
+    },
+    {
+      "uuid": "f55434b3-c32f-439a-9499-44649bf72509",
+      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "YES",
+        "index": 0,
+        "isFirst": true,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "7ef71fb2-20ba-4a47-bea5-62062abab1df",
+      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "NO",
+        "index": 1,
+        "isFirst": false,
+        "isLast": false
+      }
+    },
+    {
+      "uuid": "76781cee-6dbc-4ecf-a694-042c8158489b",
+      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "groupType": "MULTIPLE_CHOICE",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "payload": {
+        "text": "REFINE",
+        "index": 2,
+        "isFirst": false,
+        "isLast": true
+      }
+    },
+    {
+      "uuid": "d07776a5-ab12-4e7a-b991-e5e6de76cbc3",
+      "groupUuid": "d99687d9-c635-4e94-913c-8f05ead02104",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "If NO or REFINE, why are you overriding the agent?"
+      }
+    },
+    {
+      "uuid": "307c543f-4a8d-461a-a9fb-224d4657ff5b",
+      "groupUuid": "ac5df544-8181-4b2a-af27-4e574f1147a9",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. This Caug7 doesn't fit Joe Pass's chord-melody vocabulary"
+      }
+    },
+    {
+      "uuid": "bbc0624c-5d3f-403d-a9cc-e9327e5c47b2",
+      "groupUuid": "04f11206-d63f-438a-be95-254918be3f49",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Tags to add (comma-separated, optional)"
+      }
+    },
+    {
+      "uuid": "7b5210cd-5dc4-4967-a03e-6da912cc984f",
+      "groupUuid": "bc11be11-dab2-4fd5-866e-837544208c29",
+      "groupType": "INPUT_TEXT",
+      "type": "INPUT_TEXT",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "e.g. van-eps, walking-bass"
+      }
+    },
+    {
+      "uuid": "ab619562-23cb-4459-90bf-a8f4d9286ec7",
+      "groupUuid": "86ff46cc-b5a9-4651-ba1e-29bdeec8e778",
+      "groupType": "QUESTION",
+      "type": "TITLE",
+      "payload": {
+        "html": "Anything else? (optional)"
+      }
+    },
+    {
+      "uuid": "24964ea4-d437-49c5-8ab0-060d95a6f20e",
+      "groupUuid": "7c384c12-0fa0-4ea4-999b-8429569afa13",
+      "groupType": "TEXTAREA",
+      "type": "TEXTAREA",
+      "payload": {
+        "isRequired": false,
+        "placeholder": "Free-form notes"
+      }
     }
   ]
 }

--- a/scripts/voicing-tags/tally-form-payload.json
+++ b/scripts/voicing-tags/tally-form-payload.json
@@ -2,8 +2,8 @@
   "status": "DRAFT",
   "blocks": [
     {
-      "uuid": "c17c7151-3a07-4e35-9f79-c06549118f33",
-      "groupUuid": "69dc2fa3-e054-4524-822e-0cd63a1bf36b",
+      "uuid": "61e0e8c3-b4c2-4500-9399-30ede02eb1a5",
+      "groupUuid": "1c6371e9-af3a-43cd-afd3-eaf01132f3c6",
       "groupType": "TEXT",
       "type": "FORM_TITLE",
       "payload": {
@@ -12,8 +12,8 @@
       }
     },
     {
-      "uuid": "7de2305b-89bb-4ca1-adac-2b8b199d5d0c",
-      "groupUuid": "8bcde888-b172-48ea-9de5-2b4d097fece1",
+      "uuid": "80733453-a3a1-47c4-8bd6-046739bbc9ec",
+      "groupUuid": "9a6c2311-7626-4a66-83d8-d0b5d6e3b3e0",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
@@ -21,8 +21,8 @@
       }
     },
     {
-      "uuid": "e708be0c-df81-4be9-9a43-9e38d5c38035",
-      "groupUuid": "185ee2dd-09fa-47ad-a1e5-2d5e3a5a9d05",
+      "uuid": "2c0ff12a-fbb1-4065-8d4d-bd884668bc2f",
+      "groupUuid": "1ad909fb-5138-4588-be87-d8375e880017",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -30,8 +30,8 @@
       }
     },
     {
-      "uuid": "dc62ff74-2377-497a-b948-e3d2ba553587",
-      "groupUuid": "d66b2b16-5e1f-493a-8ad3-3282e41fc076",
+      "uuid": "cac81188-ba98-4169-8e87-783f33702a98",
+      "groupUuid": "19625af1-cdd9-4032-a69d-6c5c7939a074",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -44,17 +44,17 @@
       }
     },
     {
-      "uuid": "3b0bad58-ae10-46a8-9231-37b36037c95f",
-      "groupUuid": "1e7258f9-519e-4180-81ef-6a85d5e43d93",
+      "uuid": "73b83358-3923-4851-8cf5-7acb0f056b88",
+      "groupUuid": "c0a2b87b-ac43-429c-b677-d2f9f2ea6721",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "aa3d985f-b82e-4310-942c-e21475b3f712",
-      "groupUuid": "153ab8ce-5b02-4276-b942-8abcb4cb7a4f",
+      "uuid": "429dfb2b-8eb6-41fd-908a-7b43f16fef07",
+      "groupUuid": "c017bb6e-7da1-4940-99ba-e4d3893c8469",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -62,8 +62,8 @@
       }
     },
     {
-      "uuid": "41b7c8cc-5195-4bae-ac04-a86f0fe7358d",
-      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "uuid": "33bbf730-4977-4153-9ecf-3d1b8ad6aa35",
+      "groupUuid": "3c47ac9f-844d-4357-aa25-9bc17dce3f89",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -74,8 +74,8 @@
       }
     },
     {
-      "uuid": "783a6712-c91a-42fe-861b-d0de06a90a78",
-      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "uuid": "685fa856-e939-4664-8355-6260076ca294",
+      "groupUuid": "3c47ac9f-844d-4357-aa25-9bc17dce3f89",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -86,8 +86,8 @@
       }
     },
     {
-      "uuid": "626c210b-ccfd-43f0-ba0d-570a531021ca",
-      "groupUuid": "4ec9e366-df1b-457c-b732-6e9a0c6bada2",
+      "uuid": "be25ca62-606b-4e98-a957-a7614b9e53d4",
+      "groupUuid": "3c47ac9f-844d-4357-aa25-9bc17dce3f89",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -98,8 +98,8 @@
       }
     },
     {
-      "uuid": "3c08057c-696b-48f3-92bf-67eee81b367d",
-      "groupUuid": "2044bd93-fb09-434a-944e-797dd3faf3bc",
+      "uuid": "142b3da0-b84b-4ab5-b8cc-4f30db0f5f9b",
+      "groupUuid": "9341a694-a427-4650-a823-2d4a4e28a9a9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -107,8 +107,8 @@
       }
     },
     {
-      "uuid": "a88b4e00-d8fe-434c-bc52-8f24bb2e50fe",
-      "groupUuid": "7db9487d-2302-4499-b833-7ef6e01a4e2c",
+      "uuid": "1b1adcae-60fa-477a-b800-9eb884b6fc5b",
+      "groupUuid": "140045cb-fcaa-4449-ae18-2ed1c7a496af",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -117,8 +117,8 @@
       }
     },
     {
-      "uuid": "5d475e15-f266-44d5-811b-69db07274452",
-      "groupUuid": "3facb47e-6256-48a9-a97a-1d952c3aca6a",
+      "uuid": "9380fb87-285e-4efe-9474-cbb1f193e7e7",
+      "groupUuid": "dd3cb173-bbeb-4349-a279-87357e8778b0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -126,8 +126,8 @@
       }
     },
     {
-      "uuid": "60bbe785-4b24-4301-9dcc-bb8d18ce0a02",
-      "groupUuid": "588fef02-c764-4a61-8cae-9caf000ecb07",
+      "uuid": "1d43d5ec-855a-415d-8ecf-d3fa7cebf641",
+      "groupUuid": "e7894ca0-4ee7-4c2f-b0fc-7fb94221777f",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -136,8 +136,8 @@
       }
     },
     {
-      "uuid": "4d346cb4-8168-4de0-961b-ffe7000f8fcc",
-      "groupUuid": "114050b7-52f0-43da-bc48-fcbd19340aa0",
+      "uuid": "8a5ae1dd-a8b2-4f55-bf73-f931333d7188",
+      "groupUuid": "95305058-c1c7-44d3-96e1-82191b2001a2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -145,8 +145,8 @@
       }
     },
     {
-      "uuid": "a9986592-9c23-49c3-8049-58b2cb7179de",
-      "groupUuid": "aade363d-86c0-43fc-8a5f-8f903213dd5a",
+      "uuid": "9f5e96b6-e356-4c99-a74b-6c632a2f00d9",
+      "groupUuid": "8594b6a7-fef5-490f-97b8-d87eb2358ced",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -155,8 +155,8 @@
       }
     },
     {
-      "uuid": "0809a00e-1017-4bea-badb-a43463b530c8",
-      "groupUuid": "4a7aab67-9ef8-4257-8867-ddc0715e45a4",
+      "uuid": "be499240-e4cf-43bd-8b55-1dfd81a5c0c3",
+      "groupUuid": "26db5ab7-10ac-4bc0-a07c-da22b4189cd2",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -164,8 +164,8 @@
       }
     },
     {
-      "uuid": "895dbd4b-2655-4b05-bb7c-68daa8e1801e",
-      "groupUuid": "7d860845-1557-44d7-84ef-48c795e79304",
+      "uuid": "3fdd9171-87ee-4f51-bb51-94083f51b40c",
+      "groupUuid": "0ab3f4cb-86fb-4e5c-aac8-83ac10edcc86",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -178,17 +178,17 @@
       }
     },
     {
-      "uuid": "63c18e6e-e112-4998-990a-fd13934b867d",
-      "groupUuid": "3525c243-ee3c-4133-aac5-45fe66910321",
+      "uuid": "6de59e03-dc9d-4621-b1d9-74a5249138a0",
+      "groupUuid": "b8cddd29-b10d-4cce-a505-3e4d47b77ad1",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "6e9f3d10-0a04-4d69-9030-8f734132f64b",
-      "groupUuid": "0a46e748-625f-4625-a745-7afcb63bd253",
+      "uuid": "1bb68817-2621-43ce-affa-bde97f39a76b",
+      "groupUuid": "fe6c673b-7eca-4736-9047-647d001d106f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -196,8 +196,8 @@
       }
     },
     {
-      "uuid": "37653bea-172b-46eb-9490-22856b795f25",
-      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "uuid": "7d786b60-3bf8-45cc-8d3a-c8fc67d6c13e",
+      "groupUuid": "136e6900-bff8-4fa9-b131-6dc05d5f872f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -208,8 +208,8 @@
       }
     },
     {
-      "uuid": "ee9dd13e-bb85-48d2-8599-818a6997134e",
-      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "uuid": "51e4510a-d955-436f-bfad-0bbb571e24a5",
+      "groupUuid": "136e6900-bff8-4fa9-b131-6dc05d5f872f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -220,8 +220,8 @@
       }
     },
     {
-      "uuid": "bccf4890-d142-4f99-b47c-753499c2b48b",
-      "groupUuid": "9f877825-f545-4ba5-8a7d-a257764b50d6",
+      "uuid": "b18b17aa-8707-470a-a03f-965b1e448fa5",
+      "groupUuid": "136e6900-bff8-4fa9-b131-6dc05d5f872f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -232,8 +232,8 @@
       }
     },
     {
-      "uuid": "8edb0fd8-af80-4440-b80f-a289d60fc7d8",
-      "groupUuid": "ceb9688f-fa85-4315-a87e-0fa81e83a8b9",
+      "uuid": "97e74ce3-62c2-4977-af02-fbb09535eba8",
+      "groupUuid": "6f8878a0-34b8-4e92-bb6d-e1ba7a1ddba4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -241,8 +241,8 @@
       }
     },
     {
-      "uuid": "1fa34444-b550-4358-930a-231babd5b10b",
-      "groupUuid": "26101f69-48d1-49ac-8ab0-4b1cc1a233ca",
+      "uuid": "d28730b1-6178-4c73-bf05-8ce8a7771cb5",
+      "groupUuid": "288a4c9e-75d0-4623-ae7a-bd29f8132640",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -251,8 +251,8 @@
       }
     },
     {
-      "uuid": "b8b1ba98-229d-4168-8e14-ded5138c630d",
-      "groupUuid": "6ffe6ae9-ae08-44e2-9592-0c9fbf3a187f",
+      "uuid": "c710379a-73b2-4ea0-bd62-0dea2642e23a",
+      "groupUuid": "40a554e9-3be9-4eb5-b541-7bb3f4a9e50e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -260,8 +260,8 @@
       }
     },
     {
-      "uuid": "00b37e34-8461-4f90-beea-36afc9b36106",
-      "groupUuid": "bd1598d2-25ba-4165-a646-2a05048fbe0a",
+      "uuid": "40203fc8-68d7-4ad4-a40e-d2026add57e3",
+      "groupUuid": "80cad182-39e7-4cec-af93-1df30e0b61b9",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -270,8 +270,8 @@
       }
     },
     {
-      "uuid": "63685a43-b228-4765-85e0-e4d63e820522",
-      "groupUuid": "276040ec-f53c-4a50-9fa4-8b59a6ccb29b",
+      "uuid": "e2a4239b-5e1a-46f4-9c53-135596d73c68",
+      "groupUuid": "8fae55d7-d286-429d-a504-d0d2a0e6d3fa",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -279,8 +279,8 @@
       }
     },
     {
-      "uuid": "caffc9c2-9298-47b2-bcb3-ef4c2c4fbc5a",
-      "groupUuid": "e9b7ef65-c708-4bb9-acce-34a21c5ac0c2",
+      "uuid": "c72d1b97-a0eb-4696-a25f-9f494792efbd",
+      "groupUuid": "35e89d53-7e2b-4a5d-8cfc-11eb6efe1d2c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -289,8 +289,8 @@
       }
     },
     {
-      "uuid": "718adc69-8c3d-430c-a9d8-dd2a507c03df",
-      "groupUuid": "88639cfa-9e0d-428b-9436-045172f9830e",
+      "uuid": "0f78f8f4-48bb-46af-a1f2-c9799f7453a8",
+      "groupUuid": "26709f7b-c26a-4c40-9bf4-0b160adb9b43",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -298,8 +298,8 @@
       }
     },
     {
-      "uuid": "680360bd-feb4-4193-8f6c-b094b6168737",
-      "groupUuid": "70613098-8e77-45a8-8ad2-f03af35c6796",
+      "uuid": "c7e38e0d-9354-4ffd-880b-89039d2682de",
+      "groupUuid": "bcea1771-426d-472d-8b9e-5b7bef2a31db",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -312,17 +312,17 @@
       }
     },
     {
-      "uuid": "8ee74da5-60da-436f-8a1c-7c0dd5b5ac27",
-      "groupUuid": "f1ee4ec0-3712-4bb7-bb3d-519cfb291733",
+      "uuid": "60ea99d6-0e10-4ea6-9c6c-016882a87683",
+      "groupUuid": "f74265bc-9ab4-48fb-8fa4-8a88d93301dd",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "463dffa5-f9ba-4d36-a5aa-42b21a757a19",
-      "groupUuid": "d520cdc7-022b-4040-9180-4fa1cb2a75e2",
+      "uuid": "1483d331-bc66-4b43-90c5-cb2238cd841a",
+      "groupUuid": "68ccbe98-fe16-4c56-824f-8b18b9ed001f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -330,8 +330,8 @@
       }
     },
     {
-      "uuid": "987b7787-7c00-4f73-88aa-4dc13ca91fc7",
-      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "uuid": "3c71ae86-71ef-463f-9e89-16c6b7ad600a",
+      "groupUuid": "e8cf55cb-f9fb-492d-a38e-0c3604ea25a4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -342,8 +342,8 @@
       }
     },
     {
-      "uuid": "546c353c-7024-48d3-8a16-30b08adba53a",
-      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "uuid": "ae6911d4-8528-4bc7-903e-1be6a64d46a1",
+      "groupUuid": "e8cf55cb-f9fb-492d-a38e-0c3604ea25a4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -354,8 +354,8 @@
       }
     },
     {
-      "uuid": "25cf7acd-734b-4b50-a88c-0a73029128ac",
-      "groupUuid": "bd4d17ed-e54d-4951-91de-78b64422639b",
+      "uuid": "1b672e37-829a-4e19-834c-f5491beef161",
+      "groupUuid": "e8cf55cb-f9fb-492d-a38e-0c3604ea25a4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -366,8 +366,8 @@
       }
     },
     {
-      "uuid": "ccc38e85-6f30-49ff-8fae-a07c114cd5d4",
-      "groupUuid": "30f1beb0-4c88-4678-8d67-57cb9fe704a5",
+      "uuid": "72ce34c6-c2dd-4c8a-93fb-b8ec08a08f76",
+      "groupUuid": "d2f99e25-663b-4923-88f3-aa422c72cea8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -375,8 +375,8 @@
       }
     },
     {
-      "uuid": "93c3a405-efa3-4fa9-b8dd-49a7fe597496",
-      "groupUuid": "4f507a25-452b-40a4-b831-4b44a205b346",
+      "uuid": "ca00fce2-741c-40e8-a048-0b4704502a84",
+      "groupUuid": "52b996f2-bf5a-4b2a-9980-cc18d3777d24",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -385,8 +385,8 @@
       }
     },
     {
-      "uuid": "0d6dd99b-31bb-42b0-94fa-d5f7886e334f",
-      "groupUuid": "cf54d67b-7ef0-4a37-b469-417166f918fe",
+      "uuid": "49f4163c-3bf4-4e22-8235-ab83f024d1b4",
+      "groupUuid": "d820df45-12e6-41a7-8055-b353de7b71a7",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -394,8 +394,8 @@
       }
     },
     {
-      "uuid": "311e7c1b-a886-42be-9ee2-11d986236a66",
-      "groupUuid": "e6e23ce8-0300-49f9-a656-df89bf022624",
+      "uuid": "1296d6e5-168e-4a69-a48e-1eb835116055",
+      "groupUuid": "e09bbddf-3e0a-48f3-bc3e-14b796bb6e48",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -404,8 +404,8 @@
       }
     },
     {
-      "uuid": "504ca601-e8e3-4909-be3c-43a37d41b3c5",
-      "groupUuid": "81a81198-1b37-4736-be1c-14520a86037f",
+      "uuid": "7fb2c394-6de0-484c-9b74-6798257edcf9",
+      "groupUuid": "71563f07-1757-4a13-83bf-b3015260bc6d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -413,8 +413,8 @@
       }
     },
     {
-      "uuid": "d852f95e-28df-4a28-b455-90742f16dff5",
-      "groupUuid": "b9834b22-cfe8-4daa-b412-3fcb28645b0b",
+      "uuid": "55eae3c2-c9cf-45b6-acc4-26cbbdde72f6",
+      "groupUuid": "c9bef887-b9bc-4ea8-9fb3-56700782d487",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -423,8 +423,8 @@
       }
     },
     {
-      "uuid": "679140f0-2c70-4178-869c-61d6d806811a",
-      "groupUuid": "3c70610c-e845-46b6-b241-98bd1d35ef22",
+      "uuid": "96d5d2d5-d7d7-4f32-918d-c7c9dff82790",
+      "groupUuid": "9115784b-78bf-4c4d-911c-52f2244eb51a",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -432,8 +432,8 @@
       }
     },
     {
-      "uuid": "deec93d1-343f-45b6-adc0-43430e4e6252",
-      "groupUuid": "cee5869b-a606-456d-8d96-4d1c148be007",
+      "uuid": "7a56f277-8c09-4448-a8a4-a1d32b05a2d3",
+      "groupUuid": "fb50d168-fdff-4edc-acdc-6ee834d902ad",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -446,17 +446,17 @@
       }
     },
     {
-      "uuid": "5e566df4-26e3-481b-89ed-b7aa9f54bb66",
-      "groupUuid": "4292f591-c12e-49c9-b9c9-b93cb05c29ff",
+      "uuid": "8c0f2efa-f029-4243-879e-8928bfbc961a",
+      "groupUuid": "0b3fa632-fbff-41d5-92f3-8fdf816d81ac",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
       }
     },
     {
-      "uuid": "a9e16249-c732-4308-a902-4d779e7bec90",
-      "groupUuid": "dac109a2-a0fd-4a16-b8ca-a4514e5253bc",
+      "uuid": "262cd7cf-c9a2-4c93-84d6-edc67f4b10b4",
+      "groupUuid": "df626224-11fd-4425-8e48-0ecc067f8a71",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -464,8 +464,8 @@
       }
     },
     {
-      "uuid": "5d49aeca-94cd-4995-b34e-af6b8c20d664",
-      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "uuid": "34840e89-30c6-4ea6-af2d-cc54571b4aa1",
+      "groupUuid": "3df9c5ab-df56-4f3c-aa3f-c6e946bf92e5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -476,8 +476,8 @@
       }
     },
     {
-      "uuid": "037f8957-e62f-486f-8618-32d0b5a9d141",
-      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "uuid": "041c58b5-51f2-414e-b074-75ff6ad9a4aa",
+      "groupUuid": "3df9c5ab-df56-4f3c-aa3f-c6e946bf92e5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -488,8 +488,8 @@
       }
     },
     {
-      "uuid": "1bc93c39-4a01-4df3-98c9-6aa9a41439d9",
-      "groupUuid": "4273fc03-a779-4f1b-9b57-8d464e5db449",
+      "uuid": "ffd0fbcf-4bc9-4d75-9047-bd9683cf8221",
+      "groupUuid": "3df9c5ab-df56-4f3c-aa3f-c6e946bf92e5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -500,8 +500,8 @@
       }
     },
     {
-      "uuid": "f76ef314-2c6a-47ca-aeb5-e6780ec8cb7a",
-      "groupUuid": "901da8eb-286f-4d10-862b-fefc0366f6ed",
+      "uuid": "cdb09217-cbd5-4e07-b684-ddd0dfdd985d",
+      "groupUuid": "078a0a25-9e56-4bc0-89df-32bcd190ac9a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -509,8 +509,8 @@
       }
     },
     {
-      "uuid": "c05735a9-8cc4-4154-9e10-c189a29d8578",
-      "groupUuid": "9ae42de2-1d92-49dd-85f2-4643cc3a6704",
+      "uuid": "df5737c4-ed38-4e9d-a427-c0ac36cbb192",
+      "groupUuid": "bd1d1dcf-7461-41a8-9476-b66383d538d2",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -519,8 +519,8 @@
       }
     },
     {
-      "uuid": "e66c1d01-87b2-40c9-b33e-710db68de1a8",
-      "groupUuid": "74bbb138-690a-4686-9ec0-d0e5c3415ec9",
+      "uuid": "e1f1ae51-51ad-4d38-a604-9c01b6222cb9",
+      "groupUuid": "59bb3934-cbe7-4fea-a298-b79bfa32d3ea",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -528,8 +528,8 @@
       }
     },
     {
-      "uuid": "247ebd00-66c2-493f-ad0d-36a934a7e874",
-      "groupUuid": "c55eafcd-8e52-4215-85b7-a8e477d9c19f",
+      "uuid": "fe2863aa-0156-4813-8692-fc4c595b15ee",
+      "groupUuid": "a58c33fb-c00f-44c0-9183-47d24ba55dd7",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -538,8 +538,8 @@
       }
     },
     {
-      "uuid": "e79214e8-e3b7-4f78-8371-77756d0585e8",
-      "groupUuid": "6e6f80c7-fad3-430b-8b67-529d89ad2cfd",
+      "uuid": "b75f24d2-9fb5-4249-a557-29bf31043846",
+      "groupUuid": "e29c57d8-f6a1-49fe-9d13-2161151f7257",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -547,8 +547,8 @@
       }
     },
     {
-      "uuid": "a9e820d3-92de-4482-b5cd-e14693c2794c",
-      "groupUuid": "31a5bc42-2c6a-4f33-aabf-b17491396876",
+      "uuid": "8653e8e2-1216-44e4-aefb-35c88281debc",
+      "groupUuid": "9538d26c-f0a4-42f2-a280-8de6369bf691",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -557,8 +557,8 @@
       }
     },
     {
-      "uuid": "035cc6e5-62fc-4437-8de1-3d28798026d0",
-      "groupUuid": "f98a49f9-a848-4d45-9f38-f76518261678",
+      "uuid": "da8ea101-92fa-4127-a94f-5e957ca24c5f",
+      "groupUuid": "d2e66965-75ec-4f9b-8e64-cae89af6227d",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -566,8 +566,8 @@
       }
     },
     {
-      "uuid": "8b5d6a62-56e1-4f1f-9dfc-2794cb07a31e",
-      "groupUuid": "05992a9e-18bf-4c08-ac76-72f9f07719f5",
+      "uuid": "fe7537e2-4653-4e85-942b-ee68bd2d4f7b",
+      "groupUuid": "9d95f5cf-e358-4e80-a501-ba6d43040722",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -580,17 +580,17 @@
       }
     },
     {
-      "uuid": "47a44bd6-90bf-4de8-9798-b25eeabf2d62",
-      "groupUuid": "a239e8b2-f4b4-48de-82be-263dcb950bb4",
+      "uuid": "200f339f-8c88-4077-b17e-8d36fa725288",
+      "groupUuid": "302d47ce-b87f-478f-9244-cef6d1e66d15",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "c6c18aff-7994-4e36-bcb9-363ba552ea56",
-      "groupUuid": "b33aead4-2996-439a-bc03-4b62d650c7fc",
+      "uuid": "e0cac9aa-b684-4f07-89cf-06211c6dfd4b",
+      "groupUuid": "24ba7079-5a5f-471c-8462-962035246439",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -598,8 +598,8 @@
       }
     },
     {
-      "uuid": "d9346948-6d48-4450-916d-b151c2437aa9",
-      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "uuid": "3173be06-5c29-4c46-85ad-0c44d4a42b99",
+      "groupUuid": "5470595a-d149-4959-8470-a22a3945560b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -610,8 +610,8 @@
       }
     },
     {
-      "uuid": "3cddb499-91ff-42ad-a9d2-c33fb422b4fc",
-      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "uuid": "b17cfe01-7697-490b-b5a7-110e5d8bb3e1",
+      "groupUuid": "5470595a-d149-4959-8470-a22a3945560b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -622,8 +622,8 @@
       }
     },
     {
-      "uuid": "f1685d30-8ff2-4eb5-ac2f-05206da87ec2",
-      "groupUuid": "47dd3174-0b03-49ae-bb65-f5ab163ef8df",
+      "uuid": "bf5e2662-c113-4c1e-a21d-f828acba42e7",
+      "groupUuid": "5470595a-d149-4959-8470-a22a3945560b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -634,8 +634,8 @@
       }
     },
     {
-      "uuid": "e8e1b026-d536-4f2b-bc14-6a488883857c",
-      "groupUuid": "45884610-ed72-408f-bf7d-e5aa8a419ce6",
+      "uuid": "98cffbb2-fc78-4647-8c17-294330867daf",
+      "groupUuid": "10ef6388-3d35-4706-b1d1-dba50633f4e2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -643,8 +643,8 @@
       }
     },
     {
-      "uuid": "2ffb381c-3b2f-4d81-a7e0-ededcfefc7f9",
-      "groupUuid": "eabf8079-da96-4c29-b9a1-8984cfd14c2f",
+      "uuid": "fa34fd5e-8ebd-4c67-86d7-3d7f960ec1ac",
+      "groupUuid": "3a685053-62e1-408d-a5e0-7702538a4b4b",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -653,8 +653,8 @@
       }
     },
     {
-      "uuid": "1aa74f40-1259-43e6-96de-c0ebed692502",
-      "groupUuid": "8ff480e6-670e-42e1-a55c-f121c149fca2",
+      "uuid": "d2a071ff-9db0-41b3-93d5-9e31b41564ce",
+      "groupUuid": "ca7fc823-e799-4ffe-b9c2-2491e91b1cec",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -662,8 +662,8 @@
       }
     },
     {
-      "uuid": "cc1909df-f87a-41c1-8560-210516248cfe",
-      "groupUuid": "c26c42df-dcb7-4915-a0fe-0b28a002558c",
+      "uuid": "14ccba17-2d48-46c6-b60e-94b7665d3ae7",
+      "groupUuid": "8c91b4e0-8a55-429c-9352-1e88e041c132",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -672,8 +672,8 @@
       }
     },
     {
-      "uuid": "cadc1e19-6f5a-4334-ac8a-cbff2e7a1d72",
-      "groupUuid": "7b5390b5-18dc-46ae-8488-b1705833771d",
+      "uuid": "2ed79c45-980e-44b3-8724-45801d10e061",
+      "groupUuid": "ae43011f-17bc-4b74-afb4-2e68cfbebeb5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -681,8 +681,8 @@
       }
     },
     {
-      "uuid": "db97d3fa-e3ff-43d7-aadc-ed6c2f5da52b",
-      "groupUuid": "5cfd369a-8ede-48d9-a998-2eb61b01b755",
+      "uuid": "4c710d7c-4b51-4e3f-8a0a-7e0797e56e88",
+      "groupUuid": "6ae0a4ba-eb8d-4237-b5a6-714d69b8d6b5",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -691,8 +691,8 @@
       }
     },
     {
-      "uuid": "2d87a481-071f-4e31-b44e-446c8910cab8",
-      "groupUuid": "e004f887-d34d-4271-90c6-50b918503108",
+      "uuid": "ea65d9b7-cb62-4be6-95bf-a0fd5494de53",
+      "groupUuid": "438d07d9-af79-4450-970d-3dbe22bf3621",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -700,8 +700,8 @@
       }
     },
     {
-      "uuid": "d72750d0-9987-4d78-9658-56e1c0d49659",
-      "groupUuid": "78ca0ee2-8a00-409c-8913-3fb15e3056d9",
+      "uuid": "530f2794-291e-446a-ba24-8e36447262e0",
+      "groupUuid": "701f8252-1177-41a4-a585-b20977795619",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -714,17 +714,17 @@
       }
     },
     {
-      "uuid": "1040fc4f-bd60-4c3a-b392-c6971b4f663d",
-      "groupUuid": "c007aeb9-e409-40c4-ad0a-53406534abb0",
+      "uuid": "3573b157-f43a-428c-a6e6-8bff5b110192",
+      "groupUuid": "b0e730d2-9769-4c7d-b93e-1f0a3dc2db54",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "37ecff1c-2be4-4f85-9e41-6e9297ebc428",
-      "groupUuid": "13b1bcf4-713b-41fd-a4cc-39f7b9b1c722",
+      "uuid": "19eadb08-b9ac-48a6-9e6b-c85e5c7cea65",
+      "groupUuid": "444487bf-8dd2-45b8-9efe-bcc85d5f09d4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -732,8 +732,8 @@
       }
     },
     {
-      "uuid": "119c6e49-7ce6-467c-8e26-29bca9b2d800",
-      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "uuid": "030cc36d-a1c9-4919-a3ec-503f8ed8c926",
+      "groupUuid": "036e0ddc-1e14-4bd7-8dde-5bf4247d8644",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -744,8 +744,8 @@
       }
     },
     {
-      "uuid": "62e47d57-c124-41a7-8e12-cb22880f7eb1",
-      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "uuid": "612fa0e4-8dd1-4a73-b6f6-3d7e088aa480",
+      "groupUuid": "036e0ddc-1e14-4bd7-8dde-5bf4247d8644",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -756,8 +756,8 @@
       }
     },
     {
-      "uuid": "f6e7e8f9-03c5-4fd1-9f6a-48e1c07d905f",
-      "groupUuid": "73b47138-bb15-472c-a0bc-ab9c6a595591",
+      "uuid": "668034fa-5caf-421c-8bf7-cb57ee63b963",
+      "groupUuid": "036e0ddc-1e14-4bd7-8dde-5bf4247d8644",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -768,8 +768,8 @@
       }
     },
     {
-      "uuid": "0bd6800f-d80b-44a2-abd3-a505ed137fef",
-      "groupUuid": "735ca87b-5aef-42d9-ae2a-31bb69868e6b",
+      "uuid": "dd750b86-3f7b-4a92-aef8-f610c60226fb",
+      "groupUuid": "814df734-8af5-4db7-bee1-656775c328e5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -777,8 +777,8 @@
       }
     },
     {
-      "uuid": "6a94c1cb-a636-4478-89d9-01f07e674a24",
-      "groupUuid": "10df6a53-c15c-4071-b252-db387c07a6a1",
+      "uuid": "5a4a3a1c-54ad-4a61-ab78-e63914ae41bc",
+      "groupUuid": "96d67f15-a543-4e66-8ce0-c55cf2c63fb0",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -787,8 +787,8 @@
       }
     },
     {
-      "uuid": "b70c23e7-faa3-4dc2-b4d9-e2d473b63109",
-      "groupUuid": "28d16b5a-ea1b-4b5e-ae58-eeb6bc6d8d14",
+      "uuid": "f4206c29-bf98-4328-ac34-ad98f35192a6",
+      "groupUuid": "c3943683-9bfc-4ece-bd99-e5c2196e2d66",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -796,8 +796,8 @@
       }
     },
     {
-      "uuid": "9435aa04-f6f9-40f7-a6e4-25c59ed1c7f2",
-      "groupUuid": "95b0e3a2-44fb-4871-b10c-3771ba7b946c",
+      "uuid": "cb3498f9-aeb8-487f-b13b-3a586f8b962d",
+      "groupUuid": "119ad030-c120-4e66-8674-a73befbb9058",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -806,8 +806,8 @@
       }
     },
     {
-      "uuid": "645e8a06-a7b7-4bff-a4a5-4c4c4e620e6e",
-      "groupUuid": "e07e1b2d-1288-4d71-a840-3f0cb9464634",
+      "uuid": "c601ce5c-f3e2-4aa7-8aea-e1564a227a2a",
+      "groupUuid": "e2e0117a-baa8-4217-bb51-0f037b6c6ab9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -815,8 +815,8 @@
       }
     },
     {
-      "uuid": "e20a04dd-0589-469c-a516-5cac0712a388",
-      "groupUuid": "054112d6-605c-4bed-89e1-87aee8692e77",
+      "uuid": "e72c309b-9561-42a8-b41d-ce352ab6b01f",
+      "groupUuid": "7e0b6d16-b52d-46e1-b6a2-1f209432cec1",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -825,8 +825,8 @@
       }
     },
     {
-      "uuid": "61952ea6-5aec-4675-937b-8f98a3207212",
-      "groupUuid": "b34ec572-0c17-46b5-ac04-acdf273fa073",
+      "uuid": "d1e00c4a-26f6-44c8-a3f4-262a54e5f248",
+      "groupUuid": "cc11f77c-877e-4f26-9313-403c0956a174",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -834,8 +834,8 @@
       }
     },
     {
-      "uuid": "18c452be-aed5-4a5d-bdf2-8275497a5dab",
-      "groupUuid": "2c4fb82f-5fd9-4f83-879f-a13f8f8b0531",
+      "uuid": "1e130700-1a5d-4a86-827e-dbdc74aae011",
+      "groupUuid": "65feed65-15b3-4c82-8343-4c5ff120f16e",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -848,17 +848,17 @@
       }
     },
     {
-      "uuid": "bd250145-78f6-4bcc-bccd-03d5079d80c0",
-      "groupUuid": "96fcff66-e167-4ae2-b63e-5f6e9051b2b8",
+      "uuid": "d7ba07bc-f1cc-4193-8641-8fdae7e249a8",
+      "groupUuid": "ed488b86-a8b0-4090-8e8e-3d551fe69f55",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
       }
     },
     {
-      "uuid": "c8e5da45-bc8a-47ad-aab1-a284ce183d04",
-      "groupUuid": "8466802c-74f7-48f9-b7c4-b80f7c526725",
+      "uuid": "71306bd4-3c41-408b-a0a3-e45e7cd50bd4",
+      "groupUuid": "72f5b65e-8514-4534-b24b-228bb439e06b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -866,8 +866,8 @@
       }
     },
     {
-      "uuid": "286745be-221f-4f7d-917b-d2468a6dc679",
-      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "uuid": "8edbd4e7-7126-4b63-9d01-b660cc416050",
+      "groupUuid": "56eb70e9-3660-47c6-978c-20ee9b0a93c8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -878,8 +878,8 @@
       }
     },
     {
-      "uuid": "813c8172-26d5-430e-9cea-83d86e33ed88",
-      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "uuid": "e08842ba-5324-4a23-904b-9e3f517649d3",
+      "groupUuid": "56eb70e9-3660-47c6-978c-20ee9b0a93c8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -890,8 +890,8 @@
       }
     },
     {
-      "uuid": "0041a32a-23b1-47c3-ab3b-dd10b0d7d290",
-      "groupUuid": "f95a87b4-4efe-4fc4-b65c-4f53eb42bd23",
+      "uuid": "eccf0008-dcab-4343-8334-a6ddb592f6a1",
+      "groupUuid": "56eb70e9-3660-47c6-978c-20ee9b0a93c8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -902,8 +902,8 @@
       }
     },
     {
-      "uuid": "c65b3941-8aba-454a-8838-db8097064e4b",
-      "groupUuid": "0b77379f-ba0c-4a23-9312-95f4e6eb7e71",
+      "uuid": "d1b4b409-3e2f-4891-b99b-a1aa5d6ef963",
+      "groupUuid": "01ff4e18-d163-483c-87c1-1f74c93364b5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -911,8 +911,8 @@
       }
     },
     {
-      "uuid": "421423da-7ab5-4be4-a7ef-a2f2c1c16e81",
-      "groupUuid": "cf1b6aed-e323-430f-82ee-74ad0bc8755b",
+      "uuid": "a414c948-3522-4023-bac1-7a022b0634fe",
+      "groupUuid": "7b7efd63-0afe-4c70-b4cd-30206a31aa24",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -921,8 +921,8 @@
       }
     },
     {
-      "uuid": "8aab0526-2b62-4253-a29b-8c2b20aa7219",
-      "groupUuid": "80d7a050-ed08-4cc8-99f3-73bb9c370654",
+      "uuid": "21861857-bbbd-4a31-b6ba-01004af69214",
+      "groupUuid": "8fda8750-ff92-4da0-9348-798624fc933d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -930,8 +930,8 @@
       }
     },
     {
-      "uuid": "e609d1eb-f9d4-4a6e-b43d-598625089e84",
-      "groupUuid": "18315ff8-5d1f-48f3-a592-fb32f81a2cca",
+      "uuid": "97f19a2a-8ab1-4eb8-9f51-f82f5419ff32",
+      "groupUuid": "8af6a2a6-6c50-452e-9673-d3f550308c0d",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -940,8 +940,8 @@
       }
     },
     {
-      "uuid": "c794f07d-958d-4206-bf15-d87e28da2375",
-      "groupUuid": "28ad471a-691b-4b49-902a-343a9473533d",
+      "uuid": "ff15440e-d5a5-4c37-af2e-aed5f4d67220",
+      "groupUuid": "bee7e49a-a836-41c3-8f4c-0e759a3f1f71",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -949,8 +949,8 @@
       }
     },
     {
-      "uuid": "72467557-82b3-4083-8c71-3e38d0dc1d6d",
-      "groupUuid": "7610a85a-4b2c-414e-8901-daec52a0d87b",
+      "uuid": "e10bf6ec-67e9-451a-8db5-a0b8b119fcce",
+      "groupUuid": "4119b4d0-8eb5-4ebd-847a-d0a9bf938b1a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -959,8 +959,8 @@
       }
     },
     {
-      "uuid": "8bafcd5b-8104-4f15-8351-991f43b719ce",
-      "groupUuid": "99c15a84-eaee-4ac8-ae09-a5a3cb7426a2",
+      "uuid": "afd490ef-c030-4a5d-af15-4e571e569fb4",
+      "groupUuid": "f7488f91-a680-4ab4-9c9c-b12d57b06894",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -968,8 +968,8 @@
       }
     },
     {
-      "uuid": "60b4e7f2-6011-4c59-adb7-fa49c75d9132",
-      "groupUuid": "5f106e89-fe0c-425f-8b6e-3e07ac0735b7",
+      "uuid": "92d95c21-cf1d-44c4-9d59-25727717585b",
+      "groupUuid": "51586cbf-23b7-4483-91d3-3a6b20e93c38",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -982,17 +982,17 @@
       }
     },
     {
-      "uuid": "df729659-9594-492c-8144-79d7a855b0ca",
-      "groupUuid": "775c6291-42c4-4090-82bd-8510587d1d1e",
+      "uuid": "c5716631-6a75-47e0-9e74-92f4d437558f",
+      "groupUuid": "b2aad972-dc14-4831-9fa2-d2ec9cfcea54",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "b7f8195d-f38b-4ac7-8315-f2afed5a501c",
-      "groupUuid": "8f87f86d-dcbe-43d5-a3df-a16a46d22fbb",
+      "uuid": "9b4d7243-3a66-4772-8631-bb6968226c05",
+      "groupUuid": "0c8e550c-cb26-4c72-a227-6de95433165f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1000,8 +1000,8 @@
       }
     },
     {
-      "uuid": "0556b2ec-ac28-4685-947a-7c5a50f26368",
-      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "uuid": "952826ee-a650-48d6-a56b-e4b9be2a8c84",
+      "groupUuid": "9acac7a6-c09f-4a2e-8475-e33273284d5a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1012,8 +1012,8 @@
       }
     },
     {
-      "uuid": "c32a27a2-4dd1-4c75-9a62-35f028521f61",
-      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "uuid": "ccac5fe4-f464-4a0d-a19f-b3df2c41fb2e",
+      "groupUuid": "9acac7a6-c09f-4a2e-8475-e33273284d5a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1024,8 +1024,8 @@
       }
     },
     {
-      "uuid": "eaf3670a-b430-4594-b32a-075c37055808",
-      "groupUuid": "374e001c-e2f2-4a80-ab8b-2c2a852e3ede",
+      "uuid": "3eabac84-fcef-46ab-9996-c9c9c859e4a8",
+      "groupUuid": "9acac7a6-c09f-4a2e-8475-e33273284d5a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1036,8 +1036,8 @@
       }
     },
     {
-      "uuid": "b24fd514-0b57-401f-bbaa-bc51f89f8417",
-      "groupUuid": "5b255bfa-dc4e-4cc9-8697-334530110bc2",
+      "uuid": "a875cb18-4329-4ae1-8cea-21a0ab064846",
+      "groupUuid": "f2f64a37-7d51-4cdd-89b3-db9b5b18d586",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1045,8 +1045,8 @@
       }
     },
     {
-      "uuid": "1a3a40a3-0965-4851-9dec-0bec4972e6e8",
-      "groupUuid": "db3fa69d-0d95-4bca-935d-29e5c00a75e6",
+      "uuid": "5eb9536e-8e72-478b-a48b-adc7c652a59a",
+      "groupUuid": "e1435a8a-fa38-4b62-9aa9-07db3e5f6bf6",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1055,8 +1055,8 @@
       }
     },
     {
-      "uuid": "031d2805-d5f7-4fb3-a5be-ae10036fdf2d",
-      "groupUuid": "9947610a-e4a1-406c-a185-72a41a86f9ba",
+      "uuid": "6b01fb0e-4011-4dbd-b460-7a9992ecb445",
+      "groupUuid": "b944a7df-7141-466a-8798-c0e3ba582321",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1064,8 +1064,8 @@
       }
     },
     {
-      "uuid": "8c5bd1e0-3e4a-4c1a-9f8b-2661a767c0e1",
-      "groupUuid": "46828fb5-b3f3-461d-bcf0-a968acadbb2b",
+      "uuid": "fbe16426-9649-46fb-bc6e-d37e143d97bb",
+      "groupUuid": "f96b70e6-4c30-43ab-98c5-4a89f05f7f4f",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1074,8 +1074,8 @@
       }
     },
     {
-      "uuid": "214df08a-62d4-48da-b49b-2fc99e1c5386",
-      "groupUuid": "f9805e8c-4d2f-4fe3-8453-5935a5a7344c",
+      "uuid": "7857db6c-988a-4f42-980e-26d9b4947a1a",
+      "groupUuid": "0dbe54eb-578c-4b40-93ec-774bf8c22ca0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1083,8 +1083,8 @@
       }
     },
     {
-      "uuid": "db3ac9d6-b1d1-413c-8bc0-05633d80497a",
-      "groupUuid": "a7eb3f8f-e0c0-4bfa-b111-9f326a33cc18",
+      "uuid": "0bfcfea0-b4a7-4f36-84e9-711b7a269483",
+      "groupUuid": "b5be969d-8465-4ca5-83d3-94d22b5f9b52",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1093,8 +1093,8 @@
       }
     },
     {
-      "uuid": "c08e230a-e488-4aa1-87a7-0dcdd119c775",
-      "groupUuid": "86d511e3-4219-4e72-945c-2a52e5d7367b",
+      "uuid": "16a665ee-1cb7-441c-b561-f91ea0c7dfe8",
+      "groupUuid": "6acd9d73-d189-4839-8f83-cd309ab46daa",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1102,8 +1102,8 @@
       }
     },
     {
-      "uuid": "e07388e7-6b87-4d70-8e72-49e8903d61bf",
-      "groupUuid": "64c00ed2-982c-464e-9476-20d2c1426f20",
+      "uuid": "9c9256ac-5a92-4e48-9451-f2bbca5455bb",
+      "groupUuid": "cc0749c5-0b86-44a3-b394-885d0641e476",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1116,17 +1116,17 @@
       }
     },
     {
-      "uuid": "1b309670-7488-487d-b10f-6f8c07b48044",
-      "groupUuid": "5ceb96b4-bc2f-4a39-9e80-a97e919d0892",
+      "uuid": "3a15d4f0-fb4b-4535-a333-fb018287f69e",
+      "groupUuid": "c0d42aef-1764-4ef3-a856-baa8c896b32f",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
       }
     },
     {
-      "uuid": "9afc4cc7-85e6-4fd5-a32c-fb5223e0a65f",
-      "groupUuid": "4b81a4ec-0ad8-4902-ac10-e2835cfc2a68",
+      "uuid": "0df23a93-181c-4e7a-b6d1-f0468a49f34d",
+      "groupUuid": "7cff112a-b826-41e8-9689-4d9da8786dd0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1134,8 +1134,8 @@
       }
     },
     {
-      "uuid": "64d42eaf-2cf4-46c9-acb1-f16d1b0fb26a",
-      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "uuid": "b0faad89-355f-4e17-b224-fba1be883898",
+      "groupUuid": "a33cd457-a1a5-43d2-b15e-33bbd1108dc0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1146,8 +1146,8 @@
       }
     },
     {
-      "uuid": "158a2ae7-b7fd-46de-a29d-869809427091",
-      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "uuid": "fbc262cf-26a3-4b86-ad98-2d9dabc4b358",
+      "groupUuid": "a33cd457-a1a5-43d2-b15e-33bbd1108dc0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1158,8 +1158,8 @@
       }
     },
     {
-      "uuid": "30300d85-a73c-4f20-9e7b-2a596be8e184",
-      "groupUuid": "33297abc-28a6-4816-a234-0ef800bb57e0",
+      "uuid": "ae43d8f5-b429-4ecd-b2ea-2a3736a42ead",
+      "groupUuid": "a33cd457-a1a5-43d2-b15e-33bbd1108dc0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1170,8 +1170,8 @@
       }
     },
     {
-      "uuid": "17487e39-3810-4f7f-b477-270a99126982",
-      "groupUuid": "d98a0d1f-208e-4f1a-8b0f-7fdf9cefa971",
+      "uuid": "f235231a-1438-46ac-bccb-978de485da8e",
+      "groupUuid": "bec6b116-6aff-4a56-981a-e3807f23271c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1179,8 +1179,8 @@
       }
     },
     {
-      "uuid": "6695aa21-9707-4027-9a6a-8ebb736cb1ce",
-      "groupUuid": "ba049432-c710-4eef-bfc3-9ad813498c06",
+      "uuid": "459ef230-1989-465b-884f-e29e9565b292",
+      "groupUuid": "086a2429-a15f-498a-9e1b-909f862be8ce",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1189,8 +1189,8 @@
       }
     },
     {
-      "uuid": "387a5c91-bf49-4241-8cdd-e695e2efc5c4",
-      "groupUuid": "3f385118-9272-40bd-8d79-c98e49bbc65a",
+      "uuid": "9c7c3769-19d4-482d-afc1-c71191773105",
+      "groupUuid": "a5b9b51c-da94-41f4-a79a-7030a568769c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1198,8 +1198,8 @@
       }
     },
     {
-      "uuid": "b737857d-6156-4406-a330-69b393632fa1",
-      "groupUuid": "9f984b7e-5e27-438e-b1a2-3689dffa00a7",
+      "uuid": "811ebf45-9855-4e12-9f89-27a7038549e0",
+      "groupUuid": "1c8dd7d5-4709-454a-a58e-ffd222bff876",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1208,8 +1208,8 @@
       }
     },
     {
-      "uuid": "50aeada4-3017-4f27-8a51-b19d516cd109",
-      "groupUuid": "9590e54a-47d7-435d-b059-c493df2fc35b",
+      "uuid": "4fc99020-f099-4532-92a8-5a12eeed8660",
+      "groupUuid": "202b665a-3346-4def-9ba2-2ed54196701d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1217,8 +1217,8 @@
       }
     },
     {
-      "uuid": "ac0f4fe5-175a-4b72-a5ae-76f410078ea4",
-      "groupUuid": "f6bc64a8-fb8e-4345-86b8-553434c923fc",
+      "uuid": "105fd3cd-a119-4482-808b-cfba745c9adc",
+      "groupUuid": "912c6a5d-88eb-49ba-bc11-a18a379d4eeb",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1227,8 +1227,8 @@
       }
     },
     {
-      "uuid": "af7445cd-fe22-42f6-98a0-7175e380dc61",
-      "groupUuid": "8af6a962-8266-4551-9189-003be2b665f7",
+      "uuid": "80fd0f8a-cf2b-46e3-bd7a-6f93920c3b12",
+      "groupUuid": "30070f54-05fd-43d1-b935-1e9fafb91845",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1236,8 +1236,8 @@
       }
     },
     {
-      "uuid": "c71180b7-6b4a-4c05-bc30-5ca75d4bfeeb",
-      "groupUuid": "c5c3df91-2ce3-4cb6-96ee-eab0bd18b33d",
+      "uuid": "1411d5dd-8de5-4c11-b449-eb9b18380545",
+      "groupUuid": "ed697ad0-b6d7-458e-8fea-effe2923a4c3",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1250,17 +1250,17 @@
       }
     },
     {
-      "uuid": "c9236a8c-187d-4b5a-8ec5-ebe4023e4604",
-      "groupUuid": "16403e79-f89a-4469-9167-648715f0f33a",
+      "uuid": "51b5a969-edca-4216-bace-a716ca041ceb",
+      "groupUuid": "2e697fe5-bb2f-47c1-966d-7cbee7125e1a",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "b7d246c7-ffce-4723-aebb-04165860afc4",
-      "groupUuid": "788ee4a0-6822-4a56-81e3-b79a34ed3e05",
+      "uuid": "11b01412-d3ab-476d-8b99-d5ab26933835",
+      "groupUuid": "39539833-0595-4445-988f-e6c1839f9261",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1268,8 +1268,8 @@
       }
     },
     {
-      "uuid": "cff13637-f050-4853-8b81-a3e3903311aa",
-      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "uuid": "80b5a2f0-0789-4246-bf98-e66e4b9b40b1",
+      "groupUuid": "9d932a7e-06ba-4b4e-b470-c53ffc0ff7c8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1280,8 +1280,8 @@
       }
     },
     {
-      "uuid": "be20e88e-1703-473a-b677-4820515829be",
-      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "uuid": "ff5d517f-54b5-413a-b5e5-158879f97632",
+      "groupUuid": "9d932a7e-06ba-4b4e-b470-c53ffc0ff7c8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1292,8 +1292,8 @@
       }
     },
     {
-      "uuid": "6b3bd45b-8746-486a-99dd-1cc9b92b11dd",
-      "groupUuid": "a6dd0576-57ba-4393-b68b-4e6129aeff3a",
+      "uuid": "dcf1cae8-2e95-4613-8c1a-3d1a75d6d257",
+      "groupUuid": "9d932a7e-06ba-4b4e-b470-c53ffc0ff7c8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1304,8 +1304,8 @@
       }
     },
     {
-      "uuid": "c2768bfc-c8d0-4707-befa-220edeecb04e",
-      "groupUuid": "9b203b7c-3162-4cc3-8840-5b9d7fc2031b",
+      "uuid": "562d281b-f444-4b02-ba4a-b1dd2f1fefc6",
+      "groupUuid": "fdcde563-4bc8-4f9d-ba1f-efa1b27a78ec",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1313,8 +1313,8 @@
       }
     },
     {
-      "uuid": "8a6f3e0b-9cf6-4532-9189-46499547fdf8",
-      "groupUuid": "36f7b4ee-636e-4b8b-b52c-e918f1c33280",
+      "uuid": "cd9435ad-d8f4-499c-b4d2-d37381184790",
+      "groupUuid": "09d1aaf7-27f7-40e4-906d-e796fbe32b1a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1323,8 +1323,8 @@
       }
     },
     {
-      "uuid": "1ee6011f-1cf2-43a8-a4b5-6ebb03f8dfdd",
-      "groupUuid": "fe1de755-99da-4f20-bd47-2db0d39536c0",
+      "uuid": "477edcca-b88b-4a9f-9cc4-91ff3e7a3c03",
+      "groupUuid": "5c6bfa18-031f-499a-8397-dd0de5cb84e5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1332,8 +1332,8 @@
       }
     },
     {
-      "uuid": "59efa150-d7b9-49ec-9734-e3f483d736c5",
-      "groupUuid": "c51a5577-eed0-48cc-b547-f475f4f4856e",
+      "uuid": "3b87af5e-f8bd-470a-971e-de2f5428e93e",
+      "groupUuid": "4d7ddb45-19f2-45c3-b0a1-662cafe5bd2f",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1342,8 +1342,8 @@
       }
     },
     {
-      "uuid": "3a2ce510-23ee-4fa2-b157-ac9e3eb5d12a",
-      "groupUuid": "b8983597-2e6f-4b5e-9bac-9b6326552378",
+      "uuid": "85d447cf-7749-46bc-aec2-27546b7a5e54",
+      "groupUuid": "940fc085-df05-4b60-a883-4459854ce692",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1351,8 +1351,8 @@
       }
     },
     {
-      "uuid": "2c5c09cb-29d2-4b12-9a53-db18dc20dd45",
-      "groupUuid": "a9bb102e-a117-497f-80ac-aa1c728ad64a",
+      "uuid": "7f2232f5-023c-47b0-aa22-2388b1169d6a",
+      "groupUuid": "7de93e31-4e10-4752-b022-19295cb2356d",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1361,8 +1361,8 @@
       }
     },
     {
-      "uuid": "364916f4-6640-4fba-9cd3-61fad453336b",
-      "groupUuid": "6686e695-0d43-4736-aec0-6bfeb93ec335",
+      "uuid": "136ab78e-9729-4ff5-a6d3-ead9be295b56",
+      "groupUuid": "bdcabd7b-f6e2-4f5c-9338-fb32b8fe382e",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1370,8 +1370,8 @@
       }
     },
     {
-      "uuid": "43be26ad-41a7-4268-9912-de0bd35d57c9",
-      "groupUuid": "8ba589ee-c31d-47de-9159-c8374a286816",
+      "uuid": "f229c393-c7e9-45ce-8597-8382ebfa79d2",
+      "groupUuid": "fcdc29ac-1d3c-4f71-97cf-c910d830bf48",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1384,17 +1384,17 @@
       }
     },
     {
-      "uuid": "858d0998-3777-4d00-8714-343209e699a1",
-      "groupUuid": "c7f95bba-fc45-4865-9390-731cd312d26f",
+      "uuid": "32f87286-36f3-49a9-957d-d57e0e6d994c",
+      "groupUuid": "cabe64bf-f0af-4d0f-95f8-107d58d0afa2",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "125e34aa-beff-42c1-a674-bf298a891468",
-      "groupUuid": "64bd1225-6184-47d3-a99c-e72b2f431aac",
+      "uuid": "dadc41ad-7fa4-4f48-bcde-c49b427dc04d",
+      "groupUuid": "9d28c79d-153f-4ed3-aaae-33f8c426c15c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1402,8 +1402,8 @@
       }
     },
     {
-      "uuid": "1ba5a201-6a48-4ae6-b0b6-ec51358fbf75",
-      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "uuid": "8e6a285a-0204-4240-a938-61150ef5f8f0",
+      "groupUuid": "90dcb693-4e5e-4de8-9136-58110ab9136f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1414,8 +1414,8 @@
       }
     },
     {
-      "uuid": "ec0ce49f-83d2-43bf-9077-cda0faf26056",
-      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "uuid": "f78ec62b-c47a-4a5f-a8b1-577f9cf0bc2b",
+      "groupUuid": "90dcb693-4e5e-4de8-9136-58110ab9136f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1426,8 +1426,8 @@
       }
     },
     {
-      "uuid": "8059ee76-e4aa-4325-b5b4-05b03bdd9116",
-      "groupUuid": "32b95453-79c3-4b8b-9c2b-14d17442d3b0",
+      "uuid": "4d45cb39-a167-4fe6-a87e-f6724eabbc0b",
+      "groupUuid": "90dcb693-4e5e-4de8-9136-58110ab9136f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1438,8 +1438,8 @@
       }
     },
     {
-      "uuid": "8e779d95-7e5f-4d42-aa88-dfc1edc88b71",
-      "groupUuid": "2d5dce51-8cfe-4bcb-a749-c91fade2a3a9",
+      "uuid": "0c3ce38b-6aa3-4942-858d-0bfbe6931476",
+      "groupUuid": "95c565f9-a6b7-499b-8942-4fd5f1a92adf",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1447,8 +1447,8 @@
       }
     },
     {
-      "uuid": "056e214b-ce3b-4e90-b221-194027f38c78",
-      "groupUuid": "8f5ca13e-66b4-4530-b04e-3d41d40bd749",
+      "uuid": "61e2b1d3-1462-47c0-a3d8-63debd5bafc6",
+      "groupUuid": "96bb0db3-4645-497b-b046-8ef8c6894e1c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1457,8 +1457,8 @@
       }
     },
     {
-      "uuid": "49b3ffb1-db4f-4891-b157-2259e1dc6f84",
-      "groupUuid": "121ba6e7-f041-458f-a217-7b3da91f6614",
+      "uuid": "be61a682-55e9-41ff-8c94-6208fa79334b",
+      "groupUuid": "16400711-cf91-478d-a797-560cb561f70b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1466,8 +1466,8 @@
       }
     },
     {
-      "uuid": "2bb430e5-83d7-429f-95d0-32f5e1ee365f",
-      "groupUuid": "bb2f0756-6681-41b8-b1e6-141ad0db9d38",
+      "uuid": "d4fb8aa5-ebe8-4f0f-a6bb-117609c82752",
+      "groupUuid": "fbdcd3d3-ccf0-48fc-948c-84a115ab0b4b",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1476,8 +1476,8 @@
       }
     },
     {
-      "uuid": "9f08ba6a-3f41-4675-9d07-a5b367bf9028",
-      "groupUuid": "73552248-eaaa-411f-b865-d29202217009",
+      "uuid": "21971b44-deb1-4c3e-9582-0a533300e457",
+      "groupUuid": "71ac3b9a-40de-4b19-95f9-4d2026b23d58",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1485,8 +1485,8 @@
       }
     },
     {
-      "uuid": "c6f34819-9059-4471-9da5-fd28e2fbae2f",
-      "groupUuid": "26f728f6-b1aa-4f86-848c-ca320bf1a972",
+      "uuid": "d3297a9a-7308-4d81-87e6-89b77339a342",
+      "groupUuid": "d6ca0696-aa1b-4512-8985-29657cf745d9",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1495,8 +1495,8 @@
       }
     },
     {
-      "uuid": "bacbabc7-e500-4ba5-bbce-2fb90fa052ff",
-      "groupUuid": "57ed6646-e84b-4777-a699-55c49d3ab570",
+      "uuid": "0304a20d-5e86-4411-ab90-c181e53b76be",
+      "groupUuid": "463e5af2-9e38-4ca8-bd8a-8514541b37a0",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1504,8 +1504,8 @@
       }
     },
     {
-      "uuid": "72fa150e-9c05-42b9-9bc9-ab19735a7d0d",
-      "groupUuid": "2df6e4da-4b48-49f4-89d8-9599a7bc49a4",
+      "uuid": "23583bb7-ace6-4dd1-9757-8ff4a98056d3",
+      "groupUuid": "7d686aaa-e64d-4dd5-ab12-f602c72413d5",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1518,17 +1518,17 @@
       }
     },
     {
-      "uuid": "d2d4a925-c8b4-4270-99b7-bb02b41153ce",
-      "groupUuid": "b4bc5359-4c42-437e-b2cc-fad13a88757f",
+      "uuid": "bf276261-fbe1-4c46-8ab4-c2b657db5d71",
+      "groupUuid": "4e87cd2e-2a97-48f1-a9bd-2cd0d8661e76",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "87097ed3-07ed-4bc7-b412-5373a3721bcf",
-      "groupUuid": "45cc8e44-8f43-4753-af6f-186fb41384a7",
+      "uuid": "4dbd904e-0a16-4587-9497-2fc2d38738e6",
+      "groupUuid": "095bfa5f-a2c8-4c1d-a3da-de36e384608f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1536,8 +1536,8 @@
       }
     },
     {
-      "uuid": "f31f3753-d786-494f-a44f-a80f5593ff89",
-      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "uuid": "34e09a3d-4b6b-4382-b655-9df7c8774a94",
+      "groupUuid": "4b5537a1-4278-405b-9a6d-ffffbf806ab5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1548,8 +1548,8 @@
       }
     },
     {
-      "uuid": "d8bf5c2a-4c18-409f-96ad-feede953d2a4",
-      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "uuid": "2fec651b-07ee-44db-9e01-d35db54dbcf7",
+      "groupUuid": "4b5537a1-4278-405b-9a6d-ffffbf806ab5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1560,8 +1560,8 @@
       }
     },
     {
-      "uuid": "ee150ab1-69a6-484c-8c07-f968b78db070",
-      "groupUuid": "a54e5629-0d50-44cd-89ff-1552d6b4917f",
+      "uuid": "c0709510-cf06-4685-80bf-e80e8f036b0c",
+      "groupUuid": "4b5537a1-4278-405b-9a6d-ffffbf806ab5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1572,8 +1572,8 @@
       }
     },
     {
-      "uuid": "7be6d845-ce12-4edd-91b4-c163e27eccd6",
-      "groupUuid": "37091098-aa71-4456-9164-51d6375184a6",
+      "uuid": "a33b73fe-dcc1-48fa-ab94-55374f47de05",
+      "groupUuid": "45cb798a-64fe-4d18-be29-edabd1b71e42",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1581,8 +1581,8 @@
       }
     },
     {
-      "uuid": "33349f47-8f2a-4d44-9d65-78042848862a",
-      "groupUuid": "07c7f92c-26b2-4f42-904b-4da3e2a74b2f",
+      "uuid": "b9ca817d-7b49-4df7-9c70-f8bc08a146ca",
+      "groupUuid": "cff94a1c-1825-4557-8528-5da803de0ffc",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1591,8 +1591,8 @@
       }
     },
     {
-      "uuid": "3e6f441f-d15e-4156-8a88-c663a5daccde",
-      "groupUuid": "b818ab42-8697-4767-9741-9c8ec8078c05",
+      "uuid": "2cfb3bed-b7b8-4c95-b185-d437b26f06e8",
+      "groupUuid": "a87fa7c5-8f55-473f-916f-0b11e8ce6f2f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1600,8 +1600,8 @@
       }
     },
     {
-      "uuid": "6c062273-f597-4955-8850-3c6e326076fd",
-      "groupUuid": "076741e9-448d-4ec6-9a24-f41b7caf331b",
+      "uuid": "d212d3d1-1c2d-4ec3-a1a5-7992fa42c778",
+      "groupUuid": "3ff03f22-86e6-4bbf-8b64-52ef3f337e46",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1610,8 +1610,8 @@
       }
     },
     {
-      "uuid": "2a7a2134-2f0c-4daf-a655-59cbfc83b675",
-      "groupUuid": "24c191da-1336-485b-a34c-a0663265fef4",
+      "uuid": "dd47abd5-6368-4235-bad4-07bb59a600dd",
+      "groupUuid": "c8a38f13-4191-4e4b-8805-458182d9362b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1619,8 +1619,8 @@
       }
     },
     {
-      "uuid": "bd858855-9aea-43ab-98cf-72069fb2670c",
-      "groupUuid": "9f56fc2a-16fe-48fa-a987-b395ca7bfc7b",
+      "uuid": "a060fa12-3b67-44f5-9394-63713c75c86a",
+      "groupUuid": "83d2dc8e-4b24-47d8-94aa-a61c2c6b38c7",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1629,8 +1629,8 @@
       }
     },
     {
-      "uuid": "395350ff-4e77-421a-88f5-50041b74e431",
-      "groupUuid": "2d55ac60-bf6d-4023-86b3-4c01c442350b",
+      "uuid": "f962b250-eff7-4070-85cb-f626de2d6a87",
+      "groupUuid": "fd1ab288-411d-4ca4-9396-49ed6d33ab11",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1638,8 +1638,8 @@
       }
     },
     {
-      "uuid": "36bed446-e649-4571-942a-468ea38eb79c",
-      "groupUuid": "3ccd8f7b-1b74-4a2c-b505-3a097cdc70e9",
+      "uuid": "00eb3021-a5ea-48ca-a9eb-af7d041475fd",
+      "groupUuid": "7c82c2d6-d1a6-4eac-9c83-500503cbad3e",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1652,17 +1652,17 @@
       }
     },
     {
-      "uuid": "3dd34ec1-ac17-4fef-b7c8-9a872989f338",
-      "groupUuid": "7067bc97-a469-4c71-b44f-32aafe15b3be",
+      "uuid": "566c7c2e-f761-45eb-91e2-d39d7a97f959",
+      "groupUuid": "b99e627a-2764-43f3-a8a2-0b3baad64c6d",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "c27f4134-4364-4e1c-8d89-bdb5924e612d",
-      "groupUuid": "032cd38b-01c4-4be4-890f-9f2548a5e16e",
+      "uuid": "153faf61-6d77-4ac7-8958-2e0d7b3d9811",
+      "groupUuid": "90f642fe-4cd7-4935-83e5-ed456bb5615f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1670,8 +1670,8 @@
       }
     },
     {
-      "uuid": "1bbebe7a-f0cb-4667-8b91-be4302a89b74",
-      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "uuid": "143e10f0-8349-4f9a-9298-1236e32fdb71",
+      "groupUuid": "8de31ff4-3a81-4a51-8e6e-21e606b6ecc6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1682,8 +1682,8 @@
       }
     },
     {
-      "uuid": "83b5ef31-8d32-4eff-bd2f-a2800d8f4dda",
-      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "uuid": "4ad1cdf5-5769-4bfa-b917-87297db3a594",
+      "groupUuid": "8de31ff4-3a81-4a51-8e6e-21e606b6ecc6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1694,8 +1694,8 @@
       }
     },
     {
-      "uuid": "33e24eb6-4fe5-4c1c-8fb8-c064c5895d73",
-      "groupUuid": "3c63c228-a80a-4ca5-8375-6c869a09f0bd",
+      "uuid": "e6d63875-d46d-400b-b93b-f77383b43344",
+      "groupUuid": "8de31ff4-3a81-4a51-8e6e-21e606b6ecc6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1706,8 +1706,8 @@
       }
     },
     {
-      "uuid": "847c6c84-efb2-4263-a51a-668286bd0bc3",
-      "groupUuid": "11cd35d9-b65f-4274-bb5f-fa5bc8a33091",
+      "uuid": "288996b9-8d8d-4ab3-9afc-431d479be794",
+      "groupUuid": "88c0d17b-6be8-4d41-8dea-205022d2c2bc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1715,8 +1715,8 @@
       }
     },
     {
-      "uuid": "2c4ed1bf-0dc7-418d-a2e3-95d2da96248f",
-      "groupUuid": "2b00b454-fd9c-42db-b174-63d8af6c7576",
+      "uuid": "57de4d6e-7c49-438f-a432-da38d0fda3c4",
+      "groupUuid": "dcb2fba6-bf60-474a-889c-aa0f41408df1",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1725,8 +1725,8 @@
       }
     },
     {
-      "uuid": "d08145a3-6988-4f96-a99c-92b1c09eb36d",
-      "groupUuid": "ecdc1dd3-39a3-4ebf-9aab-4aa6088a7d0b",
+      "uuid": "57456168-b565-4507-b699-75c7be260239",
+      "groupUuid": "17e96853-ac69-400e-b0b3-52fd01fd314e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1734,8 +1734,8 @@
       }
     },
     {
-      "uuid": "34c7946c-7a8b-4aa2-95ab-4ece4f165df4",
-      "groupUuid": "4ca93864-6e14-4f77-abdb-a61e252e38eb",
+      "uuid": "6ff8ac99-0877-4090-bffb-0506a7351617",
+      "groupUuid": "9a5b71f0-2709-454e-ad15-84de3d4dc4df",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1744,8 +1744,8 @@
       }
     },
     {
-      "uuid": "dc61f4bc-0f66-4fca-898e-682ca5620663",
-      "groupUuid": "5a1fbf4e-87d1-41c9-9f96-22f88201fd46",
+      "uuid": "4dc13065-d7ca-4a6d-aacb-45df6a8d0421",
+      "groupUuid": "d9f31c09-3f11-4a46-8729-bcb8983c8e80",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1753,8 +1753,8 @@
       }
     },
     {
-      "uuid": "cbc90c0e-be83-45f8-b4d8-66a2131dc35e",
-      "groupUuid": "4ba35dbf-6b22-4462-9f33-94566d075ea1",
+      "uuid": "67a4de7c-ccec-4caf-8168-3fd93b1bcf5e",
+      "groupUuid": "ce87a8df-d1ae-4145-86d2-607e08157f5f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1763,8 +1763,8 @@
       }
     },
     {
-      "uuid": "eb8f091a-3e0f-4f10-a558-5a5550550d9d",
-      "groupUuid": "42a47e21-1d3d-4c93-9f95-aef31d6d3227",
+      "uuid": "d8a2b578-c1be-445b-84c5-eccc83b9ef82",
+      "groupUuid": "04db2a60-a06d-491d-a736-45f7c3bc2bef",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1772,8 +1772,8 @@
       }
     },
     {
-      "uuid": "e2012e24-2a6a-4f6a-82bd-97e1dc956b2e",
-      "groupUuid": "6fae159a-90fd-4022-b930-ce7b6e811c98",
+      "uuid": "aab9ff0b-4ae2-4fd6-8426-9c64d3a5ebfa",
+      "groupUuid": "b506ee05-3832-4057-97ed-22f3fd554423",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1786,17 +1786,17 @@
       }
     },
     {
-      "uuid": "c385163f-2747-4a50-aac4-2221de9cc55c",
-      "groupUuid": "01acd642-24ea-4c87-aefb-67814974beb6",
+      "uuid": "815c7571-3836-482a-bdec-fa79bebecdcc",
+      "groupUuid": "7fb84852-e7bd-4137-87dd-0c70e8752b3f",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
       }
     },
     {
-      "uuid": "ca9510f0-6b01-4bf2-8984-f11755110bdf",
-      "groupUuid": "14d3a75b-5bad-4d2f-8e94-c5f8675a963d",
+      "uuid": "350655ad-c071-495b-8fcf-191e6ebc53f5",
+      "groupUuid": "847ce785-6a69-4f80-8552-dd6e721ef6b9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1804,8 +1804,8 @@
       }
     },
     {
-      "uuid": "2d5e63eb-870d-49c5-bf48-c269ee6f3c71",
-      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "uuid": "f71fc572-b7c4-4350-a898-0eace57771d9",
+      "groupUuid": "1c66b6db-7878-4476-9353-a48b0eb80175",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1816,8 +1816,8 @@
       }
     },
     {
-      "uuid": "0ba4a089-2d97-4a99-8ebc-d4d8f2ac4d01",
-      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "uuid": "0be3ce83-ce55-442b-8148-a9825395ca6c",
+      "groupUuid": "1c66b6db-7878-4476-9353-a48b0eb80175",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1828,8 +1828,8 @@
       }
     },
     {
-      "uuid": "f3983be5-1a07-44a0-b32a-213d0016037b",
-      "groupUuid": "ab35c441-945e-4c50-a81c-7dcd004df52b",
+      "uuid": "14b05308-7352-46a1-b106-cdc540a3c9a7",
+      "groupUuid": "1c66b6db-7878-4476-9353-a48b0eb80175",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1840,8 +1840,8 @@
       }
     },
     {
-      "uuid": "7e254b79-56aa-4382-97ca-979677fce5d1",
-      "groupUuid": "b73c9ef7-6af4-4de8-926a-66fb936f4306",
+      "uuid": "0263c516-4787-4662-b7db-06247ccaa59c",
+      "groupUuid": "afed7862-36ef-4959-8389-4db2ce90711e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1849,8 +1849,8 @@
       }
     },
     {
-      "uuid": "c5cfacb3-acb3-4663-bff9-56f274a477b2",
-      "groupUuid": "da55fa5b-8cd9-4000-b07d-6e8dcdbdb418",
+      "uuid": "54961c3f-8897-4a63-9e58-b65fa664874f",
+      "groupUuid": "387f1165-d1fb-4363-b00d-49d5595af704",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1859,8 +1859,8 @@
       }
     },
     {
-      "uuid": "a6969fce-963a-4694-825f-ce0be0fca7f4",
-      "groupUuid": "5f97ad96-213d-45c3-a278-315e50415d25",
+      "uuid": "5c7b3236-9e5f-4b90-bdc4-e7ca0a1e1bc1",
+      "groupUuid": "27aa3484-6832-4fb8-9d25-f24abd5a14dc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1868,8 +1868,8 @@
       }
     },
     {
-      "uuid": "39f71d85-2692-41ea-917a-3bfed6e2beec",
-      "groupUuid": "ba3e1a22-bd43-4bba-910f-386973f3824b",
+      "uuid": "fffa8875-70f9-4ba2-8dbc-85d46005bfbe",
+      "groupUuid": "49c6fa65-d588-41f6-b351-10f8491708b6",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1878,8 +1878,8 @@
       }
     },
     {
-      "uuid": "f1ac6a79-bc8f-4e3e-9ada-837e8074f32e",
-      "groupUuid": "ad47373e-143d-4edc-8a25-b384c6f24c4c",
+      "uuid": "a36248de-d64c-4fef-bc31-217cabbf453e",
+      "groupUuid": "f4f237d9-7a5e-4fcb-a13b-fabf678d4515",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1887,8 +1887,8 @@
       }
     },
     {
-      "uuid": "f5d64365-f73c-43a1-9816-1b3cdd641919",
-      "groupUuid": "6d8a08b2-b86d-4fa4-ab4b-66a9d84965a7",
+      "uuid": "b9313400-dae8-42e1-90c0-ac06d26f27b8",
+      "groupUuid": "f4a44963-bec5-4758-9dc7-7aeb387a7765",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1897,8 +1897,8 @@
       }
     },
     {
-      "uuid": "2386ad47-f646-4df4-a5b7-bd754b9a63b1",
-      "groupUuid": "07fdd513-7c25-4102-a791-8c4e5e3f1cc3",
+      "uuid": "5e86a854-c540-4b9a-979d-638ef5488fa3",
+      "groupUuid": "0ae49705-ceff-4efe-815e-245cd1051bfe",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1906,8 +1906,8 @@
       }
     },
     {
-      "uuid": "9d1097cf-9cab-49bf-b38f-23295a1183c0",
-      "groupUuid": "ecdf6f82-3b73-4792-b87d-7fec5939d10b",
+      "uuid": "b0199018-a843-482e-9e9c-8a0d4fb96b3e",
+      "groupUuid": "db9c41ba-ca1c-44b7-b636-3b7f954193c4",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1920,17 +1920,17 @@
       }
     },
     {
-      "uuid": "fd780b1f-71ca-4b0b-a937-28cebbbbe8a0",
-      "groupUuid": "8401947c-d5fc-433e-af40-b93005c2f5c6",
+      "uuid": "2e074130-0c97-4c92-822e-2a3c27e40144",
+      "groupUuid": "7d417f06-9539-4d0c-bd4f-5607090bb52e",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "b7a9a410-9ef2-459c-99ba-830bf7b293c1",
-      "groupUuid": "c9c941e4-3e51-4b77-8ed7-b814c6adb0ab",
+      "uuid": "3c6a00c6-9b16-45bc-aa6b-39faf6003040",
+      "groupUuid": "c1301ee2-7805-43d7-877c-23e9e490913b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1938,8 +1938,8 @@
       }
     },
     {
-      "uuid": "e91bd587-f753-424c-b39c-04634e62e598",
-      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "uuid": "51af6dd6-f9e8-4909-be19-80c3d60f901b",
+      "groupUuid": "50abea7c-bcba-4c74-bf6a-817462d0659f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1950,8 +1950,8 @@
       }
     },
     {
-      "uuid": "8cf8eb90-8099-465f-82f3-f34efd5dbf38",
-      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "uuid": "5f24f300-9e21-4fdb-9989-58a3aeb758ae",
+      "groupUuid": "50abea7c-bcba-4c74-bf6a-817462d0659f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1962,8 +1962,8 @@
       }
     },
     {
-      "uuid": "20432ea0-7521-4eaa-ac59-28d18349286d",
-      "groupUuid": "b5c0f1b4-e6e2-4953-bf47-3bd923e7a321",
+      "uuid": "afbaaec0-fe36-4551-89b3-7cd3d0fc5b6c",
+      "groupUuid": "50abea7c-bcba-4c74-bf6a-817462d0659f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1974,8 +1974,8 @@
       }
     },
     {
-      "uuid": "0bbbec7b-6b67-41be-ad6b-300b8fd6f147",
-      "groupUuid": "8a4d5431-3cde-4009-89bf-f8e006c8a61a",
+      "uuid": "6dd351e5-f59b-4a5b-a400-57edc484e5da",
+      "groupUuid": "15852d6e-63bf-44dd-a288-a836f49041ba",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1983,8 +1983,8 @@
       }
     },
     {
-      "uuid": "d95b05b7-ede1-448d-b81b-0e0b513380b7",
-      "groupUuid": "bcd5ab61-79e9-4e2c-8b99-ad9801947db9",
+      "uuid": "9e17661f-bc1b-4f82-b90b-56dbcb0da358",
+      "groupUuid": "8792f07f-2ee5-472a-ac4a-355e60e474df",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1993,8 +1993,8 @@
       }
     },
     {
-      "uuid": "e34b1140-781b-4beb-bc52-aedbda0bbad4",
-      "groupUuid": "9eb1d5ed-4de4-4ea0-9664-d9aa9b43ef92",
+      "uuid": "f6275a57-7b19-40d4-a318-a4c734d46284",
+      "groupUuid": "0dfd3296-ecb8-42d7-945e-405b36f002f9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2002,8 +2002,8 @@
       }
     },
     {
-      "uuid": "59f73fd7-8958-49fd-9715-95a9deac071a",
-      "groupUuid": "1689d43d-cf2d-4561-a0f8-840b888bdbeb",
+      "uuid": "050445c8-9022-4601-8d03-5f7c1669d295",
+      "groupUuid": "fe9f5682-a32d-4e8c-9f01-8493459503e5",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2012,8 +2012,8 @@
       }
     },
     {
-      "uuid": "2e077090-e6f4-4953-9187-6c2bfbac1182",
-      "groupUuid": "dc4d2fb5-a2c6-4070-9e21-cc96fe438ae5",
+      "uuid": "6ce0506d-5abd-43f0-9548-be842a591a0e",
+      "groupUuid": "fdf512fc-03cc-4958-aee7-2d10ad418114",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2021,8 +2021,8 @@
       }
     },
     {
-      "uuid": "19431104-1401-4404-8024-9ce518f85dc2",
-      "groupUuid": "f995f7ca-a725-4d82-8f8f-2d5fa0fbff83",
+      "uuid": "769650cc-984c-4629-9042-329bb545e9e5",
+      "groupUuid": "ff72409d-9a74-4200-85b9-b332e76e41de",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2031,8 +2031,8 @@
       }
     },
     {
-      "uuid": "a2088f42-0c93-4bcf-8507-d540f6202798",
-      "groupUuid": "ad22af28-752b-493c-8541-f289e0693140",
+      "uuid": "ea606311-9e3c-4911-a046-6be836d3ffb3",
+      "groupUuid": "d9e2d084-1f6e-4128-ac28-3a4eaf65f34a",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2040,8 +2040,8 @@
       }
     },
     {
-      "uuid": "b82c7dea-c400-43c8-80e1-e800c71e9c56",
-      "groupUuid": "8d401c75-85e1-49a9-9c80-e3a356b73e4f",
+      "uuid": "6ce6bd5b-6eec-450c-ac87-46296677c3ea",
+      "groupUuid": "41787c5c-345a-4a20-b9c3-d707811b973e",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2054,17 +2054,17 @@
       }
     },
     {
-      "uuid": "01f760e0-75dc-44e0-8b8b-9f2222bcbef0",
-      "groupUuid": "f363bebf-a0d1-4cfe-961a-f4074cf12b1b",
+      "uuid": "0c3afc09-c522-4b17-b1a5-d120f3fa150d",
+      "groupUuid": "c9a1e960-b300-4d75-ad21-7864fa36ba8b",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "f12b60ec-06a2-40de-b372-aed5e396fe9a",
-      "groupUuid": "3ad12243-8d51-4caf-8080-3187d72eadc3",
+      "uuid": "f598c18a-4a86-42c8-a086-726a8be30e9c",
+      "groupUuid": "fbac73f3-3f1b-4e22-8d72-3d8a1f614589",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2072,8 +2072,8 @@
       }
     },
     {
-      "uuid": "91caf4fd-03b5-4b09-baf9-c6daf4152c68",
-      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "uuid": "74a1993b-804d-4a7b-baad-f95c7c2b1a49",
+      "groupUuid": "9cdfbdbc-0a22-4830-87a3-04c464117895",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2084,8 +2084,8 @@
       }
     },
     {
-      "uuid": "6cc72f69-e9b3-4370-96b3-0cdb9f602e72",
-      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "uuid": "58ecabfc-0257-46d4-ac76-8a3dfa385588",
+      "groupUuid": "9cdfbdbc-0a22-4830-87a3-04c464117895",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2096,8 +2096,8 @@
       }
     },
     {
-      "uuid": "1fefad35-60a3-4bb1-a941-9eca07280f23",
-      "groupUuid": "a91478b4-5685-41ba-bb8e-5d74e77ebd0d",
+      "uuid": "e4f73f34-0995-4acb-8653-0511c225ac3a",
+      "groupUuid": "9cdfbdbc-0a22-4830-87a3-04c464117895",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2108,8 +2108,8 @@
       }
     },
     {
-      "uuid": "1fe57405-a3db-4f4b-ba2f-0c083fc0bd78",
-      "groupUuid": "f44b967d-4f1c-412a-9884-7ee5032194c0",
+      "uuid": "8d988dd7-a902-4338-88d9-ab51edb61b22",
+      "groupUuid": "7cf83e00-666e-4021-ab3a-699ed5fd6ca6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2117,8 +2117,8 @@
       }
     },
     {
-      "uuid": "92ca8ae5-f74e-4172-ab68-003e94d431fa",
-      "groupUuid": "c96d4b7e-c6de-44bc-b57c-6094fd6d6003",
+      "uuid": "2df9130c-be5b-4982-b968-55bbea656ce0",
+      "groupUuid": "059b589c-5e6b-4083-a7cf-64e0dddb5b85",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2127,8 +2127,8 @@
       }
     },
     {
-      "uuid": "1a96ab19-164c-41f3-8a27-bae17cf54583",
-      "groupUuid": "791cd7f7-809d-4949-a638-7b7e044c0067",
+      "uuid": "30153e40-f96e-4268-a17b-a78a1b2f0a4b",
+      "groupUuid": "d0c992bb-b25a-4f6a-aca3-8ff65925cc6c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2136,8 +2136,8 @@
       }
     },
     {
-      "uuid": "8078b616-f1ea-4b40-95ef-7d0b7fee0148",
-      "groupUuid": "516856ed-675c-49b6-aa8c-97de96b47b82",
+      "uuid": "01a0cb43-478d-4ad1-9cc6-582e958e89f1",
+      "groupUuid": "50b95a81-2dcd-4622-a690-335b40a9c3b3",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2146,8 +2146,8 @@
       }
     },
     {
-      "uuid": "18e14fba-4f99-43f6-9273-9b4ce8604733",
-      "groupUuid": "0dda78fa-2a83-4316-888a-920c3312bd68",
+      "uuid": "88108664-5b87-42b5-94a1-244a2a285d3a",
+      "groupUuid": "3d0c1cfb-fbb0-4770-9bb9-0ed7446cef22",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2155,8 +2155,8 @@
       }
     },
     {
-      "uuid": "1f4e7e09-8b9b-4830-b3d6-9f163eb4c365",
-      "groupUuid": "5e08d306-480b-4faa-8bdf-49e2d86707d7",
+      "uuid": "801334cd-6f38-4279-90bf-3b0e047ca4d0",
+      "groupUuid": "d6da206b-4438-45f8-8138-9401d8a4896e",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2165,8 +2165,8 @@
       }
     },
     {
-      "uuid": "24cd7e89-3323-43fd-9968-2676b7ce4ca4",
-      "groupUuid": "0d94fdb5-fdcd-42f8-acc8-c02000f3798b",
+      "uuid": "bdff710a-212d-4aa8-b4a9-32040e0b056a",
+      "groupUuid": "509f2b55-d87e-47d0-989c-eab416373416",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2174,8 +2174,8 @@
       }
     },
     {
-      "uuid": "6eec085c-e36e-4d37-a80b-d8f72a213109",
-      "groupUuid": "4e2e2b85-70fa-47a1-b704-671e6897e07c",
+      "uuid": "b13f0d76-2db5-42b6-bec8-aacad390ca8d",
+      "groupUuid": "5228bb9c-5273-426b-b852-95d7b0f8dc3a",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2188,17 +2188,17 @@
       }
     },
     {
-      "uuid": "485ca974-9f03-4dc0-8704-5b75bdbaaf21",
-      "groupUuid": "dd9cf6f3-d9d6-42d4-a097-c5a52954c6be",
+      "uuid": "456831a0-b969-4b27-ae93-d1d3d72feff8",
+      "groupUuid": "e3f96e0e-9f95-410a-8535-0ea236900bfb",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
       }
     },
     {
-      "uuid": "60e85e67-2705-4bca-bd26-f6b84a54e789",
-      "groupUuid": "7f9545fb-22ce-4b52-be00-974f49bfe8d5",
+      "uuid": "0fe0ddcd-c566-4993-9411-faa08b942a68",
+      "groupUuid": "ef2dc87c-71d9-4e88-ba96-7a68239a977e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2206,8 +2206,8 @@
       }
     },
     {
-      "uuid": "842a7d66-3319-48df-9766-8d83c66b26e0",
-      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "uuid": "29942395-3f62-4ffb-8dcf-6a97701a46d9",
+      "groupUuid": "78cd24d0-f389-4c41-91b5-6b7ce3dd2f74",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2218,8 +2218,8 @@
       }
     },
     {
-      "uuid": "9a24876d-00d9-4637-ae0f-1582c7f7e2de",
-      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "uuid": "cb246434-1a8b-422d-a98a-366df5e49cb0",
+      "groupUuid": "78cd24d0-f389-4c41-91b5-6b7ce3dd2f74",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2230,8 +2230,8 @@
       }
     },
     {
-      "uuid": "f22e81ef-7e97-4c4d-9c9a-36f80e088d71",
-      "groupUuid": "358d385c-7ec4-48cf-b822-306d9d201e82",
+      "uuid": "5a15d106-ce8a-4be3-8a6c-fe593e10249a",
+      "groupUuid": "78cd24d0-f389-4c41-91b5-6b7ce3dd2f74",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2242,8 +2242,8 @@
       }
     },
     {
-      "uuid": "1d79de41-1d0f-4330-ad7f-e7bf9817ad94",
-      "groupUuid": "eaa8c67f-4c8a-4e2d-bb46-68de4f7971e6",
+      "uuid": "d6a5035d-4ec9-4562-b9e6-9e9926f8c57b",
+      "groupUuid": "067e2186-5b0d-4716-823d-778d9e7564be",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2251,8 +2251,8 @@
       }
     },
     {
-      "uuid": "db82030c-714f-4f51-9a68-32178b7786b0",
-      "groupUuid": "11c29064-6bfb-4553-9a5d-091a8bfb5fcc",
+      "uuid": "db32fbc1-e133-4b02-b833-c0af26cf17eb",
+      "groupUuid": "68b69d7c-b669-4daa-82d4-ec2268784a45",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2261,8 +2261,8 @@
       }
     },
     {
-      "uuid": "a81aa2fb-8057-4593-a3cd-59b12749a126",
-      "groupUuid": "9217582d-021d-4ca2-bfb4-9480e91458b4",
+      "uuid": "aac3db72-b40d-4ff9-9c10-4c1e0f8453ba",
+      "groupUuid": "e00e292f-6a9d-4b2e-ab27-29f1f7c5dcf8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2270,8 +2270,8 @@
       }
     },
     {
-      "uuid": "0ed6226b-68fb-4987-8d2e-03bf60535abd",
-      "groupUuid": "373b2d25-c6dc-432b-ae2b-c1dc5dfe9c20",
+      "uuid": "55497f9f-dbc6-40b4-8a2a-ab13ad9ef963",
+      "groupUuid": "5bf180ec-4d54-47c3-97af-751fdcfc58b4",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2280,8 +2280,8 @@
       }
     },
     {
-      "uuid": "59764e85-e92d-4256-a968-47e0b9abdc87",
-      "groupUuid": "d570c35d-9224-41c6-abd2-f9427724063d",
+      "uuid": "2d1ce19e-a937-4477-91b9-628e245f3c77",
+      "groupUuid": "98c17659-bf58-4f6a-84aa-17087cba7239",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2289,8 +2289,8 @@
       }
     },
     {
-      "uuid": "95ae587a-66f1-4e4b-aa29-01f088c975ce",
-      "groupUuid": "59e51952-a50b-4f7d-b31e-4b319b4912e0",
+      "uuid": "9a33c5ad-958e-4433-9039-05effb440f85",
+      "groupUuid": "4563fe34-42a4-4a34-be31-a01f05a91059",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2299,8 +2299,8 @@
       }
     },
     {
-      "uuid": "cdb7f469-ac55-44a0-a98d-1209d783569c",
-      "groupUuid": "04cd92e7-ca84-4a9d-9f4a-5bb837c87000",
+      "uuid": "046ecd46-62cf-40a3-8789-a32cce444b70",
+      "groupUuid": "8dae7bf4-23f0-48ad-9c25-3ad15cd058f8",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2308,8 +2308,8 @@
       }
     },
     {
-      "uuid": "7968c5e6-9454-422d-881c-9bcb48f44541",
-      "groupUuid": "03906444-1987-42ca-9d50-dfc9ccedf8c5",
+      "uuid": "185ff5ec-c4c7-4a7f-ac8b-de722cc66a17",
+      "groupUuid": "bc6b0f92-a9cd-4789-a857-d90109200c34",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2322,17 +2322,17 @@
       }
     },
     {
-      "uuid": "2dfa9683-7a57-4df0-8297-aab28da391ab",
-      "groupUuid": "b98531bc-8afc-4f46-9687-4fc9577ed41a",
+      "uuid": "d8f19d0d-ca85-49d5-b2d9-b0014b00ebba",
+      "groupUuid": "c7965045-0c31-420b-81c4-d6c17c8f64bb",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "6593c9f9-959a-4fcc-b77f-00c238e4c183",
-      "groupUuid": "9d9260ed-84ed-4902-9e76-e0635efef739",
+      "uuid": "546792c2-68a3-4b03-90e3-d632d8a79130",
+      "groupUuid": "68fd5f3d-3a17-4832-8400-796d4711eea5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2340,8 +2340,8 @@
       }
     },
     {
-      "uuid": "2f6e9a03-8290-4a35-aa6b-8b2213fb2c01",
-      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "uuid": "51ad12dc-fd33-4b94-910b-015b6838a333",
+      "groupUuid": "b95fb620-76fa-4220-9279-98e409e3c2fc",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2352,8 +2352,8 @@
       }
     },
     {
-      "uuid": "51af30bb-a2d0-4aaf-ac25-3a02f3246f51",
-      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "uuid": "19e674bd-937d-4dda-a78d-b6806f941e80",
+      "groupUuid": "b95fb620-76fa-4220-9279-98e409e3c2fc",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2364,8 +2364,8 @@
       }
     },
     {
-      "uuid": "0689d5d0-e05e-497c-950f-7d86ede17066",
-      "groupUuid": "ad3ec170-15a9-4e60-a903-2f46eb2083e7",
+      "uuid": "f14fd74a-dc5a-40e2-b21d-b776932e1040",
+      "groupUuid": "b95fb620-76fa-4220-9279-98e409e3c2fc",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2376,8 +2376,8 @@
       }
     },
     {
-      "uuid": "a26a7bca-b455-4511-9f75-d54e1e129e95",
-      "groupUuid": "40f147e3-4e83-413d-908b-404a90d12dee",
+      "uuid": "4a3ae541-98a9-4b65-80cb-379fb4ce9f9a",
+      "groupUuid": "33c79229-17d1-4ae1-9569-4247e8f25207",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2385,8 +2385,8 @@
       }
     },
     {
-      "uuid": "2f65b31c-8041-43af-b41e-a01c1081d4d3",
-      "groupUuid": "5564fcb5-1b9d-4433-be7b-6afe27cf4b5e",
+      "uuid": "912955c7-6e00-4a78-a97f-aee6879ff4ed",
+      "groupUuid": "d1957557-17d6-4006-a734-f8dd2c0a5a67",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2395,8 +2395,8 @@
       }
     },
     {
-      "uuid": "a1066c2d-5fa6-4e1b-8376-2087685265f9",
-      "groupUuid": "29266880-501f-4276-9d5c-ed41feb55f80",
+      "uuid": "b2189650-c20b-4c2b-86e9-fee7de153a8a",
+      "groupUuid": "5cdfc7a0-685e-4947-a453-a630084ecc66",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2404,8 +2404,8 @@
       }
     },
     {
-      "uuid": "8105c311-2b41-41f8-be8b-524d19ecd5af",
-      "groupUuid": "5232e123-ef2f-4fc1-ad19-d0510756b8fc",
+      "uuid": "9abe62c8-c8ee-4f7d-9e7a-4056899f9279",
+      "groupUuid": "49a1b7ae-8e5f-4310-b723-70c8f0aee94d",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2414,8 +2414,8 @@
       }
     },
     {
-      "uuid": "56cd6e53-74f6-4941-a36c-312cbdcf1bcb",
-      "groupUuid": "7cb121dd-6272-4198-bdcf-fef65968d3d8",
+      "uuid": "56b6da33-a2e9-4ac9-8d59-594cfd4bdd4a",
+      "groupUuid": "a2edf155-7470-43c2-bdbf-d4a06cacda0c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2423,8 +2423,8 @@
       }
     },
     {
-      "uuid": "ec22b29e-c4d4-4758-b426-6287a68abf62",
-      "groupUuid": "76885475-2cbd-4eee-b7bf-d3ec42fbdac1",
+      "uuid": "7fb0955d-d9b9-4690-84fd-847dfd65359d",
+      "groupUuid": "40781700-a9df-4ab8-8a01-a88a185c45e9",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2433,8 +2433,8 @@
       }
     },
     {
-      "uuid": "97542fc7-dc2a-4c0d-9217-0632886f3399",
-      "groupUuid": "99806d47-05ef-4e66-a2bb-93956edb3860",
+      "uuid": "0953dc4c-55e3-4690-b05a-de70999ff79a",
+      "groupUuid": "9f4fe7b4-a006-4fc6-821f-a42894c8fc64",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2442,8 +2442,8 @@
       }
     },
     {
-      "uuid": "3d42ba86-0f06-4659-b79f-ed4fbb86a25f",
-      "groupUuid": "18fd99d6-d46b-4377-91ba-71ec3144a8ca",
+      "uuid": "a096dcb6-5977-4885-9283-2548e1ab9148",
+      "groupUuid": "e6d081b5-3b44-4a91-94f3-8fb8ae63c5a8",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2456,17 +2456,17 @@
       }
     },
     {
-      "uuid": "028bc0d6-8b2c-44cc-89f9-a2519b0e11c3",
-      "groupUuid": "d1a77e28-41a3-49e4-94cf-7877e3481961",
+      "uuid": "c658a9b5-05d1-4462-a2f6-1677db34cfcf",
+      "groupUuid": "2e3a6395-b4f2-4067-9ff7-b7c7b9eca82a",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
       }
     },
     {
-      "uuid": "446c41ed-6c14-45e1-818b-0a379022c4d3",
-      "groupUuid": "d4498517-480b-4d18-9e1f-a1a9954de13e",
+      "uuid": "519a32fd-3b77-46ed-8b1f-029ed6d43809",
+      "groupUuid": "e231124b-f745-48b9-94ca-3c604929c1fc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2474,8 +2474,8 @@
       }
     },
     {
-      "uuid": "7c3f0def-20e5-4f0f-9fa1-52c10627f648",
-      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "uuid": "71d5839b-e14e-4df8-9deb-0edc8f8f14fc",
+      "groupUuid": "48549e24-12e3-40e5-972d-2efe281a45e4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2486,8 +2486,8 @@
       }
     },
     {
-      "uuid": "4f81999b-9eea-4565-a5d0-c5cdfbba6e26",
-      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "uuid": "7c516535-f6f4-48ab-b239-fbe231c7ff52",
+      "groupUuid": "48549e24-12e3-40e5-972d-2efe281a45e4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2498,8 +2498,8 @@
       }
     },
     {
-      "uuid": "7027c5d6-700a-4c06-a8b3-636bfd58e4ae",
-      "groupUuid": "54017584-d41c-453e-8f3e-39c5d8b43f5b",
+      "uuid": "2c22bfff-4d79-401d-9c33-c97b0af63370",
+      "groupUuid": "48549e24-12e3-40e5-972d-2efe281a45e4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2510,8 +2510,8 @@
       }
     },
     {
-      "uuid": "c00b4d38-999a-4e7c-b485-c03ad4cc20ab",
-      "groupUuid": "1839f795-b870-4ce4-81c0-9709520805bd",
+      "uuid": "4750f7f1-f3ba-42f4-b5cd-47b0d24eebc1",
+      "groupUuid": "e762b0c3-8254-49bd-bc7a-492631076c5f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2519,8 +2519,8 @@
       }
     },
     {
-      "uuid": "a366b613-4538-4bf9-b573-7c9e52f077b3",
-      "groupUuid": "e72d43d3-a1c2-4bb6-9fdd-c609728bc0d8",
+      "uuid": "2a2a7976-dee7-4d58-bc1a-067c9bcbd4d2",
+      "groupUuid": "21bcacd6-def0-4b92-bcd3-4a0b12251945",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2529,8 +2529,8 @@
       }
     },
     {
-      "uuid": "ace3d59b-8640-49d5-a112-51d2e8aea0ce",
-      "groupUuid": "1450147e-d47b-48ac-b591-26603fb3a9ed",
+      "uuid": "19799778-73da-4180-a532-161eae5b0a39",
+      "groupUuid": "4ba48eb0-570b-4189-aae8-b0b4f281129a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2538,8 +2538,8 @@
       }
     },
     {
-      "uuid": "766b2a9f-caef-42df-84a2-7e0b2929ddc8",
-      "groupUuid": "1173277d-da87-4802-bce1-0e1feff70392",
+      "uuid": "b722ad45-7397-4dac-9e33-ffa4ce11ea9c",
+      "groupUuid": "944f9aeb-17a6-44e3-94a7-dd9d98a20c62",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2548,8 +2548,8 @@
       }
     },
     {
-      "uuid": "1f913598-ebe6-4c12-8bdd-814f1849f8db",
-      "groupUuid": "b1fce695-ff35-4495-bb40-bde7ce4b90d5",
+      "uuid": "0f515dd9-cb09-4ef4-86a4-529a5f1ba4a2",
+      "groupUuid": "3a34568b-8747-455f-ab2c-e007fa8f2fc5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2557,8 +2557,8 @@
       }
     },
     {
-      "uuid": "f4390c1c-5f1a-4575-b099-39547c4ae0f2",
-      "groupUuid": "dc0d19c5-95b0-4aee-9604-8f25b84029d2",
+      "uuid": "d81e95c8-e8cc-4b41-8df4-34653d9d60e9",
+      "groupUuid": "ee03e01a-f583-4911-aee6-36755ddc9bcf",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2567,8 +2567,8 @@
       }
     },
     {
-      "uuid": "c34fe986-2a8c-41f4-bfb4-0dc4c6f71625",
-      "groupUuid": "b76a5ed6-fda2-4819-9a75-ce74fab41c0e",
+      "uuid": "4b2b5e6e-3c51-4a56-9efc-51bfbd55df2c",
+      "groupUuid": "d5ed8bad-3cb4-417f-b6f0-6cfdb573ce08",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2576,8 +2576,8 @@
       }
     },
     {
-      "uuid": "9e9680a7-cb9c-4bd5-b7e4-d59c78df4282",
-      "groupUuid": "15387662-ae3a-49c2-8b3f-032cda808a34",
+      "uuid": "1aa226a3-80a4-4bc1-b53c-b0abb6180666",
+      "groupUuid": "091ae2aa-12af-4ed1-885a-bae03ebc41db",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2590,17 +2590,17 @@
       }
     },
     {
-      "uuid": "70e9cb62-09dd-49cd-bbf1-e9aaf0890b21",
-      "groupUuid": "12dc4260-429b-41f6-a3f0-ce8cfa1132cc",
+      "uuid": "5d61f894-d477-41ab-bab3-726a47dc17e0",
+      "groupUuid": "950867cf-3ccc-4528-ab23-954326faa86e",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "46df8fb8-c3b0-4dad-878c-e0846fbd2ce8",
-      "groupUuid": "9b786217-73ca-4e86-81f4-5a65416bb885",
+      "uuid": "fc66cd91-0fce-439f-bd40-74c575e08c83",
+      "groupUuid": "8188d888-67c0-4b46-9c61-6a322519061e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2608,8 +2608,8 @@
       }
     },
     {
-      "uuid": "0faca7ac-eee9-4e52-996f-8363d741a9a5",
-      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "uuid": "309f00f3-c53e-44a3-ba2e-193729c34d43",
+      "groupUuid": "20e581fa-28f9-4173-8d8e-aee49e0334a7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2620,8 +2620,8 @@
       }
     },
     {
-      "uuid": "5425416b-4df2-4c41-8646-f8fcd73b52d8",
-      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "uuid": "41ed4afa-df2b-4bae-ab7b-21fec27d856f",
+      "groupUuid": "20e581fa-28f9-4173-8d8e-aee49e0334a7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2632,8 +2632,8 @@
       }
     },
     {
-      "uuid": "335b20b3-0b75-4d8f-8ffa-5955c1584db0",
-      "groupUuid": "907a6bb1-e690-469c-98f4-f52ff503b4db",
+      "uuid": "7c415ba1-ba7d-4f6e-b79a-74eda9623667",
+      "groupUuid": "20e581fa-28f9-4173-8d8e-aee49e0334a7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2644,8 +2644,8 @@
       }
     },
     {
-      "uuid": "facc6555-6aae-4d53-8e27-52fd9b09dc17",
-      "groupUuid": "59c503ff-1ba9-4acc-bba3-30bdeb6b75c6",
+      "uuid": "62c37fe0-1352-4090-bba3-ecaceb66a8cb",
+      "groupUuid": "2ac5976c-927e-4f04-84c7-5ca877731af8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2653,8 +2653,8 @@
       }
     },
     {
-      "uuid": "bd0511d7-99b8-41b6-a5f2-5360cd6b061d",
-      "groupUuid": "ad3e0cc4-c72d-4c95-8658-3ed40df2e28a",
+      "uuid": "5ce34e44-678f-4095-b99f-4a738bf7d0ea",
+      "groupUuid": "69be871b-dce8-4e89-8944-e9243b5390cd",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2663,8 +2663,8 @@
       }
     },
     {
-      "uuid": "d0e91305-0e36-49a1-b902-330157dac4cb",
-      "groupUuid": "dbc5e577-6058-49bb-9049-e578ffde5f4a",
+      "uuid": "e2c74e7f-2e68-49f9-b2e9-1ed991e98fb5",
+      "groupUuid": "74b56976-6dcf-4cb0-a4b1-bbd6f4be8d2f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2672,8 +2672,8 @@
       }
     },
     {
-      "uuid": "ffbad391-0588-4dd9-bcb5-de36f18085eb",
-      "groupUuid": "c36e9e47-27b8-4355-b507-73cd04fc0751",
+      "uuid": "5a52aeaf-8c2a-4392-a60d-49d95c849378",
+      "groupUuid": "102cfe5a-91dc-4d71-80fa-bfbfca159537",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2682,8 +2682,8 @@
       }
     },
     {
-      "uuid": "b0a5e0e4-ad87-42df-8552-15f8375b3c55",
-      "groupUuid": "561dec83-47f3-44fb-a63d-4beecada380a",
+      "uuid": "cd008c1c-4e57-4b72-b4fc-3b1d31fa1714",
+      "groupUuid": "ff33792d-d3ef-49ac-83f5-e22505f221c7",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2691,8 +2691,8 @@
       }
     },
     {
-      "uuid": "ff389c8b-f2f6-4a98-9433-5ecd407a70b3",
-      "groupUuid": "a5616ad7-656b-4410-bf39-edd5ed7f6a3c",
+      "uuid": "a78dbd9e-6af8-4ac2-9c63-71d097839b3b",
+      "groupUuid": "225335eb-33f8-49c4-ac6b-6e45c5ba0dae",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2701,8 +2701,8 @@
       }
     },
     {
-      "uuid": "b0b40880-4df3-40e5-8450-2d00b0f66fd3",
-      "groupUuid": "b7e72672-a846-448e-bdc5-932680e8a7ed",
+      "uuid": "17aed3cc-8db7-4d9e-b218-4ef70f6bd6dc",
+      "groupUuid": "458e8823-29b4-4f86-8b36-1644144a5503",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2710,8 +2710,8 @@
       }
     },
     {
-      "uuid": "a301ef39-9589-4ba9-8895-0a2402a4dc94",
-      "groupUuid": "3c01e147-4e3b-492c-a7ec-9e23a89b1b9d",
+      "uuid": "60d728ff-7fa4-4ad6-b718-2967b0251f0e",
+      "groupUuid": "28520148-6903-4240-8d1b-461f18b8d340",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2724,17 +2724,17 @@
       }
     },
     {
-      "uuid": "3eba18e8-d6c8-411e-8fb7-223af51cc52b",
-      "groupUuid": "1d297042-fb1e-4278-a5c0-5d7068d98d25",
+      "uuid": "bb5627d6-6232-4a5c-9cbd-7d5556f574a3",
+      "groupUuid": "c0a29d5c-12de-4785-a85d-08cadfff8b6f",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "5ad06abf-91d3-457e-a165-c3d8b27ddb93",
-      "groupUuid": "439ee468-68d1-4677-9a07-7a0adaa3affe",
+      "uuid": "ad7ec44c-806e-42a0-bca6-420a99512966",
+      "groupUuid": "c1be2383-5079-4b69-ac85-89e783d61733",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2742,8 +2742,8 @@
       }
     },
     {
-      "uuid": "1a5cc9ff-41d3-42c8-afc7-13b002bdee9c",
-      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "uuid": "ce7dd3be-e816-4abf-aae4-756d08f5f6c8",
+      "groupUuid": "dcc30ccc-570f-467e-935f-64310378a6ab",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2754,8 +2754,8 @@
       }
     },
     {
-      "uuid": "b8045ee2-30f9-4c3d-9960-b63b11069385",
-      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "uuid": "b4aa0b7a-2635-42cd-8125-903e678fb38e",
+      "groupUuid": "dcc30ccc-570f-467e-935f-64310378a6ab",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2766,8 +2766,8 @@
       }
     },
     {
-      "uuid": "bb11463b-bf24-4beb-ad86-ee33aefc0d63",
-      "groupUuid": "d8348138-167e-422c-aa38-117722143693",
+      "uuid": "880fae1c-762d-444f-8479-ed78301f6a34",
+      "groupUuid": "dcc30ccc-570f-467e-935f-64310378a6ab",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2778,8 +2778,8 @@
       }
     },
     {
-      "uuid": "c8b3833d-8d9a-4287-bf20-222d855c3ed5",
-      "groupUuid": "25b69437-e1e0-44c7-927b-33bd108ac673",
+      "uuid": "248dc7a2-626f-4353-843b-210df51fb123",
+      "groupUuid": "5dfda464-f3b6-482f-8b5e-4eb3b2ebdd2a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2787,8 +2787,8 @@
       }
     },
     {
-      "uuid": "eec1dbff-bafc-471a-8f0f-407f1ea8d950",
-      "groupUuid": "18d2b1c1-efc2-4290-bc97-bd98abd62d07",
+      "uuid": "f73ba5b1-76ca-421a-b3bd-4715f27c7fde",
+      "groupUuid": "80421982-7e9e-4939-a1f9-80ed79d4451b",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2797,8 +2797,8 @@
       }
     },
     {
-      "uuid": "cffd5cca-b889-46e4-846f-ed84bdd1206d",
-      "groupUuid": "7d90260c-526a-426d-9235-0c7b6fa8bdcc",
+      "uuid": "0021d0d1-d088-4421-8257-75474f76f5fe",
+      "groupUuid": "db0e96cc-f2c7-420c-bd4f-a131b9e629f9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2806,8 +2806,8 @@
       }
     },
     {
-      "uuid": "f419a0a3-ae58-4ef6-aa80-98333e3a8a75",
-      "groupUuid": "9475d7d3-e926-4564-8a3b-84a54c065427",
+      "uuid": "760802b5-052b-4eea-b811-2a00eb67e226",
+      "groupUuid": "10ffb2e5-639e-4a75-84ed-ff8c930fec6e",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2816,8 +2816,8 @@
       }
     },
     {
-      "uuid": "5c9139e6-3d51-4aab-9599-bb5e60efd7cd",
-      "groupUuid": "f6e050df-a299-4d71-ae00-373df1097c01",
+      "uuid": "a001d10d-19aa-4692-8fce-449558e0bf8f",
+      "groupUuid": "58b0dc90-5b35-4b8d-be2b-c293f96c904c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2825,8 +2825,8 @@
       }
     },
     {
-      "uuid": "65edf093-5b14-409d-b95a-daeb83eab607",
-      "groupUuid": "664f2a99-e6df-422e-bf47-5e99dbf7f77d",
+      "uuid": "48dacf50-f4e2-445f-a6b2-74cb52b39ceb",
+      "groupUuid": "1ff5684c-17ed-461b-b4c2-6073a6a521ad",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2835,8 +2835,8 @@
       }
     },
     {
-      "uuid": "6f65ce58-3d54-48b4-b68f-9bb0b4654c35",
-      "groupUuid": "f8011239-187b-40d1-805f-bca23d8fa0c2",
+      "uuid": "0f805061-51a8-4580-8085-8ae225e8009d",
+      "groupUuid": "e625cfb3-0a1e-4370-a94b-678ca8dce20b",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2844,8 +2844,8 @@
       }
     },
     {
-      "uuid": "d762a9c5-1337-4b84-b635-e38c9dd9a8bc",
-      "groupUuid": "db78fd9b-d2ee-4867-93cf-aebe83256aaf",
+      "uuid": "b9dacf9e-9b2d-4a63-a52b-84e994f2d15a",
+      "groupUuid": "aa928eae-952e-433c-95a7-80674d8d364b",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2858,17 +2858,17 @@
       }
     },
     {
-      "uuid": "eb53ae35-f2d5-4f49-87a6-e0159f007b6b",
-      "groupUuid": "ae5ac7e6-7c50-4a99-b5a9-13c395358f51",
+      "uuid": "437e0ca5-af23-4353-b3cf-67f0d47987e8",
+      "groupUuid": "481d4f06-6e54-4438-9cd8-da6c4344c8ba",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "7406cb91-4dc2-4467-942b-ada6623e2aaa",
-      "groupUuid": "35120bdc-9128-4dbe-a6c6-7d56d4dedcfb",
+      "uuid": "660fa41f-7897-4ca6-a349-2f8144218fcf",
+      "groupUuid": "6a7bdf77-be0f-43ca-a9e3-336089ae2393",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2876,8 +2876,8 @@
       }
     },
     {
-      "uuid": "d8c52a1c-7e88-4402-b2cd-650f5388958c",
-      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "uuid": "b1ea41d2-00a7-4526-91d6-d56856744615",
+      "groupUuid": "31bd21e3-ef2a-4b62-9f97-8480f88fa558",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2888,8 +2888,8 @@
       }
     },
     {
-      "uuid": "6267fce0-eca1-4f04-a658-3b6ea395b6a2",
-      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "uuid": "909d4571-a90f-4923-8680-cc745358f897",
+      "groupUuid": "31bd21e3-ef2a-4b62-9f97-8480f88fa558",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2900,8 +2900,8 @@
       }
     },
     {
-      "uuid": "1d348a9e-db1f-4d71-b433-8c8632501d6e",
-      "groupUuid": "58036da6-8cc0-4e6a-a6be-47a47dd97a04",
+      "uuid": "00483c12-1cf0-47d1-a2c4-93702114f13e",
+      "groupUuid": "31bd21e3-ef2a-4b62-9f97-8480f88fa558",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2912,8 +2912,8 @@
       }
     },
     {
-      "uuid": "31baae57-01a9-4843-90df-169fecbca050",
-      "groupUuid": "d54657c6-c10c-4d91-8abb-ef00af1b1b3e",
+      "uuid": "c318db0e-414d-48ae-9da7-8e5d66c13f5a",
+      "groupUuid": "e3bb59ca-af75-4fd9-a6aa-607745f918c8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2921,8 +2921,8 @@
       }
     },
     {
-      "uuid": "9fc09ab8-44a2-4992-bb14-b58784ac4f97",
-      "groupUuid": "0fbb3c17-0632-4e4f-ae60-8216d95d4225",
+      "uuid": "4fe18ba3-2683-4963-817f-4a59d02b6382",
+      "groupUuid": "110c1636-963c-4faf-b283-59b9618583cc",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2931,8 +2931,8 @@
       }
     },
     {
-      "uuid": "2b840ead-ff72-443d-a71f-0fe738526c12",
-      "groupUuid": "f807440c-522d-4f3d-9a16-a62669f9802e",
+      "uuid": "fc45549b-69a1-410e-bba1-9030343f00ef",
+      "groupUuid": "7d6da7da-e284-49d2-83f1-d5f895fe5a5f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2940,8 +2940,8 @@
       }
     },
     {
-      "uuid": "1cf9e8ca-5a02-451d-81cd-db907d331da9",
-      "groupUuid": "a4113acc-9e41-4a32-9794-3e205af26744",
+      "uuid": "a4f1391c-1375-47a3-abf3-cad6ff7b42c1",
+      "groupUuid": "2222fd9e-8744-4a00-86e4-39636d69dbc5",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2950,8 +2950,8 @@
       }
     },
     {
-      "uuid": "01674b4e-fd9e-405e-a9c7-a62b21c90c7c",
-      "groupUuid": "c85b0803-fa8e-4d5c-a492-82b87440a775",
+      "uuid": "ed2d14b2-7d72-4f21-a293-95cf8c12568f",
+      "groupUuid": "56f65a07-bb7e-4369-96af-fa7c6e740e2b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2959,8 +2959,8 @@
       }
     },
     {
-      "uuid": "358b08fc-3e65-4854-a720-c8371f2eae18",
-      "groupUuid": "06a9ca64-7107-4268-8906-2f68568414e5",
+      "uuid": "0fdb4aec-1383-41ef-9d5a-4f5de593bb12",
+      "groupUuid": "e8c784a1-cafa-4ff5-b667-44e796e14ce8",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2969,8 +2969,8 @@
       }
     },
     {
-      "uuid": "40ea7dc3-afd4-4717-9b33-c3ab6e029397",
-      "groupUuid": "b03263b1-9f4f-461a-bc79-1672f70baa2b",
+      "uuid": "87792a75-d2f0-4e9b-bb5f-741551aec2a9",
+      "groupUuid": "5c30d0a5-e878-4ad1-b0d6-d024daa45020",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2978,8 +2978,8 @@
       }
     },
     {
-      "uuid": "5fd1800b-0cd7-4b20-a2be-d55fd574989a",
-      "groupUuid": "093b9e1f-1960-4ee1-a3cd-ae59b4061899",
+      "uuid": "3ac53c43-02e2-4153-89e1-bf882d34cc82",
+      "groupUuid": "542d9ea7-f990-4848-83e3-71e1940eb41c",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2992,17 +2992,17 @@
       }
     },
     {
-      "uuid": "f8a694e6-ddab-4ac4-89fe-f65ef2eff542",
-      "groupUuid": "68013d21-9e0a-4d08-84d5-01cc821eb4dd",
+      "uuid": "68b81ca8-ea61-49f6-8da7-31e8a9d5d628",
+      "groupUuid": "6ee70eb8-1c45-4497-85a2-df592bb99015",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "e16125b6-c23e-47cd-ab46-46821d7fce8a",
-      "groupUuid": "a58e6227-df03-4f67-b0b2-bc4855f75846",
+      "uuid": "c9fc6c99-d901-4f74-a3a3-c341a088013a",
+      "groupUuid": "b48a4278-7b3a-4af9-9b66-e3d80d8721da",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3010,8 +3010,8 @@
       }
     },
     {
-      "uuid": "2ec4c649-5c54-4df1-8705-b26a4f619b8d",
-      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "uuid": "d90a001b-bd0d-4e71-abbd-c78413fb98b1",
+      "groupUuid": "aa1e949f-a37b-4a9d-999e-529f14d2909f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3022,8 +3022,8 @@
       }
     },
     {
-      "uuid": "286d7697-932a-4ea5-a32c-b1f99c58415b",
-      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "uuid": "78f96274-936d-48a9-801f-fb58c317d2ca",
+      "groupUuid": "aa1e949f-a37b-4a9d-999e-529f14d2909f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3034,8 +3034,8 @@
       }
     },
     {
-      "uuid": "e66bfa0a-2d8e-43f7-a304-0fd076cb932d",
-      "groupUuid": "c24949f8-567b-4405-a018-6c30f31e2100",
+      "uuid": "dae22688-d801-47d2-8ebc-743470fe0925",
+      "groupUuid": "aa1e949f-a37b-4a9d-999e-529f14d2909f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3046,8 +3046,8 @@
       }
     },
     {
-      "uuid": "5ca27f7f-740f-443b-b450-9e400cf7c227",
-      "groupUuid": "83385657-4969-43f2-b2be-d7948f72a1b0",
+      "uuid": "3f1d4545-714f-473f-befb-4660a20bc741",
+      "groupUuid": "efccf3a8-57d5-4508-bfd2-9754d493b90e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3055,8 +3055,8 @@
       }
     },
     {
-      "uuid": "09848665-2fe0-4ac2-9d8f-dba6caa496fc",
-      "groupUuid": "8b0e6641-f4b4-4575-9db9-5efec65c09b9",
+      "uuid": "e6f7dd39-65fb-44e6-8055-11a5849e2be2",
+      "groupUuid": "d144c891-02cb-426e-b9fd-8ab3dcdbf224",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3065,8 +3065,8 @@
       }
     },
     {
-      "uuid": "18b04268-41d4-45d5-80bd-3f73c93facac",
-      "groupUuid": "67206303-fe0e-4f98-b24d-7a97301ae56b",
+      "uuid": "aa28870e-7e30-4fc7-91d0-b6fe46b96208",
+      "groupUuid": "7dea4f3c-ccdf-40a5-b50e-abfaeb63fd9e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3074,8 +3074,8 @@
       }
     },
     {
-      "uuid": "24218a44-d89d-4cf7-8fe5-8ac05ecff855",
-      "groupUuid": "1d0c88b8-7218-4f68-9fb7-ce35c5fc7460",
+      "uuid": "22fa26d6-14a1-49fb-a612-d24ff8b0c0be",
+      "groupUuid": "ddc04400-31e7-4ffb-a58e-eed6d125d127",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3084,8 +3084,8 @@
       }
     },
     {
-      "uuid": "0008d810-79f0-427c-a6f4-efbbbd691f29",
-      "groupUuid": "27d55126-db68-4959-a229-9cb7327a01c5",
+      "uuid": "d8f7cb5d-ebc2-43f6-bdd3-b8513a8ad5a9",
+      "groupUuid": "def46ac0-f723-4fd1-b609-7451a512b762",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3093,8 +3093,8 @@
       }
     },
     {
-      "uuid": "49325246-4efa-4eff-a9aa-3fe48c4418b1",
-      "groupUuid": "d89ae9ca-23bd-419d-b4c0-529e24869f9a",
+      "uuid": "5834a179-19a6-4347-ad2a-7031f270137e",
+      "groupUuid": "9059d4a8-6138-495f-9dea-28fef7abbb46",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3103,8 +3103,8 @@
       }
     },
     {
-      "uuid": "a8e50424-4d9b-453d-8faf-fb64dc5b0bae",
-      "groupUuid": "ea9b7b7f-455a-47fe-aabb-275fdcf3f3bd",
+      "uuid": "edb2746a-5840-449d-9eae-f7402360eb20",
+      "groupUuid": "276acf3c-3906-46ab-89e6-6194fb544722",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3112,8 +3112,8 @@
       }
     },
     {
-      "uuid": "25ec42d4-8b00-4ad4-8251-985d1e5f7e8b",
-      "groupUuid": "b589ecf8-079c-447e-a94e-7b7c61660abd",
+      "uuid": "fa5365bb-b2a2-474b-9d4b-eefcff6d3129",
+      "groupUuid": "7e597bb3-bbb0-46af-b24e-4590118e6aff",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3126,17 +3126,17 @@
       }
     },
     {
-      "uuid": "ecbd9fa1-4200-4dc4-b8ac-fda577d294b5",
-      "groupUuid": "1d92b61f-9f3c-4d15-b13b-de8f0b65435e",
+      "uuid": "e1794467-1b44-4906-acd0-98e055fb5eb3",
+      "groupUuid": "a14b7b4c-0bd1-4018-bc03-a6aeba263859",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
       }
     },
     {
-      "uuid": "c031addd-f433-4bbb-9c49-80dd85c7df55",
-      "groupUuid": "be76b380-67a2-4ad3-bdd1-b1276df1dbcf",
+      "uuid": "da24b9c6-c6fc-4b7b-b937-3f694f8eb945",
+      "groupUuid": "f44328a5-43e2-4626-83a9-0fdbb61b581d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3144,8 +3144,8 @@
       }
     },
     {
-      "uuid": "134f3c12-d6d2-458a-987e-095bac00974e",
-      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "uuid": "3dfac70f-aee4-47af-8c40-da9801a2767d",
+      "groupUuid": "8782aedc-d422-4749-b067-0d86088db71f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3156,8 +3156,8 @@
       }
     },
     {
-      "uuid": "d8c79f6d-cbff-4fcd-a08e-40739c447c29",
-      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "uuid": "abd1bb13-ff8a-4ac1-a3c6-246633b8a3de",
+      "groupUuid": "8782aedc-d422-4749-b067-0d86088db71f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3168,8 +3168,8 @@
       }
     },
     {
-      "uuid": "2301c305-f7f9-429e-b2b3-26a766baff4b",
-      "groupUuid": "87c0df07-af78-4c06-a037-5eb0f9ce41a3",
+      "uuid": "dee94ada-bd7d-423a-960b-2f8dd59ff87f",
+      "groupUuid": "8782aedc-d422-4749-b067-0d86088db71f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3180,8 +3180,8 @@
       }
     },
     {
-      "uuid": "882c6945-3a7c-4507-bb73-246638f04b2d",
-      "groupUuid": "56237876-f201-4584-a381-feb770ce5bfe",
+      "uuid": "6183cc52-31ff-442b-81fc-a4c2a5d2e373",
+      "groupUuid": "1739caac-1ae0-42fd-bae4-7fd9967ca7b5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3189,8 +3189,8 @@
       }
     },
     {
-      "uuid": "c0ac7bc7-2e2d-4422-9e41-f28967201faa",
-      "groupUuid": "f8c62eb6-5d87-466d-9c87-f3de1562d49a",
+      "uuid": "e48e067c-6b1b-49c0-b3b7-c60078033ec5",
+      "groupUuid": "2e86bce1-55e3-4441-bc64-569811dbe542",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3199,8 +3199,8 @@
       }
     },
     {
-      "uuid": "b8a18b9f-cef2-4eac-9fe2-173481bbdd9e",
-      "groupUuid": "6a46d274-9821-41a8-8e24-5c03f8278ad4",
+      "uuid": "9d20e188-941f-47ed-abf4-5716f4b4a3da",
+      "groupUuid": "57448cc1-a8e4-4756-802a-2bea4772a2e2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3208,8 +3208,8 @@
       }
     },
     {
-      "uuid": "859738a6-1a71-416e-86c2-f1a7b36ae57a",
-      "groupUuid": "178fcd08-1884-4aad-8ed5-47dea5e9fa51",
+      "uuid": "36cff03a-a8cb-465c-a2e4-9dfec182c86b",
+      "groupUuid": "9efbb0af-8909-470b-86a7-dc2194dec88b",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3218,8 +3218,8 @@
       }
     },
     {
-      "uuid": "cd14f201-4417-4d90-8479-e17afb72e690",
-      "groupUuid": "88772ef5-4509-4b08-a830-4b323ea02e60",
+      "uuid": "8365eb3a-5596-485a-89fe-5465d8d01938",
+      "groupUuid": "d6d39e55-4e98-41c5-8285-8607d149625a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3227,8 +3227,8 @@
       }
     },
     {
-      "uuid": "dc532975-77bb-421a-b6a8-847d2776f208",
-      "groupUuid": "ab72c037-f486-4f85-b5a8-5fe34681a5c0",
+      "uuid": "8a956d9f-e6af-415b-ad71-45df759856b9",
+      "groupUuid": "ec5ee2c1-db4b-4e72-8856-ac615abf4671",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3237,8 +3237,8 @@
       }
     },
     {
-      "uuid": "74167e5c-71fc-421b-8eea-00e1e28a92b7",
-      "groupUuid": "356543ed-0604-4124-9ab0-36dc4539396e",
+      "uuid": "607fcb33-1528-4bb6-8f01-f0b6db1c4961",
+      "groupUuid": "1bc6be5b-986e-4b6d-ac1a-0e349d913bd2",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3246,8 +3246,8 @@
       }
     },
     {
-      "uuid": "a204fd00-6c97-44d3-ad59-daafd76eaec8",
-      "groupUuid": "36c8bb31-35b4-4491-b35c-c6dd17dd6bea",
+      "uuid": "cbf4cac4-bfaa-4c18-b28d-146ce9508120",
+      "groupUuid": "43661312-bbc3-4e18-bc0e-4d09ade21b67",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3260,17 +3260,17 @@
       }
     },
     {
-      "uuid": "b2d42386-47ba-4832-8eeb-1989f85292b4",
-      "groupUuid": "c6405ee1-cd7f-4597-b3bf-d61de14a8735",
+      "uuid": "fdb92fde-1e3c-4fe8-97d6-be53bbd5c46b",
+      "groupUuid": "d39cb9bb-5edf-4c0c-a8d0-d4e1d4c251ff",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "b2e1f7fb-d76a-48b2-a448-62d7c1d2f655",
-      "groupUuid": "b8e07dad-4f00-4a36-b521-a3e5bf1c9457",
+      "uuid": "bf48b6de-9516-4fbd-9555-532370132e9e",
+      "groupUuid": "9628f15c-34db-4407-b077-8af190ee6d62",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3278,8 +3278,8 @@
       }
     },
     {
-      "uuid": "324c53ce-8e9f-4596-bdd2-3b7958adc9b3",
-      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "uuid": "177056c8-e4f5-450e-a8fa-325549e8d0bc",
+      "groupUuid": "99a27aea-e8f1-42e0-8ec3-3a0d8f03eeda",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3290,8 +3290,8 @@
       }
     },
     {
-      "uuid": "4f0b19bf-3101-4039-857f-a4516663ba2c",
-      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "uuid": "97694967-a031-42b1-8c3c-362824f3527d",
+      "groupUuid": "99a27aea-e8f1-42e0-8ec3-3a0d8f03eeda",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3302,8 +3302,8 @@
       }
     },
     {
-      "uuid": "f600b772-8982-4f84-a183-76c1f637e4ca",
-      "groupUuid": "baffc0d3-f614-41b8-95b1-1190288c3961",
+      "uuid": "00256a5d-88f5-454d-a59c-2d7610a53448",
+      "groupUuid": "99a27aea-e8f1-42e0-8ec3-3a0d8f03eeda",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3314,8 +3314,8 @@
       }
     },
     {
-      "uuid": "31e6ea9e-8382-488d-9389-8778aae24bd1",
-      "groupUuid": "e401fc19-7680-4cd1-bf9b-d05c3d233f8b",
+      "uuid": "31cfc9fc-ad59-465a-ac92-d83b842272c0",
+      "groupUuid": "d29dec9b-c469-4dc6-a184-838870085ec1",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3323,8 +3323,8 @@
       }
     },
     {
-      "uuid": "f98087f1-3fa6-4a67-b059-49d7662157c6",
-      "groupUuid": "cf05412a-f69f-43ea-9d03-4b5e6fa6ff2e",
+      "uuid": "22beed39-842d-4bdc-be31-68488c5ea177",
+      "groupUuid": "4d586f8b-5c4e-4e00-ac2a-4aecaf46557f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3333,8 +3333,8 @@
       }
     },
     {
-      "uuid": "ea1d6f99-ee22-44d9-a04a-bfa5f74a607c",
-      "groupUuid": "c6015601-295e-488d-9a06-2fabf4d42099",
+      "uuid": "e8f355cb-6d29-4f7c-94d1-5f22ddae55b2",
+      "groupUuid": "5f4c7617-933b-44bd-94cc-20d2a182ef17",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3342,8 +3342,8 @@
       }
     },
     {
-      "uuid": "3d3ba46d-aa1f-4ecc-af1b-a75f006423af",
-      "groupUuid": "b3b5457f-470c-4073-9880-561027478f63",
+      "uuid": "c82c236d-94dd-498e-82d7-7e7f6076e23e",
+      "groupUuid": "557f2f7e-4070-4f47-bb80-2e5b4993ef1b",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3352,8 +3352,8 @@
       }
     },
     {
-      "uuid": "1f6bad36-e009-4549-80f2-c0347e4811f4",
-      "groupUuid": "0afc8213-41eb-41ab-9c2d-f04dd0ce21ef",
+      "uuid": "240d85dd-cd6f-4f0c-8c20-585ec757c2c6",
+      "groupUuid": "af20531b-29f4-42d4-9866-fcfc4da5a7a3",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3361,8 +3361,8 @@
       }
     },
     {
-      "uuid": "bf3fdab2-3591-4b84-b234-6d436924cba2",
-      "groupUuid": "0b6ecd8c-f2fb-469e-82f6-74eb1b7dc3d9",
+      "uuid": "24d27337-9175-4664-82f0-7395bddbcf16",
+      "groupUuid": "76fb1b67-eb90-474c-b18e-774754a4f2b0",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3371,8 +3371,8 @@
       }
     },
     {
-      "uuid": "cd289504-8d07-457c-a5da-0766bf529421",
-      "groupUuid": "a9ac6ce1-159a-4ea4-9c9d-311af7d3515f",
+      "uuid": "18505693-dd75-4846-bc4b-466084b793a7",
+      "groupUuid": "ff29ce93-b079-4f71-826b-01dd7805fc20",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3380,8 +3380,8 @@
       }
     },
     {
-      "uuid": "ec3b14cc-5a6c-4e15-8bc8-dfa365b3a1f6",
-      "groupUuid": "bfbe3a93-2fcd-4824-9b06-f623d6d9a093",
+      "uuid": "a7df149c-6199-4ea8-988d-7afb5cffcf73",
+      "groupUuid": "815e47e2-2ed3-45ab-9108-1851da80101a",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3394,17 +3394,17 @@
       }
     },
     {
-      "uuid": "2d60937f-f45a-4b79-a4c9-a167a99f9eed",
-      "groupUuid": "ca92d406-d17d-40d4-8630-f73a2f07925c",
+      "uuid": "1d425d05-d9c4-4821-aaaf-e25faeaff928",
+      "groupUuid": "8a40039d-975d-49cb-bf1b-af0fc06eb621",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "f489f081-d1d8-4225-8454-20c19da7056e",
-      "groupUuid": "e9859cef-ce34-4346-aceb-9b867ce6883e",
+      "uuid": "25ba1a18-7adb-4719-849c-3bfff71ef2ff",
+      "groupUuid": "d236823d-8a14-4e35-87a4-572217483acc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3412,8 +3412,8 @@
       }
     },
     {
-      "uuid": "559f7122-c2bd-4333-9be5-02deacceae83",
-      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "uuid": "cc4eda0c-d68b-4dfd-8955-a955c5b7d9f4",
+      "groupUuid": "52d98747-ef8e-4c0b-9e9b-b86de7e6cf41",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3424,8 +3424,8 @@
       }
     },
     {
-      "uuid": "e8f75ea0-94d3-4edf-bdc2-bfad3d520b74",
-      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "uuid": "f90894af-7ac1-424e-b6b3-e943572140ae",
+      "groupUuid": "52d98747-ef8e-4c0b-9e9b-b86de7e6cf41",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3436,8 +3436,8 @@
       }
     },
     {
-      "uuid": "9f5759d9-1377-4e2b-bc87-96f282b76d00",
-      "groupUuid": "4e853ffa-ee9b-43bc-b752-2bba1967c862",
+      "uuid": "8c8aa59e-58f7-43bc-ba97-aa588bcb4b92",
+      "groupUuid": "52d98747-ef8e-4c0b-9e9b-b86de7e6cf41",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3448,8 +3448,8 @@
       }
     },
     {
-      "uuid": "8ba4b10d-a4ae-4bcc-9510-5830a9c95222",
-      "groupUuid": "2fb07289-3432-4f5b-ac8f-bed701a4797f",
+      "uuid": "b62d1211-d91d-47f2-a3c8-d3cd1db47a21",
+      "groupUuid": "1dc4922b-0c78-48e6-a45e-e1587f63f4fc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3457,8 +3457,8 @@
       }
     },
     {
-      "uuid": "7858929b-2b3c-400a-a95a-236380a49fcf",
-      "groupUuid": "ab7a268f-ef06-491a-9363-270531e71ebb",
+      "uuid": "914c6d8d-4ba7-4ba2-93b8-aa3823e4d1c1",
+      "groupUuid": "9d55e6f4-e6ca-4672-94e5-92a8fe445e11",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3467,8 +3467,8 @@
       }
     },
     {
-      "uuid": "40f172d1-27fc-47df-8677-0fcf0d18ad76",
-      "groupUuid": "d5ac3edf-25de-4e6d-9cb2-b8193b34d84f",
+      "uuid": "09bc2598-9a67-442f-a01d-90dd34c01f38",
+      "groupUuid": "9cf02825-48f9-4244-b6c3-777392c52e99",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3476,8 +3476,8 @@
       }
     },
     {
-      "uuid": "c9c0fb88-7f58-415f-89d0-e9883dd58469",
-      "groupUuid": "f72b6ece-88db-476b-82ac-7042d5121984",
+      "uuid": "75d9edad-aa27-40bf-8e40-e8ae8b6c63b9",
+      "groupUuid": "9d8cd088-410b-4a68-ba88-e7832df75ff6",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3486,8 +3486,8 @@
       }
     },
     {
-      "uuid": "0f0de67d-f3e8-4d0b-b09b-871b6e658263",
-      "groupUuid": "3d2caec2-6a9a-4ba0-8384-bfda1b583321",
+      "uuid": "1da370b9-64ad-41ca-aee9-fd231b2a9d94",
+      "groupUuid": "b272fc19-1c4a-4cf2-9894-29615d6bbd78",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3495,8 +3495,8 @@
       }
     },
     {
-      "uuid": "f9276213-f9ea-457c-9c3d-f5da605a27a9",
-      "groupUuid": "32ae7bc2-2dc9-453b-83aa-a280e6104568",
+      "uuid": "8b2182bc-18a1-4427-9121-7b2f5758593d",
+      "groupUuid": "63dfb4de-7a73-493b-9759-76b59365b1ab",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3505,8 +3505,8 @@
       }
     },
     {
-      "uuid": "0c4ab215-9348-4690-8f92-849bbd75deb4",
-      "groupUuid": "2bbdb4bf-4db8-4abb-b9bd-d8416e08e273",
+      "uuid": "a0a7ee72-e2d3-4ede-a0dc-dbd4d70ab27d",
+      "groupUuid": "29144366-64d4-41fe-ac4f-deb0323b4440",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3514,8 +3514,8 @@
       }
     },
     {
-      "uuid": "bd6db14a-2ace-4a66-9461-dd8e542f3b0f",
-      "groupUuid": "3b4d96a6-2aa3-41d1-9994-00bd5b63a5f2",
+      "uuid": "6bf7a72e-bb9a-41ba-8852-5ba30be2d972",
+      "groupUuid": "96b0a9e4-d38d-4f7b-83cf-02338787a69d",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3528,17 +3528,17 @@
       }
     },
     {
-      "uuid": "680215fe-89fd-4a86-a5f8-08c6f9129008",
-      "groupUuid": "3dbdb880-e4fd-4f31-ba9d-93766d87d464",
+      "uuid": "0c99ba6c-e1ec-4e2c-817b-afa7c54b188e",
+      "groupUuid": "298a83d3-dd51-4ff4-88e1-a473f27710eb",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
       }
     },
     {
-      "uuid": "57b828d9-d959-4f2b-98a1-c9decb9b199a",
-      "groupUuid": "5fb037ac-093c-4e9a-b06f-28accec620bd",
+      "uuid": "f45c3222-8381-47db-9cc6-4aaa14a4bf19",
+      "groupUuid": "aaa39fa2-4217-46de-b627-beaf72ceda86",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3546,8 +3546,8 @@
       }
     },
     {
-      "uuid": "d52328e9-50d3-4da1-997d-9eeb38fd709b",
-      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "uuid": "737ca107-4088-4ba7-93b2-5da146f45cbd",
+      "groupUuid": "29217c98-4074-4808-ae49-2cb48b9b91e6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3558,8 +3558,8 @@
       }
     },
     {
-      "uuid": "24d37167-222e-4565-abd1-32d83ef03263",
-      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "uuid": "cd893d54-b4b4-448b-bb75-9d7ed39a37dc",
+      "groupUuid": "29217c98-4074-4808-ae49-2cb48b9b91e6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3570,8 +3570,8 @@
       }
     },
     {
-      "uuid": "92609f60-5586-4b50-bac1-381b023a6f09",
-      "groupUuid": "c3860f89-50b2-46f3-aeb2-ab66cb747f78",
+      "uuid": "108ef636-863c-48cc-afe3-beff65035239",
+      "groupUuid": "29217c98-4074-4808-ae49-2cb48b9b91e6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3582,8 +3582,8 @@
       }
     },
     {
-      "uuid": "9bc54bbb-134d-4333-a8cc-ca505afd8715",
-      "groupUuid": "13dc871e-3527-4404-b887-814736e82b67",
+      "uuid": "a9fd3e67-56ff-4bed-870a-d2816884ac98",
+      "groupUuid": "6634c8f7-5a4b-4bb3-accf-5f68406b7560",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3591,8 +3591,8 @@
       }
     },
     {
-      "uuid": "a9e0e86d-c19a-4347-9c41-d7a86a61b63f",
-      "groupUuid": "ec276ed4-4088-42d7-8751-48d41624e4b1",
+      "uuid": "3c80d65f-7a5e-49a7-8c03-3d3e9d1b85f4",
+      "groupUuid": "0b4e2845-59d1-46cf-a8f4-ed15a5ec922b",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3601,8 +3601,8 @@
       }
     },
     {
-      "uuid": "cf99d63d-170f-4e80-8d94-c76370607ed2",
-      "groupUuid": "319dbc07-e7f1-44e9-ad09-c1e3cd7a98f4",
+      "uuid": "a982bd2e-53d7-45d5-ac88-75d3d80499af",
+      "groupUuid": "c1d4a9d1-bb10-4d69-9bad-bc2b5ec207bf",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3610,8 +3610,8 @@
       }
     },
     {
-      "uuid": "c0359e32-dc9a-4eda-a679-ef237fd833dc",
-      "groupUuid": "41195467-cc3b-4a38-bbe7-54c12e4b65bc",
+      "uuid": "15a171bd-804f-41f5-95d4-95f26b663aa3",
+      "groupUuid": "9bff5563-be0d-4edb-bd6c-5fa3a200b76d",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3620,8 +3620,8 @@
       }
     },
     {
-      "uuid": "83af7353-20b2-4547-ae2c-957ee07d1364",
-      "groupUuid": "8bcdbe96-46c0-4b7e-84f4-ab2a41bbcfba",
+      "uuid": "d1898f0a-3462-4f33-b931-c0367887f03d",
+      "groupUuid": "64f870fa-1291-4bb1-a65a-133edb1e273f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3629,8 +3629,8 @@
       }
     },
     {
-      "uuid": "6d545641-675f-4586-af13-b3c32e7b927d",
-      "groupUuid": "de4c5703-5a12-4c75-96ac-50826a39d88d",
+      "uuid": "401b13dd-560e-491a-90f4-64a8df8e09d9",
+      "groupUuid": "9eb2b4bb-ae9a-4115-aad5-33f98781d77a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3639,8 +3639,8 @@
       }
     },
     {
-      "uuid": "ee12c3e9-3c32-45c3-a70e-29fad99991c1",
-      "groupUuid": "226d6e71-be29-44a4-832c-97108e41a4d5",
+      "uuid": "5441b9cf-3c76-4ad1-b0a1-8e1cad446dd7",
+      "groupUuid": "ec2cfdda-bd39-41b5-a297-de85c933c343",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3648,8 +3648,8 @@
       }
     },
     {
-      "uuid": "7dc2884e-0b48-4782-ac21-98474e75a06c",
-      "groupUuid": "0a8d5e89-2403-4813-880a-0c1a07ec6e4a",
+      "uuid": "7d23f827-f266-43da-a33d-48b37a43205c",
+      "groupUuid": "ed7365a9-5dd5-4667-bbb8-dd9e3f75f7e4",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3662,17 +3662,17 @@
       }
     },
     {
-      "uuid": "93b97553-1a68-4c7d-af6d-e94c2569a4cd",
-      "groupUuid": "3e9e474e-8aa5-48c3-9155-f89a24649b4a",
+      "uuid": "698107ce-4dd0-4329-ace0-96c002462531",
+      "groupUuid": "7de8ca81-ddc4-438d-933c-6b9e7af07ee9",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "7f340a82-49c1-44f9-b826-309b53206591",
-      "groupUuid": "fbbd04d1-eac8-42ab-acbb-324513a9c69c",
+      "uuid": "c70a4c46-28ea-4f37-ace0-b292583184ce",
+      "groupUuid": "c7ba6acd-a00d-4a97-bec6-71be276ce8fc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3680,8 +3680,8 @@
       }
     },
     {
-      "uuid": "b13c045e-90c6-41e6-8203-743bc0cf22e1",
-      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "uuid": "1e7a5b45-5703-43d7-82fd-d7a6ab681ae7",
+      "groupUuid": "d5854d80-b5c7-49e3-93d3-171d6e49b0a7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3692,8 +3692,8 @@
       }
     },
     {
-      "uuid": "b6f2da85-b368-40da-81c6-1f20586a174c",
-      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "uuid": "a61e1740-99a8-4a1e-bc4b-2da6b9867be5",
+      "groupUuid": "d5854d80-b5c7-49e3-93d3-171d6e49b0a7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3704,8 +3704,8 @@
       }
     },
     {
-      "uuid": "330bec35-ae56-4cbc-8d82-5c3301b89836",
-      "groupUuid": "240346b3-28ce-44a4-8c8a-2c12e6a6fce3",
+      "uuid": "52c94dea-81d5-436d-96c6-deac4103995e",
+      "groupUuid": "d5854d80-b5c7-49e3-93d3-171d6e49b0a7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3716,8 +3716,8 @@
       }
     },
     {
-      "uuid": "98c0c603-4f03-441f-b34c-95aa75c69283",
-      "groupUuid": "59ebea18-20e9-4d98-aa43-f36cd856418d",
+      "uuid": "8500a883-a2d0-47a6-895c-678f95b5894b",
+      "groupUuid": "61130285-d8d3-4962-8698-726c38d7aa7f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3725,8 +3725,8 @@
       }
     },
     {
-      "uuid": "9fbe10c0-92de-42bc-9d9d-9ae4891d219a",
-      "groupUuid": "8f2bddb9-1707-4b75-8a99-b1398518ade9",
+      "uuid": "8ee0d42d-2b9b-49ad-a7f2-0471518a27a2",
+      "groupUuid": "da45e535-2793-45d8-9f20-369e4da84fec",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3735,8 +3735,8 @@
       }
     },
     {
-      "uuid": "4e13e21d-c4db-45e9-b3bf-581fe0232884",
-      "groupUuid": "c1ad8918-e3fa-4162-b073-3b4d2faeee84",
+      "uuid": "b34b71e6-ce78-4aff-bc62-4baea3381982",
+      "groupUuid": "6f55350b-9b2e-454d-a369-d9bf4da3e483",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3744,8 +3744,8 @@
       }
     },
     {
-      "uuid": "0ac90f6b-987a-4721-bf4a-8081628361ed",
-      "groupUuid": "ec3f38c5-1c34-488f-b6c7-9de9384d1121",
+      "uuid": "82b89a7c-951f-40e5-9d63-05663c427269",
+      "groupUuid": "d4ce861f-1e40-4e15-9d31-be1511e928eb",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3754,8 +3754,8 @@
       }
     },
     {
-      "uuid": "2ac12ad7-a39a-41be-8190-73fb37e67a0d",
-      "groupUuid": "48aeeba6-f961-4646-91d6-407761aa24ec",
+      "uuid": "fc98d6a5-62d5-45c6-b849-c653bd3dbbdc",
+      "groupUuid": "89eba57c-7987-4770-9fc8-459772f0116d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3763,8 +3763,8 @@
       }
     },
     {
-      "uuid": "e2991fd3-d2be-49dc-9f7c-471b4f3ac750",
-      "groupUuid": "7612d54e-30f7-4fcf-bd6d-4bc7efa46144",
+      "uuid": "b05df17e-4d90-484e-af49-066d2c0f2b2e",
+      "groupUuid": "783a86c7-5519-49d4-b488-a1db2a6f16be",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3773,8 +3773,8 @@
       }
     },
     {
-      "uuid": "c0072b81-8945-4d28-a0fe-7b74b16982c7",
-      "groupUuid": "b9d226c1-a57f-4821-9da3-6da597d8289b",
+      "uuid": "e771b17e-ed25-4479-9069-b26bb8feaf6b",
+      "groupUuid": "1b18a4a4-f3f0-4457-b7dd-a1492eb37c7e",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3782,8 +3782,8 @@
       }
     },
     {
-      "uuid": "a1eaf00f-98ac-4ce9-907d-49e533bfb15d",
-      "groupUuid": "6f8c1fb3-b5c5-45ff-929d-f6cf558d9023",
+      "uuid": "0cce039f-7abc-44ed-b8fa-3344b4b75a15",
+      "groupUuid": "f879bf9a-28a8-4307-971c-6c9955ceb663",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3796,17 +3796,17 @@
       }
     },
     {
-      "uuid": "7d1367cc-1d2a-4cb2-b2c6-0fc601c67c2f",
-      "groupUuid": "0120bf5e-f14e-4d3a-a27a-f2116cbcb8e6",
+      "uuid": "0e23212b-0477-4cea-b3d9-1ad2f5a87edf",
+      "groupUuid": "2214e63d-36f6-47e4-96ae-cb01115ac88d",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
       }
     },
     {
-      "uuid": "0ae0d8c0-aa2d-476c-88aa-d34bc378b2cc",
-      "groupUuid": "5de08cc4-24f2-4ea9-a8ea-104b1cc519f8",
+      "uuid": "d6c819ec-11c9-4e58-a654-6bf326d7988f",
+      "groupUuid": "1114a047-b089-44e1-8d7f-db42ead6175e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3814,8 +3814,8 @@
       }
     },
     {
-      "uuid": "2f37fe0b-e292-4d1e-b0b4-8389e7a09029",
-      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "uuid": "32375b8b-a9a6-4808-811c-9cf73175d20e",
+      "groupUuid": "7b4fbd4c-b1ba-4404-899b-742aa10f8be7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3826,8 +3826,8 @@
       }
     },
     {
-      "uuid": "be2b516d-731a-4c7f-b5f2-ce4e21180b42",
-      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "uuid": "d20c6b95-8fa3-4e39-ad6c-4408940eaabb",
+      "groupUuid": "7b4fbd4c-b1ba-4404-899b-742aa10f8be7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3838,8 +3838,8 @@
       }
     },
     {
-      "uuid": "9e42bdee-b5a8-41a8-b75c-065dcb5a2837",
-      "groupUuid": "68d5afa9-399c-448b-837f-9e0e0f40280d",
+      "uuid": "84ff1096-5e8c-4754-b45e-2bb10f2bf53e",
+      "groupUuid": "7b4fbd4c-b1ba-4404-899b-742aa10f8be7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3850,8 +3850,8 @@
       }
     },
     {
-      "uuid": "4968a90d-af2c-4329-9f16-362025f1f9c2",
-      "groupUuid": "a3b87eba-eb75-42f5-bc3e-42b7e8f16d66",
+      "uuid": "785d994e-3ed8-4192-97de-51d71c417d89",
+      "groupUuid": "61362e93-d36f-45ad-872f-7456bedefbf1",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3859,8 +3859,8 @@
       }
     },
     {
-      "uuid": "b776b7bb-5244-45c2-96bb-4ec8b2a41db0",
-      "groupUuid": "75046a8d-0088-4863-afc6-41a84da701a3",
+      "uuid": "d67b0ca8-62c7-4149-98a7-57f40a141bfc",
+      "groupUuid": "f7415633-7093-4f3a-ae42-d5c042156597",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3869,8 +3869,8 @@
       }
     },
     {
-      "uuid": "1e374e73-e6e3-436a-9efc-e18182fa4acd",
-      "groupUuid": "9d873c00-88a5-4995-aa50-cb2ca8066102",
+      "uuid": "cced8949-109a-4501-b1e2-7147c1a588c0",
+      "groupUuid": "5c553b1a-b7e3-4deb-8022-df82a02eec88",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3878,8 +3878,8 @@
       }
     },
     {
-      "uuid": "6bfa5196-7fee-477b-8cd9-22e906f67354",
-      "groupUuid": "3d5efdd6-1537-4280-8b46-362e67dd9412",
+      "uuid": "23b53b8c-9ea7-466f-a121-3a6d87bb6c65",
+      "groupUuid": "cb622a35-b341-4f0e-92d4-8f303b9bfbcf",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3888,8 +3888,8 @@
       }
     },
     {
-      "uuid": "36df90a2-6072-4137-84cd-85aa8d2241ac",
-      "groupUuid": "e6bc6a36-fae7-4106-bde7-c25b2081ddab",
+      "uuid": "f3dd977e-1e62-46e8-9a6f-8cd40bd51661",
+      "groupUuid": "9fa8038d-95e9-45b0-a23d-434e9cddea17",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3897,8 +3897,8 @@
       }
     },
     {
-      "uuid": "a3449f55-463d-4011-adac-f99e8894879c",
-      "groupUuid": "cb692162-d741-4723-ba59-d532ef197661",
+      "uuid": "47b93168-bc26-456f-a1f1-8d12a4863a8a",
+      "groupUuid": "bc4ff7be-9b22-454d-ae52-0b2fc5d90652",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3907,8 +3907,8 @@
       }
     },
     {
-      "uuid": "76a003d8-7a82-4c35-8a9d-3c1fc5777cfe",
-      "groupUuid": "d9ea7b42-9f35-4833-b334-6c6ac998386c",
+      "uuid": "61bccc12-4653-4fa8-92ab-08f990429089",
+      "groupUuid": "bceb40f1-f312-47d9-b156-9675c4234384",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3916,8 +3916,8 @@
       }
     },
     {
-      "uuid": "735d4768-4224-4bdb-b757-7393cc09027b",
-      "groupUuid": "48253422-a5b0-428d-866d-06128391463b",
+      "uuid": "9cfe8e48-2d0a-43a9-846e-09f5fac8a34c",
+      "groupUuid": "b23905c0-2643-4e22-8914-ace9dd048201",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3930,17 +3930,17 @@
       }
     },
     {
-      "uuid": "7f5c9a3b-9fb9-45b7-b269-aeac14b4ea70",
-      "groupUuid": "c1f4f423-4b6b-459f-b301-cc4de5a2cc94",
+      "uuid": "d44a47c3-c7d1-4a4e-bdcc-c6eb26f3c3a1",
+      "groupUuid": "fb7bc901-dd51-45dc-8f10-bc9550a9665c",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "c4663e9f-699e-4a0b-bda0-2ac6522edc8f",
-      "groupUuid": "d05152f0-3d17-44d2-8be2-55bd0c376756",
+      "uuid": "d83613e9-9a64-4a1e-80f2-264856da8463",
+      "groupUuid": "b3334cb1-abc1-43da-9277-0784fb8db0b2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3948,8 +3948,8 @@
       }
     },
     {
-      "uuid": "ec1d0ce7-5bc8-4633-8afd-f309ee18ab35",
-      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "uuid": "be9507c7-e9a2-41fb-8088-cc922bbd8c92",
+      "groupUuid": "239f6d27-f484-4dbb-9e91-5cbddcdd79d1",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3960,8 +3960,8 @@
       }
     },
     {
-      "uuid": "928bcf15-c92c-46f4-b584-42f98c3b09c2",
-      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "uuid": "45f9859f-8433-40f2-a94c-96ac03c153e3",
+      "groupUuid": "239f6d27-f484-4dbb-9e91-5cbddcdd79d1",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3972,8 +3972,8 @@
       }
     },
     {
-      "uuid": "7703379b-7698-42fa-af2e-e3700a4c9ef0",
-      "groupUuid": "e7252d91-63f3-459e-acd6-ad19e517e857",
+      "uuid": "28e99c43-3f92-4775-86c8-e3abc7290883",
+      "groupUuid": "239f6d27-f484-4dbb-9e91-5cbddcdd79d1",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3984,8 +3984,8 @@
       }
     },
     {
-      "uuid": "b6bcbb45-0bc3-44b7-b3f5-88074f352433",
-      "groupUuid": "24be422c-3d8f-40a8-bfd5-12ff06c85639",
+      "uuid": "317e9262-5ed1-4e55-b2a3-9df03b04ef68",
+      "groupUuid": "09041212-e0fe-48a0-ac04-c91aeed299b3",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3993,8 +3993,8 @@
       }
     },
     {
-      "uuid": "b55d712d-facd-4374-9610-67d4e6c3d42d",
-      "groupUuid": "4d90ab62-ae16-497a-b5bf-7e4a5a458026",
+      "uuid": "1aee4d25-9794-47ee-9f17-e6cccf9338e4",
+      "groupUuid": "f20265f1-5cab-4924-96c2-10b2a07ab34b",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4003,8 +4003,8 @@
       }
     },
     {
-      "uuid": "f09e722d-0aa8-4a17-bc31-4b21f9b2b7ab",
-      "groupUuid": "8eda2592-73c5-4544-b0c9-814586d43217",
+      "uuid": "a713dbb9-649e-4c89-8876-689f663bf682",
+      "groupUuid": "920b2c4b-4c2d-436e-8b37-f78883fb29ea",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4012,8 +4012,8 @@
       }
     },
     {
-      "uuid": "1562ece9-31bf-4c5e-a6ab-9e0183a15296",
-      "groupUuid": "daa66c77-b9f4-4a97-8a17-ad3cd0b70db2",
+      "uuid": "8a2da08a-05e8-4416-a464-850f572f2174",
+      "groupUuid": "6349b1bc-b1a3-4551-a78f-a8c9a4bef3d8",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4022,8 +4022,8 @@
       }
     },
     {
-      "uuid": "1609b609-312e-4eae-baef-cde68541d506",
-      "groupUuid": "1afca7be-ae91-4103-b0a7-7fea2ff907f7",
+      "uuid": "d465ceef-9a77-46b3-ba17-b2a68ae034ef",
+      "groupUuid": "b1b621f8-d1da-4d10-b465-540ff26e9ae8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4031,8 +4031,8 @@
       }
     },
     {
-      "uuid": "53642464-4748-49ae-81fb-5c1409092f0e",
-      "groupUuid": "f7c8b1b9-53f6-4716-9cde-bb662e464bad",
+      "uuid": "ab240d8e-4661-47a9-9a18-d325e2bdf0cb",
+      "groupUuid": "0fba73be-5428-4197-9f2a-70d52d8256b5",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4041,8 +4041,8 @@
       }
     },
     {
-      "uuid": "10d04e92-75e4-4220-97c4-1d0ba2b73381",
-      "groupUuid": "31f47114-36cb-4619-ac3d-0406c68ce935",
+      "uuid": "cd3806b5-00b2-4631-b77d-3f96e0e41f2c",
+      "groupUuid": "c0a111d2-a19a-46ff-8027-a3c6d3a938ff",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4050,8 +4050,8 @@
       }
     },
     {
-      "uuid": "a2d41cfe-16bc-4706-aab8-c96c849ff2a1",
-      "groupUuid": "3b9f3e3d-a747-44ef-8076-5aaa7e695c4c",
+      "uuid": "3461c920-be5d-4fdf-9ae5-5364bcbfd084",
+      "groupUuid": "86a4fff8-16ae-4a45-8b53-9271e7c5dc11",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4064,17 +4064,17 @@
       }
     },
     {
-      "uuid": "bbc755f1-ae8f-41bc-badb-9a0328c62178",
-      "groupUuid": "8caab9a4-e731-4e2a-88db-56cf8d9efbda",
+      "uuid": "92906a23-398c-4007-9b01-014fc44cafe7",
+      "groupUuid": "1d162f99-c36e-4251-b040-899f34b740e8",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "b330e663-8d21-44e1-8ab8-b7425776f9d2",
-      "groupUuid": "88d4e4f1-8966-41a4-a346-4ae83b7e4f34",
+      "uuid": "42f5d33b-8d8f-4a6d-8aff-892af8ad0d9e",
+      "groupUuid": "d3525e7f-f8f7-4015-b263-d371a8f04a12",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4082,8 +4082,8 @@
       }
     },
     {
-      "uuid": "3c1f5e1e-5199-4010-a303-26b0e852aa01",
-      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "uuid": "e5233241-cc9a-4ed6-ac79-b32fa8348906",
+      "groupUuid": "d8b18563-6834-4f65-bb37-db914206c1f9",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4094,8 +4094,8 @@
       }
     },
     {
-      "uuid": "5e3374c5-1be0-4fed-96ad-9d9b08df5bda",
-      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "uuid": "01753435-4d29-4b69-8b95-417705ef83bd",
+      "groupUuid": "d8b18563-6834-4f65-bb37-db914206c1f9",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4106,8 +4106,8 @@
       }
     },
     {
-      "uuid": "2a61edea-62f1-4627-be45-028a0397d189",
-      "groupUuid": "eac59670-3ee8-40c7-9521-ba395ec80216",
+      "uuid": "1c60760c-b2cb-42b5-ae18-6709f2119383",
+      "groupUuid": "d8b18563-6834-4f65-bb37-db914206c1f9",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4118,8 +4118,8 @@
       }
     },
     {
-      "uuid": "2b746dcd-c854-4c5a-851a-93a515131280",
-      "groupUuid": "61b66e4d-638e-4b74-a40d-979f40628828",
+      "uuid": "24888c4e-f0e9-4ff6-a70d-a66e86d4898a",
+      "groupUuid": "507cf1d7-ff76-4c4e-8296-d1334883fe78",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4127,8 +4127,8 @@
       }
     },
     {
-      "uuid": "0041b049-1326-4d67-be24-78ea30cb4c82",
-      "groupUuid": "f52167a9-f5fa-4150-ad55-5d78c6ca59b4",
+      "uuid": "506672f8-88b1-4fdf-aad0-c870cba80994",
+      "groupUuid": "7855f898-e112-4cf9-bcb9-3508e29af04f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4137,8 +4137,8 @@
       }
     },
     {
-      "uuid": "c41278c8-ca8c-4493-8c37-edef82b195b8",
-      "groupUuid": "f6ec9c01-9f8c-403d-aec5-32f895d43636",
+      "uuid": "411d10f4-f2c3-40ea-931e-14a006c7123a",
+      "groupUuid": "a21e7c6b-fe8b-40be-8a2b-b853490aabc1",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4146,8 +4146,8 @@
       }
     },
     {
-      "uuid": "f38a3dbe-edf4-40ef-8ef6-acb9fe6ccc43",
-      "groupUuid": "38af79bb-dada-4359-9978-053f858f6ecb",
+      "uuid": "664e8f78-02dd-4064-9bd9-c9618d938c1f",
+      "groupUuid": "0c1db91b-10dc-438b-b8a1-e3caea41d006",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4156,8 +4156,8 @@
       }
     },
     {
-      "uuid": "4d11da57-9c96-4aa4-90ab-a1b4351c6188",
-      "groupUuid": "3582b87a-1bf0-4314-a139-84d295bfbb96",
+      "uuid": "3c10318e-f498-4d48-819c-6f406b0b3e64",
+      "groupUuid": "1adaa31e-256d-4ecd-b05d-d4e0203efbc5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4165,8 +4165,8 @@
       }
     },
     {
-      "uuid": "a8a3fb93-b0f1-4c2c-b7ea-7b906b82339f",
-      "groupUuid": "cb745dfa-4047-4b72-b9ee-0fad8734a5f1",
+      "uuid": "a5b791e7-b172-403a-82ad-21250d8dadcf",
+      "groupUuid": "3619fd32-f765-4724-9c12-6716e808a37b",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4175,8 +4175,8 @@
       }
     },
     {
-      "uuid": "1a60895c-5dea-454a-9b4b-0978a946439c",
-      "groupUuid": "4b781c97-ed6c-472c-afe8-249f17c9977a",
+      "uuid": "88150b73-e887-4913-89fc-4b576d92ab12",
+      "groupUuid": "2454743b-ae62-4e19-b6ca-86ecb5cfb119",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4184,8 +4184,8 @@
       }
     },
     {
-      "uuid": "83ff6013-d41f-4c22-9e57-0b667f85c468",
-      "groupUuid": "f3e4626e-dfb8-4470-ae24-8137331f845b",
+      "uuid": "16790705-126f-49bd-a065-51f27f3dbd8a",
+      "groupUuid": "d057204a-1d11-4d17-be5e-182ee294ac49",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4198,17 +4198,17 @@
       }
     },
     {
-      "uuid": "d8d5dc7e-fa19-4da1-8c05-afcd7553deae",
-      "groupUuid": "d38fe8c2-0651-4924-bdb5-be3828bc981e",
+      "uuid": "e2d6e111-0568-45c9-ac96-9e210f715070",
+      "groupUuid": "aa0c119b-e175-4b55-8dd0-86502597ddd1",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "704e92ef-c7e4-4faa-9578-b5efe718b211",
-      "groupUuid": "3fb55df2-f23d-4c6e-9401-89a7b22a632d",
+      "uuid": "11b16fda-6bce-4812-b866-1145cc9397b7",
+      "groupUuid": "b3ddbf2b-61c8-4225-950b-7338ee357196",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4216,8 +4216,8 @@
       }
     },
     {
-      "uuid": "62e0bab2-efc9-4ef7-9807-19d70fd67fbd",
-      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "uuid": "05d5a581-5064-4d52-ba3a-0f6181edfbed",
+      "groupUuid": "d50dc337-4677-4673-aed0-8a0f06e753c0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4228,8 +4228,8 @@
       }
     },
     {
-      "uuid": "48762723-d6ea-4591-aab1-22bc204c3ad9",
-      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "uuid": "b1ddd00e-c771-4637-bc2a-7277f026361d",
+      "groupUuid": "d50dc337-4677-4673-aed0-8a0f06e753c0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4240,8 +4240,8 @@
       }
     },
     {
-      "uuid": "dda979e2-da0b-4b79-be6d-a33e9a3d11df",
-      "groupUuid": "a3a5c253-4aa6-4072-9361-246e5dc1f872",
+      "uuid": "0f5678ae-1367-41af-8078-e4d562edb7fa",
+      "groupUuid": "d50dc337-4677-4673-aed0-8a0f06e753c0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4252,8 +4252,8 @@
       }
     },
     {
-      "uuid": "a93284cc-8b00-4f2e-b29e-d167651a0c36",
-      "groupUuid": "b6c0745e-7e20-48ef-8b92-7c72c118551b",
+      "uuid": "9b1fd16a-a150-4f53-88b3-c0e46eef4b84",
+      "groupUuid": "4c747dd2-430a-4a0f-b7b6-94d9b24d4a5e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4261,8 +4261,8 @@
       }
     },
     {
-      "uuid": "e99c499c-3461-40e4-801a-dd8d15292858",
-      "groupUuid": "3be7be1f-8fb1-40ae-9250-d65e127d5f72",
+      "uuid": "65a8f202-2e19-4206-a333-b233d293294c",
+      "groupUuid": "b2d01d9e-8a03-4b04-91e4-3716558e41f4",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4271,8 +4271,8 @@
       }
     },
     {
-      "uuid": "710b3691-3e19-418e-852c-90e2d820156b",
-      "groupUuid": "3a8923de-3366-4498-bacc-41a6e3e13291",
+      "uuid": "c119c314-82ca-4dd7-b5c3-b3e813cbb23f",
+      "groupUuid": "bc34cfff-efdf-4bb7-bf4f-32c81cf7a487",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4280,8 +4280,8 @@
       }
     },
     {
-      "uuid": "447f8ba8-79d6-4ecd-9b2a-dee4b15671d6",
-      "groupUuid": "75ea663d-1fff-4ef0-8440-f5182edcb820",
+      "uuid": "e55774c0-3db1-47bc-b7cf-f78f06f6e1a4",
+      "groupUuid": "979d2e53-7946-4824-863f-6b8bb6caafcd",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4290,8 +4290,8 @@
       }
     },
     {
-      "uuid": "bd6bc455-da4d-45d3-a4a6-73550f2d6fb3",
-      "groupUuid": "d4bf8965-f964-45a5-8073-51a7f1eff855",
+      "uuid": "ff1711b1-e698-4ea6-bff4-dc3d77f6f60d",
+      "groupUuid": "50740c00-2dc6-4d44-8bc9-f5cf11a3f653",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4299,8 +4299,8 @@
       }
     },
     {
-      "uuid": "90acc9b8-3b4b-4b2a-8241-dc402a776b6c",
-      "groupUuid": "06c97a8c-9852-4494-ad12-154eb0d3c803",
+      "uuid": "e0ffb2f5-899f-4d84-bbb0-3d964e85f611",
+      "groupUuid": "f27322db-9903-4281-aa7f-1a10cb8a8c8f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4309,8 +4309,8 @@
       }
     },
     {
-      "uuid": "7e2c05fb-2b0a-429a-9c0e-a2e684d2f31f",
-      "groupUuid": "99200043-f960-4ca0-8549-287b5c6d851d",
+      "uuid": "25ad9037-c9d1-40e0-87c8-bcc71497ba92",
+      "groupUuid": "07d49550-67c8-4734-94fa-6bf70928bec2",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4318,8 +4318,8 @@
       }
     },
     {
-      "uuid": "c9a1bedc-da64-44b3-9f74-99e943991c9b",
-      "groupUuid": "a75e5e70-fb98-47ad-9537-c75845e080a3",
+      "uuid": "746ff797-3d75-412a-ba8e-d007e9ee4cc3",
+      "groupUuid": "fb6fd81a-c83f-4af2-a7ac-d6d19eab754c",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4332,17 +4332,17 @@
       }
     },
     {
-      "uuid": "f8a5d71c-6daa-4dfd-addf-29843b73123d",
-      "groupUuid": "ee7414e7-d1ed-41da-bf60-0d404c11ffac",
+      "uuid": "abfc74fe-bfad-458e-899b-ab4369bff91c",
+      "groupUuid": "32936ef1-85e6-47c3-8719-3af54534bff9",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "f23a21a4-6213-4b37-a8fa-85cbc53fe85b",
-      "groupUuid": "7b99ad0d-bb17-48ae-af25-c4da47cc030d",
+      "uuid": "2a6ac9ea-2dcf-40e4-8eb8-672e3555838a",
+      "groupUuid": "bd32da2a-7a44-462a-83bf-13866e94791c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4350,8 +4350,8 @@
       }
     },
     {
-      "uuid": "d31fd062-0c1c-49e5-95b2-f87e9440f0f6",
-      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "uuid": "fe46b267-9721-4140-8fe1-4a4f028490bd",
+      "groupUuid": "fcbd104f-5873-4d52-91ab-34377ba9367e",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4362,8 +4362,8 @@
       }
     },
     {
-      "uuid": "6ecb827f-924c-462f-9409-8b489677e2bc",
-      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "uuid": "6ffa8c41-bfc8-46c0-b57d-dabdc1d30c22",
+      "groupUuid": "fcbd104f-5873-4d52-91ab-34377ba9367e",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4374,8 +4374,8 @@
       }
     },
     {
-      "uuid": "822f52ce-58c7-4a23-88ac-ff8427f1051d",
-      "groupUuid": "44825cc8-2dd9-4049-a7de-81c2688d689a",
+      "uuid": "afcdde41-7acb-42dc-a4f4-c525f5c2937c",
+      "groupUuid": "fcbd104f-5873-4d52-91ab-34377ba9367e",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4386,8 +4386,8 @@
       }
     },
     {
-      "uuid": "4bbcea86-d1a4-4622-869b-5403e8fb6376",
-      "groupUuid": "da7d32fb-8ac9-49d8-9192-a96df3f596ab",
+      "uuid": "81b47524-d5c0-4ef6-b8e2-dd244157f2d6",
+      "groupUuid": "ce9760d4-3605-49d7-b461-74b2c9a71edf",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4395,8 +4395,8 @@
       }
     },
     {
-      "uuid": "2269e23c-e57c-4b21-afe9-cf3a627be500",
-      "groupUuid": "7dfb4883-ced5-49da-856a-66ef24005cf2",
+      "uuid": "aa83d95d-377c-44ff-9b25-55a88fccc631",
+      "groupUuid": "b382813b-03de-465b-9f91-8ced4b07eca4",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4405,8 +4405,8 @@
       }
     },
     {
-      "uuid": "f890183f-b1ba-4b10-8e60-3d600fc14aa6",
-      "groupUuid": "4f3f50e1-232c-4234-a037-fd33f345da99",
+      "uuid": "fa7c1897-cd62-4478-bda6-30f50295fff6",
+      "groupUuid": "4957cf7c-2a8f-472a-833e-463854af0f94",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4414,8 +4414,8 @@
       }
     },
     {
-      "uuid": "780e39a3-fb2c-429d-8e4d-e610b0857650",
-      "groupUuid": "0aef3d67-a9a4-4b19-b831-8f9478704376",
+      "uuid": "2e4475ff-4d69-4194-ab3e-6f3b231474e6",
+      "groupUuid": "a880c370-5a72-451d-b466-d72f73180e7b",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4424,8 +4424,8 @@
       }
     },
     {
-      "uuid": "0f53e3ec-60f6-43c4-a75e-1862666ef74f",
-      "groupUuid": "4f370fba-3333-4f31-9419-9525aebc115c",
+      "uuid": "490de3c6-3b65-43a8-823b-f05c19a7f448",
+      "groupUuid": "fa1c0c00-66e2-434d-ac29-8fa55a087944",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4433,8 +4433,8 @@
       }
     },
     {
-      "uuid": "baee42ce-5cf3-4384-99bd-b77024cf06ee",
-      "groupUuid": "6f10d5e8-f4fa-4124-b085-7bbf54a214ba",
+      "uuid": "2c0dccd5-ea8e-4198-b531-417752dcfd42",
+      "groupUuid": "d95ee9ea-fe9a-4801-8c5f-6de25e6b39bb",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4443,8 +4443,8 @@
       }
     },
     {
-      "uuid": "f3985f15-17a3-4a42-b479-098942107e6e",
-      "groupUuid": "6751482b-e9ae-492e-8738-91ca3ac98145",
+      "uuid": "0c90ae11-c5a5-4eb6-85a4-74f7c8c23f59",
+      "groupUuid": "51f71be1-435b-47d5-87e5-6c194b4e4d44",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4452,8 +4452,8 @@
       }
     },
     {
-      "uuid": "4f10d424-353e-4a26-9054-c735d917740a",
-      "groupUuid": "4d9631d2-3f0c-4e08-ae7c-f5c61314d80f",
+      "uuid": "a36de668-3455-4dc8-ab25-80f0cf91c3aa",
+      "groupUuid": "300e3cf0-c43c-403d-a0b6-bea433d76d52",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4466,17 +4466,17 @@
       }
     },
     {
-      "uuid": "b55c3010-0c91-4a5d-b710-7c8ad24b78f0",
-      "groupUuid": "4e5ca35d-b579-4bdb-bff3-0e113e3c94c5",
+      "uuid": "58dab944-17f9-4f9a-a060-9a43471f9765",
+      "groupUuid": "e5e999c9-ec7e-44f1-ba66-f7945bee261d",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
       }
     },
     {
-      "uuid": "82f4f857-fa33-43be-baf1-fbfc4deb6d16",
-      "groupUuid": "15fe72f9-d7b3-49fa-8bab-eaeedd92d7e1",
+      "uuid": "9e2ad76f-483c-4207-a97c-981e994d41cb",
+      "groupUuid": "437b6b4a-0c9c-4a6f-83e6-4c72ced3f863",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4484,8 +4484,8 @@
       }
     },
     {
-      "uuid": "eb2991c2-7fd1-4ee8-822a-6e3e0868c3d9",
-      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "uuid": "fe11dda3-5ecd-4137-926c-4ab32562319b",
+      "groupUuid": "1dc76600-eb76-463f-bbc7-d3cc4a3f0347",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4496,8 +4496,8 @@
       }
     },
     {
-      "uuid": "9aaf42b4-91b5-4046-b476-adca1ff38f32",
-      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "uuid": "e0cee4b8-5e78-42d2-980f-2c5f1f2955c9",
+      "groupUuid": "1dc76600-eb76-463f-bbc7-d3cc4a3f0347",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4508,8 +4508,8 @@
       }
     },
     {
-      "uuid": "31ec2b6e-2038-4072-b831-61efff7a250d",
-      "groupUuid": "3e9aedb3-e0f3-4969-8fcc-656a60535472",
+      "uuid": "eb7c7650-8a70-4bbe-9bb0-62cf521aa569",
+      "groupUuid": "1dc76600-eb76-463f-bbc7-d3cc4a3f0347",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4520,8 +4520,8 @@
       }
     },
     {
-      "uuid": "52a6fad0-62d7-431c-8e4f-30b1240f08a6",
-      "groupUuid": "cecc01e0-09b5-492e-bc3d-6ae17747db86",
+      "uuid": "13836698-91d3-4d7a-84f8-fcf01b1cc1bb",
+      "groupUuid": "00cc27c8-d393-4282-8e4a-7c5bf3b9b662",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4529,8 +4529,8 @@
       }
     },
     {
-      "uuid": "9e059961-e344-475b-9638-7bab716b21b5",
-      "groupUuid": "c437e3be-5cfb-4d56-80eb-970a547d5407",
+      "uuid": "e9820153-ca59-4a98-9e74-c119b04132ed",
+      "groupUuid": "aa60c86a-cd87-4fda-bc68-2bae1bdda50c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4539,8 +4539,8 @@
       }
     },
     {
-      "uuid": "fba2eb5f-ec02-4b1c-b963-57ccc2ace98e",
-      "groupUuid": "4c94d566-75d6-453e-b241-4a540e47a1f9",
+      "uuid": "466fb8bf-0d36-4b0d-af09-b6d2c99e4833",
+      "groupUuid": "c4c89059-2a8d-4329-9f93-ca50e8e51e71",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4548,8 +4548,8 @@
       }
     },
     {
-      "uuid": "74deaa7b-6fb3-43d2-b8aa-e508089e0cd9",
-      "groupUuid": "2ff2989b-66dc-4fda-b017-ab287a47e417",
+      "uuid": "cfcf491f-d383-46ab-8140-995413e02f23",
+      "groupUuid": "e166e22b-76e3-456e-b995-466b51c3c3b4",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4558,8 +4558,8 @@
       }
     },
     {
-      "uuid": "3f27431b-be65-42ec-b1ec-97aa274ee5b6",
-      "groupUuid": "87c264be-e5d7-4fc7-972b-6edec7b062a2",
+      "uuid": "0a3f5eb8-cdcf-40b5-b9c0-8583ee8ea7ad",
+      "groupUuid": "62be65bb-1df4-42d8-9f80-7c7905c30436",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4567,8 +4567,8 @@
       }
     },
     {
-      "uuid": "9f7c386c-6a52-4df2-b8b0-95270ad3c06a",
-      "groupUuid": "107ce4c4-ff95-4690-8b89-4042cadc02a4",
+      "uuid": "68df2ec8-b3c0-407a-93f3-b8bee8594584",
+      "groupUuid": "f22db7b4-706c-41ca-b4df-069ebc6e195d",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4577,8 +4577,8 @@
       }
     },
     {
-      "uuid": "540af974-410e-4921-a3fe-c83f7166cdbf",
-      "groupUuid": "f09af9a9-c629-46d3-906f-a35c3c50cd60",
+      "uuid": "3a1686fc-6b82-41b8-a14c-b76ca1fd8b38",
+      "groupUuid": "d53bbdb9-de2b-4c3e-8307-d48f455ae1e4",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4586,8 +4586,8 @@
       }
     },
     {
-      "uuid": "eb88a477-f9b7-47c8-8d85-512a9181f05c",
-      "groupUuid": "7edb913e-b507-45d5-9a95-f63422108a3c",
+      "uuid": "3c01f7a6-1567-4022-ba37-fbdd67e76f8f",
+      "groupUuid": "fe2c5357-750c-40f9-86ec-f0cb304a6b91",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4600,17 +4600,17 @@
       }
     },
     {
-      "uuid": "0c70071d-d600-4133-912f-9e6ef3474d55",
-      "groupUuid": "4d9bca08-d6e8-46df-aa05-eb75d454bcda",
+      "uuid": "ab9014a7-d613-439f-b255-62a27e30aa10",
+      "groupUuid": "84052375-8c4f-4196-ba6e-5703beb23338",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "b9e47d34-3123-46c9-a90d-1e72502f5544",
-      "groupUuid": "44249be5-a373-40c3-8566-6a49f744a26c",
+      "uuid": "0b69c4eb-2c39-43bc-942a-a836f7765e15",
+      "groupUuid": "2cd842f0-e1ca-4280-82bb-32c7bc0af104",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4618,8 +4618,8 @@
       }
     },
     {
-      "uuid": "a3be660f-fb8c-4b84-bb32-a665ac6298b1",
-      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "uuid": "d8a73666-82ed-49ab-aaf6-5a5e02d7e522",
+      "groupUuid": "fc3e73be-ff47-4a98-8986-1d9161a58fce",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4630,8 +4630,8 @@
       }
     },
     {
-      "uuid": "32fa9687-60a6-4b5c-b393-94a4199c7921",
-      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "uuid": "74a7416f-5ca5-4ed0-81f6-138421822f77",
+      "groupUuid": "fc3e73be-ff47-4a98-8986-1d9161a58fce",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4642,8 +4642,8 @@
       }
     },
     {
-      "uuid": "90debe20-30c7-46a5-80e0-3ba839590e07",
-      "groupUuid": "6a6ad047-8c74-4024-9151-0eb81313edb0",
+      "uuid": "3ad5e2a1-012b-4a76-85f0-d79454f3f1e0",
+      "groupUuid": "fc3e73be-ff47-4a98-8986-1d9161a58fce",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4654,8 +4654,8 @@
       }
     },
     {
-      "uuid": "7f812914-2f50-4a68-8f9c-997ef697f08b",
-      "groupUuid": "beb4ba6d-c346-48c1-a37b-8029e06e1b83",
+      "uuid": "37223fe3-af15-4e09-8abc-5e6111a90e0d",
+      "groupUuid": "377b842a-e969-497f-a256-a8a05cb75c1f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4663,8 +4663,8 @@
       }
     },
     {
-      "uuid": "1bdf0fe8-194d-4e64-b015-8b1f40e3755b",
-      "groupUuid": "c04a8432-db5b-415a-bd9c-e78dc3019458",
+      "uuid": "c4ea283a-bd36-4dd5-9ff2-223e19ff358b",
+      "groupUuid": "4f9ce44b-1d75-4606-9eea-1dc7de02fe5c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4673,8 +4673,8 @@
       }
     },
     {
-      "uuid": "6cb126b1-7c3e-44fa-8f25-2d682a97947b",
-      "groupUuid": "759a00fc-58d8-4de3-9929-488dace52c3a",
+      "uuid": "353976f0-9522-4c71-91dc-fe089b22ffc6",
+      "groupUuid": "c0f4f57b-26a5-4eee-8ee0-bd02450b0d60",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4682,8 +4682,8 @@
       }
     },
     {
-      "uuid": "c2b202ae-dee7-43ff-8f53-ddcd7efec2cf",
-      "groupUuid": "dd854663-508b-4c98-ade6-ce49459b5f5d",
+      "uuid": "1b065373-f6be-4be8-9d5c-180beed8734c",
+      "groupUuid": "e97495f7-f7a1-480f-bc12-c1638a102eeb",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4692,8 +4692,8 @@
       }
     },
     {
-      "uuid": "be128ac4-7163-4062-91dd-59268e3852e4",
-      "groupUuid": "473feb67-5c5d-427a-a1f8-d9205b25c9a4",
+      "uuid": "6a053db5-9b27-4eee-b6a1-20670993152f",
+      "groupUuid": "3f88b509-72a8-4a29-88e7-b971720d3dd8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4701,8 +4701,8 @@
       }
     },
     {
-      "uuid": "f05aab3b-9863-4e11-94bf-9d8034322227",
-      "groupUuid": "d278fbb4-4b00-4975-8ffa-1d1c29f3bf60",
+      "uuid": "863c6e43-cfb2-49af-9312-677dd848a740",
+      "groupUuid": "24eb47d9-2f34-4e77-bd5e-4700240ee299",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4711,8 +4711,8 @@
       }
     },
     {
-      "uuid": "8eb46136-05b0-4cbe-8b65-a3fc31295551",
-      "groupUuid": "ae59d0ec-1f30-4cbf-b4b0-55b49b09bc98",
+      "uuid": "c0d1e360-7d44-4bc8-a420-6125518eb618",
+      "groupUuid": "a164c7a6-3d9b-49d3-ad12-c125e0498e09",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4720,8 +4720,8 @@
       }
     },
     {
-      "uuid": "81f38b43-948c-43be-bf9b-639be6f34ddc",
-      "groupUuid": "dfe387ee-d181-4d99-99e3-14223ce7618d",
+      "uuid": "7bb802e6-e9a5-412f-821d-3f14310c5641",
+      "groupUuid": "71affffd-73d8-4551-8f45-5aba1fb18b30",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4734,17 +4734,17 @@
       }
     },
     {
-      "uuid": "d5b18c19-87bd-45e7-9d35-2f55334841ac",
-      "groupUuid": "e6c40021-d763-4c73-94bc-ea82f889de8b",
+      "uuid": "b63043c9-aa69-46cf-b69a-b9f09673e06c",
+      "groupUuid": "acb4f4ad-e77c-435e-ad03-912000de426b",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "ad5748ed-8d62-43cf-b2b6-0e596a559cc6",
-      "groupUuid": "37406597-740e-42c6-8852-4503010b0f4b",
+      "uuid": "8207d948-0ebd-4740-bbc0-d49b0f7295de",
+      "groupUuid": "8d74fc05-8fb7-4c2a-bc18-2c9b3c50da40",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4752,8 +4752,8 @@
       }
     },
     {
-      "uuid": "7dd6148a-51a7-4ad1-9c93-357aea06b927",
-      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "uuid": "0df40b0d-81c5-43e0-8df4-24df9422cf07",
+      "groupUuid": "cd2944f4-ac45-469c-bbbc-cadb06292995",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4764,8 +4764,8 @@
       }
     },
     {
-      "uuid": "6b770d8f-4940-4a87-90c0-d1585d320110",
-      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "uuid": "1bb94431-fdf8-4c7d-a732-a4fd645f4e9c",
+      "groupUuid": "cd2944f4-ac45-469c-bbbc-cadb06292995",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4776,8 +4776,8 @@
       }
     },
     {
-      "uuid": "32fb6d6c-f0a2-4f49-a985-6f0a73a1ebf4",
-      "groupUuid": "cfb5e8d9-45ec-46c0-9b5e-f4c57c6f655d",
+      "uuid": "1fd9aba4-cd4f-4127-91b4-dcba7e58ebb6",
+      "groupUuid": "cd2944f4-ac45-469c-bbbc-cadb06292995",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4788,8 +4788,8 @@
       }
     },
     {
-      "uuid": "b051be56-d851-489c-b254-1bc8d214485e",
-      "groupUuid": "7eff275c-5e24-44ee-9801-60544dfacc5f",
+      "uuid": "0ca27988-43bc-46ce-ae92-7e12b28be0a1",
+      "groupUuid": "668e4e7a-ba38-49ba-a59f-24730d99b132",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4797,8 +4797,8 @@
       }
     },
     {
-      "uuid": "1f10520f-7812-43cd-aa4d-3f0753443201",
-      "groupUuid": "593923ee-24f2-4170-bb13-5235a6ee3cde",
+      "uuid": "d458dff5-fdd3-4546-9a65-843610e3fb6b",
+      "groupUuid": "990eff4f-1aa7-49b3-9a8f-3b20c15a199f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4807,8 +4807,8 @@
       }
     },
     {
-      "uuid": "f59ecffe-f7db-465c-a0af-3b46ea3cdb3a",
-      "groupUuid": "82d9ec75-7da2-4d7c-bf9f-d416ba1cf8b3",
+      "uuid": "55490013-d6c3-41d5-a876-a76356492e26",
+      "groupUuid": "52c22eca-2efc-4df8-a995-010531bd290a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4816,8 +4816,8 @@
       }
     },
     {
-      "uuid": "ae08a343-d516-40c8-8a27-03a497f7cd81",
-      "groupUuid": "b35ddb7a-74a1-49a6-97e7-ced3ac2db8a0",
+      "uuid": "40198c1f-7a27-4a1c-8d79-38ef38c41008",
+      "groupUuid": "b30f3eaa-26a1-4ca6-a0b4-ba7279863734",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4826,8 +4826,8 @@
       }
     },
     {
-      "uuid": "92ffd682-d5c4-437a-b473-fb3d832a03ce",
-      "groupUuid": "67197438-7292-4f6f-a73b-deae742efb49",
+      "uuid": "28651ea8-b7d6-48a5-9827-afa0f2b41d68",
+      "groupUuid": "d9af0262-ec42-4477-896c-4cad5b27b1a4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4835,8 +4835,8 @@
       }
     },
     {
-      "uuid": "52fc03ee-4e03-48bb-b03e-09a02df5a8eb",
-      "groupUuid": "cc24b9d2-414b-48e8-811e-d5c7e7787acb",
+      "uuid": "4e48a36a-4bd2-4933-aab8-9591290a160b",
+      "groupUuid": "76fe64a5-ad83-4a56-bad1-d3418dd82169",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4845,8 +4845,8 @@
       }
     },
     {
-      "uuid": "232dc08b-e21b-4832-baa8-0d4334e2c940",
-      "groupUuid": "1208053c-0fe5-458b-b8f4-9c96ff340cbf",
+      "uuid": "1fb55ac4-9ab8-4715-b42a-a396e90d921b",
+      "groupUuid": "b1628805-e982-4f55-ae0c-8f7efd3418b2",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4854,8 +4854,8 @@
       }
     },
     {
-      "uuid": "7ced6855-7a32-4b26-914d-0cf290633dc9",
-      "groupUuid": "dd17e6b2-6d76-4202-99b9-e40c05c2b295",
+      "uuid": "78868799-9261-4d53-8c11-447cb919bbd8",
+      "groupUuid": "d21272e1-969c-43cf-aa37-14b4c16250b3",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4868,17 +4868,17 @@
       }
     },
     {
-      "uuid": "75f9a1ff-685d-49c4-90be-b2974d139eff",
-      "groupUuid": "bf61dba3-bf9d-44ba-8580-c562eb3cdd6d",
+      "uuid": "48af34e6-ecb5-4d8c-b445-b20195873d14",
+      "groupUuid": "fc36abf4-ca5f-4796-9b2b-0427cd26a791",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
       }
     },
     {
-      "uuid": "d1eb1c91-25e4-4916-be9d-1c5672af1351",
-      "groupUuid": "4313f6ad-2ccb-490d-99bb-a09e923ce2bb",
+      "uuid": "64589f36-8dc1-4d48-94aa-b080af3f4bfa",
+      "groupUuid": "bc0f1e8c-bd6b-4f23-a2ce-deb02fb3b474",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4886,8 +4886,8 @@
       }
     },
     {
-      "uuid": "5be51fa9-a86b-465c-8b57-a2369a820e1a",
-      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "uuid": "dfefc5b6-bddc-452b-aa7d-5ef27646b9ee",
+      "groupUuid": "29d9ba45-0467-4852-bfdf-e967ad6e1957",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4898,8 +4898,8 @@
       }
     },
     {
-      "uuid": "a6cff27b-bd8d-4f73-8d48-2c382c125ab6",
-      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "uuid": "b826b30b-5c8d-4fc4-a418-7d87fcc0935a",
+      "groupUuid": "29d9ba45-0467-4852-bfdf-e967ad6e1957",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4910,8 +4910,8 @@
       }
     },
     {
-      "uuid": "e9207b2d-d713-40af-ad56-48d707162750",
-      "groupUuid": "c32038ea-a926-4101-b7d0-c4a6ed4d6364",
+      "uuid": "e30e9e0d-0004-440c-841b-a22237c50be7",
+      "groupUuid": "29d9ba45-0467-4852-bfdf-e967ad6e1957",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4922,8 +4922,8 @@
       }
     },
     {
-      "uuid": "3fa4988a-592a-462d-9c6a-3cb28c03feed",
-      "groupUuid": "de373cf7-139e-4de8-b313-4888045ce285",
+      "uuid": "fd453882-2867-452d-8ce6-d3f4cdf7bd82",
+      "groupUuid": "672500e5-ea43-4a35-8a02-7fe3716d673d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4931,8 +4931,8 @@
       }
     },
     {
-      "uuid": "93536e09-3893-49da-9a42-087b5fbcf2cb",
-      "groupUuid": "8bd7de98-a394-4bc2-84f4-e3dbd6112553",
+      "uuid": "7fde6a4a-91e0-429c-af62-33487d91bb43",
+      "groupUuid": "772bb8d5-c9d7-42d5-b84c-40c7c7454c8c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4941,8 +4941,8 @@
       }
     },
     {
-      "uuid": "a901dcb8-0ba7-4536-a936-b1c289de65a3",
-      "groupUuid": "0d6495d0-ec2d-40c9-89d1-829c88315ccc",
+      "uuid": "0fb98255-2172-4432-837b-d0a29a98e310",
+      "groupUuid": "dc906de9-a641-4c86-be7e-efee4aca577a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4950,8 +4950,8 @@
       }
     },
     {
-      "uuid": "bb4d2678-4649-470f-a666-3c6fde16056c",
-      "groupUuid": "9077a51a-aaf9-44c1-b1b9-73dfa113011b",
+      "uuid": "c3a53426-16a3-416a-89d4-7b5b39630d3b",
+      "groupUuid": "0f6e12e9-e427-465f-bb58-330659d0553c",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4960,8 +4960,8 @@
       }
     },
     {
-      "uuid": "938a6718-03b1-48cb-928a-4c54983e416c",
-      "groupUuid": "e57695bd-e4bf-471c-a271-7c243de64ec5",
+      "uuid": "5e2dfc5e-f4e7-48eb-8ec1-0a0f83913c7b",
+      "groupUuid": "040aaf27-4515-4306-bc02-a11d60fd6ed4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4969,8 +4969,8 @@
       }
     },
     {
-      "uuid": "96fd01b3-c73b-46c3-b78c-46c3bb28c1a6",
-      "groupUuid": "6b8e8866-c830-4fd0-8db9-8b89630f8d45",
+      "uuid": "4c6e7de2-d4ae-46c8-868c-8400b3df1769",
+      "groupUuid": "07f21e76-50d4-4041-aea3-adae8320ea4a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4979,8 +4979,8 @@
       }
     },
     {
-      "uuid": "cea78dcd-ad6c-4c46-bf94-066b0c2dfdce",
-      "groupUuid": "9b9475fb-94e8-4403-87ae-d3bf980fe57a",
+      "uuid": "83a78ca6-f5f0-4319-9797-751da9ad36dd",
+      "groupUuid": "3c0f18be-1b38-40aa-9ae4-56eae2c8cb3f",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4988,8 +4988,8 @@
       }
     },
     {
-      "uuid": "84d3aeac-2012-4785-a2fc-7c3bf2ce913d",
-      "groupUuid": "0cdb76d1-34a2-47a2-8329-278eb3362409",
+      "uuid": "7b9cada4-202b-4e8c-b1b5-940d76188d06",
+      "groupUuid": "c61f6484-416e-4c29-ad09-329096b4c6cd",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5002,17 +5002,17 @@
       }
     },
     {
-      "uuid": "f9f0b036-a803-40db-8025-1fa52e8d5b63",
-      "groupUuid": "923a07c8-3d95-49d3-a8d7-dc221d32a40c",
+      "uuid": "ae631272-59a3-4465-99cd-1b3361216e2b",
+      "groupUuid": "29688d5d-a2ae-4a79-8a0b-f03c0e1c3ac4",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "087450d3-6935-4bd5-a64d-8b7c16289747",
-      "groupUuid": "daffe69e-3ff9-4968-b8e7-aae003b2aa9c",
+      "uuid": "ceedcd6f-b638-413d-b4eb-84b507b57a7b",
+      "groupUuid": "216c78be-52bb-43cc-b09f-051f93745a37",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5020,8 +5020,8 @@
       }
     },
     {
-      "uuid": "f449cb68-dfb8-4408-b28f-92d8cada0cea",
-      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "uuid": "035c858d-c1ff-422f-99fd-d98c87fb65fa",
+      "groupUuid": "eb4e2d00-e014-4acb-bf1f-cf32b86f375d",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5032,8 +5032,8 @@
       }
     },
     {
-      "uuid": "894a3453-d208-4931-a554-57591a446fcf",
-      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "uuid": "6ae12a7e-06a3-4e89-99eb-923e7cb12112",
+      "groupUuid": "eb4e2d00-e014-4acb-bf1f-cf32b86f375d",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5044,8 +5044,8 @@
       }
     },
     {
-      "uuid": "ca281e3d-d0d0-4a18-b8dc-350bcb16d226",
-      "groupUuid": "b552f655-a5c4-47c7-9550-bbe92948ae42",
+      "uuid": "02970e56-cb98-4ca8-a448-c81fca20d66c",
+      "groupUuid": "eb4e2d00-e014-4acb-bf1f-cf32b86f375d",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5056,8 +5056,8 @@
       }
     },
     {
-      "uuid": "b09a6df7-8c1e-401c-9e8b-e803ca2cf446",
-      "groupUuid": "ec19f04b-300e-4489-bebc-fdf18535040b",
+      "uuid": "cb9da38b-76f7-4c1e-850b-10bf16d2c1e6",
+      "groupUuid": "88b255c9-f02a-4232-bddd-8a78581cb688",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5065,8 +5065,8 @@
       }
     },
     {
-      "uuid": "8fd5435c-825d-4d95-95b7-7b578886aa8f",
-      "groupUuid": "03e64fc3-9939-4d50-ab61-a4a85163299a",
+      "uuid": "afe6ffeb-af65-4234-a8a1-e69f0351b80d",
+      "groupUuid": "343ffd28-38a9-47c9-b30a-6f5205e97908",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5075,8 +5075,8 @@
       }
     },
     {
-      "uuid": "d29c08b2-a484-4c0a-ba83-01ebed8ce627",
-      "groupUuid": "b3322519-6ce4-4912-a7b7-31b2d20bbbe5",
+      "uuid": "6ccd287d-c951-424c-b7bf-d288cecc002e",
+      "groupUuid": "df59a9c5-0eb8-4b67-9e3e-b3e8ec249606",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5084,8 +5084,8 @@
       }
     },
     {
-      "uuid": "e756a7f9-c7c6-4342-9e25-4632196087b9",
-      "groupUuid": "3cc32e7a-de2e-4b82-8b37-4f5baab45a9e",
+      "uuid": "87360e97-347f-4a90-9e54-73c971f55589",
+      "groupUuid": "82d037ae-b44b-4a5b-bd10-c9b61429d830",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5094,8 +5094,8 @@
       }
     },
     {
-      "uuid": "dae1a4ed-e1d2-4d04-b996-cb52d0d42594",
-      "groupUuid": "ddcd106f-e628-46d4-8b27-8b570dd1ccd0",
+      "uuid": "08bc456c-e2b7-4fec-b090-e973f3af190b",
+      "groupUuid": "efaa767a-7c30-49fc-a015-499815033e41",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5103,8 +5103,8 @@
       }
     },
     {
-      "uuid": "9e6de611-1416-4a3e-a99e-0d0c606def9b",
-      "groupUuid": "281f18ee-4fb7-4588-9546-22719cd1b00f",
+      "uuid": "2f9dd37e-f360-4ab6-8bf6-92c2e26c2fb7",
+      "groupUuid": "305e5511-040a-474f-8088-07c17b5cdc37",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5113,8 +5113,8 @@
       }
     },
     {
-      "uuid": "cd717f3f-faa5-44a0-ad36-1c706b761423",
-      "groupUuid": "d377f844-bf66-4666-97eb-9bf2903b77fb",
+      "uuid": "5a9faa25-951a-4eeb-bd29-3dc0c5b9d7fa",
+      "groupUuid": "96c9a1a4-2467-4088-8dd5-91c6607b2536",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5122,8 +5122,8 @@
       }
     },
     {
-      "uuid": "3ca55b51-43a4-44e3-9536-5984c1209ea0",
-      "groupUuid": "53ae336f-b6a3-4f65-92b4-e8f98de34c03",
+      "uuid": "2d854235-5524-481a-9e53-9ecd5956aceb",
+      "groupUuid": "76848fec-f91b-4824-8bbf-235c353f0540",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5136,17 +5136,17 @@
       }
     },
     {
-      "uuid": "8da1ddab-ccd5-4154-b5e2-70f2cb1682c2",
-      "groupUuid": "d16c0044-51ed-4548-852a-7857261bc1c8",
+      "uuid": "ab67d033-89b5-4766-ae32-301324e65585",
+      "groupUuid": "04ad5882-e26c-42dd-a9c1-ffc657fb920c",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
       }
     },
     {
-      "uuid": "93594701-d01e-4c73-af05-02b4bf954699",
-      "groupUuid": "066f7b3a-4b3a-4b99-b3ce-634cac8793b4",
+      "uuid": "a6d79c59-d8aa-40c5-a28a-f71bbfaf7a1e",
+      "groupUuid": "0c1c00a3-fb9c-442d-9d3e-1ede4753639c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5154,8 +5154,8 @@
       }
     },
     {
-      "uuid": "512230f8-d60a-4c48-a037-28d48477d972",
-      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "uuid": "0968e5b0-8893-46de-8762-66d5ce09a3b4",
+      "groupUuid": "53e0b35f-aef8-431f-9ccc-53a3db47efdd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5166,8 +5166,8 @@
       }
     },
     {
-      "uuid": "3ae0078b-0f6e-4db9-872e-849a66ba5f3a",
-      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "uuid": "e118727a-2815-41c4-b4dc-be724263319b",
+      "groupUuid": "53e0b35f-aef8-431f-9ccc-53a3db47efdd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5178,8 +5178,8 @@
       }
     },
     {
-      "uuid": "ce58c767-e5b7-4e87-b298-d76b71ac8c63",
-      "groupUuid": "119c1355-abfc-47ec-8978-3f8167da358a",
+      "uuid": "a994c38a-1018-450b-81e6-5b121b3bcc8b",
+      "groupUuid": "53e0b35f-aef8-431f-9ccc-53a3db47efdd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5190,8 +5190,8 @@
       }
     },
     {
-      "uuid": "6f4b698a-94ae-411e-8f2f-dc4228d3c08b",
-      "groupUuid": "7078bc81-018d-42ba-9a38-e271a635bcf1",
+      "uuid": "92fe496b-3969-4319-89aa-8cc0d82f4d2e",
+      "groupUuid": "30f75880-40f3-4b4d-a30a-9f4c65a2ee3a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5199,8 +5199,8 @@
       }
     },
     {
-      "uuid": "c02b42f2-8316-4e55-aa80-50bc8e37c606",
-      "groupUuid": "2fe7776a-81fb-4db4-b3dc-6ad54e7d862c",
+      "uuid": "269269b2-4e4b-43f1-9df6-5ccea876ec6e",
+      "groupUuid": "87b8cbf8-b405-4aa0-b0c9-d9947014ccc9",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5209,8 +5209,8 @@
       }
     },
     {
-      "uuid": "149433a8-0488-4852-9c58-f3319382440b",
-      "groupUuid": "1c846cce-e2f2-4ab0-affa-249ee7d93646",
+      "uuid": "40a97c95-beb9-4d8f-a22a-16ef25af915b",
+      "groupUuid": "dda82317-fa6c-4ce0-94fc-249ddf3fbc3b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5218,8 +5218,8 @@
       }
     },
     {
-      "uuid": "c1c3d8dc-01f8-42f2-9a05-f79afda31dff",
-      "groupUuid": "f411e5fd-8a11-4399-a85e-ce1706d4ac72",
+      "uuid": "fd39f73a-5c12-4bd1-be4d-7b3503fb02be",
+      "groupUuid": "10f0ce19-4a86-4263-ba74-d6b74e124041",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5228,8 +5228,8 @@
       }
     },
     {
-      "uuid": "2da639b7-5201-4aeb-a02b-d502cbb083c6",
-      "groupUuid": "a1789c38-e83b-4233-894a-a03ce4d23cd1",
+      "uuid": "24218b1e-df09-4fd5-8508-7789c047f202",
+      "groupUuid": "ec748780-ce4c-4f8a-87c9-6d7acb7f1f81",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5237,8 +5237,8 @@
       }
     },
     {
-      "uuid": "f9d6bf4a-29f0-4682-9529-e38f98482d33",
-      "groupUuid": "364bf539-5bae-46a0-95e3-8ad2044d09fb",
+      "uuid": "181cfe44-5cb4-4b15-ab22-d4658084ee1a",
+      "groupUuid": "4e4f43b7-c2ba-4deb-bb44-311388019712",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5247,8 +5247,8 @@
       }
     },
     {
-      "uuid": "2021dc12-242a-46be-83fa-61d466211dc2",
-      "groupUuid": "e6877e1a-b848-4510-a6cd-d2dc0b630dbd",
+      "uuid": "0b71f850-0116-4e56-8971-b61043961b62",
+      "groupUuid": "8e9eb49b-db65-4bd0-abc3-4a13b0fac82b",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5256,8 +5256,8 @@
       }
     },
     {
-      "uuid": "c1aa9fdf-d4fe-4f38-b801-e1556765a87a",
-      "groupUuid": "3edc32ee-6213-44da-94a2-45432357837c",
+      "uuid": "616ed4bb-738c-4914-91fe-edff25782b82",
+      "groupUuid": "0ab242ed-2318-4ac6-9806-7e14c357c4d2",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5270,17 +5270,17 @@
       }
     },
     {
-      "uuid": "926d95e2-26a6-4d1d-83d1-5369c0b188eb",
-      "groupUuid": "4f918e72-b5f1-4adc-9d96-aa43c5a9d147",
+      "uuid": "e89b3588-30c5-40c3-81bb-7a34da3d0a43",
+      "groupUuid": "42735189-19e6-4397-bf3e-327cce0e3336",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "27dcc1a0-a56c-47bf-b91e-84aa2eed5b3f",
-      "groupUuid": "158510f4-95cc-4d1a-93f0-f5fb5e9d9cb7",
+      "uuid": "d58f4b8c-0406-4ea2-b77f-3f1d00f9f907",
+      "groupUuid": "82a0fa71-96e9-4aa2-b0ed-a11ee532f256",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5288,8 +5288,8 @@
       }
     },
     {
-      "uuid": "ab5147d6-b641-4ce5-90f3-4aa2a10c6aeb",
-      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "uuid": "3f2a0220-5253-45cd-8ed0-88195b44fe8b",
+      "groupUuid": "e6e2894c-03c4-4897-9492-7aca22036c37",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5300,8 +5300,8 @@
       }
     },
     {
-      "uuid": "5058a6b6-bb41-496f-ae03-7ea4a74d63c5",
-      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "uuid": "93f32082-8bf6-43e4-910a-3c684ba193eb",
+      "groupUuid": "e6e2894c-03c4-4897-9492-7aca22036c37",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5312,8 +5312,8 @@
       }
     },
     {
-      "uuid": "7b51fa6c-b76f-483c-9b5a-50c592b6143b",
-      "groupUuid": "8078b639-07d8-4578-bb5a-1acbf86c3791",
+      "uuid": "65fc68c1-ef7c-47b3-a034-b9765ae50d6a",
+      "groupUuid": "e6e2894c-03c4-4897-9492-7aca22036c37",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5324,8 +5324,8 @@
       }
     },
     {
-      "uuid": "e6f8de25-08ad-443d-9f42-920634082e8c",
-      "groupUuid": "89c8809f-78ba-4e2d-bddd-b092dd3f964c",
+      "uuid": "20a9994b-824f-4f4c-93f5-a84da5379a63",
+      "groupUuid": "73a8b9c1-91a6-449b-b257-3c6cc828891a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5333,8 +5333,8 @@
       }
     },
     {
-      "uuid": "5e4272af-121a-4db9-acb2-197cecb063cf",
-      "groupUuid": "3609f407-2939-4cea-9404-2afc7b04ae82",
+      "uuid": "2cd97c16-0f01-47db-8d54-178727b37d6c",
+      "groupUuid": "5e1cd4ce-c3e3-4d5d-90d5-73cfea079707",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5343,8 +5343,8 @@
       }
     },
     {
-      "uuid": "c3f6a1d0-df19-4252-aa31-094b4e3180e9",
-      "groupUuid": "c0b3ac45-b745-4b04-bd25-b2848dc84201",
+      "uuid": "05e3098a-9799-473e-a9ec-c41d9369d71f",
+      "groupUuid": "ab3ce43f-3c5b-44b4-987b-05f2a3ce706d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5352,8 +5352,8 @@
       }
     },
     {
-      "uuid": "b73c522e-f4f3-41e9-b15f-b7da5ae20abe",
-      "groupUuid": "f0603486-ae8d-43f8-bd36-0bd1ce7431ed",
+      "uuid": "12ca7157-8216-484e-b4c9-1c6d210b825c",
+      "groupUuid": "efc84b19-f14e-45cc-a1ac-a7f4dace286b",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5362,8 +5362,8 @@
       }
     },
     {
-      "uuid": "b0e2c8d9-68b2-4264-95f2-9e6a73a237a6",
-      "groupUuid": "62fe6d88-d9cc-4b8a-ba49-ef062ef6f651",
+      "uuid": "41f4a69e-bc18-4e78-b6d3-7bda914a0b3b",
+      "groupUuid": "b01f1a1d-9073-488b-b3dd-4b4aa560233e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5371,8 +5371,8 @@
       }
     },
     {
-      "uuid": "3dbce3c8-dc32-4a4e-9dc5-761626afac13",
-      "groupUuid": "0d87c0ab-e550-476b-8c07-e3cfbb7aa5c8",
+      "uuid": "d33cfb1f-7882-4384-93af-945b4aefd77e",
+      "groupUuid": "05e0d3f3-272e-4df2-a43e-f2ad71b22b0f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5381,8 +5381,8 @@
       }
     },
     {
-      "uuid": "41b0a43d-31aa-4fa1-b57e-0853bed208cc",
-      "groupUuid": "99e62a30-1633-4f0b-a94a-b0a7aea9fde5",
+      "uuid": "03420e98-1fe5-4645-8534-dd4a1359775c",
+      "groupUuid": "4b522e22-4a80-482f-9130-b280ca309861",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5390,8 +5390,8 @@
       }
     },
     {
-      "uuid": "25f2a2a0-3588-42ab-8bf4-480edbe93bd7",
-      "groupUuid": "cab433a2-532a-4af0-927a-c84550ece947",
+      "uuid": "a9d52eac-4f5c-4e6c-a8eb-765c50aa829a",
+      "groupUuid": "e61c9e10-4c17-419f-8cc4-bb52528ca32d",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5404,17 +5404,17 @@
       }
     },
     {
-      "uuid": "6ff3fe6e-7685-4c54-80e8-fb223a309b7c",
-      "groupUuid": "eff12890-1016-4151-9c71-0bda6c31e731",
+      "uuid": "55bc0b52-8683-4bd3-9690-cf6401e61ae7",
+      "groupUuid": "9261c17a-1a8a-4433-8dd3-019fcf52e3c6",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "5753a587-471b-4385-8d2f-cba8ba589e1f",
-      "groupUuid": "a7eb12df-b85d-4562-b780-1ce420c45704",
+      "uuid": "0b5ec2c7-321b-40cc-9247-dabba689e919",
+      "groupUuid": "a303adc1-dbb0-49f8-8a64-5f7e7ecddd2b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5422,8 +5422,8 @@
       }
     },
     {
-      "uuid": "707de04a-b69e-4348-859b-fd04c2a23761",
-      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "uuid": "3737ef36-6ed7-46f1-83f1-465368652ef2",
+      "groupUuid": "be72e1b6-67f9-4b09-a140-955879dbc4ac",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5434,8 +5434,8 @@
       }
     },
     {
-      "uuid": "4f413638-a136-43d2-8741-0e7f0ddd5622",
-      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "uuid": "09fe4db8-3565-41f0-b461-2f93375e6f67",
+      "groupUuid": "be72e1b6-67f9-4b09-a140-955879dbc4ac",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5446,8 +5446,8 @@
       }
     },
     {
-      "uuid": "8b4e6c46-b7f8-44d6-818b-1ceaaa54deb4",
-      "groupUuid": "6ef839be-869d-48b5-b6ab-7a0a0b3cd67c",
+      "uuid": "754759c3-1025-4719-b7bd-3c14fa4ee61e",
+      "groupUuid": "be72e1b6-67f9-4b09-a140-955879dbc4ac",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5458,8 +5458,8 @@
       }
     },
     {
-      "uuid": "3ce28b15-6855-457d-accf-7fe395d0da37",
-      "groupUuid": "b445b2b1-f508-4ed0-be35-2c1a3c9170e9",
+      "uuid": "3ffe6596-2c62-437c-80b0-a821b7844828",
+      "groupUuid": "761ac5fb-23d5-4d04-a821-b4926539f604",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5467,8 +5467,8 @@
       }
     },
     {
-      "uuid": "80825f61-a73c-4218-aac2-178f62edc8bf",
-      "groupUuid": "33c5818e-b220-4a32-b1ba-001077adc360",
+      "uuid": "1ab81e18-0b03-416b-9977-5b7c7633b403",
+      "groupUuid": "2bee07a0-abba-4eb3-b01b-eb0166ea667a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5477,8 +5477,8 @@
       }
     },
     {
-      "uuid": "d48a17b5-7e42-4ddb-9b69-7aebcba07097",
-      "groupUuid": "3a024948-7ff3-4a7c-acae-3d83b789d6ef",
+      "uuid": "09af395b-c5e8-4045-883d-582688147784",
+      "groupUuid": "a6d152e4-4325-4cc3-a308-7f70640a84d6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5486,8 +5486,8 @@
       }
     },
     {
-      "uuid": "d1e0cd31-c521-4035-8f1c-c963a9f08460",
-      "groupUuid": "73babb35-d4d8-427f-b5de-b4da665255ac",
+      "uuid": "9050b937-0d96-497a-af38-c7beda0473e4",
+      "groupUuid": "39fd65c1-ba8c-4742-9252-8040bd2efeb2",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5496,8 +5496,8 @@
       }
     },
     {
-      "uuid": "a5fa787d-12bc-4026-a18e-8894fc2b8b78",
-      "groupUuid": "8b0b0794-96b6-447b-a5a0-a3e6159b495d",
+      "uuid": "4f858130-55f9-4790-81e2-27d37a8531b2",
+      "groupUuid": "97f5a6b5-b081-48bc-ba54-7db3f11d9af9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5505,8 +5505,8 @@
       }
     },
     {
-      "uuid": "4a0f1b50-0fc9-4184-92d2-5dc0bc2e7a6e",
-      "groupUuid": "7e5dc6e8-e118-419d-bd14-462c9f80a718",
+      "uuid": "d0936bb6-3871-4bc1-81f8-ebf9a1f8de71",
+      "groupUuid": "65c4e669-0e51-4456-9d43-fdbeb3ea49f8",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5515,8 +5515,8 @@
       }
     },
     {
-      "uuid": "c8b982c9-fd09-4372-bfc5-f6e1d578d3aa",
-      "groupUuid": "69ed8f67-db9d-4002-8717-1f5f55cca93c",
+      "uuid": "36c00d42-7466-4da2-882c-2abae8747ecb",
+      "groupUuid": "caeac7d8-240f-43da-8cd6-0bbf111eedeb",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5524,8 +5524,8 @@
       }
     },
     {
-      "uuid": "794c961f-11a2-4ce8-9567-767ba2b43a89",
-      "groupUuid": "0142777b-1b49-48d0-af2e-c44120264269",
+      "uuid": "1d886c80-f891-4064-ac02-cbae11a0aedd",
+      "groupUuid": "7463f1fa-07e1-4da1-834d-2a1e4fa2642b",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5538,17 +5538,17 @@
       }
     },
     {
-      "uuid": "083885a2-e2ab-4975-9479-dcd9397cc2bc",
-      "groupUuid": "304e3561-3b84-4690-9744-98a91a69963d",
+      "uuid": "b5dbf919-5b28-4dd3-9ad6-d0bfa59dcba2",
+      "groupUuid": "d7beb072-9066-41de-b708-7a7f9fffef88",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "a7a716f9-177f-41f3-88ba-3d4154b4de24",
-      "groupUuid": "53a8ea44-aab9-488b-91ae-e403c7aa772d",
+      "uuid": "08e44e9b-b212-43c6-9887-dc908c364784",
+      "groupUuid": "5ad229b2-d16a-4ea5-ab1b-802191cf9f30",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5556,8 +5556,8 @@
       }
     },
     {
-      "uuid": "442b6f97-3f42-4848-a06c-20c98f78f55e",
-      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "uuid": "29bde560-36a8-45ee-95a8-164bb46ea4d3",
+      "groupUuid": "c4bda2d6-a3cb-4a2d-a871-651850b867ca",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5568,8 +5568,8 @@
       }
     },
     {
-      "uuid": "cac309a7-e890-489b-90a7-4f72badb91c1",
-      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "uuid": "abbf70ba-be90-4a03-b155-66d572238b7a",
+      "groupUuid": "c4bda2d6-a3cb-4a2d-a871-651850b867ca",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5580,8 +5580,8 @@
       }
     },
     {
-      "uuid": "b4d9c1a7-495a-4788-b93a-4e3209bb0cb2",
-      "groupUuid": "d0636915-bc77-4f4f-974d-5325a8d430af",
+      "uuid": "41571d23-da16-4b6a-926f-97a7fc3c91ba",
+      "groupUuid": "c4bda2d6-a3cb-4a2d-a871-651850b867ca",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5592,8 +5592,8 @@
       }
     },
     {
-      "uuid": "ca01a32b-fcbb-4c79-9fea-fa831ea56e3f",
-      "groupUuid": "1f7e7811-abd4-45d8-9578-41c231899627",
+      "uuid": "faa65171-2671-4a9c-9bee-e0baee873359",
+      "groupUuid": "177f496c-b078-4485-8857-10f7147205fd",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5601,8 +5601,8 @@
       }
     },
     {
-      "uuid": "ea862316-1d1d-448c-8972-7cfd70df76dd",
-      "groupUuid": "81169a70-ca36-4d81-b148-77791b763e56",
+      "uuid": "9c3fe8a4-55bf-4500-aa9f-d16eb2e13b14",
+      "groupUuid": "07d2f48b-ee23-4f59-a732-063475669328",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5611,8 +5611,8 @@
       }
     },
     {
-      "uuid": "16c50287-f1cf-4dca-9abf-36ac5f6fc493",
-      "groupUuid": "64fd8989-5e38-474b-90e5-103b04f10585",
+      "uuid": "09820335-5954-4e41-9b00-c7b712041849",
+      "groupUuid": "9f21dd31-ea4d-4e66-8842-27ebc7e1a632",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5620,8 +5620,8 @@
       }
     },
     {
-      "uuid": "f8ea30e2-a720-44b9-8b8b-d4879dc47d65",
-      "groupUuid": "f57d5297-ae0d-4854-85aa-157474b58422",
+      "uuid": "ec4f41c7-10d8-4ec5-8658-60bc2f63555e",
+      "groupUuid": "96f974de-c060-4af3-832f-835c8b18d6a3",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5630,8 +5630,8 @@
       }
     },
     {
-      "uuid": "f0cf788b-d59c-4253-b6c4-8be8a8bd663c",
-      "groupUuid": "65b996e6-e67a-4050-848a-1c8d13c99918",
+      "uuid": "55db9ad8-9d2c-4e65-92a1-be71f9703479",
+      "groupUuid": "07361fc1-be56-4a24-a364-833bcb291047",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5639,8 +5639,8 @@
       }
     },
     {
-      "uuid": "fd020001-02ee-43f8-b66f-72a31b3c3777",
-      "groupUuid": "1d745433-9aef-4a94-aaec-af8f9f2697f5",
+      "uuid": "63f4bf27-7b65-48d7-85c7-ff2ab96b613b",
+      "groupUuid": "9957ff05-c250-429e-a560-d4e20c74926a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5649,8 +5649,8 @@
       }
     },
     {
-      "uuid": "ec48b201-793a-4178-a26d-4a9fa2164234",
-      "groupUuid": "ed0a27cd-7d4d-482b-9446-fdb21d836820",
+      "uuid": "5014f0c5-4305-47a1-8ba1-53806d953b10",
+      "groupUuid": "45a4e31f-9431-439d-bb38-dc507b688fc9",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5658,8 +5658,8 @@
       }
     },
     {
-      "uuid": "48fde2ab-a67d-4e6a-8acd-813907211270",
-      "groupUuid": "40955f59-19e4-489e-8a39-dcc276780a35",
+      "uuid": "8930519d-f411-459e-9dba-c4962d1b18b0",
+      "groupUuid": "a94dbdf6-6695-48a7-ac56-4476f7c4d5e9",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5672,17 +5672,17 @@
       }
     },
     {
-      "uuid": "dea4a25e-7a44-4bea-bc7a-174a46aa6d75",
-      "groupUuid": "faa03219-b596-479f-b43a-7c7d10222e18",
+      "uuid": "8a36a1f6-c79f-4e19-82f2-03109380faa0",
+      "groupUuid": "86fed215-65a3-4e42-a766-ced8fd28dbef",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "bc3352d0-aaca-4c0e-a6b7-ac66b85ceb16",
-      "groupUuid": "df831fc6-cf25-4f96-9b72-96263d476886",
+      "uuid": "eca3a963-1cd7-4e5c-bd79-c87830fce9ea",
+      "groupUuid": "a9998ede-2633-46ad-81ae-fa8dd38125a6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5690,8 +5690,8 @@
       }
     },
     {
-      "uuid": "5463eecd-2785-453f-af27-c530d9fa5c4e",
-      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "uuid": "f86421be-0f12-4933-b372-839916939e13",
+      "groupUuid": "7590e0f1-fb7a-4a98-865e-288697f04cf3",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5702,8 +5702,8 @@
       }
     },
     {
-      "uuid": "16e36a87-1303-4637-916b-29fcc64e0309",
-      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "uuid": "1768aa45-ffe0-4632-ad17-8bb689d4609c",
+      "groupUuid": "7590e0f1-fb7a-4a98-865e-288697f04cf3",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5714,8 +5714,8 @@
       }
     },
     {
-      "uuid": "708db57a-03ec-4d25-8b6a-902aa4ccdcba",
-      "groupUuid": "a3ea309d-dcac-4fc4-8266-591537bae6e6",
+      "uuid": "337d3c92-9ccc-44fc-a088-87d09053add1",
+      "groupUuid": "7590e0f1-fb7a-4a98-865e-288697f04cf3",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5726,8 +5726,8 @@
       }
     },
     {
-      "uuid": "579a0408-69f1-4ff2-8cfe-5c45fdda745f",
-      "groupUuid": "ff455564-ef34-42cc-95ad-ed78e43a9100",
+      "uuid": "3ce5b78f-5bd8-49e8-bf02-10da3c0d0e01",
+      "groupUuid": "43418907-33e2-4f8f-9fb3-cb24db1e9dca",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5735,8 +5735,8 @@
       }
     },
     {
-      "uuid": "912a093d-eec0-4070-8249-c65da65b77a0",
-      "groupUuid": "92057cde-3110-4930-910c-ca27fbe1d3a1",
+      "uuid": "6e572a18-2268-4e8a-aaa0-51f6360935e2",
+      "groupUuid": "7aaf18c2-4934-49b5-904a-acc7768d08e0",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5745,8 +5745,8 @@
       }
     },
     {
-      "uuid": "41fd4afe-9468-4ff0-906c-b26917821db1",
-      "groupUuid": "cb9a73cf-e5ee-48f4-bb4a-5e5b88c1c1c2",
+      "uuid": "7ba21ae9-e25a-45ba-90e9-3bf5b59e0653",
+      "groupUuid": "8f6cb847-6161-489a-a695-432ee8abbaa1",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5754,8 +5754,8 @@
       }
     },
     {
-      "uuid": "c3999127-9d22-41c2-91dc-cffdfc0271f0",
-      "groupUuid": "672bf8f4-b5e4-4444-be7a-82730783ad29",
+      "uuid": "e12434cb-907d-4b58-98a8-2a42fced6929",
+      "groupUuid": "8e09e398-edde-4728-97fd-6a86f001281e",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5764,8 +5764,8 @@
       }
     },
     {
-      "uuid": "ba16aec6-c2bb-4e37-8e37-320a51d9cb0e",
-      "groupUuid": "fb34e7ee-dbf3-4578-a5d9-615106867a20",
+      "uuid": "024453ac-c6df-44cc-983c-d0945311a0f5",
+      "groupUuid": "140ce1ed-3194-4e6f-a609-1f6dd0f7e455",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5773,8 +5773,8 @@
       }
     },
     {
-      "uuid": "fc6783fd-7245-4f5c-8666-73d071f30dd8",
-      "groupUuid": "6c0fa537-533a-4670-a8a3-d9bd1ddeed02",
+      "uuid": "7a94ed82-15ac-4957-ad01-2de8fdeb5377",
+      "groupUuid": "fb2d944b-7227-4535-80c5-4200ad0c1934",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5783,8 +5783,8 @@
       }
     },
     {
-      "uuid": "eb0ff792-28ce-4f1a-967d-a64715d78322",
-      "groupUuid": "6cace1be-b0a8-42dd-8e47-3607f526a6bb",
+      "uuid": "7a6a2a46-6217-4d46-a0e3-1f46996c7346",
+      "groupUuid": "07d119ce-e072-41a0-b47d-ed69d172439c",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5792,8 +5792,8 @@
       }
     },
     {
-      "uuid": "d52e0a17-f761-4e91-82d6-cc0d10a3853b",
-      "groupUuid": "3096ddf2-30fc-4867-b388-4fa002b737f4",
+      "uuid": "0c47a87b-4292-4a83-9d57-f32c4f5061a7",
+      "groupUuid": "6dbe987e-59d0-4b9f-a745-d6c920cceece",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5806,17 +5806,17 @@
       }
     },
     {
-      "uuid": "62048a19-a5c1-4707-b407-17c86c5000f5",
-      "groupUuid": "e7f78358-5f0b-4fc6-89b4-874a7aabb276",
+      "uuid": "7227c6b5-5a8a-4145-901e-d711fb723b5b",
+      "groupUuid": "c7e15df4-0c77-463b-9e22-b32558dd57c1",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
       }
     },
     {
-      "uuid": "793e6459-c52b-441c-9a4f-0dfb56341452",
-      "groupUuid": "7ccfb600-41ce-467f-bacd-6d704dd78d15",
+      "uuid": "201f3526-b062-4bce-9700-129b389d3f98",
+      "groupUuid": "ae22d6d6-f6ed-4777-8dac-97e542cb33bc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5824,8 +5824,8 @@
       }
     },
     {
-      "uuid": "71b77957-a01e-497d-8eb6-19c03b0d702c",
-      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "uuid": "ac25c8f3-ff23-4457-8f80-8a454597f8b2",
+      "groupUuid": "5e96655f-8a87-44cd-8929-dac5ac8d13ed",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5836,8 +5836,8 @@
       }
     },
     {
-      "uuid": "220961a0-ef40-4ac7-b31c-a1a3c8684276",
-      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "uuid": "f30c1985-6349-4d9e-ad96-6db0bf376c9a",
+      "groupUuid": "5e96655f-8a87-44cd-8929-dac5ac8d13ed",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5848,8 +5848,8 @@
       }
     },
     {
-      "uuid": "8b17b9f0-8e9b-4825-a6d8-85cab07b28e8",
-      "groupUuid": "28b7d2a8-ab1c-4f93-b40b-c81c3e280ac1",
+      "uuid": "2b6cb2dd-4ad0-4b3e-92d9-b181a9472516",
+      "groupUuid": "5e96655f-8a87-44cd-8929-dac5ac8d13ed",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5860,8 +5860,8 @@
       }
     },
     {
-      "uuid": "31570620-2aff-40ad-ad2b-b74abf0151a9",
-      "groupUuid": "c4f7cc9e-649e-49cf-92de-324a32ccd286",
+      "uuid": "724e60d4-d1d9-474d-a146-d1f5435dab5b",
+      "groupUuid": "0ff436e3-4386-4144-ae70-d0b7e330aa7c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5869,8 +5869,8 @@
       }
     },
     {
-      "uuid": "b8ffac5d-e4be-4503-af66-d0e30e45d20d",
-      "groupUuid": "c4cdae05-9be5-4405-9f9d-d2655d391463",
+      "uuid": "6ddfb77d-ef35-469f-be66-a10e980d07e6",
+      "groupUuid": "b6867300-cbda-4d0c-a2ea-b999b218e6d0",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5879,8 +5879,8 @@
       }
     },
     {
-      "uuid": "a86649b8-fffe-481a-a0f8-b5b2eeec0b3a",
-      "groupUuid": "1c5a4db6-2174-4909-9183-6b27c1df43eb",
+      "uuid": "5e4eadd4-4306-426d-bbc2-75320d54d887",
+      "groupUuid": "7010b88a-2f79-4223-8317-c2c780140f61",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5888,8 +5888,8 @@
       }
     },
     {
-      "uuid": "abe91b9b-74ee-474f-aaf3-bea93f7b78c2",
-      "groupUuid": "5543aa1d-ecb5-4be1-875d-23eae751b6e0",
+      "uuid": "dba2df71-e99d-4161-985e-dbe0000fc685",
+      "groupUuid": "5ce5a50e-316c-45b4-b80c-75b7b3328645",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5898,8 +5898,8 @@
       }
     },
     {
-      "uuid": "d8097245-8c03-4154-bdac-18347b862494",
-      "groupUuid": "a65a6137-36b3-4ef1-9249-8e91fd0abb38",
+      "uuid": "c38a38fa-4d38-4cee-97ae-4401df21829e",
+      "groupUuid": "4a53bf3f-8916-49cf-ba8c-0d44cc088785",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5907,8 +5907,8 @@
       }
     },
     {
-      "uuid": "03ae81fb-03d5-4715-acde-7d4a2148aa63",
-      "groupUuid": "ccad0310-dcf4-461e-8165-6bc3495eade1",
+      "uuid": "6d6f34fd-8fef-400c-aad7-fd3fb7d0d579",
+      "groupUuid": "b5221a10-1849-4057-a7e0-d532ed0070ab",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5917,8 +5917,8 @@
       }
     },
     {
-      "uuid": "d32baba1-fded-4602-8c9d-a03082c82a52",
-      "groupUuid": "70a76780-2472-424a-b560-3a65f43c1293",
+      "uuid": "545934d4-4d49-407f-9836-be8bdc9a1907",
+      "groupUuid": "da1af38a-8c4e-40ca-a795-dd9a986741d2",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5926,8 +5926,8 @@
       }
     },
     {
-      "uuid": "b88949ff-6fa4-45fd-b5e0-52a9f53e8c3f",
-      "groupUuid": "45d0aacf-2677-4476-94ba-b8c71d8914ea",
+      "uuid": "ee7ee4aa-ec6d-4b2d-8221-9e9eeded2538",
+      "groupUuid": "7f292128-5c27-45ad-970f-250a9a0f9962",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5940,17 +5940,17 @@
       }
     },
     {
-      "uuid": "5766c1e4-de03-4ccd-a045-b91db05965da",
-      "groupUuid": "094c6463-eb9e-4623-821a-dcfc120c87cc",
+      "uuid": "7bb665c3-5422-44bc-a664-c14838523497",
+      "groupUuid": "6a050cb4-6e6c-429c-8a8c-7d5f4acc291b",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
       }
     },
     {
-      "uuid": "8b41de44-8d37-42d3-beba-a37b2e86831f",
-      "groupUuid": "14e9e83e-92de-469a-a596-d3a4da1893b7",
+      "uuid": "ba7d2d7a-42bf-4fd3-a7b2-499698af035b",
+      "groupUuid": "90e86a4c-8742-493c-a4fd-303da777dcc2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5958,8 +5958,8 @@
       }
     },
     {
-      "uuid": "403ad666-dced-4c8c-b6bb-4b6faa0af7cd",
-      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "uuid": "fd474796-60fc-4159-ae0e-dd66ae9505f3",
+      "groupUuid": "fc6eef54-2c64-45a5-bd9c-6b7a044ef126",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5970,8 +5970,8 @@
       }
     },
     {
-      "uuid": "42958008-56d5-4cee-ae82-4fe42d808868",
-      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "uuid": "5e1c5c33-4a93-4ffd-94c9-93f64fa73b8c",
+      "groupUuid": "fc6eef54-2c64-45a5-bd9c-6b7a044ef126",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5982,8 +5982,8 @@
       }
     },
     {
-      "uuid": "cda9a2c4-2558-466a-880f-111c5721fb51",
-      "groupUuid": "19e3a64c-1637-4434-94dc-d239452308b4",
+      "uuid": "24f0c243-1a11-47f8-af65-c10e10d1a2e9",
+      "groupUuid": "fc6eef54-2c64-45a5-bd9c-6b7a044ef126",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5994,8 +5994,8 @@
       }
     },
     {
-      "uuid": "0d82f393-a301-43b6-bd75-94e4ccf9b182",
-      "groupUuid": "f7d7ad39-d707-4d2f-ae05-91a386d15ecf",
+      "uuid": "ec34fb62-92b9-4a53-8023-710c639b78d4",
+      "groupUuid": "ad89b391-e8e3-4164-a0ad-2aaba6dc777c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6003,8 +6003,8 @@
       }
     },
     {
-      "uuid": "be3618f0-b29c-4f92-992e-8066798e5a84",
-      "groupUuid": "ce3c7d14-09b5-46ab-ac58-2871b1977a81",
+      "uuid": "4d0a30a9-7461-43b1-8947-237c811a6d09",
+      "groupUuid": "ad37d2bc-b102-4441-9740-7552430d410a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6013,8 +6013,8 @@
       }
     },
     {
-      "uuid": "5499bcb9-a4a4-4355-a778-4a58e4d79250",
-      "groupUuid": "6720f043-d16e-4989-87a8-29b908ae5292",
+      "uuid": "13baaed6-a364-439c-a0c3-3e78c5dfbc22",
+      "groupUuid": "4f7c1efe-e256-4aa4-8281-498a0ffa66de",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6022,8 +6022,8 @@
       }
     },
     {
-      "uuid": "31698d7a-82dd-4039-b420-9a3f68f5cd8c",
-      "groupUuid": "e6832902-5651-45d8-a6d2-62ef53a4bc86",
+      "uuid": "db0ed09a-3c14-42cf-93dd-fb71c9f4a01f",
+      "groupUuid": "becdd511-75af-43b3-b95f-78cbab57b440",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6032,8 +6032,8 @@
       }
     },
     {
-      "uuid": "5ba1204c-992a-4a0e-9301-bf118d57c114",
-      "groupUuid": "55a16adb-52f3-47f3-9c33-4551d3a6b4fe",
+      "uuid": "81a8d3d3-d537-4803-909d-c4319ecb579c",
+      "groupUuid": "38cb7e7a-24fb-4e10-b509-0677e159929e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6041,8 +6041,8 @@
       }
     },
     {
-      "uuid": "1dd35627-74b1-4d9c-9e22-24ff7da1a3c4",
-      "groupUuid": "ef0d6a4e-ec22-422e-9d53-89f3bfbe1196",
+      "uuid": "fae5b538-b09c-4211-bc2a-7829342c3738",
+      "groupUuid": "260aa4ab-c0ab-4e29-bc3b-6fff9918be36",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6051,8 +6051,8 @@
       }
     },
     {
-      "uuid": "aa96cdf1-75e5-4e8a-b78a-9220d2a469d3",
-      "groupUuid": "00f5fb26-8bfb-48e6-8030-6ffdd3bd572b",
+      "uuid": "a551a216-b895-497d-b031-3c78e2518691",
+      "groupUuid": "09660ddb-24d0-4560-a978-63e8288c9a02",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6060,8 +6060,8 @@
       }
     },
     {
-      "uuid": "b9c839bd-09dd-4d68-a4eb-b40be3e6fb33",
-      "groupUuid": "b0479704-8274-492d-9ab3-499074c1f75a",
+      "uuid": "6a0e09aa-46c5-47a7-86c1-6f2b992b4372",
+      "groupUuid": "9fc9615f-360e-47fd-83e1-f97c466c2caa",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6074,17 +6074,17 @@
       }
     },
     {
-      "uuid": "060edd23-ead3-474d-8d0e-aaf1e0daafe4",
-      "groupUuid": "4b445692-fe07-41f9-b1a3-e5f0268862ea",
+      "uuid": "f11ad451-5aff-4966-8191-41d5021800a6",
+      "groupUuid": "552bd68d-47d6-420c-aed6-90e2bcf4bca6",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "c7fec2a0-791d-45ee-8023-20eb47e3550c",
-      "groupUuid": "00d215fe-763f-4ae5-9bfc-1daa2cf41127",
+      "uuid": "909dba01-bf7b-4795-9eac-d9940a9f2c1d",
+      "groupUuid": "9a82adb7-f7e2-467e-a22a-899afc9bd34b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6092,8 +6092,8 @@
       }
     },
     {
-      "uuid": "f7ffe4ac-c58d-46fa-b74c-43d4af6c8375",
-      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "uuid": "fff1c901-c1cf-487e-9e68-9038ff9d1a06",
+      "groupUuid": "f1d57823-f3ee-4aa2-9cf1-ff7e9149a58c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6104,8 +6104,8 @@
       }
     },
     {
-      "uuid": "f04043d8-642c-47c8-9fc5-7e37ca0d2e0a",
-      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "uuid": "cb5ca320-bd54-4d64-a022-82edded71827",
+      "groupUuid": "f1d57823-f3ee-4aa2-9cf1-ff7e9149a58c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6116,8 +6116,8 @@
       }
     },
     {
-      "uuid": "63d69419-0396-4276-8756-212468add79f",
-      "groupUuid": "14fa2932-3f22-4ac5-b558-1cd34bf42190",
+      "uuid": "7ce0ae3c-7849-4b0d-9f26-8f37de359b5f",
+      "groupUuid": "f1d57823-f3ee-4aa2-9cf1-ff7e9149a58c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6128,8 +6128,8 @@
       }
     },
     {
-      "uuid": "4425e508-2bfb-40ee-ac5b-b66ce2de2e7d",
-      "groupUuid": "6ee257ad-1bb5-447b-8226-5880f13bf38a",
+      "uuid": "4c436030-17b6-4a40-a62f-1b4dde6bcc11",
+      "groupUuid": "6d6b3f6c-04a6-4c46-ba5a-e6de65ea9036",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6137,8 +6137,8 @@
       }
     },
     {
-      "uuid": "2d106145-5753-4fc0-b8cd-8c3d3025e5a8",
-      "groupUuid": "5fa9c36c-b4ae-467a-b4a0-f7109b4962d2",
+      "uuid": "b54aed9f-6531-4f5a-9ecb-bcfda7e40f4d",
+      "groupUuid": "bd1830e8-ac1d-4c24-bca2-de3644dbbe9c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6147,8 +6147,8 @@
       }
     },
     {
-      "uuid": "f270534a-fdd3-4a57-9500-1e3259c58a0d",
-      "groupUuid": "f89ba019-40cc-4be0-82a1-5da2faea8099",
+      "uuid": "ad46080c-70e0-4642-8dc2-b4f9ec4f14ae",
+      "groupUuid": "7de015e2-6a32-43d6-91f7-be65b821fbee",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6156,8 +6156,8 @@
       }
     },
     {
-      "uuid": "a16d82c2-8165-4805-8595-538c984fd79c",
-      "groupUuid": "bc999126-b5bd-4609-be00-4303cd8e485f",
+      "uuid": "64c25568-a468-4ad7-9472-1a39411d3098",
+      "groupUuid": "2e990c04-1ce6-40ac-a2dd-04c382d773ba",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6166,8 +6166,8 @@
       }
     },
     {
-      "uuid": "80880c81-4fa9-41d7-b811-107a5451bff2",
-      "groupUuid": "7d952d18-574e-4115-bfd2-bb30a0021e22",
+      "uuid": "ec5a938f-97e3-44ad-bfd4-9e3be8b2e567",
+      "groupUuid": "c159671c-9b66-4ea1-9ff5-b54c4cb5b6c7",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6175,8 +6175,8 @@
       }
     },
     {
-      "uuid": "a30a1081-da53-4646-b772-7bbef0cc036c",
-      "groupUuid": "ddd8d6bd-10fa-4ac6-827f-6f392aed859c",
+      "uuid": "840aa818-2b98-4349-af75-525d53841d03",
+      "groupUuid": "a427f415-66f8-4fb3-8fef-c0588b7299b6",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6185,8 +6185,8 @@
       }
     },
     {
-      "uuid": "dafc741d-067b-497c-b8ba-6e0147505e96",
-      "groupUuid": "84bebb52-a6eb-4307-8eb6-eaa523effb67",
+      "uuid": "b1efcdff-5106-4640-85a2-9e2c87bda099",
+      "groupUuid": "05391e58-8d2a-4fc1-8418-8bff585cad1e",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6194,8 +6194,8 @@
       }
     },
     {
-      "uuid": "2a8dfbf5-5a18-4454-9781-00da6835c1b8",
-      "groupUuid": "f625eb4f-6781-4f17-9967-822844c11509",
+      "uuid": "8be39843-5bc0-4e5c-9a58-5fc82302fb12",
+      "groupUuid": "cb4b67d6-6a81-4c68-9f20-ea664f02a870",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6208,17 +6208,17 @@
       }
     },
     {
-      "uuid": "68c5d171-ff8d-4b1b-9d10-a6f0d4b815da",
-      "groupUuid": "81961b0b-7c5e-4d52-87b8-d322c1fd22a7",
+      "uuid": "6bc89d8d-b93b-4bc6-97ff-f92a3ca78709",
+      "groupUuid": "65060685-bb58-4585-bdc2-be8316130729",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
       }
     },
     {
-      "uuid": "20bb956a-dcd4-4e3a-8b2d-173db373ec23",
-      "groupUuid": "ce95625b-5a91-452e-ab2d-1b095344d299",
+      "uuid": "a6fd2644-8ae3-4199-8bd4-5eef3a35f500",
+      "groupUuid": "94d4d0c7-e370-48c2-8ce6-431649a467bf",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6226,8 +6226,8 @@
       }
     },
     {
-      "uuid": "d13ed91c-a069-48f8-8ef6-84949e42bda1",
-      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "uuid": "0be29414-7d0e-4002-8813-9785d15d4f77",
+      "groupUuid": "704e0633-d4e7-42f9-996f-8a571ed360ef",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6238,8 +6238,8 @@
       }
     },
     {
-      "uuid": "677d6370-78c2-4e51-bbae-60e409fc320b",
-      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "uuid": "6ecb5c6c-7812-47b1-955b-ca6758aeb37f",
+      "groupUuid": "704e0633-d4e7-42f9-996f-8a571ed360ef",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6250,8 +6250,8 @@
       }
     },
     {
-      "uuid": "846dc22f-f088-451b-8673-a9daebbb804f",
-      "groupUuid": "4ea30314-1f53-4761-840c-388dd6d96532",
+      "uuid": "343f863b-077a-41b2-99fb-3c23e4417958",
+      "groupUuid": "704e0633-d4e7-42f9-996f-8a571ed360ef",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6262,8 +6262,8 @@
       }
     },
     {
-      "uuid": "941db39a-e263-4a5e-a1da-bf4637bf6201",
-      "groupUuid": "3dc76610-b321-43c3-a0b7-a25716bdefc5",
+      "uuid": "84d93005-a3ae-4cac-a071-071122a1a04d",
+      "groupUuid": "1b6c60ce-9270-4366-b38c-697767d7c2e1",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6271,8 +6271,8 @@
       }
     },
     {
-      "uuid": "867a5e31-1b80-40e0-9d97-ad69db1924e3",
-      "groupUuid": "9c10db46-d24f-4363-89fd-0ac3302a3ddb",
+      "uuid": "a183bd6e-87c7-413f-a75b-8c5e21d47844",
+      "groupUuid": "a4dbde33-6fc5-44b1-a1ed-2f724b69765d",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6281,8 +6281,8 @@
       }
     },
     {
-      "uuid": "49fccdc9-0862-48ab-b544-3efb6470ad6f",
-      "groupUuid": "1c0ae8fc-a778-46c1-bba5-468187a0f6b4",
+      "uuid": "529fc60d-b9db-4a44-b70c-7d04cfb48ae3",
+      "groupUuid": "99fb1604-a407-4995-b1e7-64990938bf04",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6290,8 +6290,8 @@
       }
     },
     {
-      "uuid": "90e32e8d-e945-467c-b933-8e4cbfd63714",
-      "groupUuid": "0f1b7bd5-f20b-4166-a1e3-a5742c0b3f60",
+      "uuid": "c2d81e2f-fb38-4f7d-a656-3a6ba2e1191e",
+      "groupUuid": "c44d20e2-7376-4484-9adc-7b0b90b4a94e",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6300,8 +6300,8 @@
       }
     },
     {
-      "uuid": "5032e9a9-ef6a-420b-bf04-c73511ff758c",
-      "groupUuid": "b10a4af3-7966-43b0-9cdc-73b491a51353",
+      "uuid": "48682b63-e86e-471f-9eee-095702696a00",
+      "groupUuid": "6d1aabc3-18d8-4297-802c-9c86a1229720",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6309,8 +6309,8 @@
       }
     },
     {
-      "uuid": "c017105a-fba7-4c4b-840e-97ade7c4062e",
-      "groupUuid": "6aec69dd-cd33-402d-9de6-8e67446b367d",
+      "uuid": "af5a2953-a99c-48e6-ad7f-682a85eae722",
+      "groupUuid": "db2a41e3-fdb2-4d15-a512-0ebc185604c7",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6319,8 +6319,8 @@
       }
     },
     {
-      "uuid": "8894e7a9-3e83-4623-aef7-af290f13221f",
-      "groupUuid": "3daca940-0165-4c4d-82b5-018d40cc8d46",
+      "uuid": "1e21129f-c7d9-4823-9137-40d43c6111e4",
+      "groupUuid": "8af6d100-8bb0-4c2d-8c13-75bcbe5d836d",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6328,8 +6328,8 @@
       }
     },
     {
-      "uuid": "a9528c51-32cb-4d6b-9922-e3e25378e4a0",
-      "groupUuid": "26689754-4c0a-4a9c-a19d-c295c61b4430",
+      "uuid": "61ccf572-dbca-4def-a666-8a2ec822f60a",
+      "groupUuid": "a2de9bb9-9fba-4646-a261-046ffb2798ae",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6342,17 +6342,17 @@
       }
     },
     {
-      "uuid": "76ccb174-44a8-42fc-8c71-7187b1068fb5",
-      "groupUuid": "60db7725-1db7-4ea8-bae1-a88ad0a7c494",
+      "uuid": "9b7864ff-7fb1-4dfa-9a1a-e1d76169db80",
+      "groupUuid": "433fd460-d45d-446b-89e2-7d79615cebef",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
       }
     },
     {
-      "uuid": "ce58e6c4-d34b-42b8-9e57-ee70ba2313e8",
-      "groupUuid": "82e05010-0657-4d6e-ac0d-b27fe41edbdf",
+      "uuid": "59c1bd16-9003-4478-9dfc-a35e6cc1eb39",
+      "groupUuid": "1c51b7ec-ccef-4f02-aa01-6d3a5a8a7c2f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6360,8 +6360,8 @@
       }
     },
     {
-      "uuid": "d7f3f8a1-90a9-4574-a7b3-dea6a999cd7c",
-      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "uuid": "0cfda9df-a9d6-4f18-b075-bdf420d9550e",
+      "groupUuid": "098a2284-1219-4a9d-85e6-a26b79386ea3",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6372,8 +6372,8 @@
       }
     },
     {
-      "uuid": "469e5419-294a-44ea-9035-61c464bd5ea5",
-      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "uuid": "0a939a50-18cd-4378-8066-6532f59dddf4",
+      "groupUuid": "098a2284-1219-4a9d-85e6-a26b79386ea3",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6384,8 +6384,8 @@
       }
     },
     {
-      "uuid": "3fdc5e80-97b1-4998-b27b-19a293c5c1a1",
-      "groupUuid": "6c00c041-5c69-4645-a0db-b4bd3c10f03e",
+      "uuid": "b0b8896f-7191-4cf5-a766-c9ad58658460",
+      "groupUuid": "098a2284-1219-4a9d-85e6-a26b79386ea3",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6396,8 +6396,8 @@
       }
     },
     {
-      "uuid": "553bfe02-104c-4814-889f-873aef992a6b",
-      "groupUuid": "b1b6f7d6-e6d4-4e1c-acea-29fda297c81d",
+      "uuid": "8e4a538b-efc1-447f-a9cf-47eb9bca26b2",
+      "groupUuid": "c6c9a0ad-69fd-4a2d-95d3-acedfdb06bd8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6405,8 +6405,8 @@
       }
     },
     {
-      "uuid": "ad546ec1-7bd8-45ce-8db3-77936b0ea822",
-      "groupUuid": "43689250-2088-4234-add1-e4eb2058eb5b",
+      "uuid": "b41ce938-ce6c-495a-a31f-4467500f6351",
+      "groupUuid": "b85daed8-c727-430f-9357-5ec6d739a0be",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6415,8 +6415,8 @@
       }
     },
     {
-      "uuid": "2efde63b-e908-498d-95fb-d6ee0f3c1001",
-      "groupUuid": "c6e37d2f-29aa-4f06-8014-ed6243e492c7",
+      "uuid": "1e7de301-5f48-490f-a87b-caf09cef4610",
+      "groupUuid": "8d9e418a-f6ae-449a-ad7c-5c549365acf8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6424,8 +6424,8 @@
       }
     },
     {
-      "uuid": "a6037b8c-0ab6-49c6-aabe-acaf4266d7ff",
-      "groupUuid": "9f0e29b7-b07c-47a7-9f63-cc51d0435c6a",
+      "uuid": "90b1aaac-f93c-4855-ab63-078991e1bd17",
+      "groupUuid": "516cc31a-91df-4d3a-88db-98ddeecc5928",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6434,8 +6434,8 @@
       }
     },
     {
-      "uuid": "bb7907e5-4823-407d-bcfc-3b3dcedd2932",
-      "groupUuid": "210f5c70-daf9-4abf-9810-dbc3d42a6edd",
+      "uuid": "7d4182a0-dc75-42c3-b489-dac3aea9b1b2",
+      "groupUuid": "079ba583-5215-42ca-98cf-d1b61eb333bf",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6443,8 +6443,8 @@
       }
     },
     {
-      "uuid": "8597cb09-98a4-4a1d-b63f-cf7538960e16",
-      "groupUuid": "40f3c065-9b2f-4053-b9ad-8243c64aa0e5",
+      "uuid": "2f659ca6-2888-4385-9b96-bf315e49b17e",
+      "groupUuid": "94c20900-565a-4a6e-ae46-5f9857546e46",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6453,8 +6453,8 @@
       }
     },
     {
-      "uuid": "89d3d083-65ad-4c9a-bc33-39b3932d18ea",
-      "groupUuid": "e6b6aae4-6774-4cbd-8c04-e52ba39c6654",
+      "uuid": "abcb3631-5877-4137-8f93-f3c08481dbc1",
+      "groupUuid": "9f7e70ae-ddb1-434c-ae81-b661587bebfa",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6462,8 +6462,8 @@
       }
     },
     {
-      "uuid": "36e9c273-47ca-4480-9421-e69fbd9e875e",
-      "groupUuid": "9911edbb-c657-4cf2-982e-ae85cb6794ac",
+      "uuid": "138d1b2f-d5fe-493a-a4fd-fc713fd2f4d9",
+      "groupUuid": "fef187dd-d37f-4366-9c19-a20f2afbe6cc",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6476,17 +6476,17 @@
       }
     },
     {
-      "uuid": "dbb357e6-8270-4fd5-850c-5e159b6f42a8",
-      "groupUuid": "496ebb3c-937a-45ee-a626-4ec5102f337e",
+      "uuid": "ad87620d-c36d-4d7b-b605-629fe65d7fbf",
+      "groupUuid": "767c24a6-e97d-4f0a-b58c-5cc29e34d9a8",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
       }
     },
     {
-      "uuid": "89904d62-8d5e-4ecf-8970-1cca3679def9",
-      "groupUuid": "402d42bc-1138-40c6-b801-b502b5bf3ad1",
+      "uuid": "4cd044ad-2ea6-497e-b4e5-1fc6c156497b",
+      "groupUuid": "9c53ed60-353a-4458-97e9-f0bc288bffb2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6494,8 +6494,8 @@
       }
     },
     {
-      "uuid": "338a439c-2cc4-40ad-b1d6-e708f3ba3c8a",
-      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "uuid": "07ecfc71-2384-4cec-8daf-c5ca21c1d550",
+      "groupUuid": "9899d3a1-f413-4f54-9aa8-97e5c5b422dd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6506,8 +6506,8 @@
       }
     },
     {
-      "uuid": "a4adc444-bb49-423e-88e5-1364f8701c35",
-      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "uuid": "2b80989a-5ee1-42b0-b69d-e8c98ad51778",
+      "groupUuid": "9899d3a1-f413-4f54-9aa8-97e5c5b422dd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6518,8 +6518,8 @@
       }
     },
     {
-      "uuid": "ba1530c6-58fb-459f-80b4-0974ffa16504",
-      "groupUuid": "49e0889e-13b2-4b21-bfa8-54e2f275bd1c",
+      "uuid": "8efc7b69-b836-4595-94ee-8dcc5f32cb6f",
+      "groupUuid": "9899d3a1-f413-4f54-9aa8-97e5c5b422dd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6530,8 +6530,8 @@
       }
     },
     {
-      "uuid": "240b495f-4b9c-4096-b295-d5d3cf374993",
-      "groupUuid": "43e13724-807e-4ad4-acd7-8381718af026",
+      "uuid": "0e1d83f7-83ad-4b3b-b886-191edb242730",
+      "groupUuid": "7a025ff3-34d7-43aa-a526-29832302213b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6539,8 +6539,8 @@
       }
     },
     {
-      "uuid": "d431f25f-4dda-4db5-9452-d1846a44c287",
-      "groupUuid": "99bc9ec7-21b9-4a6b-a7cb-35354e2cbe41",
+      "uuid": "9fb4f010-3273-4882-9c36-4628f65d190c",
+      "groupUuid": "25c0963d-3129-4d64-af9f-1853aae5f3ca",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6549,8 +6549,8 @@
       }
     },
     {
-      "uuid": "e63c6cab-6f04-4713-81e1-d701b91fe9be",
-      "groupUuid": "0be66d93-3392-41d3-84c0-d9cb5a1cc28b",
+      "uuid": "440e175c-4d1b-4cc6-9080-b18d7cedba71",
+      "groupUuid": "3bd825a1-2fe6-4db8-aff5-ebde3daf4df1",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6558,8 +6558,8 @@
       }
     },
     {
-      "uuid": "10769c3e-1714-48d2-8a99-b4fbc391f8c4",
-      "groupUuid": "4e9d4cd8-1090-4c93-bcfb-548338e40cb8",
+      "uuid": "4e017148-7f03-4141-ae4b-b615177553f2",
+      "groupUuid": "f39d9170-afd4-4b5d-9e36-727f6b505778",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6568,8 +6568,8 @@
       }
     },
     {
-      "uuid": "c4c2e72a-e86d-4d8b-9583-be2b8dc3dcad",
-      "groupUuid": "6e67967c-763e-4fe7-92f0-23be8cd63275",
+      "uuid": "e9ea24e0-cc1d-484a-9ac2-d9df709806a3",
+      "groupUuid": "148e45db-c000-4718-af66-2ffaaab64e11",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6577,8 +6577,8 @@
       }
     },
     {
-      "uuid": "4757491b-219c-494b-b1ef-6f75b434131a",
-      "groupUuid": "0910252b-baae-44cc-9896-ed56ddb12456",
+      "uuid": "76491286-10a2-420c-8199-988bc6c0a5bf",
+      "groupUuid": "2368052b-bd4c-4606-ad9f-4947dce81d10",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6587,8 +6587,8 @@
       }
     },
     {
-      "uuid": "d93449f9-e555-48ed-ae35-86f417cc3294",
-      "groupUuid": "d5e0d2ec-5382-4687-86a6-88b9ac5eb4c3",
+      "uuid": "bbbeb133-26c9-43b0-a447-0b8af7295629",
+      "groupUuid": "7dd991fc-1672-4db8-96d6-1621ae6c3f91",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6596,8 +6596,8 @@
       }
     },
     {
-      "uuid": "88183b60-65e2-4531-a971-5514fff26ca2",
-      "groupUuid": "228a6546-8b25-4594-b4c8-1da550631d17",
+      "uuid": "a4b10f3d-7891-44d5-8ec3-1b8bb77cca75",
+      "groupUuid": "38b69232-4e07-44ee-b804-605142b9faba",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6610,17 +6610,17 @@
       }
     },
     {
-      "uuid": "fb995954-0cda-425d-a0f0-ac55dd70452f",
-      "groupUuid": "ed3d795b-5874-43c4-b6ce-6b06e93dbc32",
+      "uuid": "b42b974d-c539-498d-8406-960f1a770e17",
+      "groupUuid": "54475ea7-c57f-4cb0-aa27-b60752c72bdc",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "31acc926-8a0e-4c2f-b642-a1fdd97c10af",
-      "groupUuid": "19115a2f-b721-424c-9afb-2834529b60f4",
+      "uuid": "30f24f85-4886-4c4e-bd07-306c8c2ab38e",
+      "groupUuid": "84ef4ad1-7070-4e78-8933-59d6d3e6c2f9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6628,8 +6628,8 @@
       }
     },
     {
-      "uuid": "f55434b3-c32f-439a-9499-44649bf72509",
-      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "uuid": "3dff64be-2aa4-4a63-a47b-e9085158abb3",
+      "groupUuid": "7db5082e-ef48-47f2-a7b2-3b1d07f8523f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6640,8 +6640,8 @@
       }
     },
     {
-      "uuid": "7ef71fb2-20ba-4a47-bea5-62062abab1df",
-      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "uuid": "0caba1d4-9b4c-48e7-a1f5-f222ed574aa4",
+      "groupUuid": "7db5082e-ef48-47f2-a7b2-3b1d07f8523f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6652,8 +6652,8 @@
       }
     },
     {
-      "uuid": "76781cee-6dbc-4ecf-a694-042c8158489b",
-      "groupUuid": "9739beaf-3588-43ef-b400-51cf406b07b3",
+      "uuid": "46438fbb-444a-4953-a3d8-215744f0b925",
+      "groupUuid": "7db5082e-ef48-47f2-a7b2-3b1d07f8523f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6664,8 +6664,8 @@
       }
     },
     {
-      "uuid": "d07776a5-ab12-4e7a-b991-e5e6de76cbc3",
-      "groupUuid": "d99687d9-c635-4e94-913c-8f05ead02104",
+      "uuid": "0794669d-7b98-4d56-9848-abdccc7201cf",
+      "groupUuid": "6cb7db04-4c04-4c24-8cf8-1b092110fc5c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6673,8 +6673,8 @@
       }
     },
     {
-      "uuid": "307c543f-4a8d-461a-a9fb-224d4657ff5b",
-      "groupUuid": "ac5df544-8181-4b2a-af27-4e574f1147a9",
+      "uuid": "d3022e43-8f76-4298-8c6e-184157827342",
+      "groupUuid": "82f125f4-954b-45f6-9875-3b4b5d33765f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6683,8 +6683,8 @@
       }
     },
     {
-      "uuid": "bbc0624c-5d3f-403d-a9cc-e9327e5c47b2",
-      "groupUuid": "04f11206-d63f-438a-be95-254918be3f49",
+      "uuid": "781a5718-573f-464e-9f42-c9548cb0148d",
+      "groupUuid": "42dd7614-9b58-4aeb-928a-dd13e5a9d3d8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6692,8 +6692,8 @@
       }
     },
     {
-      "uuid": "7b5210cd-5dc4-4967-a03e-6da912cc984f",
-      "groupUuid": "bc11be11-dab2-4fd5-866e-837544208c29",
+      "uuid": "9ceddba7-d219-41c1-9cec-54909f6cbde1",
+      "groupUuid": "9567b408-bd0e-4499-8fef-8a7f915b326a",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6702,8 +6702,8 @@
       }
     },
     {
-      "uuid": "ab619562-23cb-4459-90bf-a8f4d9286ec7",
-      "groupUuid": "86ff46cc-b5a9-4651-ba1e-29bdeec8e778",
+      "uuid": "b00f1da1-f4a6-4170-ab0f-85755a14c53c",
+      "groupUuid": "b87d1eee-3c1f-4874-ab20-b96481fea6ab",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6711,8 +6711,8 @@
       }
     },
     {
-      "uuid": "24964ea4-d437-49c5-8ab0-060d95a6f20e",
-      "groupUuid": "7c384c12-0fa0-4ea4-999b-8429569afa13",
+      "uuid": "ddf033f6-ed37-451f-932b-667ba2d9910e",
+      "groupUuid": "3e2fa313-e551-4e05-9c05-ce6990138b04",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {

--- a/scripts/voicing-tags/tally-form-payload.json
+++ b/scripts/voicing-tags/tally-form-payload.json
@@ -1,0 +1,3967 @@
+{
+  "status": "DRAFT",
+  "blocks": [
+    {
+      "uuid": "0c40ffc6-1a00-4117-b478-9e6f1caaa343",
+      "groupUuid": "5ad255f4-137b-4801-a41f-ecad2e0aee6f",
+      "type": "FORM_TITLE",
+      "title": "Voicing-tag review \u2014 pilot (#395)"
+    },
+    {
+      "uuid": "26dab5d8-6313-4d74-85b3-772079e16755",
+      "groupUuid": "bb8443cf-8cd3-4535-9969-a0b78d3c6c70",
+      "type": "TEXT",
+      "html": "<p>Thanks for helping. Each page shows one guitar voicing, the tags an automated tagger guessed, and a fretboard diagram. For each, click <b>YES</b>, <b>NO</b>, or <b>REFINE</b>, and tell us why if you disagree.</p><p>You can skip rows you're unsure about \u2014 quality of judgment beats coverage.</p>"
+    },
+    {
+      "uuid": "9241de52-fc7f-4cdb-9211-44a352ea9473",
+      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "type": "TITLE",
+      "title": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+    },
+    {
+      "uuid": "dc805d9c-f12a-4cd0-bb0a-96a737192bf4",
+      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm6-altered-6str-26.png",
+      "altText": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+    },
+    {
+      "uuid": "0cd2e828-7a1a-4aad-bdf0-c1342f93053c",
+      "groupUuid": "20421f4e-6248-4ccc-9690-f22fe5f6dcb4",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "aba40be8-ef7c-4f72-a19e-c839babadc36",
+      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "c276313e-3365-4b6b-a86e-ffeace37aef0",
+      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "cde62618-2e0b-4506-9218-560b1f8e1c4c",
+      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "cce314ce-4bf2-41c3-b690-ecd4ab26c1c1",
+      "groupUuid": "407fae85-df18-4f11-a6e8-45291f8aabe9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "507599b0-4ac3-468d-a828-a812ab6e7aeb",
+      "groupUuid": "677dd3ef-f4f6-473f-a2ba-4cd0ad6d371d",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "36bb211a-6f5f-4f84-bab9-bdd6c5d97315",
+      "groupUuid": "f692a045-b69a-4b3c-8c64-c815edf9b12e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "43750726-e587-4dfc-af1d-4a7e22316c71",
+      "groupUuid": "38dc92e6-84d7-455f-b95c-454c321b8294",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "b81149e9-98d4-451b-9e6e-470d9b3298b6",
+      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "b33a0941-181c-4446-9044-dd1f37f4510c",
+      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-b7top-6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
+    },
+    {
+      "uuid": "7ff0b510-8117-4651-b924-8855d0b76000",
+      "groupUuid": "898a3982-84f1-4b81-bb7d-97a87535950f",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "aaf62e08-cbef-4ae2-a19a-4fc201bbd960",
+      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "73735b80-d45b-42ab-ad2b-71db51c9d090",
+      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e63c7c64-599a-4cb4-b5cd-aa0a21e60d24",
+      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "044f3136-1539-4013-948c-a87a9a1865f2",
+      "groupUuid": "8ab3fd4f-f514-4770-ab05-404759b99601",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4e16c380-eef5-4dff-b023-7fc5b6835b46",
+      "groupUuid": "1946ffb0-fbc8-40be-b957-a7238a66222d",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "993eaaaf-0d00-4f46-9255-8f6e07287542",
+      "groupUuid": "a3fc5d7f-030a-4237-94a2-9f055d66287e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "19918d02-5ac8-409e-b10b-9410208bd07b",
+      "groupUuid": "4d29dada-99fe-4a57-a7dc-1956ac17dd74",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "e9a35697-b5bc-4071-a88a-df3701c66118",
+      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
+      "type": "TITLE",
+      "title": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+    },
+    {
+      "uuid": "e14033c6-c87f-4694-9932-f352983075e8",
+      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "3602578f-3a3c-456d-ad70-3714d2396a1a",
+      "groupUuid": "b6bd81f0-f7da-48d2-bc4f-ccfe5306cd0e",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "da50f515-049a-43c7-92c5-efdec5b10eb6",
+      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "f0837946-b10e-4264-8976-ae62ebea4437",
+      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4b40c83f-bc5b-429f-bb9f-4e77d9df707f",
+      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "47d507fc-dfb2-437c-b169-2e8760d2d9ce",
+      "groupUuid": "6753989a-78b6-4e91-b32a-3628a8577bc2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "cfec88fc-6226-4415-937b-ec972ec850f9",
+      "groupUuid": "1d455bb0-2faf-48b6-801b-0f1c110d399d",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "44dc0684-2355-4b04-a25b-d6889e439434",
+      "groupUuid": "621f4055-e3c7-42b7-b0f4-6375d71a94fe",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "c82acce8-7a53-45b3-830e-f0f752c114bd",
+      "groupUuid": "549c1800-e651-47f9-8b2d-e92720221343",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d623267c-2e53-4ca9-8393-cd8a00494f84",
+      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+    },
+    {
+      "uuid": "674edda9-0685-416b-a744-2f139ff95ce5",
+      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+    },
+    {
+      "uuid": "83d0188b-794a-4f1e-bb4f-5e0198997eb1",
+      "groupUuid": "367dfd23-20b7-4f91-9d1c-6adc168aca5f",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "9f4e6e20-a201-401c-9ea3-9cd7160b7788",
+      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "12f6ddbb-8ec7-4464-b54d-79cfd4b120e9",
+      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "7692d7a8-8a36-41c8-87fc-2fcbea480154",
+      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "df880eac-acdb-40ff-8c80-6b249517c682",
+      "groupUuid": "da008810-b025-4451-8a28-fed684c750ed",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4fb33aa3-2f3a-4be1-8bc2-b09c208d719a",
+      "groupUuid": "1e25d394-3c6a-4327-abbf-5e66c4d1bc2c",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "6120424f-3421-40a6-ab42-617129671e72",
+      "groupUuid": "325f949c-43e0-4bab-9c5e-d37cfc3d0a68",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "02d5f65d-214d-4cc3-8928-4d8ca58e325c",
+      "groupUuid": "73eedec6-6374-4303-94bd-cb7ea0de0a05",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d9b9fa2f-d441-4170-8b24-5c2a5ceac914",
+      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
+      "type": "TITLE",
+      "title": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+    },
+    {
+      "uuid": "0f151d90-b230-4f1c-afd7-0f986d3cb9c3",
+      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm6-extended-6str-18.png",
+      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
+    },
+    {
+      "uuid": "b92969c0-4c68-4560-aad7-2c67f030903d",
+      "groupUuid": "b0041ceb-a5c8-41e6-86b7-4d26e148aeb5",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "d7518955-34ea-4e91-848e-3549e3c45494",
+      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "5d634695-898c-455e-8820-eb9781920511",
+      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "ec7bc0a2-7c93-4f38-a2d1-008c4f5efe9b",
+      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "2818e5e9-24ec-469d-b75b-5bf5116812c9",
+      "groupUuid": "92ef9d02-f101-40ea-ba5e-03c8c9b4bbe1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "dc9c0357-688f-46bd-8d3a-92460b314b86",
+      "groupUuid": "6e34fcbf-61db-4924-a1e5-f6e060cdfa24",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "ae9df3f3-569a-4d51-993c-3e0211a6cb08",
+      "groupUuid": "07c8d9ee-b308-4b59-be74-099a82233a1d",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "d670a294-2cd0-4d9f-a48c-e33c093af389",
+      "groupUuid": "5b3b5f20-bc44-44fb-af5b-a4727d560abc",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "695504ff-fe66-4ff3-860f-c18aa79aeda2",
+      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 Fret 1 \u2014 Extended \u2014 dim7 extended"
+    },
+    {
+      "uuid": "b89c4975-1397-433d-92c3-534093bec121",
+      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f1-6.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 Fret 1 \u2014 Extended"
+    },
+    {
+      "uuid": "ba421523-b5ff-4ce4-84f6-2432701fcf91",
+      "groupUuid": "0ac2ce16-dc90-4d77-8bbe-ec1fc9b049ea",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "119ddde1-4405-4bb4-8e5b-f21c5ad03db1",
+      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "f703cb9a-8b97-4860-bf9f-bd7d83a71ac3",
+      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "f4b97315-44ca-46dc-9701-2b3c6a0e81ba",
+      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5ed591f4-2876-4caf-9fa2-7b56a15364e6",
+      "groupUuid": "d4ac2e71-95c8-47f8-9f96-cd65d81e0bc0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "8d261219-166f-4322-9230-3b4906771830",
+      "groupUuid": "a8554d70-bf68-4e08-b36f-981f3376163b",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "16b8bede-afa0-40ad-bb78-a478a02b9d0c",
+      "groupUuid": "540d1d0d-4f73-42bc-9d18-de52e997dd6e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "4eb07632-c246-4c22-bdd0-eed37c281c87",
+      "groupUuid": "ca48c3a2-348b-49a6-814b-0f7fd1b36a14",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "3ed6cf37-7722-419b-98b5-3f273a97d65e",
+      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "6158986a-8a6a-4701-9704-db21c063144e",
+      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-a-lower-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)"
+    },
+    {
+      "uuid": "272b0e56-33a3-4e92-8ce3-950939119b4b",
+      "groupUuid": "09880ffd-6b74-46be-a019-ca152a704657",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "4a5c9659-83b1-4930-b544-0b18b3c6b405",
+      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "c53b33b3-8c71-4eb3-817e-97fd4c96a243",
+      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5ad782f0-69d8-4c73-9db9-6074f153c18c",
+      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "ddaeeb75-0cae-4972-956e-256dbd006b82",
+      "groupUuid": "974a4ac7-9e42-44f5-be28-5b2304cfdb29",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "42a239cf-056c-48db-b2e5-b15e5e55b0d9",
+      "groupUuid": "cf6a7974-e1d6-4354-aa60-2fd0f27db53f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "d59aa06b-9be3-4915-9216-a8bd7255b9d1",
+      "groupUuid": "cf4f405f-055b-433c-bfb2-8f1200c69918",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "86e84ea6-dc7b-435a-a782-b7fb591cdd1f",
+      "groupUuid": "e15a78e0-dd90-409c-8176-257ad0ded7ed",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d7227947-3055-4572-8a21-1fce6fef0cb1",
+      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+    },
+    {
+      "uuid": "cb58c681-06bd-4cba-b4d7-ad7d5fea29ec",
+      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cm7-shell-7str-7.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
+    },
+    {
+      "uuid": "44b2afbe-e3c3-40c3-b8c3-c92be82e523f",
+      "groupUuid": "5228785d-21cf-4465-8c16-fd492edd2c0a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "535987ed-808c-431c-91b1-c54980c24466",
+      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "ced810e1-5775-483e-8696-2e543a2af3f7",
+      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d19f10f2-9760-4069-ae66-b68a63e330cf",
+      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bddeb376-3d80-4d3a-a577-13abb27627f6",
+      "groupUuid": "6db8b963-b836-4a6e-8565-fcff863c64c3",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "50b3cfa7-066d-4a68-9c56-7ff929bf948b",
+      "groupUuid": "afedb3de-4462-4f86-abe5-1a60f27278b2",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "4767d72e-aeeb-4235-a434-7e2e66af7153",
+      "groupUuid": "83aac471-159c-4dc9-9ece-adde8d7a2c76",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "b24bc649-ad86-48b5-9639-5c7156e4a10c",
+      "groupUuid": "f0d91a60-1f33-46b9-80cc-947bef0bc3ef",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f7b27ddb-c0aa-46e6-8593-280e1675474d",
+      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
+      "type": "TITLE",
+      "title": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "bd0d4fad-fba8-4166-8562-c177b5a1fc40",
+      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-shell-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "6f49deaf-8cd4-4568-9f0b-82760a8b44b9",
+      "groupUuid": "0c1ef2d9-ee67-4899-b130-8e6208d18a65",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "dffc6c87-be39-4d41-8863-4df66aaef04b",
+      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "fbe87aa5-8334-41f3-9319-3fa07517a7d7",
+      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3d8b6cdc-651b-420d-9e96-8cbdb31c3a94",
+      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6a24fa95-cbd7-4a71-b91d-3f3501084ef4",
+      "groupUuid": "5d600836-4001-4f5d-ba8d-323e46c3bfc5",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "1ce6263e-7fe3-480a-a77c-4b497cc5f674",
+      "groupUuid": "5b2ccbb8-eda6-4f1a-a8de-17a97ba4f5cb",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "cf720845-3261-479f-9568-fa0004867578",
+      "groupUuid": "db87245e-a283-45e8-ba06-686ad7d360c9",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "266b9f0c-7137-4592-90eb-a4190d30f8ff",
+      "groupUuid": "ebd60563-9f12-4c68-aaa2-53c22c0c43c0",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "b8f3f244-3bb5-42c8-b03c-3bbba68d4e2e",
+      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "238c34ae-1e30-45e5-833d-a99749787b0b",
+      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-shell-a-6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "dec52203-ca80-4a6d-bbb0-13941d649cb1",
+      "groupUuid": "fef7b7aa-9719-4c98-ba9a-dfa3b18b1877",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "41af78e2-3154-41de-8207-83d1d6308230",
+      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "bf6471a7-29d6-4500-96be-605cf9bf9d8a",
+      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9939690b-7ffd-4a5f-99b0-4e17cca54efa",
+      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d59178b6-88a9-468c-9bb0-20ce9fef35a8",
+      "groupUuid": "5d2d1828-3817-4309-af7b-bfbc598c5427",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "672a1490-97f5-43c3-96ee-db7b8f2fe6ed",
+      "groupUuid": "f3855be6-6472-46fd-a5cb-9d5a90372c7e",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "a2cbf463-8f4d-4542-a45b-d33860f384fb",
+      "groupUuid": "7a52c501-ba1a-4e56-89cd-e273c769d906",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "cb48ed2d-098f-4e1a-8d78-c656b04b7198",
+      "groupUuid": "a1766295-c960-4ca9-accb-47d8e6adc940",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "2653e49a-4c56-4a8e-ac09-2159f8f4312b",
+      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "type": "TITLE",
+      "title": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+    },
+    {
+      "uuid": "e75225a4-902b-48e0-9d12-d7a5ede1c5e4",
+      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cm7-altered-7str-28.png",
+      "altText": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+    },
+    {
+      "uuid": "7f94485b-3d7b-46a9-b67a-1c76b1be1525",
+      "groupUuid": "455b0c72-e7ad-4cc5-8a67-2c1a9eb5714e",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "468aff08-f935-4120-beff-af4eb0c91780",
+      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "a088afa7-3e2f-4614-a956-32406ccc3818",
+      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5a2ef048-5882-4f6e-90e6-6455df3aece8",
+      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "a6da2fa9-d5e0-499f-894b-786cc9ff3552",
+      "groupUuid": "43629114-faec-45d2-a439-64ec19b2ea0b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b3845bf1-b9f9-42a4-b780-3b09506a8293",
+      "groupUuid": "3e144962-4441-4929-a8e8-12a858d7c437",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "3fb309b3-1766-4b24-8bde-7c13c7a9c8fd",
+      "groupUuid": "de0c1dcb-fdb9-4c56-9ce1-860298823093",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "b5a4d9cd-3da4-46cb-a3ff-08592b6aa664",
+      "groupUuid": "44480b32-565c-49e6-8c9d-cfc0ef4c8e0f",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "9dfd6b20-f093-49b8-aa1f-c4d679f2c4c9",
+      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "306f6597-a7a0-4aad-ab21-4009faec9d7d",
+      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-1top-6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
+    },
+    {
+      "uuid": "5fd86c89-a22b-40f6-a55c-4b6ee6761ff5",
+      "groupUuid": "eae060b0-26dc-4363-9ba7-466aadad3237",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "9f6c92b4-4290-41b9-89b2-8288f74a0e06",
+      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "6ce1f6a8-11ea-4bb0-b67c-59dade51ef09",
+      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "db59a909-6b0f-45b6-89a0-38cdd9d01596",
+      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "ffe8cfd4-201d-4616-830f-4803aa355885",
+      "groupUuid": "d5b343e4-73d6-4143-b1a0-651590a23bae",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "78649e80-b8de-4ffe-82ef-5ba1131a420e",
+      "groupUuid": "19c40bf5-de9a-4e46-850b-07e12e7b1f23",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "9b8d3c02-fd04-4214-b71c-9157fc2c9df5",
+      "groupUuid": "e34cd2fe-a1b9-40cb-a3a8-fe404cd75129",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "5ad343cf-d67d-45e1-8d69-3c4042a6309f",
+      "groupUuid": "ba698029-c5a7-4732-ac17-c047c6c85ded",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "ce603121-719e-4b9b-ae71-cc4bd0b7ef4d",
+      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
+      "type": "TITLE",
+      "title": "C7 \u2014 7-str bass \u2014 Drop 3 \u2014 dom7 drop3"
+    },
+    {
+      "uuid": "22ba7a9c-10ed-4dd8-b794-d7019b5ede40",
+      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "9fadad97-39ad-46fa-95e9-f802c4dc5446",
+      "groupUuid": "24d8266f-c973-48bb-b24b-57b0f5da55fe",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "758a0092-68ca-4689-b8ef-1ccc1a7ef461",
+      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "96bf288f-baed-4024-8a37-17d75412a4e1",
+      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c6bed596-04d4-4854-973c-c4a20aaaa1d6",
+      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "a73b5af3-32d9-46a5-8199-40ea2f70eef8",
+      "groupUuid": "163db6b8-e620-457d-ab7e-cae553a68e46",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "46d17dc0-54c2-47e8-9b98-e42503641b21",
+      "groupUuid": "256613fd-cc0d-42a6-805e-b7705fc8ca9d",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "6d8b58c6-5d03-40bb-9e83-94eec8753e3c",
+      "groupUuid": "d1b90612-d158-4c31-8fd9-f3851376310f",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "4084b415-d7fd-4a18-b715-5ac409594cec",
+      "groupUuid": "57c01c7c-867c-41b9-8417-eec93b149293",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "1a26360b-1423-4f4e-b959-f39bb07a8777",
+      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+    },
+    {
+      "uuid": "f61607ed-71e5-42a2-b82c-34bd5725ed12",
+      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7-cm7.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+    },
+    {
+      "uuid": "514ca0e1-aa11-4447-a183-2de4f481b8de",
+      "groupUuid": "9a3a845d-cb3e-4d33-bc57-ece1931749fc",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "e83b024a-d3cf-4a23-9215-51cba6a9de41",
+      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "92034c6d-4bf5-431f-9a65-687008a124e0",
+      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "19e7b88c-6b13-4749-9fc1-a50652aa07f7",
+      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c7f752fb-ae98-4ccd-bf62-08d5138e6d6b",
+      "groupUuid": "36ac0607-3388-4db2-8fad-e6e5e85be5e2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "eee36fce-70e4-47b0-aa03-1fbfca9d63c2",
+      "groupUuid": "ba98e64e-6811-43c0-804a-0bafa794d717",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "85e0c33b-738c-4490-927d-95a14ec67118",
+      "groupUuid": "0f572aed-dda4-4fdd-958a-8cddc3708405",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "5836d893-eceb-4781-af39-d2d9c2343d8c",
+      "groupUuid": "73e6b5a8-ea0c-427e-b71a-80288d3e4d47",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "9dee9dd0-73d6-452a-89d2-eb22b76ad557",
+      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
+      "type": "TITLE",
+      "title": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+    },
+    {
+      "uuid": "7fb6ff38-679c-49d1-9479-91674f373188",
+      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cm7-extended-7str-20.png",
+      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
+    },
+    {
+      "uuid": "b3b8ed71-44e7-489b-a859-65415ca3ba57",
+      "groupUuid": "f94cf719-e12f-4c07-803f-9e9417882187",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "7f20d579-c15d-42e4-9e10-bc7c698a9336",
+      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "d1be8de4-64ef-4c4a-935b-52fc58d95258",
+      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "75adba5a-7b10-4099-a4f4-1fb5d7a863e2",
+      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "7db93cfa-0dad-42ae-b55c-1bc7f4250751",
+      "groupUuid": "a2284384-4ee4-4133-8b15-7f1e2cbd30dc",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3737a7b7-73e0-4522-95d2-0a4f0bfedb52",
+      "groupUuid": "06430510-b8a8-4e9e-8aad-ae340fa05fa5",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "62b4e713-1f3c-4920-9207-9cab68aeb6b8",
+      "groupUuid": "90ed6530-e271-433e-b0c3-57310244a028",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "08194532-6766-4082-932f-dbe4c7c66ce7",
+      "groupUuid": "346fa57d-0169-4616-aedc-72eeb4a467a9",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d1affda3-23e9-4c34-bca8-8f7e5ea48bb4",
+      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 Fret 2 \u2014 Extended \u2014 dim7 extended"
+    },
+    {
+      "uuid": "f6d544d7-68ed-4a9b-91ea-9d1aab1853a1",
+      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-chordsdb-f2-6.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 Fret 2 \u2014 Extended"
+    },
+    {
+      "uuid": "80a5ed0c-b51a-46d0-a89f-3d29be79c17b",
+      "groupUuid": "bce92d49-b4e4-40c4-9397-718cddae8fc1",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "58d87b5e-3350-4a44-a5ac-464f2dd4b2f8",
+      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "74053019-0275-4507-8281-85bd6990e505",
+      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c9cef4ec-befb-49d0-ada9-1aadaffe75fc",
+      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "ac6c7670-b30b-4f87-9a7a-c9445e0c57a9",
+      "groupUuid": "5c183dda-fa04-4b7b-b165-37d6cf95e1a1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "f1c78e68-b04f-4a67-8f67-ee8b359612cd",
+      "groupUuid": "f3c604fa-b10f-47fc-976c-c74ca440a6c0",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "9fddc19c-d293-4044-9d8f-22524727d472",
+      "groupUuid": "0ab467c8-ebf2-476a-9564-2d103fda0b64",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "43761be2-2fcb-4ace-bb1c-a6b16bf0dba4",
+      "groupUuid": "463e2215-01ef-4836-ae6d-7086246bc0e8",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "ac4a4660-c429-46d6-9776-120962abd35e",
+      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "0d399ea8-14e7-401d-a8b6-2eea507a3973",
+      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-bb-lower-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)"
+    },
+    {
+      "uuid": "c29eda75-55e3-4849-a413-3c24b74b471a",
+      "groupUuid": "1a0b44fb-e546-4c24-9f76-f0c65730be24",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "26add9fc-3ebe-4cd8-8c1e-091311e029a4",
+      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "a5cdbf0d-1721-48f1-b725-388b4bd725d3",
+      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bfe9f8c3-42a0-4033-9c59-f876c3b1da2f",
+      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "290131d3-efb2-4a56-bf01-f762eddc8b8f",
+      "groupUuid": "522c75c1-7dbc-4932-b228-92574e4e1f75",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "173c54b7-62fd-4d13-981e-05ff8caade56",
+      "groupUuid": "e755dc00-f6a9-4216-8161-e4c908c80ea1",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "465be447-c7b1-418b-ba7d-3a9aec00d77e",
+      "groupUuid": "c8eed5c3-b81f-4aa1-9587-77c4379d1974",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "b65aa45c-4883-428b-8780-d8d07d7a749b",
+      "groupUuid": "77047e7d-c861-4cbc-8339-745a383e93a5",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "b0722b10-45ce-4f7c-bbd9-b51b3203354f",
+      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top) \u2014 dim7 shell"
+    },
+    {
+      "uuid": "1644577f-7c71-49fc-8775-7c1e50be98db",
+      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-cv7-shell-7str-7.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)"
+    },
+    {
+      "uuid": "e05e6245-2813-497c-b0a8-73c25755d512",
+      "groupUuid": "4f088bf5-b4f9-4114-a5c1-808f0a615f38",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "af4c00c0-eee4-4e5a-b51c-b26982990cc6",
+      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "dc3c6c77-19a2-4625-af62-ba78a9e37ebb",
+      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9569ee20-d8fa-4a0b-84fb-be7cda1c1068",
+      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "00ac7444-7879-4fcd-9a34-992ea8b74bb7",
+      "groupUuid": "64dbdd9d-da6f-4759-8dc6-5738340d063e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "37c0136b-dd1e-4e74-949f-3e291f3ec45e",
+      "groupUuid": "83cf3ca3-3e91-4d67-a6ad-027028e09503",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "580ccacd-1b6b-4874-b876-f89bf5314b5e",
+      "groupUuid": "38daf8f1-5cc5-4268-92f2-baffcc3ea956",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "c42092fc-6d05-49b6-8928-3cf4e14c875c",
+      "groupUuid": "12e80f5c-683c-48ca-a852-0b50ac12f47c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "25b333c3-8e90-4af1-b427-dd0ef0ddf0f9",
+      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
+      "type": "TITLE",
+      "title": "C7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "572c2907-8d76-4862-aded-2b42248cf01f",
+      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "a2362c3b-2f8b-4a69-9bef-eb358b320e6f",
+      "groupUuid": "45a9248b-c4da-456b-9d65-7841589c8907",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "26501dc4-c8a9-474d-99a9-9d4bd4a6c9fa",
+      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "8ac30034-24e8-4ca8-bacd-2eec398f9ad5",
+      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "03958566-7afe-423b-ab51-71ce3c52bb72",
+      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c553c45d-dba3-4cde-b40b-e03731284b74",
+      "groupUuid": "55e46566-179a-4130-b17f-0cdb9e3f14fa",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "1c26c729-91ff-4371-bb38-e54e5babdcd8",
+      "groupUuid": "87fc2670-6f51-4dd1-99b1-34ce6e17396a",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "80082bf4-3cdc-49fd-a5d4-3cb9c2f22396",
+      "groupUuid": "d118f94c-4aff-43ab-af17-88da156eb0c7",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "f0fb50ce-6209-4839-8cb5-14cb9f6978ef",
+      "groupUuid": "fd02e2bf-1d66-4af0-b01b-13cf40d7b820",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "218f2455-426d-4d7a-b5b3-abf2c694cc34",
+      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 A shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "d56b4f09-b1ff-4672-b6e4-368177288b15",
+      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "e81efed4-181d-4b51-9550-2f27148986d7",
+      "groupUuid": "d3d9d54e-a3d3-4eea-9ebd-1ffbf840093a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "2f6de2b4-8ab8-471a-be27-ec6e089776ed",
+      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "2388035c-1837-402b-ac80-0dc8e04ad28c",
+      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e97a07a6-73cb-478b-9681-91041c818a24",
+      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "868e817a-22a9-4b4d-b073-46d7ba6c52dc",
+      "groupUuid": "a2b32c61-90ab-4ea5-b7a3-903ead9a3149",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "953e2a01-9fe4-4d80-821a-de1ad9f56adb",
+      "groupUuid": "a0b5ad15-b8f8-4fc5-bffb-bf0d78ecb828",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "7e8e64dc-4c18-4393-bfb2-93e6978ab071",
+      "groupUuid": "121c37f2-8225-4d96-87a0-a5a60a2fdff9",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "98b547b4-1ed9-4978-b379-bb513363fa0e",
+      "groupUuid": "0c0786ca-e812-47db-837f-1ba8c7e18d48",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "5fee96fa-3c66-4aa8-a2e7-23637bcafb5f",
+      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "type": "TITLE",
+      "title": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top) \u2014 13b9 altered"
+    },
+    {
+      "uuid": "02c5a1d5-72e3-4cb0-9cfc-1b9e2c22dc85",
+      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv6-altered-6str-25.png",
+      "altText": "Fretboard diagram for C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)"
+    },
+    {
+      "uuid": "3eb31a58-b3e9-41f4-b2b8-78a033bd3635",
+      "groupUuid": "b5897bda-439c-4378-a619-f505bc38b456",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "bfcf5fb0-ac5d-4b77-be0d-d783236a5384",
+      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "01e00aec-3975-44e0-8df0-1a9e6c9bddc1",
+      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3454ed97-3866-4f18-951f-0c7a6e234e9b",
+      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "51979008-ab50-4d44-ac6f-634ca67271ae",
+      "groupUuid": "12a1594c-a842-481b-89f5-9ff22d18044e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4f1ed7bf-47ba-4565-9465-9a347df68e2b",
+      "groupUuid": "3d9c15ff-49b7-4060-95a2-9b9e3a3b348e",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "ee61bd1b-6cb0-4861-920f-9543dcb25c1c",
+      "groupUuid": "88ae5c0e-351a-4832-8ab1-a32ea885b46c",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "cd04e6eb-198b-4e69-809f-d6d71aa3fd8d",
+      "groupUuid": "f3c355bf-b0c2-4d12-9de2-a48f4158a81d",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "aa4bc9b2-9edd-4ef0-8bc9-78d3829d8989",
+      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 10 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "fe37c064-df7e-42f6-9e85-adcc0f26b671",
+      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm6-drop2-3rdtop-6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 10 \u2014 Drop 2"
+    },
+    {
+      "uuid": "55f3ca6e-5dd0-4169-8424-245d645e8c51",
+      "groupUuid": "6e22aa38-d327-4192-8aa1-b17cc14ba491",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "053e9051-065c-4048-b39f-07bff28b2356",
+      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "f3703285-12c0-42e1-aa78-3d189f9f021c",
+      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "1a71ac8b-f6b7-41a5-8623-7470f6483179",
+      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b23ac411-d4b6-48ff-a63e-9bfc1067819f",
+      "groupUuid": "8a5f8805-4e32-4f74-8482-dfbfa4c266bf",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "f3d0d16d-9df3-4a3c-b062-a847eef9adcb",
+      "groupUuid": "2a2263f1-2a9a-48e7-8895-e0b95ba43f46",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "ee8cac93-a3ed-4899-be30-249fac034e8c",
+      "groupUuid": "d554026a-d61f-463f-88ec-ec5b9808aa9e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "d49bf708-025a-443e-b4a4-2df946f8b171",
+      "groupUuid": "9f76d292-acdb-45c4-962b-402504a9992e",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "cd991eb3-4641-433d-8dab-53b2116d12c0",
+      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
+      "type": "TITLE",
+      "title": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+    },
+    {
+      "uuid": "71ad91ae-db35-403f-beee-be1facc72f4d",
+      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cm7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "bbd78b2b-f732-4590-a04e-aa3e1a286c37",
+      "groupUuid": "a9343f91-67c1-4e99-9fa9-91542b58f0e4",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "c80ee2ba-16d3-4809-b9da-23294752bd6e",
+      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "18fdc133-6c06-44bc-bcd4-d6c9ead77ccd",
+      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c02f7dad-b635-4473-8bdd-71974a21c436",
+      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9d9ee1e2-0a6a-4596-a249-1123738d7891",
+      "groupUuid": "88578e1f-8bd6-4890-864f-27d812c6a3c9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b8c225ac-e10b-4ac0-8e33-61037de956cc",
+      "groupUuid": "29067ecf-ea88-4196-b2f4-65b4be7f8b0f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "fdf79f25-c6c3-4b3e-9584-f630b08c4053",
+      "groupUuid": "f3b8ac56-d172-4510-845d-3c779dca0c67",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "32622073-0ce3-42cb-a8c2-0f2fc25536e4",
+      "groupUuid": "a722cb93-4b42-4d61-9615-14e11fc28908",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "79378017-4799-492d-8bf6-88f5a601db0d",
+      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+    },
+    {
+      "uuid": "357581d8-af4a-426d-a6f4-3dadf6017898",
+      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-6.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+    },
+    {
+      "uuid": "7aa20b82-16b0-4f8c-971b-c89532ebd85e",
+      "groupUuid": "8fab9a6b-c281-4c8c-b34a-d1afa3271047",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "8fc6fcdc-3793-43c6-9f72-3fd3a693eec8",
+      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "b4ab1445-d527-4e46-a8c1-5002b555a863",
+      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "313a9187-a1af-4418-b554-d5a568f368ed",
+      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "52701873-33af-4436-9866-e7eff38fabbb",
+      "groupUuid": "e3c0f620-08c8-4f19-88fe-d8cffcab29c8",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b517b4de-3e03-4a48-a3bd-ead6a92c5199",
+      "groupUuid": "7aa19bfe-c3f8-47a4-bb48-8caf30d811c4",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "768499da-5202-4c93-b246-c6e314bf40eb",
+      "groupUuid": "ab950fc0-a516-4914-b8e8-1f1fdf5229a6",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "59065509-8749-4c5a-9931-00a5f5e866a8",
+      "groupUuid": "81c458a6-dc42-4c7d-856b-90b460ad9e76",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "37348e24-94be-4039-9020-1eeb41a1d1a7",
+      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
+      "type": "TITLE",
+      "title": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top) \u2014 13sus4 extended"
+    },
+    {
+      "uuid": "0689e9be-85e2-40f6-8760-d0e5e16f9d91",
+      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv6-extended-6str-17.png",
+      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)"
+    },
+    {
+      "uuid": "c6e37d0c-6ba7-4f30-bf83-0c59c60bce24",
+      "groupUuid": "e9df45de-6f1d-49ca-8eea-5c9c0e120e1b",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "5e08bfd0-7fda-4c7e-996b-3ee0ad14ea3d",
+      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "664b46ed-4d48-4f04-aff7-480861e2084d",
+      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "08c5c8ac-539d-4c73-9f7a-a56091f792a6",
+      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "88e876cb-f615-4de0-80bb-879c596e37e7",
+      "groupUuid": "f7f10ce2-f01f-4931-93b6-077f4277d2b7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "80200bcc-db9c-4979-9dee-5a41cc893cb3",
+      "groupUuid": "c993170b-6c46-46f7-b599-0005632d9bb5",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "c4089129-2330-4ee7-a686-8c5f946bf465",
+      "groupUuid": "bd0ad227-8a09-4fb8-a08c-ba170daa4c60",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "ccb9ac4d-2313-4fb0-a1da-9e7aa7c7e84e",
+      "groupUuid": "8707d525-da19-4a7e-9855-767f161e2fcb",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f814c69b-9c38-4893-93b0-ce13c9309fb7",
+      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "type": "TITLE",
+      "title": "C13 \u2014 Fret 2 \u2014 Extended \u2014 dom13 extended"
+    },
+    {
+      "uuid": "e74633fc-1384-489c-b6d3-e22fd4cb97f5",
+      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f2-6.png",
+      "altText": "Fretboard diagram for C13 \u2014 Fret 2 \u2014 Extended"
+    },
+    {
+      "uuid": "63879f62-37cf-40f9-bc45-32a8504c4c06",
+      "groupUuid": "27202e9b-1499-4f6f-8d07-447ccb26308e",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "1af4c108-e7f0-45e8-8b4f-74d675089089",
+      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "fe9cff38-c532-42fa-8ac7-1b5361bef908",
+      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "0faa4700-c47b-4a0a-930c-8c44adbef5fb",
+      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "7d3958d1-3200-4b90-aa02-25a8fbfb41d6",
+      "groupUuid": "188b6f38-b940-43c2-afec-80ceeff40eb2",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4fc9b7af-3033-4e72-a4ee-7b07fd5cfc1a",
+      "groupUuid": "50f1ee99-df58-4b46-9cc6-9cff7655d4ff",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "525ec07b-1296-47dc-b6dc-24d732d442b0",
+      "groupUuid": "e2b59c7f-1414-4629-ba8c-0a61a2983751",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "dad24204-9ece-489d-8951-0f8cbd40e7fb",
+      "groupUuid": "2c944705-dfa0-4755-81a7-42b605c888e4",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "287d459a-d3a8-4c49-8c89-89d19eed6a16",
+      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "852e1746-4498-4f64-a14d-9da445bb2406",
+      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-d-upper-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)"
+    },
+    {
+      "uuid": "9f483536-442a-4ba1-8658-57f262577804",
+      "groupUuid": "42a87dc5-65f4-4b8f-b719-5ee4eb5daf6a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "20702ecd-76a1-493d-a309-3a85e58cbcd4",
+      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "0bf4c9b8-45eb-4cab-bfdb-0ddf69022964",
+      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "89735065-c650-41a8-a979-b436fd0b512e",
+      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4c8eb53f-52a6-4681-a02c-e98a1ebf02d2",
+      "groupUuid": "fa88a274-74ff-4ca6-a100-b3525c69a179",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "a3ec6e74-e868-44cf-9dd3-90eb47725a34",
+      "groupUuid": "721d69d8-2a4b-46df-a08c-be0eec66d62f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "8e6857c2-db16-40cf-8c74-9e8278766e95",
+      "groupUuid": "e9a81313-1ee4-454f-a086-29de029a17ef",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "7c6e5af2-6eac-41fc-86e6-afa49b9108fb",
+      "groupUuid": "2057b940-1097-4f10-a217-645885b60ece",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "2f5f7349-db4d-4d88-9eb7-bb59ceda495d",
+      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
+      "type": "TITLE",
+      "title": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "19a34b88-f930-40bc-8559-d5d109b557f7",
+      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cm7-shell-7str-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "6400ba0b-cb7e-49fd-ae7f-43e596a2a58a",
+      "groupUuid": "ac9c33cb-838f-48fb-b44c-bb397da30791",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "429df7d8-99a7-4c18-8bb0-b6a3fdcda833",
+      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "d7c14493-3ca8-42be-ad1d-8d8618d4df2e",
+      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "138caade-148b-457a-a1d5-6ad6684c2324",
+      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9daaa065-108a-490c-9877-0a595cdab2b9",
+      "groupUuid": "a106d3f1-b85d-4422-b80b-adad2a91aaeb",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "65720faf-f8ea-496b-802f-2e2603c4e74f",
+      "groupUuid": "6aaca151-acf1-485f-8f7a-51697bde034e",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "1f07089b-70cb-4b23-9c8e-36e3c266cba8",
+      "groupUuid": "f58819aa-eb9c-48c8-b6c6-02bd155dd4e1",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "25a5e488-2665-401c-9f0a-e6a9d93991c9",
+      "groupUuid": "79129a45-055f-44a5-9713-55cd722de8e4",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "a8c7de1d-8055-4cd4-b0b7-c8fc59c80a66",
+      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
+      "type": "TITLE",
+      "title": "C7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "df4381ee-c670-4098-abc7-e751571d2130",
+      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-e-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 E shape \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "09a79f85-14c2-42c2-bb9e-44f22555ffb6",
+      "groupUuid": "ad27ef36-e52c-4198-9638-0ee470669c2a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "07935a10-843c-4516-b0d3-5d28a83c4c96",
+      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "62a30ede-db71-44c0-a422-91778213ec47",
+      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e5060334-2040-4740-989b-31a9d83d859c",
+      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "45307e52-b53f-482a-8242-2f3d85b2cf8d",
+      "groupUuid": "21ef7ace-23fe-49af-83f6-86722c673dd6",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5ed8f79e-8e5f-48aa-bcbb-80bbd8d8fd67",
+      "groupUuid": "44e45643-ba2b-460e-a5af-0b5f481b230c",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "9043978a-52e8-46d6-8dfc-929791ac9e9f",
+      "groupUuid": "4b635864-7a12-44d8-8188-c7e667fa0716",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "683b5203-49bd-43e9-ae72-a5b86314cce3",
+      "groupUuid": "6c0817b9-b229-47b7-aac1-358f97f9a95c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "ddf17afa-3e2e-438f-89c2-52bd41948660",
+      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 E shape \u2014 Shell (3rd on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "6bece04b-552b-4ca3-bc0f-23d0886035fa",
+      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-e-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 E shape \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "a1bcc03b-f712-42ba-8bd4-e60db29c8355",
+      "groupUuid": "3a36afbd-b837-4e91-b75f-0ef55087d414",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "612dd531-2dab-4519-b2a5-c8c13a2c3be6",
+      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "2cbd48b3-5ef4-4d35-826c-4aa318b59e49",
+      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9de0323d-51cf-45fe-a0c6-d4910198ba86",
+      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "db4dee78-9973-4363-8166-d160815357b5",
+      "groupUuid": "a4ccdc11-7932-4cee-95aa-bf7c91fa3ab0",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "28370580-8839-44d5-b7c0-a70539b4a479",
+      "groupUuid": "17526745-6ef0-4c7a-940d-d8c2d3702f1b",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5202a849-1275-493d-98e1-f732f185ee9c",
+      "groupUuid": "3e97a0d4-2d45-4ced-8880-21977a4d1e2a",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "b18a1c2e-35ae-436f-aa91-a686b9b98cfe",
+      "groupUuid": "406320bc-47fb-4c27-976f-3019e5770114",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "55fc101c-8701-4c16-9df8-90bbbb612888",
+      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "type": "TITLE",
+      "title": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top) \u2014 13b9 altered"
+    },
+    {
+      "uuid": "225c4ec2-a3de-4a21-97bd-5fe2ce0b07a3",
+      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13b9-cv7-altered-7str-27.png",
+      "altText": "Fretboard diagram for C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)"
+    },
+    {
+      "uuid": "5307c100-0703-4206-9c6b-4cd7997e4e65",
+      "groupUuid": "055109f9-15a6-44b4-9b2e-2db9b027c07f",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "69af7813-df13-4b7c-8c45-45332945bb4d",
+      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "cfa7ad9d-b53c-42d0-9846-7122c9d91f12",
+      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bf0afe32-e5d1-40e8-84f8-ccdd83c8432f",
+      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "69b9187c-e97b-4b01-ba06-ed9e4e0f36b5",
+      "groupUuid": "2bfce729-518d-4344-8868-f37fa446e09d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4b9bb1da-301a-42e3-b37d-521a99213e6c",
+      "groupUuid": "65ae06b6-32ee-492d-9bf6-e961f654163e",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "0878dafe-5a3d-4fc1-8918-677e110a89df",
+      "groupUuid": "e22d9f40-7c24-4066-9aa2-272e41965ba7",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "9b8f8b51-7fae-4ef5-a71a-82c204d37dd1",
+      "groupUuid": "f80e2dbb-ee70-4244-bbf0-be8cc011df5c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "756a579e-c7a3-4fe7-8dd2-c07c4fd7a357",
+      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 5 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "0f0d0d19-dcaf-4dda-a872-6f7429a5bdea",
+      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-b7top-7.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 5 \u2014 Drop 2"
+    },
+    {
+      "uuid": "9b0b55cb-6266-47c3-b185-b5efd93f6885",
+      "groupUuid": "5e8250d2-572e-4322-955a-934fd3f32153",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "257c0f14-3f96-4ea1-8ec5-688f517936fb",
+      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "9ecc7cb9-37a8-497a-a08c-83fec03ab998",
+      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3b69cc3f-5485-482d-b73f-b8c9902e1868",
+      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "be3cb1e3-e149-4ae3-9423-16b55847f728",
+      "groupUuid": "36bd02d4-7d86-4cf8-9ca7-27d6c559323e",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "47d2be8c-aaf9-4db0-838e-a26858e19022",
+      "groupUuid": "8588b4a7-9f07-4b39-a36b-139000a4b5c9",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "d07f02ff-032d-4429-8d2a-ffaf64f9df1a",
+      "groupUuid": "e44a6fae-9501-4173-8870-8edb9db83cdf",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "00ba9499-8152-4c07-96e5-3aa18536e552",
+      "groupUuid": "61f00353-0140-4f0a-a81d-91362904983c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "1a4becb8-2da6-4d38-a2ea-11506dc80d2d",
+      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
+      "type": "TITLE",
+      "title": "Cmaj7 \u2014 7-str bass \u2014 Drop 3 \u2014 maj7 drop3"
+    },
+    {
+      "uuid": "c81e26b7-b508-40f3-8770-9767848e1b85",
+      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cmaj7-cv7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for Cmaj7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "8e436b8f-89b3-4403-97c6-9e8dc9215101",
+      "groupUuid": "80bc8174-7a9a-4378-9877-13340f26c80a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "f0835501-3fc1-46f3-9f39-5bb302495558",
+      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "d43785b6-a408-470d-b4d1-2a0d9a0f28c6",
+      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "25e3a1df-edd2-4d1d-8e84-e1ebc2603dc8",
+      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "af916e45-a325-4693-9595-9c147326dc4e",
+      "groupUuid": "96f8958f-90b8-423d-bc0e-2768f09e14ba",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "40712420-89e4-42ce-adc9-3c5fb2fb5f9b",
+      "groupUuid": "0232f786-4bd7-40ad-99a6-633fed50e3b6",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "7bb92140-b87a-4038-bbe3-f07c6d108a8b",
+      "groupUuid": "d085a76f-95e7-4700-9829-3d64ab8c2833",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "1fff0dc6-bb43-4a1c-8ffd-8c9e04ea612d",
+      "groupUuid": "246cd770-7d49-475f-b513-bbdcc3428eda",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "10a01755-b9a5-44bf-9cd9-ad93ea0b778f",
+      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
+      "type": "TITLE",
+      "title": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top) \u2014 dim7 drop3"
+    },
+    {
+      "uuid": "afed22d5-5d04-4e15-af04-e8b688b1f29a",
+      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdim7-drop3-a-shape-7.png",
+      "altText": "Fretboard diagram for Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)"
+    },
+    {
+      "uuid": "a01583d0-d549-4c19-8d25-ba25d65775ed",
+      "groupUuid": "8be8e0bf-dfe6-4048-9a96-d393723d0525",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "37f72730-eed8-48a6-a797-24763cd10c67",
+      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "4300f613-020c-4f77-8031-40d899230210",
+      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "45b1cbfb-6bb3-4f2d-b876-1579d187c592",
+      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "89786d00-9f4d-4dd3-8a2a-49cb8aeef664",
+      "groupUuid": "f8a7ef1c-5bc2-4ddb-935f-cb29f13e4608",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b3c54dfa-2b58-4e21-9c0d-4193f5ca3fc7",
+      "groupUuid": "17b19449-821f-4d31-8b2c-df636a63422f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "475f341c-c6af-4c15-959c-9f63f5d038cf",
+      "groupUuid": "bfe4bd45-c721-45b2-9075-664747f06a79",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "71dfb8df-045d-4125-a828-38f3d2e4423f",
+      "groupUuid": "41725abb-1ae3-4920-b756-3d0f43cc040b",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "9eab1645-b716-4e7e-a702-fcb84de8dfe5",
+      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
+      "type": "TITLE",
+      "title": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top) \u2014 13sus4 extended"
+    },
+    {
+      "uuid": "bc99c817-cd82-40ac-b188-71e155c72b89",
+      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13sus4-cv7-extended-7str-19.png",
+      "altText": "Fretboard diagram for C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)"
+    },
+    {
+      "uuid": "72dca44d-e96b-4284-87e7-0dce4ed789df",
+      "groupUuid": "4ceb2c6b-908c-411d-bab9-981b98342f42",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "315fbc82-9b46-4370-a5a6-62d2ef82e2c7",
+      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "d5287e6e-78af-465e-a8aa-661c94c65444",
+      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d59e31ea-505c-40c8-ae88-204c2105ed5a",
+      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "7688b107-d174-4c47-8144-3fcdfa7f2a60",
+      "groupUuid": "ae38d0d9-efff-4f04-a399-ea7ffe5f04da",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d7d82079-eb70-4801-8cbf-529563c06934",
+      "groupUuid": "89687b3c-6893-40e7-b888-5d1b3fb7d0aa",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "23f6cec6-c94a-4b71-89c5-6ee06fc9137e",
+      "groupUuid": "e88ea530-3fdd-4208-a376-0deb3df5cb4b",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "32961283-b398-4699-9793-aa6fc2614b2e",
+      "groupUuid": "d9df36d4-ce88-4d58-ae93-a79b1c41c024",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d4d45bf6-69e9-4722-abad-4ef6025810fa",
+      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "type": "TITLE",
+      "title": "C13 \u2014 Fret 3 \u2014 Extended \u2014 dom13 extended"
+    },
+    {
+      "uuid": "e5bbedc2-6f77-440f-bfbb-4223483139d0",
+      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13-chordsdb-f3-6.png",
+      "altText": "Fretboard diagram for C13 \u2014 Fret 3 \u2014 Extended"
+    },
+    {
+      "uuid": "435b816f-db94-490b-83ce-ace6384f6ef0",
+      "groupUuid": "2c88d9e4-9b7d-48f7-9a36-082b8653e8a6",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "3dd0a387-2b13-47ca-bcf9-75b06ee75368",
+      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "40363cc8-555e-4b5d-8cba-155be8b2f752",
+      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "b1b5343a-370d-4670-b6ec-0fe3fd327137",
+      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "2df8188d-7a70-4a67-afaa-a9d5bf31db4d",
+      "groupUuid": "6784d4db-8bd4-42e4-bdd1-a6fdd05fef36",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "67a9cc3f-43b2-4c0c-b177-2f96ab7d4235",
+      "groupUuid": "6dc237a9-744d-4698-bd3b-9669cfe28656",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5c18081d-bb05-4618-8fae-5afc1bdc1908",
+      "groupUuid": "2cfefaf0-17f2-49b1-9237-9f4d06d62162",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "6d91a078-d6dc-4460-9176-6f15604d4fb0",
+      "groupUuid": "ee729eb0-04be-4a38-bec7-fbb386c2304c",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "349d4223-46cb-44ba-8a9f-59710dad5cc3",
+      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "7ea93e42-9c49-475a-943b-0e5466a37c1a",
+      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-eb-upper-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)"
+    },
+    {
+      "uuid": "57e01598-fc07-470e-b763-b8a8bee9c78d",
+      "groupUuid": "6a2dbb24-a3ce-4525-88c2-dee5247856c2",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "1badea63-dd8a-429b-bf9d-fd1a96f192ef",
+      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "c5f012fa-7c0a-44ed-b556-6d085672ec66",
+      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "15ad7860-7a0a-4909-be67-e7aa6d44b8b1",
+      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "48b8b349-6c90-41dc-8b80-cc8abd9909d3",
+      "groupUuid": "babc169d-42a1-49a6-8709-63a6cece17c7",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "36d8e845-5f1b-4ced-9eb1-436a47bca1b5",
+      "groupUuid": "6cfe9126-1606-4b5f-a422-b54bd7076f24",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "98a0ba9c-dc2e-4831-83f3-1db98b064a67",
+      "groupUuid": "4fac16d7-af2d-4e0f-88e8-5a1364088e87",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "f7fe6c29-9e1e-419d-9161-2212964f8878",
+      "groupUuid": "8d04dbd4-c630-4a76-b317-0f500114e7a2",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "a8af50d0-b2aa-4731-990f-054ebcf1e200",
+      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
+      "type": "TITLE",
+      "title": "C7 \u2014 7-str root \u2014 Shell (3rd on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "1a30ba61-c119-42da-a74f-94534db0d8fe",
+      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-cv7-shell-7str-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 7-str root \u2014 Shell (3rd on top)"
+    },
+    {
+      "uuid": "2df31218-1523-46d5-9ac5-31589035069b",
+      "groupUuid": "ff56bd26-224f-48c3-abc6-5122212cd24a",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "a31b42d3-ead4-491f-a6b4-a8f633da745e",
+      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "2721f571-fb44-4c31-b854-211b584bfbe9",
+      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6714b741-fef1-49fc-a892-5a2c33c9a8ed",
+      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "318312f3-0e78-4cc7-b9fd-1c34e26f78ff",
+      "groupUuid": "24a609ae-a6fe-4320-9924-f833dab7669c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "1cde45b7-d3c4-49e0-bd66-46ad507fd896",
+      "groupUuid": "93ff54b3-557e-4b31-b3c7-49d1d2c0a8b0",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "acb9a0c1-bb65-4915-88f2-7917890a5e51",
+      "groupUuid": "9cb5784d-9dcc-4497-ae75-456c6e828d17",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "50913830-61fa-4b29-a7ce-1ccb3a17d1ca",
+      "groupUuid": "c5d1a5f6-16e9-41cc-81db-654c443dfc1e",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f1f281a8-b398-4002-9133-38c89a3e1901",
+      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
+      "type": "TITLE",
+      "title": "C7 \u2014 D shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "a791522d-bb38-4c66-b054-eec7501626b7",
+      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-shell-d-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 D shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "5c19fd15-54cf-47e6-bbe7-6ec44a15776b",
+      "groupUuid": "2ff5b49b-3632-4f00-bc7c-4f6c63ad97b5",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "7fb3b944-4033-403a-b048-cb8f67669611",
+      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "c51b1f91-0396-43da-b85b-20ac42b53756",
+      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "910f95a2-0645-4ea3-ad26-1b87c342e0df",
+      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e3cba564-26fd-4702-b974-ad4119fbb697",
+      "groupUuid": "89dbc000-11af-421a-a11c-840fa8fe54d1",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "2f970bdc-7421-4271-8e6b-4e5f5d99478c",
+      "groupUuid": "97abf557-f69d-4eed-8752-e6d5bc7f49dc",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "59bb51aa-3344-4128-833e-1a4f0627d826",
+      "groupUuid": "02805b15-8376-4944-8eb0-0126064d12cc",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "de0caac2-88ce-4335-ab18-a863c7cb3a43",
+      "groupUuid": "8ee6a9e9-000b-4e7f-b938-399c34327d16",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "57ddf894-e162-40fd-8932-4e7c1d99c637",
+      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 D shape \u2014 Shell (7th on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "370376e1-0abf-4824-b180-0a19926e1ba8",
+      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-shell-d-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 D shape \u2014 Shell (7th on top)"
+    },
+    {
+      "uuid": "e8a1d145-f376-4486-a9d5-4a92a0092725",
+      "groupUuid": "3e3aebf7-4f35-460c-ba65-01a751a212ef",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "a2f88aeb-ade1-459e-9c83-73b77273fd5d",
+      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "fb240565-9ff7-4cb9-824e-7818248d5795",
+      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e2b83d70-ac2e-46e3-be9b-8ed24ea2f532",
+      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "9f26087c-5275-49a0-a64a-fe1badd1c767",
+      "groupUuid": "e4b2866f-ea3e-4b3c-8a0e-4ec67488453b",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "67303188-7c3a-4b95-986c-88ff11aed4d6",
+      "groupUuid": "854a2b1e-0497-4962-8b3c-13eba5364ccf",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "0a4d24fb-cfba-4678-9bff-f3c6c0982b00",
+      "groupUuid": "31773d14-1762-4025-a789-f3e8f5f45ff0",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "e76ef653-ac42-4a2e-b9af-63d47b92fc07",
+      "groupUuid": "c67b9065-d279-4c43-9ffa-bffdcacfc14f",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "55ff35da-e6cc-4590-aeb5-da21d1f41cea",
+      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "type": "TITLE",
+      "title": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top) \u2014 13sharp9 altered"
+    },
+    {
+      "uuid": "f31fc6e6-57e8-43df-bd32-e1bbaf8bd299",
+      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c13s9-cm6-altered-6str-30.png",
+      "altText": "Fretboard diagram for C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)"
+    },
+    {
+      "uuid": "3de586ac-bb54-482f-81f5-a5c90c1dab40",
+      "groupUuid": "a5a57bab-9971-4f98-8e29-3192c1380aaa",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "51afdcd3-f827-4b56-81ab-8aa435dd3bc6",
+      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "966e9a29-d96f-438c-8985-48c3ecfb59f7",
+      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "318db960-f91f-42b2-ae76-5d4496a266e2",
+      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d5d03872-4935-4e18-a990-ae78428d7683",
+      "groupUuid": "76f04830-ba93-4182-8ac8-3b947e53a7b9",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c34cd776-ecc8-4ced-a35b-71fee5efc8dd",
+      "groupUuid": "05026a47-7afb-4335-9864-eedcd0dd85fd",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "9ea0f0dd-ef10-4cd8-a138-71efb2b4a707",
+      "groupUuid": "9d66a7df-2adf-4416-b000-89bfa73539e7",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "48edbc7e-1512-4a86-83da-3da2158322c5",
+      "groupUuid": "7f94e18e-bd3c-472f-a29c-6836b2819852",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "1bb91d0a-0083-4add-8a82-75841f77e46b",
+      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 Fret 8 \u2014 Drop 2 \u2014 aug7 drop2"
+    },
+    {
+      "uuid": "ebfd9b59-b554-447b-bb5f-2e948769234c",
+      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-drop2-1top-7.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 Fret 8 \u2014 Drop 2"
+    },
+    {
+      "uuid": "b6d8fcb0-0cd0-4490-aa26-b120722e18c9",
+      "groupUuid": "8519ae1b-254a-4f47-9fd3-7606a44c15bf",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p>"
+    },
+    {
+      "uuid": "89f25c3b-39ca-401c-8244-70aaef21f609",
+      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "23dc80aa-429e-42fd-a82c-13b213cbf4a6",
+      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "c6a2cac3-3b11-451c-9b97-f733ec701b37",
+      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "dee6c2a6-6fd3-4b8b-b82d-268b0e349641",
+      "groupUuid": "6282a41c-8d60-4a10-9850-3cc5dc908d1a",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "0ff19939-5921-4ddf-96c0-6bf44c064010",
+      "groupUuid": "bbdd8101-74d8-40fe-9300-f97c24891c81",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "0fff037d-aa78-4ff1-a2d9-d26313bac4fc",
+      "groupUuid": "7264e2a1-4d35-460c-ad2c-c76245623720",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "052e861d-a856-48a6-b4a7-fd1e5f620843",
+      "groupUuid": "66397392-ef3d-4818-b037-a58658984d04",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "bb078603-99ab-4b09-8a20-26dd2a2ae617",
+      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
+      "type": "TITLE",
+      "title": "Cm7 \u2014 7-str bass \u2014 Drop 3 \u2014 min7 drop3"
+    },
+    {
+      "uuid": "9eff256a-f236-442a-800a-a61f433fd2cc",
+      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cm7-cm7-drop3-7str-7.png",
+      "altText": "Fretboard diagram for Cm7 \u2014 7-str bass \u2014 Drop 3"
+    },
+    {
+      "uuid": "96039c62-7fd2-414d-a7c1-263e8b017923",
+      "groupUuid": "9741a812-ec3f-4401-b75c-beeb0b1dcbc8",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p>"
+    },
+    {
+      "uuid": "5dd8dfca-8359-4532-b9a7-c0bc10878038",
+      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "af97a963-cc8f-459f-880a-fb6a32136ec0",
+      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "73cf399e-2093-4181-82a6-ab3dc34389ad",
+      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bdf628a4-ebf9-4709-8ccb-ec73f7da31f9",
+      "groupUuid": "d987ab91-441e-4a73-85b9-cc9d570a2497",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "d22c13ac-6625-45b7-b9b5-a39631b99321",
+      "groupUuid": "97b6fa6e-23ee-4df7-93af-898ff48bff90",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5694c323-053d-42ff-ad2a-6c0c3120fdde",
+      "groupUuid": "3833a370-ecbc-4a05-9c94-b827e0581c19",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "c2cd7c84-84db-40eb-b623-f68dafbc048b",
+      "groupUuid": "a3638690-425c-4a40-9dc4-23d08d81f8ca",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "d74d77b1-d65c-4f35-96f0-e8617990c98b",
+      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
+      "type": "TITLE",
+      "title": "C7 \u2014 A shape \u2014 Drop 3 (5th on top) \u2014 dom7 drop3"
+    },
+    {
+      "uuid": "94daab2a-285b-4688-bdb4-d8bb7a95b673",
+      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7-drop3-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Drop 3 (5th on top)"
+    },
+    {
+      "uuid": "9f8e435a-4da8-4fb7-ab7f-0805503281df",
+      "groupUuid": "03073491-e42d-4381-99fc-dbaf5217afa2",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p>"
+    },
+    {
+      "uuid": "4c183f33-d0b5-4d56-993b-bb7375d7170f",
+      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "9f889f66-1487-43cc-b310-1b30181baabc",
+      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "5a21fe6c-b3f1-45aa-8406-8abf01564119",
+      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "29aba4c0-e17e-45e7-b362-a1884499db61",
+      "groupUuid": "0d3049bb-ac2b-4844-b0c3-c831d45f302d",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "60638d71-0c04-4ede-a21a-736c9c464445",
+      "groupUuid": "a322ee8e-004e-4146-ab83-a2228ba2ece4",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "4294161a-59f0-479f-a619-187caa4ab548",
+      "groupUuid": "11a419b7-b92b-43d1-ac66-109b698b227c",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "fd299442-d19c-4275-932a-e927c9deb998",
+      "groupUuid": "6ae51c8a-47b8-41c7-9d9f-ceb4fb574f85",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "89c9e374-85a8-494a-a573-c89617f637e0",
+      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
+      "type": "TITLE",
+      "title": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top) \u2014 9sus4 extended"
+    },
+    {
+      "uuid": "eeccf321-f1b0-4667-a99e-0bbd2deb620f",
+      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c9sus4-cm6-extended-6str-14.png",
+      "altText": "Fretboard diagram for C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)"
+    },
+    {
+      "uuid": "21d02841-96e2-4919-bd3d-ba3fc9edd74c",
+      "groupUuid": "c286d18c-8d9f-4b89-a69c-3edae6cdb1a1",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p>"
+    },
+    {
+      "uuid": "c2091452-d196-4764-8f77-ee6527ffa1f6",
+      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "7ceb6c55-6bc0-4ce3-9fc3-97cce28a9974",
+      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "4cddba25-8e5d-4095-a0b7-c4937e1ce638",
+      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "a7581be4-8d50-4107-9367-83903e8b8e2c",
+      "groupUuid": "0ae2bc23-0776-42bd-9ed0-015a1f48fb63",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "77bc03e1-825a-4f8b-890b-a2ed51f33813",
+      "groupUuid": "2dec5983-cebe-4201-a82a-781381fe1e0b",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "dc050f9a-c1e0-43b3-9b28-c5d4f4793758",
+      "groupUuid": "5b9812c3-0950-49ef-a462-f71088084739",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "7cd14cc7-e44a-4651-9742-3b0b814c5d4f",
+      "groupUuid": "d6da7167-93dc-4896-acf5-f622ee9bc3a6",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f0b9028b-5ad3-410f-97da-3e114c6c6119",
+      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "type": "TITLE",
+      "title": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top) \u2014 dom7b13 extended"
+    },
+    {
+      "uuid": "eae8bc8d-6163-44ae-bdc7-747a1d3b2d31",
+      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7b13-ext-a-shape-6-cm6.png",
+      "altText": "Fretboard diagram for Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)"
+    },
+    {
+      "uuid": "7cca705d-bc30-4f8d-a5d8-a728f0435c49",
+      "groupUuid": "4364f881-ee40-4c01-a8f3-0d283f5e59b9",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "066e0ac9-79a8-47e4-99de-fcdd39957a54",
+      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "8290f569-c603-4349-a66e-d83540e44dd5",
+      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "e62efc35-3621-4d70-aed5-9540406d00e3",
+      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "20210696-5cdb-4431-93d0-e98ce5871b52",
+      "groupUuid": "59f8ead2-8891-4c84-9512-24181aac5c78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "bfdb7ecd-a7b8-43b2-9a5c-56e973f64624",
+      "groupUuid": "295e9bb8-0425-476c-b893-884976c376ea",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5d970d2e-1248-4799-8781-582989375347",
+      "groupUuid": "962bb09a-4e29-4f38-9105-01dbc3751b49",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "a0176b80-da31-4dfe-9ca1-5e9efb97b580",
+      "groupUuid": "857b0d05-c085-43f5-bc33-8ea8d607a412",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "f6e09cbe-fa2a-4300-bdb6-eaf8104ec617",
+      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
+      "type": "TITLE",
+      "title": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top) \u2014 quartal quartal"
+    },
+    {
+      "uuid": "e424249b-2889-40d0-8280-cb6846a8bbe1",
+      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cquartal-f-upper-6-cm6.png",
+      "altText": "Fretboard diagram for Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)"
+    },
+    {
+      "uuid": "2b1b3df5-994f-46f8-b3f9-c902d254b9ae",
+      "groupUuid": "f614b3e3-2bd5-4d71-913e-43beea15d9a0",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p>"
+    },
+    {
+      "uuid": "4e0ddd14-be3c-4c1a-a36a-76834993a806",
+      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "7b8284c7-a120-4c17-a25f-00dd19e1a9c3",
+      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "dce3d3e7-feb1-4b52-80ab-58f0201facc9",
+      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "177066ed-0d9e-4cc9-bab1-196512fe288c",
+      "groupUuid": "5626380f-4bb1-4e28-a261-42be1e5cd321",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6dadb013-12d1-44f1-99c1-1860e23078ea",
+      "groupUuid": "b3b89b5f-0f52-44b0-92eb-e9b06f02a05f",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "b3096b33-a3f8-45a7-9611-91a7c3aa08b7",
+      "groupUuid": "69a8ddd3-1957-435a-b8f3-36b318446f75",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "3d08e72c-1f48-4e76-b91d-7b6c17588640",
+      "groupUuid": "6d4ba774-ecb7-4745-a646-afff792d5703",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "0ac282fe-52b0-4a61-b4b3-50ba88890517",
+      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
+      "type": "TITLE",
+      "title": "C7alt \u2014 7-str root \u2014 Shell (b5 on top) \u2014 dom7alt shell"
+    },
+    {
+      "uuid": "4f33ff9b-383a-4f0f-ab90-3f3dce62faf3",
+      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/c7alt-cm7-shell-7str-7.png",
+      "altText": "Fretboard diagram for C7alt \u2014 7-str root \u2014 Shell (b5 on top)"
+    },
+    {
+      "uuid": "96e071db-45a4-4673-bbd3-d3058410f08c",
+      "groupUuid": "89a2c64b-5619-41cf-bf28-0dd446e1646d",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p>"
+    },
+    {
+      "uuid": "563310c4-7939-48c6-a5ba-c46de7ddea93",
+      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "5a307b16-7c57-4bfa-8bb6-8e4897f38d65",
+      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "2c61c1db-9bbf-4659-ac58-8783a0d0e580",
+      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "444c15cb-4d39-4bb4-abf6-070161509dbc",
+      "groupUuid": "12d536cd-f561-4a95-a5ec-eb74b210aa78",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "0ab5fdf8-5931-4854-8615-71fa50b626b0",
+      "groupUuid": "1d3cc254-8140-4fce-8ec0-c5f884045c71",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "26f5688f-36c9-498e-80cb-5d4f582b8704",
+      "groupUuid": "cc5f4a7f-ecf5-487b-8798-a034c989977e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "67fd6f51-1033-4aa3-8eb8-f79d3cf51ba3",
+      "groupUuid": "cf44c64b-26d2-4851-8794-0702d3a2a80d",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "351364c5-da6d-4dfa-8fc1-08aeb0d86399",
+      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
+      "type": "TITLE",
+      "title": "C7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 dom7 shell"
+    },
+    {
+      "uuid": "df5d4ab1-4ee3-4da5-8dbe-fb6321768188",
+      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/cdom7-cm7-shell-a-7.png",
+      "altText": "Fretboard diagram for C7 \u2014 A shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "b66636e0-b7ff-4bd3-95e3-8e3f6876cfeb",
+      "groupUuid": "09d7195f-9cd5-4fc6-af2a-8d30fbd127de",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p>"
+    },
+    {
+      "uuid": "fb9d3e57-222f-4862-8a29-09bf660dd362",
+      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "71307d7d-e1fe-4c91-adbb-368b26a067ec",
+      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "3167fdb3-7106-48fa-9d15-65008e4ebad0",
+      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "eca4e1a3-3fe9-4c13-9d0a-7a149433d71a",
+      "groupUuid": "83d46097-e146-4e0b-8600-adcd56087a8c",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "65eea098-1c44-4fb1-939a-6c4bfae76b4e",
+      "groupUuid": "0a2bad26-e332-492b-bc27-088b56835ca5",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "5fa0158c-6fcc-49a2-bfed-19a2d6b11064",
+      "groupUuid": "16432b0c-c374-4f2d-8961-b6dfb2c3dc1e",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "e23ef9dd-6bda-464e-8750-a9b0a81ce335",
+      "groupUuid": "bac8e138-b707-4423-b670-a0fa10a35997",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    },
+    {
+      "uuid": "4c8617b1-d6f8-471d-a7f3-9e0740063e20",
+      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "type": "TITLE",
+      "title": "Caug7 \u2014 A shape \u2014 Shell (b7 on top) \u2014 aug7 shell"
+    },
+    {
+      "uuid": "e2cc6918-3d7f-4cc3-9371-da81ebdb2641",
+      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "type": "IMAGE",
+      "imageUrl": "https://raw.githubusercontent.com/siege-analytics/musescore4-chord-library-plugin/develop/scripts/voicing-tags/diagrams/caug7-cm7-shell-a-7.png",
+      "altText": "Fretboard diagram for Caug7 \u2014 A shape \u2014 Shell (b7 on top)"
+    },
+    {
+      "uuid": "252ffc5d-6b99-48a6-9c23-a48214d45681",
+      "groupUuid": "7a2bd725-22fd-45c9-82f5-f385f92487e6",
+      "type": "TEXT",
+      "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p>"
+    },
+    {
+      "uuid": "2b1cfa5e-365a-49a1-98fc-ace303c311e3",
+      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "type": "MULTIPLE_CHOICE",
+      "title": "Do these tags fit this voicing?"
+    },
+    {
+      "uuid": "b665bf70-684f-4bb4-a1ab-c4124faf410c",
+      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "YES",
+      "isFirstOption": true,
+      "isLastOption": false,
+      "optionIndex": 0,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "f9ba926f-0e0f-40dc-ad64-79c09c6cd6e3",
+      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "NO",
+      "isFirstOption": false,
+      "isLastOption": false,
+      "optionIndex": 1,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6ac32c1f-0364-4b02-98b9-478ebf10ba02",
+      "groupUuid": "e11436a0-2788-41f3-aa0b-260bec8d4fac",
+      "type": "MULTIPLE_CHOICE_OPTION",
+      "title": "REFINE",
+      "isFirstOption": false,
+      "isLastOption": true,
+      "optionIndex": 2,
+      "allowMultiple": false
+    },
+    {
+      "uuid": "6892e91e-e4f1-4db5-b954-81b75c53527d",
+      "groupUuid": "7973a3dc-7819-4bbf-9b25-dad30f829a5b",
+      "type": "TEXTAREA",
+      "title": "If NO or REFINE, why are you overriding the agent?",
+      "placeholder": "e.g. 'This Caug7 doesn't fit Joe Pass's chord-melody vocabulary'",
+      "isRequired": false
+    },
+    {
+      "uuid": "637b1619-6712-416d-9822-abee1e3cc5b0",
+      "groupUuid": "96d9c470-e42b-4cb5-801f-fe2975f81cfa",
+      "type": "INPUT_TEXT",
+      "title": "Tags to add (comma-separated, optional)",
+      "placeholder": "e.g. van-eps, walking-bass",
+      "isRequired": false
+    },
+    {
+      "uuid": "878ddfc6-4203-4d12-805b-8798f1536fc8",
+      "groupUuid": "83fd1c72-079b-407d-baee-6b7f68787902",
+      "type": "TEXTAREA",
+      "title": "Anything else? (optional)",
+      "placeholder": "Free-form notes",
+      "isRequired": false
+    }
+  ]
+}

--- a/scripts/voicing-tags/tally-form-payload.json
+++ b/scripts/voicing-tags/tally-form-payload.json
@@ -2,8 +2,8 @@
   "status": "DRAFT",
   "blocks": [
     {
-      "uuid": "61e0e8c3-b4c2-4500-9399-30ede02eb1a5",
-      "groupUuid": "1c6371e9-af3a-43cd-afd3-eaf01132f3c6",
+      "uuid": "a31b4572-8e3b-41c9-9fe9-475710adcfd8",
+      "groupUuid": "a4aad519-01df-466e-91bb-4e76caf9508d",
       "groupType": "TEXT",
       "type": "FORM_TITLE",
       "payload": {
@@ -12,8 +12,8 @@
       }
     },
     {
-      "uuid": "80733453-a3a1-47c4-8bd6-046739bbc9ec",
-      "groupUuid": "9a6c2311-7626-4a66-83d8-d0b5d6e3b3e0",
+      "uuid": "7fbc1241-9853-4d73-add1-113446de70fa",
+      "groupUuid": "a3224601-3bdd-497e-9c19-bf8d5f50aa0e",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
@@ -21,8 +21,8 @@
       }
     },
     {
-      "uuid": "2c0ff12a-fbb1-4065-8d4d-bd884668bc2f",
-      "groupUuid": "1ad909fb-5138-4588-be87-d8375e880017",
+      "uuid": "e2e5b816-8bff-4b99-8b29-aa6aa4b21147",
+      "groupUuid": "5c540564-c1b1-4e92-8235-e85c35b5a221",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -30,8 +30,8 @@
       }
     },
     {
-      "uuid": "cac81188-ba98-4169-8e87-783f33702a98",
-      "groupUuid": "19625af1-cdd9-4032-a69d-6c5c7939a074",
+      "uuid": "2adfbb1b-6413-4a50-9888-1d0a7e719fe6",
+      "groupUuid": "d4889960-bb4e-495a-a780-a57a8a305b6b",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -44,17 +44,17 @@
       }
     },
     {
-      "uuid": "73b83358-3923-4851-8cf5-7acb0f056b88",
-      "groupUuid": "c0a2b87b-ac43-429c-b677-d2f9f2ea6721",
+      "uuid": "41f38d5b-3371-41b3-9b30-bbfc16f4ddc5",
+      "groupUuid": "0e7007c6-a1a8-4079-842c-42cc9632c52e",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: altered-dominant<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Altered voicing:</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "429dfb2b-8eb6-41fd-908a-7b43f16fef07",
-      "groupUuid": "c017bb6e-7da1-4940-99ba-e4d3893c8469",
+      "uuid": "d5c9c421-0cfb-421f-98ff-2453ff22533b",
+      "groupUuid": "80927a65-532e-46d0-98d5-82cec8ccc409",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -62,8 +62,8 @@
       }
     },
     {
-      "uuid": "33bbf730-4977-4153-9ecf-3d1b8ad6aa35",
-      "groupUuid": "3c47ac9f-844d-4357-aa25-9bc17dce3f89",
+      "uuid": "a42df419-a66c-416a-a41f-8dc64c517a50",
+      "groupUuid": "4b5ef77e-d9e0-461a-832d-1a5efc11e1d2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -74,8 +74,8 @@
       }
     },
     {
-      "uuid": "685fa856-e939-4664-8355-6260076ca294",
-      "groupUuid": "3c47ac9f-844d-4357-aa25-9bc17dce3f89",
+      "uuid": "e0e6ca88-46e2-4329-9e24-ccbf976b0a5b",
+      "groupUuid": "4b5ef77e-d9e0-461a-832d-1a5efc11e1d2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -86,8 +86,8 @@
       }
     },
     {
-      "uuid": "be25ca62-606b-4e98-a957-a7614b9e53d4",
-      "groupUuid": "3c47ac9f-844d-4357-aa25-9bc17dce3f89",
+      "uuid": "53615867-0b76-44fc-912b-1902b1dec72b",
+      "groupUuid": "4b5ef77e-d9e0-461a-832d-1a5efc11e1d2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -98,8 +98,8 @@
       }
     },
     {
-      "uuid": "142b3da0-b84b-4ab5-b8cc-4f30db0f5f9b",
-      "groupUuid": "9341a694-a427-4650-a823-2d4a4e28a9a9",
+      "uuid": "76b18884-9a9f-4829-bae5-8fbfc06a0fea",
+      "groupUuid": "bef6e28a-d49d-474b-be8f-323e68bdc9a8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -107,8 +107,8 @@
       }
     },
     {
-      "uuid": "1b1adcae-60fa-477a-b800-9eb884b6fc5b",
-      "groupUuid": "140045cb-fcaa-4449-ae18-2ed1c7a496af",
+      "uuid": "83507465-bf75-4f81-875e-1764bafcd91a",
+      "groupUuid": "7bbb0dc9-78a6-452c-9a0f-5d9c5a03fe25",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -117,8 +117,8 @@
       }
     },
     {
-      "uuid": "9380fb87-285e-4efe-9474-cbb1f193e7e7",
-      "groupUuid": "dd3cb173-bbeb-4349-a279-87357e8778b0",
+      "uuid": "ddb9d136-7bb6-44f2-ad40-42c5eecd4f86",
+      "groupUuid": "3a5d7776-50aa-4f9b-ba43-8b197f5b4983",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -126,8 +126,8 @@
       }
     },
     {
-      "uuid": "1d43d5ec-855a-415d-8ecf-d3fa7cebf641",
-      "groupUuid": "e7894ca0-4ee7-4c2f-b0fc-7fb94221777f",
+      "uuid": "2a5c19f6-1905-47e2-b93e-9f7c80a05b99",
+      "groupUuid": "97fede94-c095-4d64-9b46-16521ce05c15",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -136,8 +136,8 @@
       }
     },
     {
-      "uuid": "8a5ae1dd-a8b2-4f55-bf73-f931333d7188",
-      "groupUuid": "95305058-c1c7-44d3-96e1-82191b2001a2",
+      "uuid": "e8fb91c7-095b-4657-b40e-60408575ead1",
+      "groupUuid": "dcb4a1c2-abd9-4c93-b896-8980ea921134",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -145,8 +145,8 @@
       }
     },
     {
-      "uuid": "9f5e96b6-e356-4c99-a74b-6c632a2f00d9",
-      "groupUuid": "8594b6a7-fef5-490f-97b8-d87eb2358ced",
+      "uuid": "67a3831c-d6b1-4072-ae34-844a84452db4",
+      "groupUuid": "c9951570-b44d-4710-8bac-8c4e29b291f0",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -155,8 +155,8 @@
       }
     },
     {
-      "uuid": "be499240-e4cf-43bd-8b55-1dfd81a5c0c3",
-      "groupUuid": "26db5ab7-10ac-4bc0-a07c-da22b4189cd2",
+      "uuid": "a1099d14-d140-4748-b9ff-1081abb77cb1",
+      "groupUuid": "a9a225ab-7a2e-4df8-8e30-cb4952de2afa",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -164,8 +164,8 @@
       }
     },
     {
-      "uuid": "3fdd9171-87ee-4f51-bb51-94083f51b40c",
-      "groupUuid": "0ab3f4cb-86fb-4e5c-aac8-83ac10edcc86",
+      "uuid": "c36f614a-d096-4404-ab44-ea2aa3fb37ad",
+      "groupUuid": "988462c2-491d-4b57-b035-a8b396a6a3f9",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -178,17 +178,17 @@
       }
     },
     {
-      "uuid": "6de59e03-dc9d-4621-b1d9-74a5249138a0",
-      "groupUuid": "b8cddd29-b10d-4cce-a505-3e4d47b77ad1",
+      "uuid": "fa02b980-5c01-4542-8b97-c736a3eaad5a",
+      "groupUuid": "3f0dd958-5eb8-4071-b7a6-742bbaf3003a",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-2, block<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>Drop-2:</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "1bb68817-2621-43ce-affa-bde97f39a76b",
-      "groupUuid": "fe6c673b-7eca-4736-9047-647d001d106f",
+      "uuid": "44198917-60a8-4267-bbb5-4257702b1468",
+      "groupUuid": "e41b4f0e-afb5-46e7-82f5-4a73725b97f9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -196,8 +196,8 @@
       }
     },
     {
-      "uuid": "7d786b60-3bf8-45cc-8d3a-c8fc67d6c13e",
-      "groupUuid": "136e6900-bff8-4fa9-b131-6dc05d5f872f",
+      "uuid": "fa4fb17a-02b6-4f2c-b426-bc1f3923c612",
+      "groupUuid": "286a8fcc-1328-4ea1-b89d-28b526c72124",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -208,8 +208,8 @@
       }
     },
     {
-      "uuid": "51e4510a-d955-436f-bfad-0bbb571e24a5",
-      "groupUuid": "136e6900-bff8-4fa9-b131-6dc05d5f872f",
+      "uuid": "27c63a81-37ff-457a-b3f4-0ece5b3ccbe4",
+      "groupUuid": "286a8fcc-1328-4ea1-b89d-28b526c72124",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -220,8 +220,8 @@
       }
     },
     {
-      "uuid": "b18b17aa-8707-470a-a03f-965b1e448fa5",
-      "groupUuid": "136e6900-bff8-4fa9-b131-6dc05d5f872f",
+      "uuid": "086efd41-23a1-441e-a896-30eb01379714",
+      "groupUuid": "286a8fcc-1328-4ea1-b89d-28b526c72124",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -232,8 +232,8 @@
       }
     },
     {
-      "uuid": "97e74ce3-62c2-4977-af02-fbb09535eba8",
-      "groupUuid": "6f8878a0-34b8-4e92-bb6d-e1ba7a1ddba4",
+      "uuid": "535d0359-8586-4f9c-a3a9-71db12c8c2fd",
+      "groupUuid": "d97b2b6a-0417-40c0-9d78-ff35617ae4d2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -241,8 +241,8 @@
       }
     },
     {
-      "uuid": "d28730b1-6178-4c73-bf05-8ce8a7771cb5",
-      "groupUuid": "288a4c9e-75d0-4623-ae7a-bd29f8132640",
+      "uuid": "5cfcd256-37dd-43f6-a2fb-7496172bf4a3",
+      "groupUuid": "f3f61431-dde8-49ee-963a-82b8f0affbd3",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -251,8 +251,8 @@
       }
     },
     {
-      "uuid": "c710379a-73b2-4ea0-bd62-0dea2642e23a",
-      "groupUuid": "40a554e9-3be9-4eb5-b541-7bb3f4a9e50e",
+      "uuid": "afb92866-7cf3-4a06-906e-b24a0ca6ce0a",
+      "groupUuid": "b7ef5861-75e0-4520-a0bd-8bf5b6a7999d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -260,8 +260,8 @@
       }
     },
     {
-      "uuid": "40203fc8-68d7-4ad4-a40e-d2026add57e3",
-      "groupUuid": "80cad182-39e7-4cec-af93-1df30e0b61b9",
+      "uuid": "b0c6a7a3-e0a4-4f9a-bce3-d944af7aba95",
+      "groupUuid": "5c660fe0-ed61-4c26-878b-73e93ae10e0f",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -270,8 +270,8 @@
       }
     },
     {
-      "uuid": "e2a4239b-5e1a-46f4-9c53-135596d73c68",
-      "groupUuid": "8fae55d7-d286-429d-a504-d0d2a0e6d3fa",
+      "uuid": "11bbcacc-f504-45c3-8ce1-7500aa4b24e9",
+      "groupUuid": "719b3802-a213-4705-96a9-52e18aed62fc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -279,8 +279,8 @@
       }
     },
     {
-      "uuid": "c72d1b97-a0eb-4696-a25f-9f494792efbd",
-      "groupUuid": "35e89d53-7e2b-4a5d-8cfc-11eb6efe1d2c",
+      "uuid": "3faf1d7b-00c2-40c4-af56-0bb55a3fbadb",
+      "groupUuid": "da52a9d1-eb26-48f5-9747-b508d7af8088",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -289,8 +289,8 @@
       }
     },
     {
-      "uuid": "0f78f8f4-48bb-46af-a1f2-c9799f7453a8",
-      "groupUuid": "26709f7b-c26a-4c40-9bf4-0b160adb9b43",
+      "uuid": "06d4912c-3e2f-41d3-8176-2275f1e270d1",
+      "groupUuid": "6e278acf-9f3f-43d6-a19e-c2e1b99d4eb1",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -298,8 +298,8 @@
       }
     },
     {
-      "uuid": "c7e38e0d-9354-4ffd-880b-89039d2682de",
-      "groupUuid": "bcea1771-426d-472d-8b9e-5b7bef2a31db",
+      "uuid": "c300fea1-0dab-466b-8c28-1bf0a7cc0308",
+      "groupUuid": "1e2b39dc-a8a4-448d-83d4-1ea5e527db9c",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -312,17 +312,17 @@
       }
     },
     {
-      "uuid": "60ea99d6-0e10-4ea6-9c6c-016882a87683",
-      "groupUuid": "f74265bc-9ab4-48fb-8fa4-8a88d93301dd",
+      "uuid": "d4e54398-8ab9-4f1d-97a5-c730000f0db1",
+      "groupUuid": "a52ab317-9b43-4a93-969a-268acdb390c4",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: drop-3, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "1483d331-bc66-4b43-90c5-cb2238cd841a",
-      "groupUuid": "68ccbe98-fe16-4c56-824f-8b18b9ed001f",
+      "uuid": "6702aafb-c64b-4bc6-9235-904dd8ad389a",
+      "groupUuid": "cb253394-f4de-474c-b240-c01e4fd6c6d2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -330,8 +330,8 @@
       }
     },
     {
-      "uuid": "3c71ae86-71ef-463f-9e89-16c6b7ad600a",
-      "groupUuid": "e8cf55cb-f9fb-492d-a38e-0c3604ea25a4",
+      "uuid": "0b02db51-7585-422b-af5c-95b629792cda",
+      "groupUuid": "8776ba90-b22d-4779-b2b9-cf7405bf191f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -342,8 +342,8 @@
       }
     },
     {
-      "uuid": "ae6911d4-8528-4bc7-903e-1be6a64d46a1",
-      "groupUuid": "e8cf55cb-f9fb-492d-a38e-0c3604ea25a4",
+      "uuid": "96478680-ee3c-4940-931b-713692334527",
+      "groupUuid": "8776ba90-b22d-4779-b2b9-cf7405bf191f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -354,8 +354,8 @@
       }
     },
     {
-      "uuid": "1b672e37-829a-4e19-834c-f5491beef161",
-      "groupUuid": "e8cf55cb-f9fb-492d-a38e-0c3604ea25a4",
+      "uuid": "54a38f39-53e8-4d84-a8c2-58985229630c",
+      "groupUuid": "8776ba90-b22d-4779-b2b9-cf7405bf191f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -366,8 +366,8 @@
       }
     },
     {
-      "uuid": "72ce34c6-c2dd-4c8a-93fb-b8ec08a08f76",
-      "groupUuid": "d2f99e25-663b-4923-88f3-aa422c72cea8",
+      "uuid": "f98c7450-7488-4c73-8e76-4c25fb56ec0b",
+      "groupUuid": "99820cfc-7088-4069-a08e-e715c0640a81",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -375,8 +375,8 @@
       }
     },
     {
-      "uuid": "ca00fce2-741c-40e8-a048-0b4704502a84",
-      "groupUuid": "52b996f2-bf5a-4b2a-9980-cc18d3777d24",
+      "uuid": "5ff706e5-bb33-4968-861f-e4818d762e05",
+      "groupUuid": "5dd14118-0e69-43f9-abc2-85c28b28db58",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -385,8 +385,8 @@
       }
     },
     {
-      "uuid": "49f4163c-3bf4-4e22-8235-ab83f024d1b4",
-      "groupUuid": "d820df45-12e6-41a7-8055-b353de7b71a7",
+      "uuid": "d92a81c5-e715-4a61-90b6-40cab3bec491",
+      "groupUuid": "004364dd-de14-4a23-bfe3-007c0271d43f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -394,8 +394,8 @@
       }
     },
     {
-      "uuid": "1296d6e5-168e-4a69-a48e-1eb835116055",
-      "groupUuid": "e09bbddf-3e0a-48f3-bc3e-14b796bb6e48",
+      "uuid": "0ba2c9da-9d6b-435a-b4c2-64873ce950ec",
+      "groupUuid": "eacbb43f-86bb-4a04-8714-80df41e7323c",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -404,8 +404,8 @@
       }
     },
     {
-      "uuid": "7fb2c394-6de0-484c-9b74-6798257edcf9",
-      "groupUuid": "71563f07-1757-4a13-83bf-b3015260bc6d",
+      "uuid": "b4995eec-b5a3-4f11-a639-1bb97c8f2496",
+      "groupUuid": "b01e7528-a4ab-4564-a148-820b65c14120",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -413,8 +413,8 @@
       }
     },
     {
-      "uuid": "55eae3c2-c9cf-45b6-acc4-26cbbdde72f6",
-      "groupUuid": "c9bef887-b9bc-4ea8-9fb3-56700782d487",
+      "uuid": "12d74953-f9ef-49de-a04e-d1d7d8cb73e3",
+      "groupUuid": "63890df6-d876-4f7a-9131-2eb5506eb834",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -423,8 +423,8 @@
       }
     },
     {
-      "uuid": "96d5d2d5-d7d7-4f32-918d-c7c9dff82790",
-      "groupUuid": "9115784b-78bf-4c4d-911c-52f2244eb51a",
+      "uuid": "f84c4a58-9028-426a-9f23-6ae0ad24c4d1",
+      "groupUuid": "1502e6cf-e6d8-4153-9ea8-3d75db6f7f3f",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -432,8 +432,8 @@
       }
     },
     {
-      "uuid": "7a56f277-8c09-4448-a8a4-a1d32b05a2d3",
-      "groupUuid": "fb50d168-fdff-4edc-acdc-6ee834d902ad",
+      "uuid": "355fb811-bfa9-47a8-b026-166e0f1be56d",
+      "groupUuid": "19345d2a-b906-4f57-a33f-77a8af5b7e72",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -446,17 +446,17 @@
       }
     },
     {
-      "uuid": "8c0f2efa-f029-4243-879e-8928bfbc961a",
-      "groupUuid": "0b3fa632-fbff-41d5-92f3-8fdf816d81ac",
+      "uuid": "04c117b4-9931-48c4-b2cc-45b882fb1a4c",
+      "groupUuid": "b7d65e28-b8a0-4192-b6df-78724ec6c49a",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-3<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</p>"
       }
     },
     {
-      "uuid": "262cd7cf-c9a2-4c93-84d6-edc67f4b10b4",
-      "groupUuid": "df626224-11fd-4425-8e48-0ecc067f8a71",
+      "uuid": "34611f64-874e-4f38-a1ca-cff70a092c13",
+      "groupUuid": "cbfec45d-cd9a-4201-95aa-27ca07c81505",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -464,8 +464,8 @@
       }
     },
     {
-      "uuid": "34840e89-30c6-4ea6-af2d-cc54571b4aa1",
-      "groupUuid": "3df9c5ab-df56-4f3c-aa3f-c6e946bf92e5",
+      "uuid": "6d735f91-9da4-405f-8eb7-db23b522b066",
+      "groupUuid": "4e9c929a-6eaa-44ac-bbac-3c13f452a9e6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -476,8 +476,8 @@
       }
     },
     {
-      "uuid": "041c58b5-51f2-414e-b074-75ff6ad9a4aa",
-      "groupUuid": "3df9c5ab-df56-4f3c-aa3f-c6e946bf92e5",
+      "uuid": "69d81056-51ad-463e-8fef-f6a5491c7a22",
+      "groupUuid": "4e9c929a-6eaa-44ac-bbac-3c13f452a9e6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -488,8 +488,8 @@
       }
     },
     {
-      "uuid": "ffd0fbcf-4bc9-4d75-9047-bd9683cf8221",
-      "groupUuid": "3df9c5ab-df56-4f3c-aa3f-c6e946bf92e5",
+      "uuid": "31505fd2-ba66-4fa0-befe-f41926843cc0",
+      "groupUuid": "4e9c929a-6eaa-44ac-bbac-3c13f452a9e6",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -500,8 +500,8 @@
       }
     },
     {
-      "uuid": "cdb09217-cbd5-4e07-b684-ddd0dfdd985d",
-      "groupUuid": "078a0a25-9e56-4bc0-89df-32bcd190ac9a",
+      "uuid": "b5edfffc-c95b-4899-9dc1-3899e4b4b6b3",
+      "groupUuid": "77db9c61-3da8-4280-8d72-8bcf915149a6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -509,8 +509,8 @@
       }
     },
     {
-      "uuid": "df5737c4-ed38-4e9d-a427-c0ac36cbb192",
-      "groupUuid": "bd1d1dcf-7461-41a8-9476-b66383d538d2",
+      "uuid": "2310c74d-5564-49ae-a98c-2a206224e7f4",
+      "groupUuid": "d864820b-d7a1-4ade-aef0-b5369e91a66c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -519,8 +519,8 @@
       }
     },
     {
-      "uuid": "e1f1ae51-51ad-4d38-a604-9c01b6222cb9",
-      "groupUuid": "59bb3934-cbe7-4fea-a298-b79bfa32d3ea",
+      "uuid": "a43d735b-3da1-409f-85b0-c8cfba98db4f",
+      "groupUuid": "8a71b6a0-6d6d-44d4-a191-6070c48da4e0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -528,8 +528,8 @@
       }
     },
     {
-      "uuid": "fe2863aa-0156-4813-8692-fc4c595b15ee",
-      "groupUuid": "a58c33fb-c00f-44c0-9183-47d24ba55dd7",
+      "uuid": "a9d23621-28ac-413f-8ce2-40d2be5971d9",
+      "groupUuid": "a08a96ad-57e4-459c-ae72-ecf5fe814c14",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -538,8 +538,8 @@
       }
     },
     {
-      "uuid": "b75f24d2-9fb5-4249-a557-29bf31043846",
-      "groupUuid": "e29c57d8-f6a1-49fe-9d13-2161151f7257",
+      "uuid": "5f387b4c-34d9-4dcb-9ac3-71672c0e6ce6",
+      "groupUuid": "e5e20753-64cd-4385-abfb-243bcfa00862",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -547,8 +547,8 @@
       }
     },
     {
-      "uuid": "8653e8e2-1216-44e4-aefb-35c88281debc",
-      "groupUuid": "9538d26c-f0a4-42f2-a280-8de6369bf691",
+      "uuid": "3490fcd0-3206-4973-857d-b2a6d9f3afba",
+      "groupUuid": "ff40348a-7369-4177-8f2a-91fb81b5fc7c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -557,8 +557,8 @@
       }
     },
     {
-      "uuid": "da8ea101-92fa-4127-a94f-5e957ca24c5f",
-      "groupUuid": "d2e66965-75ec-4f9b-8e64-cae89af6227d",
+      "uuid": "0990aef8-1630-48b1-9230-4a43fc47e713",
+      "groupUuid": "d03e0473-273f-4bb8-a509-ff592ee9bba4",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -566,8 +566,8 @@
       }
     },
     {
-      "uuid": "fe7537e2-4653-4e85-942b-ee68bd2d4f7b",
-      "groupUuid": "9d95f5cf-e358-4e80-a501-ba6d43040722",
+      "uuid": "efe77400-2a8e-4f92-95ba-7c3e2e36f851",
+      "groupUuid": "95f1e445-3565-479c-ae1e-4b420dde3f33",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -580,17 +580,17 @@
       }
     },
     {
-      "uuid": "200f339f-8c88-4077-b17e-8d36fa725288",
-      "groupUuid": "302d47ce-b87f-478f-9244-cef6d1e66d15",
+      "uuid": "aae1ff12-70b7-4aee-a748-5a52eeaf58ae",
+      "groupUuid": "895fd0b6-6dc9-4671-9088-1f7343f58274",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "e0cac9aa-b684-4f07-89cf-06211c6dfd4b",
-      "groupUuid": "24ba7079-5a5f-471c-8462-962035246439",
+      "uuid": "29c02559-9104-452d-82d8-0503f9c192e6",
+      "groupUuid": "b6404c69-9017-4c3d-ba39-7ef7ffadbba0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -598,8 +598,8 @@
       }
     },
     {
-      "uuid": "3173be06-5c29-4c46-85ad-0c44d4a42b99",
-      "groupUuid": "5470595a-d149-4959-8470-a22a3945560b",
+      "uuid": "1ab3d92a-9eb8-40ef-b553-ae11baae16ed",
+      "groupUuid": "4e76c405-16ac-4f83-b48c-7977a8fffbef",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -610,8 +610,8 @@
       }
     },
     {
-      "uuid": "b17cfe01-7697-490b-b5a7-110e5d8bb3e1",
-      "groupUuid": "5470595a-d149-4959-8470-a22a3945560b",
+      "uuid": "d54cb574-a55b-4898-a4f5-e65df6099127",
+      "groupUuid": "4e76c405-16ac-4f83-b48c-7977a8fffbef",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -622,8 +622,8 @@
       }
     },
     {
-      "uuid": "bf5e2662-c113-4c1e-a21d-f828acba42e7",
-      "groupUuid": "5470595a-d149-4959-8470-a22a3945560b",
+      "uuid": "b04267c0-0958-41cc-a6b7-c1944e9359a6",
+      "groupUuid": "4e76c405-16ac-4f83-b48c-7977a8fffbef",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -634,8 +634,8 @@
       }
     },
     {
-      "uuid": "98cffbb2-fc78-4647-8c17-294330867daf",
-      "groupUuid": "10ef6388-3d35-4706-b1d1-dba50633f4e2",
+      "uuid": "679c08a7-e35d-44cc-8e4c-5cbd1a42d158",
+      "groupUuid": "7f441487-5e1a-4c27-a5cb-10e3e6d67f42",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -643,8 +643,8 @@
       }
     },
     {
-      "uuid": "fa34fd5e-8ebd-4c67-86d7-3d7f960ec1ac",
-      "groupUuid": "3a685053-62e1-408d-a5e0-7702538a4b4b",
+      "uuid": "82b72290-670f-40c8-85a7-115cd823144e",
+      "groupUuid": "74f736df-db74-4429-a1bf-d3cdb8137503",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -653,8 +653,8 @@
       }
     },
     {
-      "uuid": "d2a071ff-9db0-41b3-93d5-9e31b41564ce",
-      "groupUuid": "ca7fc823-e799-4ffe-b9c2-2491e91b1cec",
+      "uuid": "fa4bd76a-6a7b-4b2d-9002-badc82796208",
+      "groupUuid": "3a9a4bc4-9a29-4e5e-b89b-9e1e516b5863",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -662,8 +662,8 @@
       }
     },
     {
-      "uuid": "14ccba17-2d48-46c6-b60e-94b7665d3ae7",
-      "groupUuid": "8c91b4e0-8a55-429c-9352-1e88e041c132",
+      "uuid": "efcf404d-b735-47b0-bfd5-07fcb94a5ce7",
+      "groupUuid": "14f05256-bc01-4eed-ab48-4ad152d794fe",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -672,8 +672,8 @@
       }
     },
     {
-      "uuid": "2ed79c45-980e-44b3-8724-45801d10e061",
-      "groupUuid": "ae43011f-17bc-4b74-afb4-2e68cfbebeb5",
+      "uuid": "5c6a83f5-f2d9-4646-80e8-25391e3a0026",
+      "groupUuid": "035ffcef-8a92-4f85-88dd-cf76738587b6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -681,8 +681,8 @@
       }
     },
     {
-      "uuid": "4c710d7c-4b51-4e3f-8a0a-7e0797e56e88",
-      "groupUuid": "6ae0a4ba-eb8d-4237-b5a6-714d69b8d6b5",
+      "uuid": "0fae39eb-2d2a-43a7-8631-c2c7d10f8d0e",
+      "groupUuid": "6ae60ac4-4c56-495e-a567-12d108d27caf",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -691,8 +691,8 @@
       }
     },
     {
-      "uuid": "ea65d9b7-cb62-4be6-95bf-a0fd5494de53",
-      "groupUuid": "438d07d9-af79-4450-970d-3dbe22bf3621",
+      "uuid": "68a717b4-726e-4137-9120-b3ddec27dea4",
+      "groupUuid": "be381662-748f-4447-a705-045ebca4759e",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -700,8 +700,8 @@
       }
     },
     {
-      "uuid": "530f2794-291e-446a-ba24-8e36447262e0",
-      "groupUuid": "701f8252-1177-41a4-a585-b20977795619",
+      "uuid": "b1156e04-48a0-4d64-8674-0d73cc1b68ae",
+      "groupUuid": "b6ad3c42-7466-434b-9ae9-7afe5da3885e",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -714,17 +714,17 @@
       }
     },
     {
-      "uuid": "3573b157-f43a-428c-a6e6-8bff5b110192",
-      "groupUuid": "b0e730d2-9769-4c7d-b93e-1f0a3dc2db54",
+      "uuid": "3f49b97f-023c-4037-b271-f4e5325f3d8e",
+      "groupUuid": "b7bf7432-22bc-4f36-9fc2-73a90628e9f8",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "19eadb08-b9ac-48a6-9e6b-c85e5c7cea65",
-      "groupUuid": "444487bf-8dd2-45b8-9efe-bcc85d5f09d4",
+      "uuid": "ec5b8f9f-7450-4ca8-9efa-2ecca6c0423a",
+      "groupUuid": "64eaab35-18ec-4077-b775-a5535128e35e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -732,8 +732,8 @@
       }
     },
     {
-      "uuid": "030cc36d-a1c9-4919-a3ec-503f8ed8c926",
-      "groupUuid": "036e0ddc-1e14-4bd7-8dde-5bf4247d8644",
+      "uuid": "86b965e7-cf7b-4aa7-bfe3-cbd9d1366910",
+      "groupUuid": "76e40f9c-9670-431e-8551-6524ecf8dcca",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -744,8 +744,8 @@
       }
     },
     {
-      "uuid": "612fa0e4-8dd1-4a73-b6f6-3d7e088aa480",
-      "groupUuid": "036e0ddc-1e14-4bd7-8dde-5bf4247d8644",
+      "uuid": "e406313e-4661-428a-915f-55af54bf8737",
+      "groupUuid": "76e40f9c-9670-431e-8551-6524ecf8dcca",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -756,8 +756,8 @@
       }
     },
     {
-      "uuid": "668034fa-5caf-421c-8bf7-cb57ee63b963",
-      "groupUuid": "036e0ddc-1e14-4bd7-8dde-5bf4247d8644",
+      "uuid": "125955e1-0c48-47f3-9c79-ab4cb17f3b39",
+      "groupUuid": "76e40f9c-9670-431e-8551-6524ecf8dcca",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -768,8 +768,8 @@
       }
     },
     {
-      "uuid": "dd750b86-3f7b-4a92-aef8-f610c60226fb",
-      "groupUuid": "814df734-8af5-4db7-bee1-656775c328e5",
+      "uuid": "253cd972-b6cf-4ad4-bda5-ad8a665eef65",
+      "groupUuid": "9a2ddc38-9dcc-4b3f-b6a6-3feee5efeb75",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -777,8 +777,8 @@
       }
     },
     {
-      "uuid": "5a4a3a1c-54ad-4a61-ab78-e63914ae41bc",
-      "groupUuid": "96d67f15-a543-4e66-8ce0-c55cf2c63fb0",
+      "uuid": "581d1ab9-f0bb-4143-a5df-a3e6ac415f26",
+      "groupUuid": "601c945c-3e3f-403e-8777-c0dcc7524dcc",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -787,8 +787,8 @@
       }
     },
     {
-      "uuid": "f4206c29-bf98-4328-ac34-ad98f35192a6",
-      "groupUuid": "c3943683-9bfc-4ece-bd99-e5c2196e2d66",
+      "uuid": "6bc21d73-a076-4777-9b71-4a66248bd3ac",
+      "groupUuid": "291c7898-0d5c-45a6-95b3-280042fa0631",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -796,8 +796,8 @@
       }
     },
     {
-      "uuid": "cb3498f9-aeb8-487f-b13b-3a586f8b962d",
-      "groupUuid": "119ad030-c120-4e66-8674-a73befbb9058",
+      "uuid": "7bdec76e-6783-4032-8f13-f730e384d52b",
+      "groupUuid": "cf186124-4ac9-400c-b6ad-5493411c0f9d",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -806,8 +806,8 @@
       }
     },
     {
-      "uuid": "c601ce5c-f3e2-4aa7-8aea-e1564a227a2a",
-      "groupUuid": "e2e0117a-baa8-4217-bb51-0f037b6c6ab9",
+      "uuid": "4c07e2dc-2674-4557-911b-0ff15a2979c2",
+      "groupUuid": "2f5fe71e-982c-4362-af42-d06a333b5fba",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -815,8 +815,8 @@
       }
     },
     {
-      "uuid": "e72c309b-9561-42a8-b41d-ce352ab6b01f",
-      "groupUuid": "7e0b6d16-b52d-46e1-b6a2-1f209432cec1",
+      "uuid": "742054a1-6778-4959-a0a0-fbf7753a5a44",
+      "groupUuid": "6f5e5bc5-a030-473f-891a-479ff4a5c0ad",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -825,8 +825,8 @@
       }
     },
     {
-      "uuid": "d1e00c4a-26f6-44c8-a3f4-262a54e5f248",
-      "groupUuid": "cc11f77c-877e-4f26-9313-403c0956a174",
+      "uuid": "7049067e-3321-4fa2-8d92-cbfc551049e8",
+      "groupUuid": "561c982b-9519-47ca-a9e2-9757022a64d1",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -834,8 +834,8 @@
       }
     },
     {
-      "uuid": "1e130700-1a5d-4a86-827e-dbdc74aae011",
-      "groupUuid": "65feed65-15b3-4c82-8343-4c5ff120f16e",
+      "uuid": "499e11e0-586a-4855-b981-8f4116724d4a",
+      "groupUuid": "f70d95f6-ae69-41f2-b2ae-8e0b9b4e7ebd",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -848,17 +848,17 @@
       }
     },
     {
-      "uuid": "d7ba07bc-f1cc-4193-8641-8fdae7e249a8",
-      "groupUuid": "ed488b86-a8b0-4090-8e8e-3d551fe69f55",
+      "uuid": "0711c046-457b-44b2-a97f-708f9a5d88fe",
+      "groupUuid": "a0abcb12-8253-4b45-9df6-7d970a34c1e2",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: quartal<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>Quartal voicing:</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>quartal</b> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</p>"
       }
     },
     {
-      "uuid": "71306bd4-3c41-408b-a0a3-e45e7cd50bd4",
-      "groupUuid": "72f5b65e-8514-4534-b24b-228bb439e06b",
+      "uuid": "58d40b86-f77e-41f0-ba56-290b210ef979",
+      "groupUuid": "e4a20402-35a6-4ea7-96bd-d72ca8f47d6a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -866,8 +866,8 @@
       }
     },
     {
-      "uuid": "8edbd4e7-7126-4b63-9d01-b660cc416050",
-      "groupUuid": "56eb70e9-3660-47c6-978c-20ee9b0a93c8",
+      "uuid": "ea997376-9d27-4261-b01a-b21a0a181b4c",
+      "groupUuid": "c5d57d25-4752-4964-87a8-e9fa63c1f0bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -878,8 +878,8 @@
       }
     },
     {
-      "uuid": "e08842ba-5324-4a23-904b-9e3f517649d3",
-      "groupUuid": "56eb70e9-3660-47c6-978c-20ee9b0a93c8",
+      "uuid": "1111ae21-174f-4562-a37a-ab8686fd8e85",
+      "groupUuid": "c5d57d25-4752-4964-87a8-e9fa63c1f0bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -890,8 +890,8 @@
       }
     },
     {
-      "uuid": "eccf0008-dcab-4343-8334-a6ddb592f6a1",
-      "groupUuid": "56eb70e9-3660-47c6-978c-20ee9b0a93c8",
+      "uuid": "256bf58a-51d7-4f08-9a6f-63f5047b419e",
+      "groupUuid": "c5d57d25-4752-4964-87a8-e9fa63c1f0bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -902,8 +902,8 @@
       }
     },
     {
-      "uuid": "d1b4b409-3e2f-4891-b99b-a1aa5d6ef963",
-      "groupUuid": "01ff4e18-d163-483c-87c1-1f74c93364b5",
+      "uuid": "45369cf6-5e37-484c-8df2-494065befc18",
+      "groupUuid": "ec99ffde-77f2-4c1b-a169-00b78218cac8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -911,8 +911,8 @@
       }
     },
     {
-      "uuid": "a414c948-3522-4023-bac1-7a022b0634fe",
-      "groupUuid": "7b7efd63-0afe-4c70-b4cd-30206a31aa24",
+      "uuid": "f47428ce-191f-4493-93e0-77f0d061e7e9",
+      "groupUuid": "3270691b-aea2-40fc-ae5c-98e3e6c65784",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -921,8 +921,8 @@
       }
     },
     {
-      "uuid": "21861857-bbbd-4a31-b6ba-01004af69214",
-      "groupUuid": "8fda8750-ff92-4da0-9348-798624fc933d",
+      "uuid": "075bce0e-c131-4a94-bfde-e9f1a8982daa",
+      "groupUuid": "c5474051-ad9c-4706-aae2-265b525b53de",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -930,8 +930,8 @@
       }
     },
     {
-      "uuid": "97f19a2a-8ab1-4eb8-9f51-f82f5419ff32",
-      "groupUuid": "8af6a2a6-6c50-452e-9673-d3f550308c0d",
+      "uuid": "40284bd2-b529-4814-8916-975b184a2443",
+      "groupUuid": "b5c11502-21e9-4721-89e6-f6a81e206d5b",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -940,8 +940,8 @@
       }
     },
     {
-      "uuid": "ff15440e-d5a5-4c37-af2e-aed5f4d67220",
-      "groupUuid": "bee7e49a-a836-41c3-8f4c-0e759a3f1f71",
+      "uuid": "6711e868-5752-411b-a923-3b980e61f933",
+      "groupUuid": "d26c16d1-15d3-47cd-9e55-e7ad90af5f15",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -949,8 +949,8 @@
       }
     },
     {
-      "uuid": "e10bf6ec-67e9-451a-8db5-a0b8b119fcce",
-      "groupUuid": "4119b4d0-8eb5-4ebd-847a-d0a9bf938b1a",
+      "uuid": "9723e8df-6bb5-4493-b2de-5c59c5bcf1c8",
+      "groupUuid": "cdbbc73b-933c-44c8-bf14-292a554d8225",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -959,8 +959,8 @@
       }
     },
     {
-      "uuid": "afd490ef-c030-4a5d-af15-4e571e569fb4",
-      "groupUuid": "f7488f91-a680-4ab4-9c9c-b12d57b06894",
+      "uuid": "fe9c6e3f-fabb-4660-b042-e01125cae751",
+      "groupUuid": "ff0aecf2-c78c-4610-acf6-9134cc9bbf4b",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -968,8 +968,8 @@
       }
     },
     {
-      "uuid": "92d95c21-cf1d-44c4-9d59-25727717585b",
-      "groupUuid": "51586cbf-23b7-4483-91d3-3a6b20e93c38",
+      "uuid": "0ef58982-5d36-4483-b8dd-00e7f8da3c61",
+      "groupUuid": "b47927c9-1bda-4e54-8629-c9385dfc6dea",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -982,17 +982,17 @@
       }
     },
     {
-      "uuid": "c5716631-6a75-47e0-9e74-92f4d437558f",
-      "groupUuid": "b2aad972-dc14-4831-9fa2-d2ec9cfcea54",
+      "uuid": "34fcb224-0865-4624-811b-23692db7154f",
+      "groupUuid": "e5a4d9d3-d3b3-46b6-b376-55b405893b18",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "9b4d7243-3a66-4772-8631-bb6968226c05",
-      "groupUuid": "0c8e550c-cb26-4c72-a227-6de95433165f",
+      "uuid": "514248c0-3849-4b5f-9437-01ffb69525ac",
+      "groupUuid": "9668a7c2-0cdf-466c-b96e-6f8e4121ab16",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1000,8 +1000,8 @@
       }
     },
     {
-      "uuid": "952826ee-a650-48d6-a56b-e4b9be2a8c84",
-      "groupUuid": "9acac7a6-c09f-4a2e-8475-e33273284d5a",
+      "uuid": "8a44ce4c-2c4f-4431-8586-4995e79b45be",
+      "groupUuid": "e8ee47c7-061e-4f15-ad89-08a2fdb20696",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1012,8 +1012,8 @@
       }
     },
     {
-      "uuid": "ccac5fe4-f464-4a0d-a19f-b3df2c41fb2e",
-      "groupUuid": "9acac7a6-c09f-4a2e-8475-e33273284d5a",
+      "uuid": "c01fc5e9-8ef0-4a75-96be-4afe7acbb0ef",
+      "groupUuid": "e8ee47c7-061e-4f15-ad89-08a2fdb20696",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1024,8 +1024,8 @@
       }
     },
     {
-      "uuid": "3eabac84-fcef-46ab-9996-c9c9c859e4a8",
-      "groupUuid": "9acac7a6-c09f-4a2e-8475-e33273284d5a",
+      "uuid": "46bcf507-e532-4f95-b1b2-a1739b356825",
+      "groupUuid": "e8ee47c7-061e-4f15-ad89-08a2fdb20696",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1036,8 +1036,8 @@
       }
     },
     {
-      "uuid": "a875cb18-4329-4ae1-8cea-21a0ab064846",
-      "groupUuid": "f2f64a37-7d51-4cdd-89b3-db9b5b18d586",
+      "uuid": "27579a60-d9b2-4697-88b1-991318356c93",
+      "groupUuid": "f7124da7-23b9-4c42-9e1b-3657a9a1e1e5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1045,8 +1045,8 @@
       }
     },
     {
-      "uuid": "5eb9536e-8e72-478b-a48b-adc7c652a59a",
-      "groupUuid": "e1435a8a-fa38-4b62-9aa9-07db3e5f6bf6",
+      "uuid": "8e9eb8bd-658b-4f4e-8426-4239c3284082",
+      "groupUuid": "6254236a-4f81-40de-9365-18400308d19c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1055,8 +1055,8 @@
       }
     },
     {
-      "uuid": "6b01fb0e-4011-4dbd-b460-7a9992ecb445",
-      "groupUuid": "b944a7df-7141-466a-8798-c0e3ba582321",
+      "uuid": "db220c6d-0279-4070-8d9b-ae27d533cff4",
+      "groupUuid": "c31f3c2d-f2b3-4616-9151-8c53df7beb11",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1064,8 +1064,8 @@
       }
     },
     {
-      "uuid": "fbe16426-9649-46fb-bc6e-d37e143d97bb",
-      "groupUuid": "f96b70e6-4c30-43ab-98c5-4a89f05f7f4f",
+      "uuid": "f826a0ef-cdcd-4ea4-8603-bca23adbf077",
+      "groupUuid": "04cb105f-2c52-4ea0-8f76-a8287433653a",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1074,8 +1074,8 @@
       }
     },
     {
-      "uuid": "7857db6c-988a-4f42-980e-26d9b4947a1a",
-      "groupUuid": "0dbe54eb-578c-4b40-93ec-774bf8c22ca0",
+      "uuid": "b41cef17-12c2-4f2a-8c06-bb049bb55c78",
+      "groupUuid": "4d3565bd-fccd-42c7-8793-8ea61a57f6e8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1083,8 +1083,8 @@
       }
     },
     {
-      "uuid": "0bfcfea0-b4a7-4f36-84e9-711b7a269483",
-      "groupUuid": "b5be969d-8465-4ca5-83d3-94d22b5f9b52",
+      "uuid": "9dc9b49e-ab94-428c-9b63-b0beed27725b",
+      "groupUuid": "a1f27ba5-a2d8-4e24-8fe4-9fcf2840fcc5",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1093,8 +1093,8 @@
       }
     },
     {
-      "uuid": "16a665ee-1cb7-441c-b561-f91ea0c7dfe8",
-      "groupUuid": "6acd9d73-d189-4839-8f83-cd309ab46daa",
+      "uuid": "c81a01fd-754d-45f8-aa19-6fc611236fde",
+      "groupUuid": "952b89e7-3478-4b4a-8ff1-ae2a0283a43d",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1102,8 +1102,8 @@
       }
     },
     {
-      "uuid": "9c9256ac-5a92-4e48-9451-f2bbca5455bb",
-      "groupUuid": "cc0749c5-0b86-44a3-b394-885d0641e476",
+      "uuid": "2c2eee3b-c147-4242-9368-1598cf657154",
+      "groupUuid": "a4b12f95-5600-4025-abd3-5f75f23cc95c",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1116,17 +1116,17 @@
       }
     },
     {
-      "uuid": "3a15d4f0-fb4b-4535-a333-fb018287f69e",
-      "groupUuid": "c0d42aef-1764-4ef3-a856-baa8c896b32f",
+      "uuid": "c40c9d27-7974-4d53-ac7e-12850003b940",
+      "groupUuid": "7a53fdd9-97df-472e-a90c-7a02927da04e",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</p>"
       }
     },
     {
-      "uuid": "0df23a93-181c-4e7a-b6d1-f0468a49f34d",
-      "groupUuid": "7cff112a-b826-41e8-9689-4d9da8786dd0",
+      "uuid": "97cbfeb3-511c-48c3-8a8f-9aa26570b0d2",
+      "groupUuid": "5392d8f1-9b97-4b03-9d2f-533222c49629",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1134,8 +1134,8 @@
       }
     },
     {
-      "uuid": "b0faad89-355f-4e17-b224-fba1be883898",
-      "groupUuid": "a33cd457-a1a5-43d2-b15e-33bbd1108dc0",
+      "uuid": "6a95221e-a87d-48c1-8637-2241806e3888",
+      "groupUuid": "ea4a7083-cbf2-4460-ac10-307d733a046d",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1146,8 +1146,8 @@
       }
     },
     {
-      "uuid": "fbc262cf-26a3-4b86-ad98-2d9dabc4b358",
-      "groupUuid": "a33cd457-a1a5-43d2-b15e-33bbd1108dc0",
+      "uuid": "3a660d32-19b3-4217-bce4-68553587f69d",
+      "groupUuid": "ea4a7083-cbf2-4460-ac10-307d733a046d",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1158,8 +1158,8 @@
       }
     },
     {
-      "uuid": "ae43d8f5-b429-4ecd-b2ea-2a3736a42ead",
-      "groupUuid": "a33cd457-a1a5-43d2-b15e-33bbd1108dc0",
+      "uuid": "f2152268-8507-4ff7-a11f-323f378540f6",
+      "groupUuid": "ea4a7083-cbf2-4460-ac10-307d733a046d",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1170,8 +1170,8 @@
       }
     },
     {
-      "uuid": "f235231a-1438-46ac-bccb-978de485da8e",
-      "groupUuid": "bec6b116-6aff-4a56-981a-e3807f23271c",
+      "uuid": "46f19a7a-a3b8-43cb-9011-78dd02c40e13",
+      "groupUuid": "5a7bfa9b-64be-49e4-a60d-cc7146e3d35b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1179,8 +1179,8 @@
       }
     },
     {
-      "uuid": "459ef230-1989-465b-884f-e29e9565b292",
-      "groupUuid": "086a2429-a15f-498a-9e1b-909f862be8ce",
+      "uuid": "00c6e5e7-eaad-4047-8112-b8fe79b1df2c",
+      "groupUuid": "072633f0-e1c8-4625-853f-7a86787872ce",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1189,8 +1189,8 @@
       }
     },
     {
-      "uuid": "9c7c3769-19d4-482d-afc1-c71191773105",
-      "groupUuid": "a5b9b51c-da94-41f4-a79a-7030a568769c",
+      "uuid": "7eb8ae26-6ad4-4198-bb55-1d60a4ae85d6",
+      "groupUuid": "3eb8fbe8-260a-4a53-8d25-f3e789063448",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1198,8 +1198,8 @@
       }
     },
     {
-      "uuid": "811ebf45-9855-4e12-9f89-27a7038549e0",
-      "groupUuid": "1c8dd7d5-4709-454a-a58e-ffd222bff876",
+      "uuid": "a903e182-7aba-4e95-8750-3368ae279832",
+      "groupUuid": "7d14b3b3-0c55-43c8-a392-8f2453578c53",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1208,8 +1208,8 @@
       }
     },
     {
-      "uuid": "4fc99020-f099-4532-92a8-5a12eeed8660",
-      "groupUuid": "202b665a-3346-4def-9ba2-2ed54196701d",
+      "uuid": "6a3c0d39-b2c7-4cd6-89b0-4c681fb08d95",
+      "groupUuid": "f01b99e6-a06d-4553-b9e9-35f218fe292b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1217,8 +1217,8 @@
       }
     },
     {
-      "uuid": "105fd3cd-a119-4482-808b-cfba745c9adc",
-      "groupUuid": "912c6a5d-88eb-49ba-bc11-a18a379d4eeb",
+      "uuid": "3edef0f0-5d98-4013-aeb9-e3de379cf96a",
+      "groupUuid": "22ccb9af-62ae-4d79-929d-69f7d0657bb9",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1227,8 +1227,8 @@
       }
     },
     {
-      "uuid": "80fd0f8a-cf2b-46e3-bd7a-6f93920c3b12",
-      "groupUuid": "30070f54-05fd-43d1-b935-1e9fafb91845",
+      "uuid": "73d93aa7-b2b9-4acc-9794-a9ac522976fd",
+      "groupUuid": "c892bc7e-5feb-4336-804c-3678b70d1933",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1236,8 +1236,8 @@
       }
     },
     {
-      "uuid": "1411d5dd-8de5-4c11-b449-eb9b18380545",
-      "groupUuid": "ed697ad0-b6d7-458e-8fea-effe2923a4c3",
+      "uuid": "8471de5c-16d2-4a6e-adb5-bbfb10b343ea",
+      "groupUuid": "b2b64cce-336b-4de4-a6b3-16ab95513bd5",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1250,17 +1250,17 @@
       }
     },
     {
-      "uuid": "51b5a969-edca-4216-bace-a716ca041ceb",
-      "groupUuid": "2e697fe5-bb2f-47c1-966d-7cbee7125e1a",
+      "uuid": "70967801-5287-4255-9014-d697fff266da",
+      "groupUuid": "78292e1e-bfad-49a9-819a-cf9113e14cc6",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "11b01412-d3ab-476d-8b99-d5ab26933835",
-      "groupUuid": "39539833-0595-4445-988f-e6c1839f9261",
+      "uuid": "4f29fa7e-3f1a-42bd-abd8-fccc2689ff5b",
+      "groupUuid": "1da36178-61e3-4410-9366-b6c34faae7dd",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1268,8 +1268,8 @@
       }
     },
     {
-      "uuid": "80b5a2f0-0789-4246-bf98-e66e4b9b40b1",
-      "groupUuid": "9d932a7e-06ba-4b4e-b470-c53ffc0ff7c8",
+      "uuid": "a8a48900-752a-40d6-b270-ee9325688c02",
+      "groupUuid": "74b9533f-43ef-4e84-b809-a7c03828f579",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1280,8 +1280,8 @@
       }
     },
     {
-      "uuid": "ff5d517f-54b5-413a-b5e5-158879f97632",
-      "groupUuid": "9d932a7e-06ba-4b4e-b470-c53ffc0ff7c8",
+      "uuid": "1ab582c1-5546-4999-ad90-9964bb20e332",
+      "groupUuid": "74b9533f-43ef-4e84-b809-a7c03828f579",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1292,8 +1292,8 @@
       }
     },
     {
-      "uuid": "dcf1cae8-2e95-4613-8c1a-3d1a75d6d257",
-      "groupUuid": "9d932a7e-06ba-4b4e-b470-c53ffc0ff7c8",
+      "uuid": "0eaab5b6-e9f5-418f-b7a8-014e64b0d7bf",
+      "groupUuid": "74b9533f-43ef-4e84-b809-a7c03828f579",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1304,8 +1304,8 @@
       }
     },
     {
-      "uuid": "562d281b-f444-4b02-ba4a-b1dd2f1fefc6",
-      "groupUuid": "fdcde563-4bc8-4f9d-ba1f-efa1b27a78ec",
+      "uuid": "e0e71fd1-9f3e-478c-9dfd-10810c97da0e",
+      "groupUuid": "c6761cae-60a1-49b9-997c-5209997121f2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1313,8 +1313,8 @@
       }
     },
     {
-      "uuid": "cd9435ad-d8f4-499c-b4d2-d37381184790",
-      "groupUuid": "09d1aaf7-27f7-40e4-906d-e796fbe32b1a",
+      "uuid": "20156b3a-e9a6-4f3e-ae14-2fa9d72ac4b7",
+      "groupUuid": "cd90b440-af3a-4a47-a5d0-752a8ceaa4e7",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1323,8 +1323,8 @@
       }
     },
     {
-      "uuid": "477edcca-b88b-4a9f-9cc4-91ff3e7a3c03",
-      "groupUuid": "5c6bfa18-031f-499a-8397-dd0de5cb84e5",
+      "uuid": "a1bcdc05-4ebb-4170-a87d-43a57a1f3ac7",
+      "groupUuid": "1e212815-9930-44b8-a40f-931100056f21",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1332,8 +1332,8 @@
       }
     },
     {
-      "uuid": "3b87af5e-f8bd-470a-971e-de2f5428e93e",
-      "groupUuid": "4d7ddb45-19f2-45c3-b0a1-662cafe5bd2f",
+      "uuid": "644833fd-1384-4c80-8a8e-7717dc4b9382",
+      "groupUuid": "4ee497f6-6d57-4738-9600-4b1bfdd19fbd",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1342,8 +1342,8 @@
       }
     },
     {
-      "uuid": "85d447cf-7749-46bc-aec2-27546b7a5e54",
-      "groupUuid": "940fc085-df05-4b60-a883-4459854ce692",
+      "uuid": "dd8287a1-ee07-4b43-8302-4dbb05d16819",
+      "groupUuid": "0626e55b-4332-46d2-8365-a5ff0ca351cf",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1351,8 +1351,8 @@
       }
     },
     {
-      "uuid": "7f2232f5-023c-47b0-aa22-2388b1169d6a",
-      "groupUuid": "7de93e31-4e10-4752-b022-19295cb2356d",
+      "uuid": "84522ade-a557-431f-b913-bfc0d8d05b1b",
+      "groupUuid": "05f25a67-4edd-4058-8ac2-25d4a397372c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1361,8 +1361,8 @@
       }
     },
     {
-      "uuid": "136ab78e-9729-4ff5-a6d3-ead9be295b56",
-      "groupUuid": "bdcabd7b-f6e2-4f5c-9338-fb32b8fe382e",
+      "uuid": "6a724854-2e97-4d1b-b946-3d995dbf40fe",
+      "groupUuid": "aae02bc1-f308-4a09-be83-afe02f604c6f",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1370,8 +1370,8 @@
       }
     },
     {
-      "uuid": "f229c393-c7e9-45ce-8597-8382ebfa79d2",
-      "groupUuid": "fcdc29ac-1d3c-4f71-97cf-c910d830bf48",
+      "uuid": "0f0e6e2f-d404-45b1-96b8-cf2884cb4871",
+      "groupUuid": "04c190c2-3f93-4c62-b5aa-4adf27c15292",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1384,17 +1384,17 @@
       }
     },
     {
-      "uuid": "32f87286-36f3-49a9-957d-d57e0e6d994c",
-      "groupUuid": "cabe64bf-f0af-4d0f-95f8-107d58d0afa2",
+      "uuid": "c194290d-4ea2-4d45-9c3d-bb4afca39593",
+      "groupUuid": "c92fac60-b5f9-45c1-afe8-f6aaec470fe3",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: altered-dominant<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Altered voicing:</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "dadc41ad-7fa4-4f48-bcde-c49b427dc04d",
-      "groupUuid": "9d28c79d-153f-4ed3-aaae-33f8c426c15c",
+      "uuid": "30d3bd5c-6053-456b-9f30-33e33b3dae33",
+      "groupUuid": "12d4789c-49bf-4348-b3db-1cc247745eb5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1402,8 +1402,8 @@
       }
     },
     {
-      "uuid": "8e6a285a-0204-4240-a938-61150ef5f8f0",
-      "groupUuid": "90dcb693-4e5e-4de8-9136-58110ab9136f",
+      "uuid": "700429be-60e7-4136-a7cf-9ea7ab04f430",
+      "groupUuid": "4e2daf67-738a-4326-99bc-c1fbe060e161",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1414,8 +1414,8 @@
       }
     },
     {
-      "uuid": "f78ec62b-c47a-4a5f-a8b1-577f9cf0bc2b",
-      "groupUuid": "90dcb693-4e5e-4de8-9136-58110ab9136f",
+      "uuid": "9a0af6a1-333f-47c4-984b-f72135ad7ba0",
+      "groupUuid": "4e2daf67-738a-4326-99bc-c1fbe060e161",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1426,8 +1426,8 @@
       }
     },
     {
-      "uuid": "4d45cb39-a167-4fe6-a87e-f6724eabbc0b",
-      "groupUuid": "90dcb693-4e5e-4de8-9136-58110ab9136f",
+      "uuid": "ea69e7a6-6d5f-4f95-a417-d4a9c7f4a3d2",
+      "groupUuid": "4e2daf67-738a-4326-99bc-c1fbe060e161",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1438,8 +1438,8 @@
       }
     },
     {
-      "uuid": "0c3ce38b-6aa3-4942-858d-0bfbe6931476",
-      "groupUuid": "95c565f9-a6b7-499b-8942-4fd5f1a92adf",
+      "uuid": "7989a711-ff7b-4866-90a0-0c35aac327c5",
+      "groupUuid": "f9c33e32-b670-4456-aeca-7d1b10b14f6f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1447,8 +1447,8 @@
       }
     },
     {
-      "uuid": "61e2b1d3-1462-47c0-a3d8-63debd5bafc6",
-      "groupUuid": "96bb0db3-4645-497b-b046-8ef8c6894e1c",
+      "uuid": "b5ad7690-36a2-4b97-a6a0-b0ba82c81769",
+      "groupUuid": "63cc6a91-cd6f-4c10-a035-a3acc68bcf5c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1457,8 +1457,8 @@
       }
     },
     {
-      "uuid": "be61a682-55e9-41ff-8c94-6208fa79334b",
-      "groupUuid": "16400711-cf91-478d-a797-560cb561f70b",
+      "uuid": "27eb0c9d-3bb4-4ea5-bca4-56dac14507e0",
+      "groupUuid": "ee778f07-e0a0-4dc8-8f3d-40cd16273a2c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1466,8 +1466,8 @@
       }
     },
     {
-      "uuid": "d4fb8aa5-ebe8-4f0f-a6bb-117609c82752",
-      "groupUuid": "fbdcd3d3-ccf0-48fc-948c-84a115ab0b4b",
+      "uuid": "68fdca87-d93e-4ec4-af03-7f86fc106102",
+      "groupUuid": "dc07b089-3213-4967-950e-d83a826b5dac",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1476,8 +1476,8 @@
       }
     },
     {
-      "uuid": "21971b44-deb1-4c3e-9582-0a533300e457",
-      "groupUuid": "71ac3b9a-40de-4b19-95f9-4d2026b23d58",
+      "uuid": "e64fb8b9-f946-469b-bf86-810f8317c9dc",
+      "groupUuid": "6188b372-679c-4853-b244-3f7df7cf9752",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1485,8 +1485,8 @@
       }
     },
     {
-      "uuid": "d3297a9a-7308-4d81-87e6-89b77339a342",
-      "groupUuid": "d6ca0696-aa1b-4512-8985-29657cf745d9",
+      "uuid": "6056ab9c-33a5-4dc3-9bfa-6a5b91d04453",
+      "groupUuid": "b161c37c-1ab5-4d18-9992-e1d7a5668967",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1495,8 +1495,8 @@
       }
     },
     {
-      "uuid": "0304a20d-5e86-4411-ab90-c181e53b76be",
-      "groupUuid": "463e5af2-9e38-4ca8-bd8a-8514541b37a0",
+      "uuid": "5b3597a3-e95c-4a7e-9a51-5f96d5f89025",
+      "groupUuid": "c0cb8405-88c7-4764-a003-79adfa09261c",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1504,8 +1504,8 @@
       }
     },
     {
-      "uuid": "23583bb7-ace6-4dd1-9757-8ff4a98056d3",
-      "groupUuid": "7d686aaa-e64d-4dd5-ab12-f602c72413d5",
+      "uuid": "c3cbdd67-4691-449c-bf30-3985ab82b5a8",
+      "groupUuid": "3ff931bb-a6d9-42f0-8a83-56aca40beb4d",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1518,17 +1518,17 @@
       }
     },
     {
-      "uuid": "bf276261-fbe1-4c46-8ab4-c2b657db5d71",
-      "groupUuid": "4e87cd2e-2a97-48f1-a9bd-2cd0d8661e76",
+      "uuid": "10ab65cc-e908-4274-a05f-07a47bc5d4fd",
+      "groupUuid": "d9ca9770-c8f0-4a43-87e5-3fbf61a15d94",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-2, block<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>Drop-2:</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "4dbd904e-0a16-4587-9497-2fc2d38738e6",
-      "groupUuid": "095bfa5f-a2c8-4c1d-a3da-de36e384608f",
+      "uuid": "d3177c0d-5f0d-4a84-8f66-d991663e3d19",
+      "groupUuid": "660e2293-cf28-4fee-943b-666d1e128011",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1536,8 +1536,8 @@
       }
     },
     {
-      "uuid": "34e09a3d-4b6b-4382-b655-9df7c8774a94",
-      "groupUuid": "4b5537a1-4278-405b-9a6d-ffffbf806ab5",
+      "uuid": "c5ff4277-6683-4c35-a714-2fa86d8e6eab",
+      "groupUuid": "a3649faa-0da5-4cd1-99a4-2b8e0adc0ab1",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1548,8 +1548,8 @@
       }
     },
     {
-      "uuid": "2fec651b-07ee-44db-9e01-d35db54dbcf7",
-      "groupUuid": "4b5537a1-4278-405b-9a6d-ffffbf806ab5",
+      "uuid": "b1e44c6b-f604-447b-98b4-5aa16bdd3d67",
+      "groupUuid": "a3649faa-0da5-4cd1-99a4-2b8e0adc0ab1",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1560,8 +1560,8 @@
       }
     },
     {
-      "uuid": "c0709510-cf06-4685-80bf-e80e8f036b0c",
-      "groupUuid": "4b5537a1-4278-405b-9a6d-ffffbf806ab5",
+      "uuid": "4852387d-99b7-4ed7-a32e-9052b44ef626",
+      "groupUuid": "a3649faa-0da5-4cd1-99a4-2b8e0adc0ab1",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1572,8 +1572,8 @@
       }
     },
     {
-      "uuid": "a33b73fe-dcc1-48fa-ab94-55374f47de05",
-      "groupUuid": "45cb798a-64fe-4d18-be29-edabd1b71e42",
+      "uuid": "6af7f3a2-b3a0-4ef8-8bd6-fcf025ec6ffc",
+      "groupUuid": "1e94f92c-4cfb-480e-aaac-461e05b5790e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1581,8 +1581,8 @@
       }
     },
     {
-      "uuid": "b9ca817d-7b49-4df7-9c70-f8bc08a146ca",
-      "groupUuid": "cff94a1c-1825-4557-8528-5da803de0ffc",
+      "uuid": "c58e4609-4e00-47f1-863e-e52ef91ef9e7",
+      "groupUuid": "b73c2e13-ff3a-4fbc-b214-04e8a99c52fd",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1591,8 +1591,8 @@
       }
     },
     {
-      "uuid": "2cfb3bed-b7b8-4c95-b185-d437b26f06e8",
-      "groupUuid": "a87fa7c5-8f55-473f-916f-0b11e8ce6f2f",
+      "uuid": "96f5266d-f394-4a9c-a15c-dc84a3245213",
+      "groupUuid": "9526b9b2-c77b-4542-b493-faf2ec228999",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1600,8 +1600,8 @@
       }
     },
     {
-      "uuid": "d212d3d1-1c2d-4ec3-a1a5-7992fa42c778",
-      "groupUuid": "3ff03f22-86e6-4bbf-8b64-52ef3f337e46",
+      "uuid": "15bc830b-a330-40e6-9478-b158e59dc2a2",
+      "groupUuid": "e3582858-9157-4db3-9244-73ebf56d483a",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1610,8 +1610,8 @@
       }
     },
     {
-      "uuid": "dd47abd5-6368-4235-bad4-07bb59a600dd",
-      "groupUuid": "c8a38f13-4191-4e4b-8805-458182d9362b",
+      "uuid": "a3876ee0-43d6-4afe-ad65-0784357249c4",
+      "groupUuid": "bcaad50e-27d5-4204-b81e-a612841211a0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1619,8 +1619,8 @@
       }
     },
     {
-      "uuid": "a060fa12-3b67-44f5-9394-63713c75c86a",
-      "groupUuid": "83d2dc8e-4b24-47d8-94aa-a61c2c6b38c7",
+      "uuid": "f9f2d5bd-e1b5-4d10-8c89-c9bdc2b7bf81",
+      "groupUuid": "d1320409-59e1-442b-bd90-a30662444c77",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1629,8 +1629,8 @@
       }
     },
     {
-      "uuid": "f962b250-eff7-4070-85cb-f626de2d6a87",
-      "groupUuid": "fd1ab288-411d-4ca4-9396-49ed6d33ab11",
+      "uuid": "992d6dce-4fab-4b4c-a244-1896791084b7",
+      "groupUuid": "45ad8437-60c4-4c61-b051-c47a3b13a95f",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1638,8 +1638,8 @@
       }
     },
     {
-      "uuid": "00eb3021-a5ea-48ca-a9eb-af7d041475fd",
-      "groupUuid": "7c82c2d6-d1a6-4eac-9c83-500503cbad3e",
+      "uuid": "c2ff8b7d-b357-4c2b-9ba3-72e6a224d9c8",
+      "groupUuid": "3aba998e-69c0-4ced-b551-eb72cefeee3e",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1652,17 +1652,17 @@
       }
     },
     {
-      "uuid": "566c7c2e-f761-45eb-91e2-d39d7a97f959",
-      "groupUuid": "b99e627a-2764-43f3-a8a2-0b3baad64c6d",
+      "uuid": "f478b58d-1744-4b11-a9d0-bc254a079b51",
+      "groupUuid": "b752e2e7-7162-421b-a627-14be5b0ab762",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: drop-3, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "153faf61-6d77-4ac7-8958-2e0d7b3d9811",
-      "groupUuid": "90f642fe-4cd7-4935-83e5-ed456bb5615f",
+      "uuid": "34a87f80-0b28-4408-b3bc-645cd242992f",
+      "groupUuid": "2f0a3d17-66e7-4d34-a703-86363e5d1d56",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1670,8 +1670,8 @@
       }
     },
     {
-      "uuid": "143e10f0-8349-4f9a-9298-1236e32fdb71",
-      "groupUuid": "8de31ff4-3a81-4a51-8e6e-21e606b6ecc6",
+      "uuid": "18ccaf5e-4f58-4fa3-a4c6-3c5a8fe0f181",
+      "groupUuid": "062dbdf3-2587-4fb9-bafc-5036d5868d7b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1682,8 +1682,8 @@
       }
     },
     {
-      "uuid": "4ad1cdf5-5769-4bfa-b917-87297db3a594",
-      "groupUuid": "8de31ff4-3a81-4a51-8e6e-21e606b6ecc6",
+      "uuid": "e8b5e162-58aa-4c8a-8d42-fe7afcefaf80",
+      "groupUuid": "062dbdf3-2587-4fb9-bafc-5036d5868d7b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1694,8 +1694,8 @@
       }
     },
     {
-      "uuid": "e6d63875-d46d-400b-b93b-f77383b43344",
-      "groupUuid": "8de31ff4-3a81-4a51-8e6e-21e606b6ecc6",
+      "uuid": "7ed4ab1f-97ec-4c45-8f10-3d7e405148d9",
+      "groupUuid": "062dbdf3-2587-4fb9-bafc-5036d5868d7b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1706,8 +1706,8 @@
       }
     },
     {
-      "uuid": "288996b9-8d8d-4ab3-9afc-431d479be794",
-      "groupUuid": "88c0d17b-6be8-4d41-8dea-205022d2c2bc",
+      "uuid": "cbf00b9d-e3f9-4bd0-9520-2fa54075b176",
+      "groupUuid": "3ff7b16f-9daf-4165-b394-d8bc858e2567",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1715,8 +1715,8 @@
       }
     },
     {
-      "uuid": "57de4d6e-7c49-438f-a432-da38d0fda3c4",
-      "groupUuid": "dcb2fba6-bf60-474a-889c-aa0f41408df1",
+      "uuid": "9e3a29fa-4b0b-4dc9-af77-3234305810cf",
+      "groupUuid": "a7eb4ca7-3612-4906-95b2-13350a9357aa",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1725,8 +1725,8 @@
       }
     },
     {
-      "uuid": "57456168-b565-4507-b699-75c7be260239",
-      "groupUuid": "17e96853-ac69-400e-b0b3-52fd01fd314e",
+      "uuid": "b5694fc7-2a65-4dd1-bf63-37510daeaed2",
+      "groupUuid": "9c17144e-fefa-43af-8caf-78a7166236ab",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1734,8 +1734,8 @@
       }
     },
     {
-      "uuid": "6ff8ac99-0877-4090-bffb-0506a7351617",
-      "groupUuid": "9a5b71f0-2709-454e-ad15-84de3d4dc4df",
+      "uuid": "8180ef9a-cc4e-4f5a-bdea-eeb3fa0c6be8",
+      "groupUuid": "7b5150ee-8cef-4ae6-9354-89e40741bfb6",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1744,8 +1744,8 @@
       }
     },
     {
-      "uuid": "4dc13065-d7ca-4a6d-aacb-45df6a8d0421",
-      "groupUuid": "d9f31c09-3f11-4a46-8729-bcb8983c8e80",
+      "uuid": "70b89801-80bc-4e9f-b5d1-37d9a2a8bae1",
+      "groupUuid": "c5a7c9bf-a4df-46b9-ad05-191ae1941112",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1753,8 +1753,8 @@
       }
     },
     {
-      "uuid": "67a4de7c-ccec-4caf-8168-3fd93b1bcf5e",
-      "groupUuid": "ce87a8df-d1ae-4145-86d2-607e08157f5f",
+      "uuid": "5fb75301-5a45-416d-9efa-acb8b2b1565b",
+      "groupUuid": "721854e1-4c51-47aa-abbd-2095e3b19d3c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1763,8 +1763,8 @@
       }
     },
     {
-      "uuid": "d8a2b578-c1be-445b-84c5-eccc83b9ef82",
-      "groupUuid": "04db2a60-a06d-491d-a736-45f7c3bc2bef",
+      "uuid": "35bbf3e0-413b-46df-b98a-860407297b89",
+      "groupUuid": "b1a740ed-1877-49f3-a5c6-13939b6a1867",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1772,8 +1772,8 @@
       }
     },
     {
-      "uuid": "aab9ff0b-4ae2-4fd6-8426-9c64d3a5ebfa",
-      "groupUuid": "b506ee05-3832-4057-97ed-22f3fd554423",
+      "uuid": "d32911a0-63a2-4145-ab27-4862434f3896",
+      "groupUuid": "9b2628e6-c11f-4acb-a8fb-a19c71cdd923",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1786,17 +1786,17 @@
       }
     },
     {
-      "uuid": "815c7571-3836-482a-bdec-fa79bebecdcc",
-      "groupUuid": "7fb84852-e7bd-4137-87dd-0c70e8752b3f",
+      "uuid": "f9d31ad4-a910-4051-9bcc-959dd70bbf5b",
+      "groupUuid": "b2c89d53-4876-48ee-ab6b-1ce935ab93b3",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-3<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</p>"
       }
     },
     {
-      "uuid": "350655ad-c071-495b-8fcf-191e6ebc53f5",
-      "groupUuid": "847ce785-6a69-4f80-8552-dd6e721ef6b9",
+      "uuid": "fcf23bbf-8ff9-40ab-9416-94e76713f539",
+      "groupUuid": "8b6d6195-6c3d-4ca0-b45d-74025ae90064",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1804,8 +1804,8 @@
       }
     },
     {
-      "uuid": "f71fc572-b7c4-4350-a898-0eace57771d9",
-      "groupUuid": "1c66b6db-7878-4476-9353-a48b0eb80175",
+      "uuid": "5b055352-7081-42f6-b1e9-1f2abd82138b",
+      "groupUuid": "b3e76f46-417e-4d50-af05-bf9266e8b9c5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1816,8 +1816,8 @@
       }
     },
     {
-      "uuid": "0be3ce83-ce55-442b-8148-a9825395ca6c",
-      "groupUuid": "1c66b6db-7878-4476-9353-a48b0eb80175",
+      "uuid": "8b4524b7-ac75-4ee1-be62-6213e7d0bc8a",
+      "groupUuid": "b3e76f46-417e-4d50-af05-bf9266e8b9c5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1828,8 +1828,8 @@
       }
     },
     {
-      "uuid": "14b05308-7352-46a1-b106-cdc540a3c9a7",
-      "groupUuid": "1c66b6db-7878-4476-9353-a48b0eb80175",
+      "uuid": "ec1c3ab2-33c2-4b9a-b0ee-52663721f4a0",
+      "groupUuid": "b3e76f46-417e-4d50-af05-bf9266e8b9c5",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1840,8 +1840,8 @@
       }
     },
     {
-      "uuid": "0263c516-4787-4662-b7db-06247ccaa59c",
-      "groupUuid": "afed7862-36ef-4959-8389-4db2ce90711e",
+      "uuid": "b047a80e-d36f-4b64-842c-42d5cd3cd45f",
+      "groupUuid": "adea79a6-78ff-4dcb-9737-7f828740467e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1849,8 +1849,8 @@
       }
     },
     {
-      "uuid": "54961c3f-8897-4a63-9e58-b65fa664874f",
-      "groupUuid": "387f1165-d1fb-4363-b00d-49d5595af704",
+      "uuid": "7dc526fd-e671-4ce8-93d4-a8dc4daaadee",
+      "groupUuid": "6f0333fb-7fc4-4e85-b3db-63ee9b10ca3b",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1859,8 +1859,8 @@
       }
     },
     {
-      "uuid": "5c7b3236-9e5f-4b90-bdc4-e7ca0a1e1bc1",
-      "groupUuid": "27aa3484-6832-4fb8-9d25-f24abd5a14dc",
+      "uuid": "7e8a48d1-154b-4336-936a-1f1a87859e8e",
+      "groupUuid": "570042e8-7ebc-41ec-84dc-4ae0761c5483",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1868,8 +1868,8 @@
       }
     },
     {
-      "uuid": "fffa8875-70f9-4ba2-8dbc-85d46005bfbe",
-      "groupUuid": "49c6fa65-d588-41f6-b351-10f8491708b6",
+      "uuid": "3a11a77b-dca7-45b4-ad26-8c2e7b486a3b",
+      "groupUuid": "6918efdd-1e1e-4710-81f8-48cb11ca6185",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -1878,8 +1878,8 @@
       }
     },
     {
-      "uuid": "a36248de-d64c-4fef-bc31-217cabbf453e",
-      "groupUuid": "f4f237d9-7a5e-4fcb-a13b-fabf678d4515",
+      "uuid": "bde84d7f-b849-4ea6-abf4-d8233b50db9d",
+      "groupUuid": "37a28abb-2d53-4b9d-b5a2-bca98150b296",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1887,8 +1887,8 @@
       }
     },
     {
-      "uuid": "b9313400-dae8-42e1-90c0-ac06d26f27b8",
-      "groupUuid": "f4a44963-bec5-4758-9dc7-7aeb387a7765",
+      "uuid": "8eb5671a-58af-4179-a512-f32880ff3d8f",
+      "groupUuid": "77da2aac-fb4d-4e25-94c3-b6f99170de6e",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1897,8 +1897,8 @@
       }
     },
     {
-      "uuid": "5e86a854-c540-4b9a-979d-638ef5488fa3",
-      "groupUuid": "0ae49705-ceff-4efe-815e-245cd1051bfe",
+      "uuid": "7cdc5193-f464-43de-ba5d-be67c142e1f1",
+      "groupUuid": "ca98935d-ccc8-417c-b883-fc9e8d3592b4",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -1906,8 +1906,8 @@
       }
     },
     {
-      "uuid": "b0199018-a843-482e-9e9c-8a0d4fb96b3e",
-      "groupUuid": "db9c41ba-ca1c-44b7-b636-3b7f954193c4",
+      "uuid": "2163fce9-aaae-4336-bdef-a60ea1658813",
+      "groupUuid": "5dad3cf5-fce8-4d62-ba31-b202aa726f62",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -1920,17 +1920,17 @@
       }
     },
     {
-      "uuid": "2e074130-0c97-4c92-822e-2a3c27e40144",
-      "groupUuid": "7d417f06-9539-4d0c-bd4f-5607090bb52e",
+      "uuid": "2edef655-df47-4542-a532-f40964aada0d",
+      "groupUuid": "48befd65-e5d1-44f9-b676-c6df85652fa9",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "3c6a00c6-9b16-45bc-aa6b-39faf6003040",
-      "groupUuid": "c1301ee2-7805-43d7-877c-23e9e490913b",
+      "uuid": "4ba3c005-a305-4d0b-99f6-628d77530266",
+      "groupUuid": "1a35d835-6453-44e9-96bb-13fc89521eed",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1938,8 +1938,8 @@
       }
     },
     {
-      "uuid": "51af6dd6-f9e8-4909-be19-80c3d60f901b",
-      "groupUuid": "50abea7c-bcba-4c74-bf6a-817462d0659f",
+      "uuid": "f656a020-1068-4188-bb2a-c0b2a122d50d",
+      "groupUuid": "193f8762-ff18-49f2-80a0-41969c06a962",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1950,8 +1950,8 @@
       }
     },
     {
-      "uuid": "5f24f300-9e21-4fdb-9989-58a3aeb758ae",
-      "groupUuid": "50abea7c-bcba-4c74-bf6a-817462d0659f",
+      "uuid": "689a7886-6e1d-4f10-8ed6-194cb487dc13",
+      "groupUuid": "193f8762-ff18-49f2-80a0-41969c06a962",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1962,8 +1962,8 @@
       }
     },
     {
-      "uuid": "afbaaec0-fe36-4551-89b3-7cd3d0fc5b6c",
-      "groupUuid": "50abea7c-bcba-4c74-bf6a-817462d0659f",
+      "uuid": "ed705cf2-5bca-4f26-9a37-cd22bc5dc3f2",
+      "groupUuid": "193f8762-ff18-49f2-80a0-41969c06a962",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -1974,8 +1974,8 @@
       }
     },
     {
-      "uuid": "6dd351e5-f59b-4a5b-a400-57edc484e5da",
-      "groupUuid": "15852d6e-63bf-44dd-a288-a836f49041ba",
+      "uuid": "eec381cb-3973-45c7-a951-d70b7b1cc350",
+      "groupUuid": "d8be682e-e29e-4466-8c46-5237bc44a8e5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -1983,8 +1983,8 @@
       }
     },
     {
-      "uuid": "9e17661f-bc1b-4f82-b90b-56dbcb0da358",
-      "groupUuid": "8792f07f-2ee5-472a-ac4a-355e60e474df",
+      "uuid": "5862eb31-d1f8-4766-847e-48fb43deb5c9",
+      "groupUuid": "4c07d218-7753-47ec-bd77-ef9c33e70712",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -1993,8 +1993,8 @@
       }
     },
     {
-      "uuid": "f6275a57-7b19-40d4-a318-a4c734d46284",
-      "groupUuid": "0dfd3296-ecb8-42d7-945e-405b36f002f9",
+      "uuid": "ac0c251d-fb96-4298-a684-d8fb2141efa7",
+      "groupUuid": "4e59f499-2815-49c7-abc4-a42104c479e2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2002,8 +2002,8 @@
       }
     },
     {
-      "uuid": "050445c8-9022-4601-8d03-5f7c1669d295",
-      "groupUuid": "fe9f5682-a32d-4e8c-9f01-8493459503e5",
+      "uuid": "0097fcea-0edb-42bc-9036-2255e1775cf5",
+      "groupUuid": "b80e93c0-7874-4a25-a962-8510b0d02b5b",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2012,8 +2012,8 @@
       }
     },
     {
-      "uuid": "6ce0506d-5abd-43f0-9548-be842a591a0e",
-      "groupUuid": "fdf512fc-03cc-4958-aee7-2d10ad418114",
+      "uuid": "f0e60ca8-9af3-4dbd-b5ed-cd99f1c3abef",
+      "groupUuid": "a75352c7-f957-4a30-8623-442d2c9108ac",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2021,8 +2021,8 @@
       }
     },
     {
-      "uuid": "769650cc-984c-4629-9042-329bb545e9e5",
-      "groupUuid": "ff72409d-9a74-4200-85b9-b332e76e41de",
+      "uuid": "5c05ebb5-cf4d-4915-9c34-f15dcf2b84ca",
+      "groupUuid": "3427d1b5-466d-4d83-9e72-635aab7e6131",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2031,8 +2031,8 @@
       }
     },
     {
-      "uuid": "ea606311-9e3c-4911-a046-6be836d3ffb3",
-      "groupUuid": "d9e2d084-1f6e-4128-ac28-3a4eaf65f34a",
+      "uuid": "ede02f9c-f385-4ff9-9655-e8c7fcd2a45b",
+      "groupUuid": "d3f8efcb-8fb6-4793-8605-082632740c57",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2040,8 +2040,8 @@
       }
     },
     {
-      "uuid": "6ce6bd5b-6eec-450c-ac87-46296677c3ea",
-      "groupUuid": "41787c5c-345a-4a20-b9c3-d707811b973e",
+      "uuid": "9c10c71c-f691-41eb-8b53-721e6e34025a",
+      "groupUuid": "9e5e044e-6205-48e2-9926-e751ae334680",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2054,17 +2054,17 @@
       }
     },
     {
-      "uuid": "0c3afc09-c522-4b17-b1a5-d120f3fa150d",
-      "groupUuid": "c9a1e960-b300-4d75-ad21-7864fa36ba8b",
+      "uuid": "afb62405-7587-49dd-b661-74ebfca91c9d",
+      "groupUuid": "3a3186b6-a63a-4de7-b8e3-c094ecba5c8a",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "f598c18a-4a86-42c8-a086-726a8be30e9c",
-      "groupUuid": "fbac73f3-3f1b-4e22-8d72-3d8a1f614589",
+      "uuid": "c8cdcdf4-8072-494c-adfa-0f6af0ff8f7e",
+      "groupUuid": "d71512f1-88ad-4d72-9ffc-427212f92a4b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2072,8 +2072,8 @@
       }
     },
     {
-      "uuid": "74a1993b-804d-4a7b-baad-f95c7c2b1a49",
-      "groupUuid": "9cdfbdbc-0a22-4830-87a3-04c464117895",
+      "uuid": "f9c5a44f-5d5d-4512-bde2-78e8e570aa1a",
+      "groupUuid": "5baea851-6b60-40cf-8b2f-3646efc11ece",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2084,8 +2084,8 @@
       }
     },
     {
-      "uuid": "58ecabfc-0257-46d4-ac76-8a3dfa385588",
-      "groupUuid": "9cdfbdbc-0a22-4830-87a3-04c464117895",
+      "uuid": "2b6cf634-83d7-469f-8e98-c883aaa6065d",
+      "groupUuid": "5baea851-6b60-40cf-8b2f-3646efc11ece",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2096,8 +2096,8 @@
       }
     },
     {
-      "uuid": "e4f73f34-0995-4acb-8653-0511c225ac3a",
-      "groupUuid": "9cdfbdbc-0a22-4830-87a3-04c464117895",
+      "uuid": "7aaf8993-d258-464b-bdbb-35f95fcfbc91",
+      "groupUuid": "5baea851-6b60-40cf-8b2f-3646efc11ece",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2108,8 +2108,8 @@
       }
     },
     {
-      "uuid": "8d988dd7-a902-4338-88d9-ab51edb61b22",
-      "groupUuid": "7cf83e00-666e-4021-ab3a-699ed5fd6ca6",
+      "uuid": "a9bf75b3-9fbb-40f0-991a-31bae8e0aadd",
+      "groupUuid": "685e30e7-a2aa-4270-a18d-7756a0763dbd",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2117,8 +2117,8 @@
       }
     },
     {
-      "uuid": "2df9130c-be5b-4982-b968-55bbea656ce0",
-      "groupUuid": "059b589c-5e6b-4083-a7cf-64e0dddb5b85",
+      "uuid": "54f7ac79-52fd-43c0-8c0e-d545f77a77a1",
+      "groupUuid": "6688a1cb-4a10-4aca-926a-696862db6663",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2127,8 +2127,8 @@
       }
     },
     {
-      "uuid": "30153e40-f96e-4268-a17b-a78a1b2f0a4b",
-      "groupUuid": "d0c992bb-b25a-4f6a-aca3-8ff65925cc6c",
+      "uuid": "bffcc1ad-a357-4dc4-ae2d-d3c9b3b5b8ca",
+      "groupUuid": "b4e6af92-4ce9-4d6d-9b36-2d5d8714a11c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2136,8 +2136,8 @@
       }
     },
     {
-      "uuid": "01a0cb43-478d-4ad1-9cc6-582e958e89f1",
-      "groupUuid": "50b95a81-2dcd-4622-a690-335b40a9c3b3",
+      "uuid": "48762d72-cf84-47e2-9790-5b518070f4f5",
+      "groupUuid": "7619356e-385c-4546-ae62-a74ca3e586ea",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2146,8 +2146,8 @@
       }
     },
     {
-      "uuid": "88108664-5b87-42b5-94a1-244a2a285d3a",
-      "groupUuid": "3d0c1cfb-fbb0-4770-9bb9-0ed7446cef22",
+      "uuid": "aa05f821-32fd-4600-875a-6fbeec4478c5",
+      "groupUuid": "aac5c4c0-b48d-405c-9050-f5980f0839fe",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2155,8 +2155,8 @@
       }
     },
     {
-      "uuid": "801334cd-6f38-4279-90bf-3b0e047ca4d0",
-      "groupUuid": "d6da206b-4438-45f8-8138-9401d8a4896e",
+      "uuid": "c6a01efd-2f45-4486-971f-09b3ef5c589d",
+      "groupUuid": "dcce9060-093a-4e71-b34f-356542d047a1",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2165,8 +2165,8 @@
       }
     },
     {
-      "uuid": "bdff710a-212d-4aa8-b4a9-32040e0b056a",
-      "groupUuid": "509f2b55-d87e-47d0-989c-eab416373416",
+      "uuid": "2057a1ec-bf0e-4fa3-9cbb-35487778a917",
+      "groupUuid": "3432f210-5a82-4e7b-8880-b83baf0c9ecf",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2174,8 +2174,8 @@
       }
     },
     {
-      "uuid": "b13f0d76-2db5-42b6-bec8-aacad390ca8d",
-      "groupUuid": "5228bb9c-5273-426b-b852-95d7b0f8dc3a",
+      "uuid": "7182621d-0377-478a-b5f8-e0a873d37f20",
+      "groupUuid": "97966c71-489e-4246-bf0e-4a5b5d402d5b",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2188,17 +2188,17 @@
       }
     },
     {
-      "uuid": "456831a0-b969-4b27-ae93-d1d3d72feff8",
-      "groupUuid": "e3f96e0e-9f95-410a-8535-0ea236900bfb",
+      "uuid": "9efa3e3e-4bc9-4643-94eb-333c27652a0b",
+      "groupUuid": "756525c8-6bda-4263-9a2e-278b2b2419cb",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: quartal<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>Quartal voicing:</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>quartal</b> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</p>"
       }
     },
     {
-      "uuid": "0fe0ddcd-c566-4993-9411-faa08b942a68",
-      "groupUuid": "ef2dc87c-71d9-4e88-ba96-7a68239a977e",
+      "uuid": "69f296e4-043c-4edc-972f-4e3026a3efdf",
+      "groupUuid": "41c1cf73-cac8-49d6-9235-a02092b50c18",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2206,8 +2206,8 @@
       }
     },
     {
-      "uuid": "29942395-3f62-4ffb-8dcf-6a97701a46d9",
-      "groupUuid": "78cd24d0-f389-4c41-91b5-6b7ce3dd2f74",
+      "uuid": "8f6f1b46-c1db-49ae-b996-3882f0082de7",
+      "groupUuid": "498b3517-b8b3-4844-9b5c-470b262a16fc",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2218,8 +2218,8 @@
       }
     },
     {
-      "uuid": "cb246434-1a8b-422d-a98a-366df5e49cb0",
-      "groupUuid": "78cd24d0-f389-4c41-91b5-6b7ce3dd2f74",
+      "uuid": "1f11cbf6-f1f8-455d-845c-f3ff4e0a5120",
+      "groupUuid": "498b3517-b8b3-4844-9b5c-470b262a16fc",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2230,8 +2230,8 @@
       }
     },
     {
-      "uuid": "5a15d106-ce8a-4be3-8a6c-fe593e10249a",
-      "groupUuid": "78cd24d0-f389-4c41-91b5-6b7ce3dd2f74",
+      "uuid": "552e2cc6-52fe-4be9-995d-00adbb75a907",
+      "groupUuid": "498b3517-b8b3-4844-9b5c-470b262a16fc",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2242,8 +2242,8 @@
       }
     },
     {
-      "uuid": "d6a5035d-4ec9-4562-b9e6-9e9926f8c57b",
-      "groupUuid": "067e2186-5b0d-4716-823d-778d9e7564be",
+      "uuid": "4ce448ac-c0c3-4f07-a018-df1146652c33",
+      "groupUuid": "55a2cd3b-4566-46f3-86f6-9859091bb9db",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2251,8 +2251,8 @@
       }
     },
     {
-      "uuid": "db32fbc1-e133-4b02-b833-c0af26cf17eb",
-      "groupUuid": "68b69d7c-b669-4daa-82d4-ec2268784a45",
+      "uuid": "3518826a-424f-4c34-9d30-c27c95ae20e8",
+      "groupUuid": "bd1dabb1-5506-4b14-aee0-c07ae6928b2e",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2261,8 +2261,8 @@
       }
     },
     {
-      "uuid": "aac3db72-b40d-4ff9-9c10-4c1e0f8453ba",
-      "groupUuid": "e00e292f-6a9d-4b2e-ab27-29f1f7c5dcf8",
+      "uuid": "c1c99ff2-7b97-480e-8459-21262b108bde",
+      "groupUuid": "3c53786f-e52c-451c-9abe-7168a8026139",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2270,8 +2270,8 @@
       }
     },
     {
-      "uuid": "55497f9f-dbc6-40b4-8a2a-ab13ad9ef963",
-      "groupUuid": "5bf180ec-4d54-47c3-97af-751fdcfc58b4",
+      "uuid": "79304ee8-6575-493f-be23-598f54872dd5",
+      "groupUuid": "a59976da-4f3c-4fb4-95fd-33ad791ad0bb",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2280,8 +2280,8 @@
       }
     },
     {
-      "uuid": "2d1ce19e-a937-4477-91b9-628e245f3c77",
-      "groupUuid": "98c17659-bf58-4f6a-84aa-17087cba7239",
+      "uuid": "c761d884-7937-4b09-9f56-bc8ada262f88",
+      "groupUuid": "9cbe660e-e0d5-42be-b0bb-3b417426c1da",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2289,8 +2289,8 @@
       }
     },
     {
-      "uuid": "9a33c5ad-958e-4433-9039-05effb440f85",
-      "groupUuid": "4563fe34-42a4-4a34-be31-a01f05a91059",
+      "uuid": "a3882249-1feb-4cb4-acf5-87fd43fe4351",
+      "groupUuid": "c5d5f3f5-7a1a-4248-bc87-82b96981b3af",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2299,8 +2299,8 @@
       }
     },
     {
-      "uuid": "046ecd46-62cf-40a3-8789-a32cce444b70",
-      "groupUuid": "8dae7bf4-23f0-48ad-9c25-3ad15cd058f8",
+      "uuid": "149ce6a8-12a9-44ac-9ee9-d7b45dee504f",
+      "groupUuid": "fe60e458-5efc-488a-bc12-279e2e090a59",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2308,8 +2308,8 @@
       }
     },
     {
-      "uuid": "185ff5ec-c4c7-4a7f-ac8b-de722cc66a17",
-      "groupUuid": "bc6b0f92-a9cd-4789-a857-d90109200c34",
+      "uuid": "5f6ecc5b-0502-4213-8ed5-02ee1d306fd6",
+      "groupUuid": "44c33423-7dfa-427b-b815-dba72a103283",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2322,17 +2322,17 @@
       }
     },
     {
-      "uuid": "d8f19d0d-ca85-49d5-b2d9-b0014b00ebba",
-      "groupUuid": "c7965045-0c31-420b-81c4-d6c17c8f64bb",
+      "uuid": "0e882400-1ade-42e8-b1e1-3fdd1edae995",
+      "groupUuid": "4747d4d8-f2c5-446d-a56a-c8920a125e87",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "546792c2-68a3-4b03-90e3-d632d8a79130",
-      "groupUuid": "68fd5f3d-3a17-4832-8400-796d4711eea5",
+      "uuid": "5386a8a3-dc87-4a86-9943-3440a9b64af8",
+      "groupUuid": "2cf3a516-ea2a-4116-b23c-1d6f299ef268",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2340,8 +2340,8 @@
       }
     },
     {
-      "uuid": "51ad12dc-fd33-4b94-910b-015b6838a333",
-      "groupUuid": "b95fb620-76fa-4220-9279-98e409e3c2fc",
+      "uuid": "91f97330-735f-4014-a96c-85392e7b3ddf",
+      "groupUuid": "9db653d8-ba93-4bd9-8770-530a577a781b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2352,8 +2352,8 @@
       }
     },
     {
-      "uuid": "19e674bd-937d-4dda-a78d-b6806f941e80",
-      "groupUuid": "b95fb620-76fa-4220-9279-98e409e3c2fc",
+      "uuid": "d5a20a48-d265-4f36-adec-3be1105afabf",
+      "groupUuid": "9db653d8-ba93-4bd9-8770-530a577a781b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2364,8 +2364,8 @@
       }
     },
     {
-      "uuid": "f14fd74a-dc5a-40e2-b21d-b776932e1040",
-      "groupUuid": "b95fb620-76fa-4220-9279-98e409e3c2fc",
+      "uuid": "2022a9c7-d087-49ef-832f-acc650f6ac5a",
+      "groupUuid": "9db653d8-ba93-4bd9-8770-530a577a781b",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2376,8 +2376,8 @@
       }
     },
     {
-      "uuid": "4a3ae541-98a9-4b65-80cb-379fb4ce9f9a",
-      "groupUuid": "33c79229-17d1-4ae1-9569-4247e8f25207",
+      "uuid": "947c5d4f-dd1b-4193-8f10-3e441e1c70da",
+      "groupUuid": "6507b21a-6848-4880-b773-503ece00b2d0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2385,8 +2385,8 @@
       }
     },
     {
-      "uuid": "912955c7-6e00-4a78-a97f-aee6879ff4ed",
-      "groupUuid": "d1957557-17d6-4006-a734-f8dd2c0a5a67",
+      "uuid": "3d2de8bb-9ced-4bb8-9880-e2788ebda3ec",
+      "groupUuid": "ceead5c4-3525-4507-8aba-366da7ce2da3",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2395,8 +2395,8 @@
       }
     },
     {
-      "uuid": "b2189650-c20b-4c2b-86e9-fee7de153a8a",
-      "groupUuid": "5cdfc7a0-685e-4947-a453-a630084ecc66",
+      "uuid": "9230de48-138b-4275-a648-78dced69ab2b",
+      "groupUuid": "40cc4584-f00b-441c-a678-c3cae293d00b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2404,8 +2404,8 @@
       }
     },
     {
-      "uuid": "9abe62c8-c8ee-4f7d-9e7a-4056899f9279",
-      "groupUuid": "49a1b7ae-8e5f-4310-b723-70c8f0aee94d",
+      "uuid": "69e9ad54-4fe0-40bc-a7c7-b153a66e9d38",
+      "groupUuid": "802eacd1-6c1b-46a8-a771-7ef49777360a",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2414,8 +2414,8 @@
       }
     },
     {
-      "uuid": "56b6da33-a2e9-4ac9-8d59-594cfd4bdd4a",
-      "groupUuid": "a2edf155-7470-43c2-bdbf-d4a06cacda0c",
+      "uuid": "bec0d983-d3f5-48d6-ae59-1e32c90ef7ea",
+      "groupUuid": "60fa6729-d6e0-4c77-866c-52b9dbf6c9cd",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2423,8 +2423,8 @@
       }
     },
     {
-      "uuid": "7fb0955d-d9b9-4690-84fd-847dfd65359d",
-      "groupUuid": "40781700-a9df-4ab8-8a01-a88a185c45e9",
+      "uuid": "9f82fdbf-357a-41d6-bc73-ea07d37f1166",
+      "groupUuid": "f84bd395-e698-469d-a7cf-5c77661df40d",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2433,8 +2433,8 @@
       }
     },
     {
-      "uuid": "0953dc4c-55e3-4690-b05a-de70999ff79a",
-      "groupUuid": "9f4fe7b4-a006-4fc6-821f-a42894c8fc64",
+      "uuid": "88f9d222-f96e-4dea-8bc8-a0b8286c2d0c",
+      "groupUuid": "20ba286d-8f3c-4518-b007-0d538ab9bb4e",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2442,8 +2442,8 @@
       }
     },
     {
-      "uuid": "a096dcb6-5977-4885-9283-2548e1ab9148",
-      "groupUuid": "e6d081b5-3b44-4a91-94f3-8fb8ae63c5a8",
+      "uuid": "95882ab2-6f48-4dba-8d10-932e251d0c83",
+      "groupUuid": "ef590caf-8cc5-48a7-bcb0-bcc8c05b2b4a",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2456,17 +2456,17 @@
       }
     },
     {
-      "uuid": "c658a9b5-05d1-4462-a2f6-1677db34cfcf",
-      "groupUuid": "2e3a6395-b4f2-4067-9ff7-b7c7b9eca82a",
+      "uuid": "d811a95f-cfd9-4646-a1db-2c3ca5b811cb",
+      "groupUuid": "c22ee414-d50d-4476-a323-de2ae30f4dc8",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</p>"
       }
     },
     {
-      "uuid": "519a32fd-3b77-46ed-8b1f-029ed6d43809",
-      "groupUuid": "e231124b-f745-48b9-94ca-3c604929c1fc",
+      "uuid": "59ebd2d1-eb04-4d0f-917d-1c7778a7245a",
+      "groupUuid": "b4e1aaf0-4dc2-42de-ab82-b630aa1bc46b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2474,8 +2474,8 @@
       }
     },
     {
-      "uuid": "71d5839b-e14e-4df8-9deb-0edc8f8f14fc",
-      "groupUuid": "48549e24-12e3-40e5-972d-2efe281a45e4",
+      "uuid": "39be1b70-435e-4897-a1a7-6b0ac4d13e1b",
+      "groupUuid": "15885e87-651d-48fe-99e0-23a059ec7c0f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2486,8 +2486,8 @@
       }
     },
     {
-      "uuid": "7c516535-f6f4-48ab-b239-fbe231c7ff52",
-      "groupUuid": "48549e24-12e3-40e5-972d-2efe281a45e4",
+      "uuid": "2e2edcc9-e9eb-4cfb-9421-0b2f30f66a3b",
+      "groupUuid": "15885e87-651d-48fe-99e0-23a059ec7c0f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2498,8 +2498,8 @@
       }
     },
     {
-      "uuid": "2c22bfff-4d79-401d-9c33-c97b0af63370",
-      "groupUuid": "48549e24-12e3-40e5-972d-2efe281a45e4",
+      "uuid": "17d16ac3-5d88-4fb7-902f-f8673dd50c78",
+      "groupUuid": "15885e87-651d-48fe-99e0-23a059ec7c0f",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2510,8 +2510,8 @@
       }
     },
     {
-      "uuid": "4750f7f1-f3ba-42f4-b5cd-47b0d24eebc1",
-      "groupUuid": "e762b0c3-8254-49bd-bc7a-492631076c5f",
+      "uuid": "14416b03-afe6-4e86-8b2e-e8f0636b352d",
+      "groupUuid": "36e6dfa7-c4f7-4460-bfe6-8f901f6bb4d4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2519,8 +2519,8 @@
       }
     },
     {
-      "uuid": "2a2a7976-dee7-4d58-bc1a-067c9bcbd4d2",
-      "groupUuid": "21bcacd6-def0-4b92-bcd3-4a0b12251945",
+      "uuid": "27e286d0-76d1-4ca5-893d-a80ee5a3a585",
+      "groupUuid": "ebdb98c9-3a8d-4e27-92e6-a654a7a6530a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2529,8 +2529,8 @@
       }
     },
     {
-      "uuid": "19799778-73da-4180-a532-161eae5b0a39",
-      "groupUuid": "4ba48eb0-570b-4189-aae8-b0b4f281129a",
+      "uuid": "2123c87e-89b5-4d5c-8d66-001fba78c1cd",
+      "groupUuid": "383fed86-656d-4952-be2b-f2312ca544a6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2538,8 +2538,8 @@
       }
     },
     {
-      "uuid": "b722ad45-7397-4dac-9e33-ffa4ce11ea9c",
-      "groupUuid": "944f9aeb-17a6-44e3-94a7-dd9d98a20c62",
+      "uuid": "adc6718e-4bf1-4123-a5e7-b6e9aa10d8e9",
+      "groupUuid": "5842201f-c7f1-46a9-a6d4-c1f979201849",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2548,8 +2548,8 @@
       }
     },
     {
-      "uuid": "0f515dd9-cb09-4ef4-86a4-529a5f1ba4a2",
-      "groupUuid": "3a34568b-8747-455f-ab2c-e007fa8f2fc5",
+      "uuid": "52544c46-d314-4a9c-93d3-d3f11a66dc92",
+      "groupUuid": "a569fbf2-fb3a-4466-8ed0-445d878c7757",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2557,8 +2557,8 @@
       }
     },
     {
-      "uuid": "d81e95c8-e8cc-4b41-8df4-34653d9d60e9",
-      "groupUuid": "ee03e01a-f583-4911-aee6-36755ddc9bcf",
+      "uuid": "d509db52-c97b-4fe1-aa88-de33b58b3f0a",
+      "groupUuid": "037d2624-7217-48c8-ac11-0e349a7ba4f7",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2567,8 +2567,8 @@
       }
     },
     {
-      "uuid": "4b2b5e6e-3c51-4a56-9efc-51bfbd55df2c",
-      "groupUuid": "d5ed8bad-3cb4-417f-b6f0-6cfdb573ce08",
+      "uuid": "ad92a320-6406-44ac-ac0a-7609ba24d92c",
+      "groupUuid": "ce9beb31-92e2-4ff9-abf9-07ed653d6b1f",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2576,8 +2576,8 @@
       }
     },
     {
-      "uuid": "1aa226a3-80a4-4bc1-b53c-b0abb6180666",
-      "groupUuid": "091ae2aa-12af-4ed1-885a-bae03ebc41db",
+      "uuid": "0e8a6bbc-bdbf-461f-9be3-d7d6a01bbc02",
+      "groupUuid": "190cae11-634c-4d81-be8d-29d406cd2977",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2590,17 +2590,17 @@
       }
     },
     {
-      "uuid": "5d61f894-d477-41ab-bab3-726a47dc17e0",
-      "groupUuid": "950867cf-3ccc-4528-ab23-954326faa86e",
+      "uuid": "c0a605e3-729e-4ec3-bd0d-956595110e0a",
+      "groupUuid": "3763a682-edd4-4051-ab48-bea0afdd0506",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "fc66cd91-0fce-439f-bd40-74c575e08c83",
-      "groupUuid": "8188d888-67c0-4b46-9c61-6a322519061e",
+      "uuid": "e8f61f7b-f8b5-463d-ab4d-bda7ad5fb0f7",
+      "groupUuid": "86a1ac27-3ca6-4c49-918d-6a6525cfd183",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2608,8 +2608,8 @@
       }
     },
     {
-      "uuid": "309f00f3-c53e-44a3-ba2e-193729c34d43",
-      "groupUuid": "20e581fa-28f9-4173-8d8e-aee49e0334a7",
+      "uuid": "fc984fa4-ceec-482f-a39e-ef59ae67d823",
+      "groupUuid": "db64148a-c3d2-409d-af70-5084e97880d2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2620,8 +2620,8 @@
       }
     },
     {
-      "uuid": "41ed4afa-df2b-4bae-ab7b-21fec27d856f",
-      "groupUuid": "20e581fa-28f9-4173-8d8e-aee49e0334a7",
+      "uuid": "a4a0e64a-6f01-4683-94ba-9fae12995ab6",
+      "groupUuid": "db64148a-c3d2-409d-af70-5084e97880d2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2632,8 +2632,8 @@
       }
     },
     {
-      "uuid": "7c415ba1-ba7d-4f6e-b79a-74eda9623667",
-      "groupUuid": "20e581fa-28f9-4173-8d8e-aee49e0334a7",
+      "uuid": "a8e53e62-569a-426f-b40f-6fbf1d752acf",
+      "groupUuid": "db64148a-c3d2-409d-af70-5084e97880d2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2644,8 +2644,8 @@
       }
     },
     {
-      "uuid": "62c37fe0-1352-4090-bba3-ecaceb66a8cb",
-      "groupUuid": "2ac5976c-927e-4f04-84c7-5ca877731af8",
+      "uuid": "b226855a-442e-4cf3-8c44-27a8ee02f9dd",
+      "groupUuid": "0e1d5744-4a7c-40ea-9848-e52b84e91725",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2653,8 +2653,8 @@
       }
     },
     {
-      "uuid": "5ce34e44-678f-4095-b99f-4a738bf7d0ea",
-      "groupUuid": "69be871b-dce8-4e89-8944-e9243b5390cd",
+      "uuid": "96e9c0b1-07a7-4210-9ca2-21e5d4926e43",
+      "groupUuid": "1224ff5c-63b2-42a0-b1a0-aad4fcc8c715",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2663,8 +2663,8 @@
       }
     },
     {
-      "uuid": "e2c74e7f-2e68-49f9-b2e9-1ed991e98fb5",
-      "groupUuid": "74b56976-6dcf-4cb0-a4b1-bbd6f4be8d2f",
+      "uuid": "6f5dcb5f-8ad4-4dc0-b37e-3f0d833bf46b",
+      "groupUuid": "a11d727f-1d31-4aed-b32e-fad61135599c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2672,8 +2672,8 @@
       }
     },
     {
-      "uuid": "5a52aeaf-8c2a-4392-a60d-49d95c849378",
-      "groupUuid": "102cfe5a-91dc-4d71-80fa-bfbfca159537",
+      "uuid": "8446d987-ea33-4a11-90d1-7b42ef666929",
+      "groupUuid": "ace54adf-19cf-49ff-9cd5-9607db72a755",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2682,8 +2682,8 @@
       }
     },
     {
-      "uuid": "cd008c1c-4e57-4b72-b4fc-3b1d31fa1714",
-      "groupUuid": "ff33792d-d3ef-49ac-83f5-e22505f221c7",
+      "uuid": "581c2d3d-5ada-4170-b0ae-e85145b5353d",
+      "groupUuid": "c2169c68-6aa1-4bf3-a4ef-2a113d6a3601",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2691,8 +2691,8 @@
       }
     },
     {
-      "uuid": "a78dbd9e-6af8-4ac2-9c63-71d097839b3b",
-      "groupUuid": "225335eb-33f8-49c4-ac6b-6e45c5ba0dae",
+      "uuid": "1d0a9dac-0de5-4c13-b29e-2430b7df9201",
+      "groupUuid": "7da69dfa-b096-480f-9bea-36b0dafe5709",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2701,8 +2701,8 @@
       }
     },
     {
-      "uuid": "17aed3cc-8db7-4d9e-b218-4ef70f6bd6dc",
-      "groupUuid": "458e8823-29b4-4f86-8b36-1644144a5503",
+      "uuid": "a9fb9852-6ba3-41e5-94b8-3be8e151e789",
+      "groupUuid": "da0f2994-adee-43be-b53e-cdf14e481b40",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2710,8 +2710,8 @@
       }
     },
     {
-      "uuid": "60d728ff-7fa4-4ad6-b718-2967b0251f0e",
-      "groupUuid": "28520148-6903-4240-8d1b-461f18b8d340",
+      "uuid": "b36912d2-f2e6-4861-a6fe-1a44bd8ad3a5",
+      "groupUuid": "472c5ef9-10bd-4796-98e2-996c89c5449e",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2724,17 +2724,17 @@
       }
     },
     {
-      "uuid": "bb5627d6-6232-4a5c-9cbd-7d5556f574a3",
-      "groupUuid": "c0a29d5c-12de-4785-a85d-08cadfff8b6f",
+      "uuid": "751c8055-1843-46fe-b9a1-89af2e75bb9d",
+      "groupUuid": "ddb0f8ea-9402-4645-be06-8c23a78dd6d7",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: altered-dominant<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Altered voicing:</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "ad7ec44c-806e-42a0-bca6-420a99512966",
-      "groupUuid": "c1be2383-5079-4b69-ac85-89e783d61733",
+      "uuid": "b6d7e6ac-b152-496e-a36d-2308864549da",
+      "groupUuid": "a5692625-5781-4121-9f69-219ffb6e1575",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2742,8 +2742,8 @@
       }
     },
     {
-      "uuid": "ce7dd3be-e816-4abf-aae4-756d08f5f6c8",
-      "groupUuid": "dcc30ccc-570f-467e-935f-64310378a6ab",
+      "uuid": "bf3ef5e1-926c-4c17-838b-98dc1303f30b",
+      "groupUuid": "d3144064-86e8-4179-93df-ebd487009662",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2754,8 +2754,8 @@
       }
     },
     {
-      "uuid": "b4aa0b7a-2635-42cd-8125-903e678fb38e",
-      "groupUuid": "dcc30ccc-570f-467e-935f-64310378a6ab",
+      "uuid": "5b885dad-4a7f-457f-a676-630ee4155277",
+      "groupUuid": "d3144064-86e8-4179-93df-ebd487009662",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2766,8 +2766,8 @@
       }
     },
     {
-      "uuid": "880fae1c-762d-444f-8479-ed78301f6a34",
-      "groupUuid": "dcc30ccc-570f-467e-935f-64310378a6ab",
+      "uuid": "6b71d81d-7527-4258-b322-ed1af9afee54",
+      "groupUuid": "d3144064-86e8-4179-93df-ebd487009662",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2778,8 +2778,8 @@
       }
     },
     {
-      "uuid": "248dc7a2-626f-4353-843b-210df51fb123",
-      "groupUuid": "5dfda464-f3b6-482f-8b5e-4eb3b2ebdd2a",
+      "uuid": "ad1cf36c-4e53-4585-8a49-b98a7affa8a5",
+      "groupUuid": "f090ce46-9556-41b1-a159-8e23d1850e64",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2787,8 +2787,8 @@
       }
     },
     {
-      "uuid": "f73ba5b1-76ca-421a-b3bd-4715f27c7fde",
-      "groupUuid": "80421982-7e9e-4939-a1f9-80ed79d4451b",
+      "uuid": "9348e3e3-b41e-4b74-9fc6-6b34b6352ca1",
+      "groupUuid": "7ee217a1-f33e-4512-96c5-112400bcaca6",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2797,8 +2797,8 @@
       }
     },
     {
-      "uuid": "0021d0d1-d088-4421-8257-75474f76f5fe",
-      "groupUuid": "db0e96cc-f2c7-420c-bd4f-a131b9e629f9",
+      "uuid": "b8b71c7f-84f6-4790-a4d5-7c26555ec145",
+      "groupUuid": "648132c8-fdf4-46d7-8259-876a2952e603",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2806,8 +2806,8 @@
       }
     },
     {
-      "uuid": "760802b5-052b-4eea-b811-2a00eb67e226",
-      "groupUuid": "10ffb2e5-639e-4a75-84ed-ff8c930fec6e",
+      "uuid": "52b553a9-70d1-453f-b8b2-e0a18c3c24d3",
+      "groupUuid": "2b3bb756-d44a-4b96-9d99-9906781fbab0",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2816,8 +2816,8 @@
       }
     },
     {
-      "uuid": "a001d10d-19aa-4692-8fce-449558e0bf8f",
-      "groupUuid": "58b0dc90-5b35-4b8d-be2b-c293f96c904c",
+      "uuid": "21e7e419-ed5f-48eb-bf60-4c5c08176c8e",
+      "groupUuid": "b8a7e4be-3086-4b5b-9e1a-43d72360d8e9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2825,8 +2825,8 @@
       }
     },
     {
-      "uuid": "48dacf50-f4e2-445f-a6b2-74cb52b39ceb",
-      "groupUuid": "1ff5684c-17ed-461b-b4c2-6073a6a521ad",
+      "uuid": "1c14d7a5-672f-4714-80f4-4389e750c686",
+      "groupUuid": "5f556268-22ff-4037-b78b-6052fb196877",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2835,8 +2835,8 @@
       }
     },
     {
-      "uuid": "0f805061-51a8-4580-8085-8ae225e8009d",
-      "groupUuid": "e625cfb3-0a1e-4370-a94b-678ca8dce20b",
+      "uuid": "7d596a03-c766-4222-ba96-256a6c240c44",
+      "groupUuid": "0e3c686f-972b-4f12-9ba0-fe815d59dc63",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2844,8 +2844,8 @@
       }
     },
     {
-      "uuid": "b9dacf9e-9b2d-4a63-a52b-84e994f2d15a",
-      "groupUuid": "aa928eae-952e-433c-95a7-80674d8d364b",
+      "uuid": "0678c915-8dd5-4baf-9f0f-96fc2d7647c5",
+      "groupUuid": "500335ee-bb40-4296-8240-78e49b6e03ee",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2858,17 +2858,17 @@
       }
     },
     {
-      "uuid": "437e0ca5-af23-4353-b3cf-67f0d47987e8",
-      "groupUuid": "481d4f06-6e54-4438-9cd8-da6c4344c8ba",
+      "uuid": "caaee298-2ff1-44d6-861c-db2b97e330a7",
+      "groupUuid": "1fa98b31-2288-4095-8060-0524eae51288",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-2, block<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>Drop-2:</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "660fa41f-7897-4ca6-a349-2f8144218fcf",
-      "groupUuid": "6a7bdf77-be0f-43ca-a9e3-336089ae2393",
+      "uuid": "1bdac8f8-d899-48d7-a360-c2a67cf273ad",
+      "groupUuid": "79ae2d21-1cf3-47be-bc3d-26efedd7b3b6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2876,8 +2876,8 @@
       }
     },
     {
-      "uuid": "b1ea41d2-00a7-4526-91d6-d56856744615",
-      "groupUuid": "31bd21e3-ef2a-4b62-9f97-8480f88fa558",
+      "uuid": "1268b571-6e5b-478a-89f6-6c3d00e53ee4",
+      "groupUuid": "704c1bde-bcaf-4f43-afb6-d397c893ad76",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2888,8 +2888,8 @@
       }
     },
     {
-      "uuid": "909d4571-a90f-4923-8680-cc745358f897",
-      "groupUuid": "31bd21e3-ef2a-4b62-9f97-8480f88fa558",
+      "uuid": "e66773ae-59c5-45cf-85e6-5015b8ed0800",
+      "groupUuid": "704c1bde-bcaf-4f43-afb6-d397c893ad76",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2900,8 +2900,8 @@
       }
     },
     {
-      "uuid": "00483c12-1cf0-47d1-a2c4-93702114f13e",
-      "groupUuid": "31bd21e3-ef2a-4b62-9f97-8480f88fa558",
+      "uuid": "db1239cf-f7aa-4ae2-9583-fc354a60115a",
+      "groupUuid": "704c1bde-bcaf-4f43-afb6-d397c893ad76",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -2912,8 +2912,8 @@
       }
     },
     {
-      "uuid": "c318db0e-414d-48ae-9da7-8e5d66c13f5a",
-      "groupUuid": "e3bb59ca-af75-4fd9-a6aa-607745f918c8",
+      "uuid": "37b6c25c-a9c7-4a7e-95a1-d44f7dde4ac1",
+      "groupUuid": "a3903983-65b8-4d78-8923-cd4267e13c5d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2921,8 +2921,8 @@
       }
     },
     {
-      "uuid": "4fe18ba3-2683-4963-817f-4a59d02b6382",
-      "groupUuid": "110c1636-963c-4faf-b283-59b9618583cc",
+      "uuid": "b9ebe4d9-b459-4e4f-870c-7c10728d43cf",
+      "groupUuid": "aa216dc0-b52b-4123-8a79-a868bec92ff2",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2931,8 +2931,8 @@
       }
     },
     {
-      "uuid": "fc45549b-69a1-410e-bba1-9030343f00ef",
-      "groupUuid": "7d6da7da-e284-49d2-83f1-d5f895fe5a5f",
+      "uuid": "2134b40b-21db-4e72-a84b-e2a049860691",
+      "groupUuid": "5e9fc340-efe1-4eda-9032-b0c3e77523bc",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2940,8 +2940,8 @@
       }
     },
     {
-      "uuid": "a4f1391c-1375-47a3-abf3-cad6ff7b42c1",
-      "groupUuid": "2222fd9e-8744-4a00-86e4-39636d69dbc5",
+      "uuid": "40601a95-4aef-4966-9113-39270b82c0c7",
+      "groupUuid": "42d22213-d5d6-4e5b-85a3-6a867dee7559",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -2950,8 +2950,8 @@
       }
     },
     {
-      "uuid": "ed2d14b2-7d72-4f21-a293-95cf8c12568f",
-      "groupUuid": "56f65a07-bb7e-4369-96af-fa7c6e740e2b",
+      "uuid": "c2a948b5-d679-4824-b548-095d1777247b",
+      "groupUuid": "22a9ae85-655b-46b5-8054-97aef74d5d55",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -2959,8 +2959,8 @@
       }
     },
     {
-      "uuid": "0fdb4aec-1383-41ef-9d5a-4f5de593bb12",
-      "groupUuid": "e8c784a1-cafa-4ff5-b667-44e796e14ce8",
+      "uuid": "63fdeb5f-3e35-44e2-aada-2967ebba61cf",
+      "groupUuid": "ade26e68-1a7b-4fcb-9d0e-47164e5c47e4",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -2969,8 +2969,8 @@
       }
     },
     {
-      "uuid": "87792a75-d2f0-4e9b-bb5f-741551aec2a9",
-      "groupUuid": "5c30d0a5-e878-4ad1-b0d6-d024daa45020",
+      "uuid": "790e82d2-bec7-4702-9b8d-43085be199d5",
+      "groupUuid": "8ae0c1da-5058-47bd-aea3-0d45cfc91c4f",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -2978,8 +2978,8 @@
       }
     },
     {
-      "uuid": "3ac53c43-02e2-4153-89e1-bf882d34cc82",
-      "groupUuid": "542d9ea7-f990-4848-83e3-71e1940eb41c",
+      "uuid": "0dbcef36-fd51-41fa-aba9-9a39e5e8d18c",
+      "groupUuid": "289c6049-c6f1-46a8-927e-0812f8aa47fa",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -2992,17 +2992,17 @@
       }
     },
     {
-      "uuid": "68b81ca8-ea61-49f6-8da7-31e8a9d5d628",
-      "groupUuid": "6ee70eb8-1c45-4497-85a2-df592bb99015",
+      "uuid": "71aea7e5-f982-466e-ab63-bdc9370aed34",
+      "groupUuid": "ae8e0b46-f986-4e24-bda4-176f22302026",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: drop-3, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "c9fc6c99-d901-4f74-a3a3-c341a088013a",
-      "groupUuid": "b48a4278-7b3a-4af9-9b66-e3d80d8721da",
+      "uuid": "1668387b-02f2-4270-9e5e-219c0ce3a618",
+      "groupUuid": "d513789c-1ff7-46e1-afac-f7855e78f618",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3010,8 +3010,8 @@
       }
     },
     {
-      "uuid": "d90a001b-bd0d-4e71-abbd-c78413fb98b1",
-      "groupUuid": "aa1e949f-a37b-4a9d-999e-529f14d2909f",
+      "uuid": "9b9ae349-cceb-44cf-8eef-f45335e95426",
+      "groupUuid": "ed4c0f29-4aa1-42e0-94c9-3a2fd28b60bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3022,8 +3022,8 @@
       }
     },
     {
-      "uuid": "78f96274-936d-48a9-801f-fb58c317d2ca",
-      "groupUuid": "aa1e949f-a37b-4a9d-999e-529f14d2909f",
+      "uuid": "aad5afbb-0c32-4550-b9c9-94291c41d487",
+      "groupUuid": "ed4c0f29-4aa1-42e0-94c9-3a2fd28b60bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3034,8 +3034,8 @@
       }
     },
     {
-      "uuid": "dae22688-d801-47d2-8ebc-743470fe0925",
-      "groupUuid": "aa1e949f-a37b-4a9d-999e-529f14d2909f",
+      "uuid": "9c9cc8a8-59cb-4c88-9a86-c5691da637a4",
+      "groupUuid": "ed4c0f29-4aa1-42e0-94c9-3a2fd28b60bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3046,8 +3046,8 @@
       }
     },
     {
-      "uuid": "3f1d4545-714f-473f-befb-4660a20bc741",
-      "groupUuid": "efccf3a8-57d5-4508-bfd2-9754d493b90e",
+      "uuid": "9ef10cb4-85fd-46cf-af08-93efe27cbe26",
+      "groupUuid": "853c4072-af59-48ef-b2c8-1573c8750dd4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3055,8 +3055,8 @@
       }
     },
     {
-      "uuid": "e6f7dd39-65fb-44e6-8055-11a5849e2be2",
-      "groupUuid": "d144c891-02cb-426e-b9fd-8ab3dcdbf224",
+      "uuid": "71ec3c95-9ddd-45b8-905c-087f356408dc",
+      "groupUuid": "3e3852a5-c77e-4b1d-a1fd-c7f4224a1702",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3065,8 +3065,8 @@
       }
     },
     {
-      "uuid": "aa28870e-7e30-4fc7-91d0-b6fe46b96208",
-      "groupUuid": "7dea4f3c-ccdf-40a5-b50e-abfaeb63fd9e",
+      "uuid": "65b391a8-a87f-41fb-a542-f02561e39c93",
+      "groupUuid": "7c9c3e07-8890-4298-8dc2-48c7dfc5df0e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3074,8 +3074,8 @@
       }
     },
     {
-      "uuid": "22fa26d6-14a1-49fb-a612-d24ff8b0c0be",
-      "groupUuid": "ddc04400-31e7-4ffb-a58e-eed6d125d127",
+      "uuid": "3bfcbc17-f7a3-42e5-a8d7-90fea89872a5",
+      "groupUuid": "e93d9d21-92a7-4c7a-8b8e-a928ea921265",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3084,8 +3084,8 @@
       }
     },
     {
-      "uuid": "d8f7cb5d-ebc2-43f6-bdd3-b8513a8ad5a9",
-      "groupUuid": "def46ac0-f723-4fd1-b609-7451a512b762",
+      "uuid": "ae0d3d65-dc5e-4be2-aecd-3dfcbef14d48",
+      "groupUuid": "8ccdbe09-a677-4022-881f-586a9950a9f8",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3093,8 +3093,8 @@
       }
     },
     {
-      "uuid": "5834a179-19a6-4347-ad2a-7031f270137e",
-      "groupUuid": "9059d4a8-6138-495f-9dea-28fef7abbb46",
+      "uuid": "f1e7e3d2-087e-4ec9-b695-7333300ac6de",
+      "groupUuid": "726419b0-e46e-41bc-a984-dd749510579f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3103,8 +3103,8 @@
       }
     },
     {
-      "uuid": "edb2746a-5840-449d-9eae-f7402360eb20",
-      "groupUuid": "276acf3c-3906-46ab-89e6-6194fb544722",
+      "uuid": "3b896140-5903-4d60-bb73-5eab0a354a78",
+      "groupUuid": "e3cebea8-bc35-4d06-8b26-34ae66a0bc09",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3112,8 +3112,8 @@
       }
     },
     {
-      "uuid": "fa5365bb-b2a2-474b-9d4b-eefcff6d3129",
-      "groupUuid": "7e597bb3-bbb0-46af-b24e-4590118e6aff",
+      "uuid": "650697fa-6b4c-45c6-8837-7c3c3209ae10",
+      "groupUuid": "2baf2ac4-3d42-483c-aa4f-cb24de2affe8",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3126,17 +3126,17 @@
       }
     },
     {
-      "uuid": "e1794467-1b44-4906-acd0-98e055fb5eb3",
-      "groupUuid": "a14b7b4c-0bd1-4018-bc03-a6aeba263859",
+      "uuid": "4d14ea42-5e9b-4764-8ea0-977154c55cd5",
+      "groupUuid": "5cf2939e-ddf2-4cdc-8a4c-432220ca50f6",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-3<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</p>"
       }
     },
     {
-      "uuid": "da24b9c6-c6fc-4b7b-b937-3f694f8eb945",
-      "groupUuid": "f44328a5-43e2-4626-83a9-0fdbb61b581d",
+      "uuid": "3380b0cb-c5b5-4fb7-83c6-6887a972fc02",
+      "groupUuid": "3bab7d6c-0b26-487d-97dc-ad88a2e3d0ac",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3144,8 +3144,8 @@
       }
     },
     {
-      "uuid": "3dfac70f-aee4-47af-8c40-da9801a2767d",
-      "groupUuid": "8782aedc-d422-4749-b067-0d86088db71f",
+      "uuid": "47ebd769-067f-4cab-b9f2-a00a3168053e",
+      "groupUuid": "29982ec9-74c6-4d13-8a62-a845c6e5b951",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3156,8 +3156,8 @@
       }
     },
     {
-      "uuid": "abd1bb13-ff8a-4ac1-a3c6-246633b8a3de",
-      "groupUuid": "8782aedc-d422-4749-b067-0d86088db71f",
+      "uuid": "c144addb-a2f8-4ad2-9915-992137a339f7",
+      "groupUuid": "29982ec9-74c6-4d13-8a62-a845c6e5b951",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3168,8 +3168,8 @@
       }
     },
     {
-      "uuid": "dee94ada-bd7d-423a-960b-2f8dd59ff87f",
-      "groupUuid": "8782aedc-d422-4749-b067-0d86088db71f",
+      "uuid": "18327bf9-39d8-4a78-8a57-d356fc2776fb",
+      "groupUuid": "29982ec9-74c6-4d13-8a62-a845c6e5b951",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3180,8 +3180,8 @@
       }
     },
     {
-      "uuid": "6183cc52-31ff-442b-81fc-a4c2a5d2e373",
-      "groupUuid": "1739caac-1ae0-42fd-bae4-7fd9967ca7b5",
+      "uuid": "8af6ff5d-85f0-441f-8e51-8093083d4935",
+      "groupUuid": "e38610f8-a7b1-4f86-a5e9-92ade2d9c571",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3189,8 +3189,8 @@
       }
     },
     {
-      "uuid": "e48e067c-6b1b-49c0-b3b7-c60078033ec5",
-      "groupUuid": "2e86bce1-55e3-4441-bc64-569811dbe542",
+      "uuid": "c14adfea-1a16-4a43-bfa6-de5ad47b6499",
+      "groupUuid": "1bdf9529-d7fa-40a9-8ba6-f67d0383f4fe",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3199,8 +3199,8 @@
       }
     },
     {
-      "uuid": "9d20e188-941f-47ed-abf4-5716f4b4a3da",
-      "groupUuid": "57448cc1-a8e4-4756-802a-2bea4772a2e2",
+      "uuid": "55a8c5a0-82e4-4fd0-8d10-ea5996f8fd8c",
+      "groupUuid": "df4837ae-ab5a-42d3-9beb-e871e8195482",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3208,8 +3208,8 @@
       }
     },
     {
-      "uuid": "36cff03a-a8cb-465c-a2e4-9dfec182c86b",
-      "groupUuid": "9efbb0af-8909-470b-86a7-dc2194dec88b",
+      "uuid": "96ca3216-bcb7-4f90-b726-7ee134f4bc61",
+      "groupUuid": "c6c07b8a-d065-4c34-9472-d0b3657b6189",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3218,8 +3218,8 @@
       }
     },
     {
-      "uuid": "8365eb3a-5596-485a-89fe-5465d8d01938",
-      "groupUuid": "d6d39e55-4e98-41c5-8285-8607d149625a",
+      "uuid": "0f87c282-5f42-4c8a-b3ca-503c6726f9ce",
+      "groupUuid": "9d201af6-08f3-4357-9d7d-27ad03ef0ea5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3227,8 +3227,8 @@
       }
     },
     {
-      "uuid": "8a956d9f-e6af-415b-ad71-45df759856b9",
-      "groupUuid": "ec5ee2c1-db4b-4e72-8856-ac615abf4671",
+      "uuid": "986cf430-15eb-4aa2-b509-36e795b96bd0",
+      "groupUuid": "dd1428f5-37ce-4713-8637-2792412c94af",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3237,8 +3237,8 @@
       }
     },
     {
-      "uuid": "607fcb33-1528-4bb6-8f01-f0b6db1c4961",
-      "groupUuid": "1bc6be5b-986e-4b6d-ac1a-0e349d913bd2",
+      "uuid": "c6d93f2d-ef1f-4645-a04c-aa5ca76d0a24",
+      "groupUuid": "a879c77b-120c-4f5d-bfd8-ae41ee6cd6cc",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3246,8 +3246,8 @@
       }
     },
     {
-      "uuid": "cbf4cac4-bfaa-4c18-b28d-146ce9508120",
-      "groupUuid": "43661312-bbc3-4e18-bc0e-4d09ade21b67",
+      "uuid": "c6ab32f3-29b5-4b6c-9d9d-5e7c53fbf7a6",
+      "groupUuid": "a9e87b2d-779f-44fe-8c88-d3f036afc182",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3260,17 +3260,17 @@
       }
     },
     {
-      "uuid": "fdb92fde-1e3c-4fe8-97d6-be53bbd5c46b",
-      "groupUuid": "d39cb9bb-5edf-4c0c-a8d0-d4e1d4c251ff",
+      "uuid": "db5e1ac0-2038-4fdd-8801-e731fe92f19a",
+      "groupUuid": "6c7ea873-2985-42b6-a3da-a1c105ec0113",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "bf48b6de-9516-4fbd-9555-532370132e9e",
-      "groupUuid": "9628f15c-34db-4407-b077-8af190ee6d62",
+      "uuid": "6ff8b0cb-6e38-4046-92a0-02c75f2f51e7",
+      "groupUuid": "aa15cbe6-57be-4a05-a2da-820a88c941cd",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3278,8 +3278,8 @@
       }
     },
     {
-      "uuid": "177056c8-e4f5-450e-a8fa-325549e8d0bc",
-      "groupUuid": "99a27aea-e8f1-42e0-8ec3-3a0d8f03eeda",
+      "uuid": "d905a3dd-f4da-48eb-ad40-9b09d0d2db47",
+      "groupUuid": "2c10c70f-35de-495d-afb8-91f785e24d41",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3290,8 +3290,8 @@
       }
     },
     {
-      "uuid": "97694967-a031-42b1-8c3c-362824f3527d",
-      "groupUuid": "99a27aea-e8f1-42e0-8ec3-3a0d8f03eeda",
+      "uuid": "0168f3a6-a1e7-422d-b400-b6ea0ce3e7d2",
+      "groupUuid": "2c10c70f-35de-495d-afb8-91f785e24d41",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3302,8 +3302,8 @@
       }
     },
     {
-      "uuid": "00256a5d-88f5-454d-a59c-2d7610a53448",
-      "groupUuid": "99a27aea-e8f1-42e0-8ec3-3a0d8f03eeda",
+      "uuid": "dd964204-dcc8-4e8c-ae65-133719b02fc3",
+      "groupUuid": "2c10c70f-35de-495d-afb8-91f785e24d41",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3314,8 +3314,8 @@
       }
     },
     {
-      "uuid": "31cfc9fc-ad59-465a-ac92-d83b842272c0",
-      "groupUuid": "d29dec9b-c469-4dc6-a184-838870085ec1",
+      "uuid": "ef5d5131-56b5-4c31-b71d-3115bb59b576",
+      "groupUuid": "95c757d3-acf8-48fa-9367-78ac5bd1e11b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3323,8 +3323,8 @@
       }
     },
     {
-      "uuid": "22beed39-842d-4bdc-be31-68488c5ea177",
-      "groupUuid": "4d586f8b-5c4e-4e00-ac2a-4aecaf46557f",
+      "uuid": "49251302-aa63-446f-a9e6-cf453a79437e",
+      "groupUuid": "0cf57a24-9dea-4264-834c-b638b0bed84d",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3333,8 +3333,8 @@
       }
     },
     {
-      "uuid": "e8f355cb-6d29-4f7c-94d1-5f22ddae55b2",
-      "groupUuid": "5f4c7617-933b-44bd-94cc-20d2a182ef17",
+      "uuid": "950ed968-5196-4b93-b342-539fb9d12418",
+      "groupUuid": "4342f860-7640-439e-beab-8328a975ca72",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3342,8 +3342,8 @@
       }
     },
     {
-      "uuid": "c82c236d-94dd-498e-82d7-7e7f6076e23e",
-      "groupUuid": "557f2f7e-4070-4f47-bb80-2e5b4993ef1b",
+      "uuid": "d857b34f-4093-40e3-b9cc-2f1c1f0abd10",
+      "groupUuid": "6eb186a0-ad73-4486-ac5e-b51324adc2b9",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3352,8 +3352,8 @@
       }
     },
     {
-      "uuid": "240d85dd-cd6f-4f0c-8c20-585ec757c2c6",
-      "groupUuid": "af20531b-29f4-42d4-9866-fcfc4da5a7a3",
+      "uuid": "0be985d5-dc6b-4693-8984-e9a7d744190e",
+      "groupUuid": "e288fbfd-0b63-4a70-9059-ccb42264237b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3361,8 +3361,8 @@
       }
     },
     {
-      "uuid": "24d27337-9175-4664-82f0-7395bddbcf16",
-      "groupUuid": "76fb1b67-eb90-474c-b18e-774754a4f2b0",
+      "uuid": "86c74d45-c0ec-4aaa-8d1d-9bef4a6851dd",
+      "groupUuid": "b556c856-cb58-4729-ae44-230cc2fd2697",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3371,8 +3371,8 @@
       }
     },
     {
-      "uuid": "18505693-dd75-4846-bc4b-466084b793a7",
-      "groupUuid": "ff29ce93-b079-4f71-826b-01dd7805fc20",
+      "uuid": "1555cb63-cb75-4b29-807f-a3ee4a030605",
+      "groupUuid": "42ee9fab-6199-4146-9b1e-e53b9227161a",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3380,8 +3380,8 @@
       }
     },
     {
-      "uuid": "a7df149c-6199-4ea8-988d-7afb5cffcf73",
-      "groupUuid": "815e47e2-2ed3-45ab-9108-1851da80101a",
+      "uuid": "8dc6757f-7ab1-40f1-a7cf-720286f5f415",
+      "groupUuid": "28cc1f29-c11d-4821-8425-25d534310df9",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3394,17 +3394,17 @@
       }
     },
     {
-      "uuid": "1d425d05-d9c4-4821-aaaf-e25faeaff928",
-      "groupUuid": "8a40039d-975d-49cb-bf1b-af0fc06eb621",
+      "uuid": "0dba3f44-966d-40f2-b3e8-0067b59670e2",
+      "groupUuid": "36d9c792-ea7c-45b6-9f1f-40a707201c50",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "25ba1a18-7adb-4719-849c-3bfff71ef2ff",
-      "groupUuid": "d236823d-8a14-4e35-87a4-572217483acc",
+      "uuid": "73f9eb2b-f847-4876-a243-c14b910a3e02",
+      "groupUuid": "783d0bc5-dfb1-4f32-ab6a-ab247de3b92d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3412,8 +3412,8 @@
       }
     },
     {
-      "uuid": "cc4eda0c-d68b-4dfd-8955-a955c5b7d9f4",
-      "groupUuid": "52d98747-ef8e-4c0b-9e9b-b86de7e6cf41",
+      "uuid": "db5d13e0-f21f-4c23-9b09-2fdca3374845",
+      "groupUuid": "39e4c7c7-90c8-4424-bb2f-4b97e1f2fa99",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3424,8 +3424,8 @@
       }
     },
     {
-      "uuid": "f90894af-7ac1-424e-b6b3-e943572140ae",
-      "groupUuid": "52d98747-ef8e-4c0b-9e9b-b86de7e6cf41",
+      "uuid": "4839c752-4e7d-4f43-8965-123520aec484",
+      "groupUuid": "39e4c7c7-90c8-4424-bb2f-4b97e1f2fa99",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3436,8 +3436,8 @@
       }
     },
     {
-      "uuid": "8c8aa59e-58f7-43bc-ba97-aa588bcb4b92",
-      "groupUuid": "52d98747-ef8e-4c0b-9e9b-b86de7e6cf41",
+      "uuid": "b8172fbd-5ab7-457d-86cb-714a5e6b1047",
+      "groupUuid": "39e4c7c7-90c8-4424-bb2f-4b97e1f2fa99",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3448,8 +3448,8 @@
       }
     },
     {
-      "uuid": "b62d1211-d91d-47f2-a3c8-d3cd1db47a21",
-      "groupUuid": "1dc4922b-0c78-48e6-a45e-e1587f63f4fc",
+      "uuid": "887683ca-4716-4385-9981-1a615d353499",
+      "groupUuid": "d5b817b1-29cc-43bb-8ddb-7000cef5fc31",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3457,8 +3457,8 @@
       }
     },
     {
-      "uuid": "914c6d8d-4ba7-4ba2-93b8-aa3823e4d1c1",
-      "groupUuid": "9d55e6f4-e6ca-4672-94e5-92a8fe445e11",
+      "uuid": "c8127348-6ddc-4e6b-b5cf-f8273f1f6b2d",
+      "groupUuid": "f19ced76-6b15-42c9-8b4c-e222d4e0d789",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3467,8 +3467,8 @@
       }
     },
     {
-      "uuid": "09bc2598-9a67-442f-a01d-90dd34c01f38",
-      "groupUuid": "9cf02825-48f9-4244-b6c3-777392c52e99",
+      "uuid": "45fee63f-eb6a-49aa-86c4-7bec8847b672",
+      "groupUuid": "a8974a76-f33a-42b1-8e05-c3e5669fc0f9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3476,8 +3476,8 @@
       }
     },
     {
-      "uuid": "75d9edad-aa27-40bf-8e40-e8ae8b6c63b9",
-      "groupUuid": "9d8cd088-410b-4a68-ba88-e7832df75ff6",
+      "uuid": "ecc34517-e481-49d6-8745-63c40ee03e48",
+      "groupUuid": "5aecd4c1-c90c-4212-b3f1-b3ac3b5ee426",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3486,8 +3486,8 @@
       }
     },
     {
-      "uuid": "1da370b9-64ad-41ca-aee9-fd231b2a9d94",
-      "groupUuid": "b272fc19-1c4a-4cf2-9894-29615d6bbd78",
+      "uuid": "25a4c1aa-3b83-4550-8f22-91fa40fefecf",
+      "groupUuid": "38e2689a-56a8-4664-ab73-49163c3c26a6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3495,8 +3495,8 @@
       }
     },
     {
-      "uuid": "8b2182bc-18a1-4427-9121-7b2f5758593d",
-      "groupUuid": "63dfb4de-7a73-493b-9759-76b59365b1ab",
+      "uuid": "5b8eae30-e9de-478b-856f-11e5ae7736c8",
+      "groupUuid": "7fea24d6-30cb-405e-89aa-e12bba5ac365",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3505,8 +3505,8 @@
       }
     },
     {
-      "uuid": "a0a7ee72-e2d3-4ede-a0dc-dbd4d70ab27d",
-      "groupUuid": "29144366-64d4-41fe-ac4f-deb0323b4440",
+      "uuid": "c927b8e0-1472-47a5-b79a-5e4354b6b10d",
+      "groupUuid": "0facfafa-7f59-4f64-b302-de18d29be188",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3514,8 +3514,8 @@
       }
     },
     {
-      "uuid": "6bf7a72e-bb9a-41ba-8852-5ba30be2d972",
-      "groupUuid": "96b0a9e4-d38d-4f7b-83cf-02338787a69d",
+      "uuid": "fe9a8812-0a8a-444e-a05d-748e9113fddb",
+      "groupUuid": "8ba5da1d-8bf5-4de8-87b2-b49eb450f0d6",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3528,17 +3528,17 @@
       }
     },
     {
-      "uuid": "0c99ba6c-e1ec-4e2c-817b-afa7c54b188e",
-      "groupUuid": "298a83d3-dd51-4ff4-88e1-a473f27710eb",
+      "uuid": "a2363d69-3da9-4708-8af5-414852a6f0ec",
+      "groupUuid": "7a3f5e19-c4bc-4715-be44-d095a4cf5e46",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: quartal<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>Quartal voicing:</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>quartal</b> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</p>"
       }
     },
     {
-      "uuid": "f45c3222-8381-47db-9cc6-4aaa14a4bf19",
-      "groupUuid": "aaa39fa2-4217-46de-b627-beaf72ceda86",
+      "uuid": "5c013e3e-a1d7-4a85-babd-df41b92e1d45",
+      "groupUuid": "d95a974d-1ed5-4e0f-b9a8-0f295503f05d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3546,8 +3546,8 @@
       }
     },
     {
-      "uuid": "737ca107-4088-4ba7-93b2-5da146f45cbd",
-      "groupUuid": "29217c98-4074-4808-ae49-2cb48b9b91e6",
+      "uuid": "92ee2b90-1879-4b0d-8688-f0806ac0acfd",
+      "groupUuid": "2042374e-b3fe-4e9e-b0fa-01e96f5f7399",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3558,8 +3558,8 @@
       }
     },
     {
-      "uuid": "cd893d54-b4b4-448b-bb75-9d7ed39a37dc",
-      "groupUuid": "29217c98-4074-4808-ae49-2cb48b9b91e6",
+      "uuid": "48c6f656-5ce5-4d00-af38-2b4304584663",
+      "groupUuid": "2042374e-b3fe-4e9e-b0fa-01e96f5f7399",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3570,8 +3570,8 @@
       }
     },
     {
-      "uuid": "108ef636-863c-48cc-afe3-beff65035239",
-      "groupUuid": "29217c98-4074-4808-ae49-2cb48b9b91e6",
+      "uuid": "72109ae4-583d-410d-9045-f0d82cf1ca53",
+      "groupUuid": "2042374e-b3fe-4e9e-b0fa-01e96f5f7399",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3582,8 +3582,8 @@
       }
     },
     {
-      "uuid": "a9fd3e67-56ff-4bed-870a-d2816884ac98",
-      "groupUuid": "6634c8f7-5a4b-4bb3-accf-5f68406b7560",
+      "uuid": "d95dd043-2beb-441a-9008-25169af2f7bb",
+      "groupUuid": "37f8c459-2139-4388-a1db-b67196c28b5c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3591,8 +3591,8 @@
       }
     },
     {
-      "uuid": "3c80d65f-7a5e-49a7-8c03-3d3e9d1b85f4",
-      "groupUuid": "0b4e2845-59d1-46cf-a8f4-ed15a5ec922b",
+      "uuid": "bcbe9e18-928d-49b7-8326-dfebb5d17e2a",
+      "groupUuid": "16fb2321-8d36-43fd-8f61-6db8785ab3c6",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3601,8 +3601,8 @@
       }
     },
     {
-      "uuid": "a982bd2e-53d7-45d5-ac88-75d3d80499af",
-      "groupUuid": "c1d4a9d1-bb10-4d69-9bad-bc2b5ec207bf",
+      "uuid": "4b5c30a3-eff2-4988-9ef3-f80ea2a5ca4b",
+      "groupUuid": "5a63b0be-32e7-4e98-920b-c0218fd8e47c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3610,8 +3610,8 @@
       }
     },
     {
-      "uuid": "15a171bd-804f-41f5-95d4-95f26b663aa3",
-      "groupUuid": "9bff5563-be0d-4edb-bd6c-5fa3a200b76d",
+      "uuid": "d891533a-74d5-4d50-a08d-9122a74caf88",
+      "groupUuid": "16d7ce90-66f1-4e59-bacb-1f8811ee4328",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3620,8 +3620,8 @@
       }
     },
     {
-      "uuid": "d1898f0a-3462-4f33-b931-c0367887f03d",
-      "groupUuid": "64f870fa-1291-4bb1-a65a-133edb1e273f",
+      "uuid": "629c51d4-a04f-46c5-b8c1-402af7ad3014",
+      "groupUuid": "b7b94c7b-6cf8-43b4-99da-4478f7283305",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3629,8 +3629,8 @@
       }
     },
     {
-      "uuid": "401b13dd-560e-491a-90f4-64a8df8e09d9",
-      "groupUuid": "9eb2b4bb-ae9a-4115-aad5-33f98781d77a",
+      "uuid": "17310219-4bb4-4e57-859c-d9dcf6742cea",
+      "groupUuid": "94518194-0426-4589-a66f-049ddcb10a0f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3639,8 +3639,8 @@
       }
     },
     {
-      "uuid": "5441b9cf-3c76-4ad1-b0a1-8e1cad446dd7",
-      "groupUuid": "ec2cfdda-bd39-41b5-a297-de85c933c343",
+      "uuid": "a1ae999b-1b5a-45ee-8c48-42d6b4bf841f",
+      "groupUuid": "66f09db8-9785-4513-82e1-28214c155cf6",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3648,8 +3648,8 @@
       }
     },
     {
-      "uuid": "7d23f827-f266-43da-a33d-48b37a43205c",
-      "groupUuid": "ed7365a9-5dd5-4667-bbb8-dd9e3f75f7e4",
+      "uuid": "fd2ae0e6-544d-4df5-aeb7-c713ef7d68fd",
+      "groupUuid": "f3b3be8a-9f5a-4caf-9610-41f7111f5fa4",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3662,17 +3662,17 @@
       }
     },
     {
-      "uuid": "698107ce-4dd0-4329-ace0-96c002462531",
-      "groupUuid": "7de8ca81-ddc4-438d-933c-6b9e7af07ee9",
+      "uuid": "bc4eea53-38ea-49a4-b925-822d5333197a",
+      "groupUuid": "99cd051b-4384-49c1-8fd5-e72b95fe1d07",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "c70a4c46-28ea-4f37-ace0-b292583184ce",
-      "groupUuid": "c7ba6acd-a00d-4a97-bec6-71be276ce8fc",
+      "uuid": "c48ec35c-e8f4-499a-8945-fbe4d814157f",
+      "groupUuid": "64722c72-3973-4633-9a80-d53922d2597c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3680,8 +3680,8 @@
       }
     },
     {
-      "uuid": "1e7a5b45-5703-43d7-82fd-d7a6ab681ae7",
-      "groupUuid": "d5854d80-b5c7-49e3-93d3-171d6e49b0a7",
+      "uuid": "15ee3d6b-b785-460f-a2e5-36242a2c968a",
+      "groupUuid": "44660c85-0396-4991-bf41-d6eaab5591bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3692,8 +3692,8 @@
       }
     },
     {
-      "uuid": "a61e1740-99a8-4a1e-bc4b-2da6b9867be5",
-      "groupUuid": "d5854d80-b5c7-49e3-93d3-171d6e49b0a7",
+      "uuid": "ac6c35e3-b71e-46fa-8fb1-42e9b9f85e43",
+      "groupUuid": "44660c85-0396-4991-bf41-d6eaab5591bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3704,8 +3704,8 @@
       }
     },
     {
-      "uuid": "52c94dea-81d5-436d-96c6-deac4103995e",
-      "groupUuid": "d5854d80-b5c7-49e3-93d3-171d6e49b0a7",
+      "uuid": "60357e82-99e6-4669-8b73-ca0fe8fb24e9",
+      "groupUuid": "44660c85-0396-4991-bf41-d6eaab5591bb",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3716,8 +3716,8 @@
       }
     },
     {
-      "uuid": "8500a883-a2d0-47a6-895c-678f95b5894b",
-      "groupUuid": "61130285-d8d3-4962-8698-726c38d7aa7f",
+      "uuid": "996119fe-a877-41b6-a5e5-243c5afe1f4d",
+      "groupUuid": "f18930c2-c9b1-4aec-a2d3-f021637d6625",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3725,8 +3725,8 @@
       }
     },
     {
-      "uuid": "8ee0d42d-2b9b-49ad-a7f2-0471518a27a2",
-      "groupUuid": "da45e535-2793-45d8-9f20-369e4da84fec",
+      "uuid": "3365f044-b80b-455b-a313-8b7a89261bdd",
+      "groupUuid": "6e83ec4a-6f5c-4ac7-ab67-193f39473df6",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3735,8 +3735,8 @@
       }
     },
     {
-      "uuid": "b34b71e6-ce78-4aff-bc62-4baea3381982",
-      "groupUuid": "6f55350b-9b2e-454d-a369-d9bf4da3e483",
+      "uuid": "9c4baa70-96d6-48ef-8610-cdafc4b3d266",
+      "groupUuid": "fc244582-a1cf-43f0-bb5e-672383f13126",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3744,8 +3744,8 @@
       }
     },
     {
-      "uuid": "82b89a7c-951f-40e5-9d63-05663c427269",
-      "groupUuid": "d4ce861f-1e40-4e15-9d31-be1511e928eb",
+      "uuid": "8e63025d-8fae-4786-bed7-14c2f61bbc73",
+      "groupUuid": "ab9fd557-7095-4544-b95e-95c35c35d825",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3754,8 +3754,8 @@
       }
     },
     {
-      "uuid": "fc98d6a5-62d5-45c6-b849-c653bd3dbbdc",
-      "groupUuid": "89eba57c-7987-4770-9fc8-459772f0116d",
+      "uuid": "af866f32-9512-41ab-85c8-466434ca61d2",
+      "groupUuid": "6a0891c0-50a4-4234-beac-a8abf94f2faf",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3763,8 +3763,8 @@
       }
     },
     {
-      "uuid": "b05df17e-4d90-484e-af49-066d2c0f2b2e",
-      "groupUuid": "783a86c7-5519-49d4-b488-a1db2a6f16be",
+      "uuid": "32a98d61-71f8-46b1-9c11-2bf077869150",
+      "groupUuid": "f7d036ef-12a5-4bdb-95b7-1de807f1d336",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3773,8 +3773,8 @@
       }
     },
     {
-      "uuid": "e771b17e-ed25-4479-9069-b26bb8feaf6b",
-      "groupUuid": "1b18a4a4-f3f0-4457-b7dd-a1492eb37c7e",
+      "uuid": "3b77a74b-f659-40bd-9310-6b818560c009",
+      "groupUuid": "1c2966ab-b07b-46e4-9240-b9a0138d65af",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3782,8 +3782,8 @@
       }
     },
     {
-      "uuid": "0cce039f-7abc-44ed-b8fa-3344b4b75a15",
-      "groupUuid": "f879bf9a-28a8-4307-971c-6c9955ceb663",
+      "uuid": "7b2426af-2538-4a63-b437-f91f7995d3a5",
+      "groupUuid": "3a32776d-1b14-435e-9f74-22e294f955e0",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3796,17 +3796,17 @@
       }
     },
     {
-      "uuid": "0e23212b-0477-4cea-b3d9-1ad2f5a87edf",
-      "groupUuid": "2214e63d-36f6-47e4-96ae-cb01115ac88d",
+      "uuid": "2253010d-7b13-4d3d-b491-3b43fb3e0d1f",
+      "groupUuid": "1e9a9f6a-5f57-4a77-a1ad-04b34f5748c2",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</p>"
       }
     },
     {
-      "uuid": "d6c819ec-11c9-4e58-a654-6bf326d7988f",
-      "groupUuid": "1114a047-b089-44e1-8d7f-db42ead6175e",
+      "uuid": "4f9cb855-7387-4d2f-b1de-8230b5823f2c",
+      "groupUuid": "bc7dca85-6b65-468c-85f1-dd8b53e01770",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3814,8 +3814,8 @@
       }
     },
     {
-      "uuid": "32375b8b-a9a6-4808-811c-9cf73175d20e",
-      "groupUuid": "7b4fbd4c-b1ba-4404-899b-742aa10f8be7",
+      "uuid": "868fcf15-5f21-4921-a6ed-fa0b7678cc58",
+      "groupUuid": "19a9eaea-3b8d-4021-a77e-26d81ef88bed",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3826,8 +3826,8 @@
       }
     },
     {
-      "uuid": "d20c6b95-8fa3-4e39-ad6c-4408940eaabb",
-      "groupUuid": "7b4fbd4c-b1ba-4404-899b-742aa10f8be7",
+      "uuid": "4836ab2e-b60b-4443-82b9-0b4589b6b1c6",
+      "groupUuid": "19a9eaea-3b8d-4021-a77e-26d81ef88bed",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3838,8 +3838,8 @@
       }
     },
     {
-      "uuid": "84ff1096-5e8c-4754-b45e-2bb10f2bf53e",
-      "groupUuid": "7b4fbd4c-b1ba-4404-899b-742aa10f8be7",
+      "uuid": "067beaba-2a75-4d00-8031-9aeb69ef6b93",
+      "groupUuid": "19a9eaea-3b8d-4021-a77e-26d81ef88bed",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3850,8 +3850,8 @@
       }
     },
     {
-      "uuid": "785d994e-3ed8-4192-97de-51d71c417d89",
-      "groupUuid": "61362e93-d36f-45ad-872f-7456bedefbf1",
+      "uuid": "3cd4461b-88ee-4664-90d0-5b714afff83b",
+      "groupUuid": "3c23c084-f985-405f-a48e-ef6ca048da8e",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3859,8 +3859,8 @@
       }
     },
     {
-      "uuid": "d67b0ca8-62c7-4149-98a7-57f40a141bfc",
-      "groupUuid": "f7415633-7093-4f3a-ae42-d5c042156597",
+      "uuid": "744b6fc1-f114-4477-9b62-1904be905408",
+      "groupUuid": "ea758fd7-4810-4b0f-be15-bc022d347a5c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3869,8 +3869,8 @@
       }
     },
     {
-      "uuid": "cced8949-109a-4501-b1e2-7147c1a588c0",
-      "groupUuid": "5c553b1a-b7e3-4deb-8022-df82a02eec88",
+      "uuid": "2e3e4f6f-8b60-4907-91b3-090d4d902e77",
+      "groupUuid": "667240bb-4da3-4d89-8786-24e916f95564",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3878,8 +3878,8 @@
       }
     },
     {
-      "uuid": "23b53b8c-9ea7-466f-a121-3a6d87bb6c65",
-      "groupUuid": "cb622a35-b341-4f0e-92d4-8f303b9bfbcf",
+      "uuid": "a6191e79-1b60-476c-8173-3ab19245a50c",
+      "groupUuid": "781259c0-120b-4ee1-aa31-34e7a33fc9f1",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -3888,8 +3888,8 @@
       }
     },
     {
-      "uuid": "f3dd977e-1e62-46e8-9a6f-8cd40bd51661",
-      "groupUuid": "9fa8038d-95e9-45b0-a23d-434e9cddea17",
+      "uuid": "a64cc80c-febb-43de-8106-82952c3e722a",
+      "groupUuid": "99db271c-5b24-4910-9335-237b1e59416d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3897,8 +3897,8 @@
       }
     },
     {
-      "uuid": "47b93168-bc26-456f-a1f1-8d12a4863a8a",
-      "groupUuid": "bc4ff7be-9b22-454d-ae52-0b2fc5d90652",
+      "uuid": "cfb638f1-c26b-4117-a2c6-c21bee55ca0a",
+      "groupUuid": "82e960a9-408c-4fee-8961-d820c645ce97",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -3907,8 +3907,8 @@
       }
     },
     {
-      "uuid": "61bccc12-4653-4fa8-92ab-08f990429089",
-      "groupUuid": "bceb40f1-f312-47d9-b156-9675c4234384",
+      "uuid": "34c77901-ee4d-4283-b715-7eeda3161d8e",
+      "groupUuid": "2b4e5ea7-9a6e-45ac-937b-f07ead2d1242",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -3916,8 +3916,8 @@
       }
     },
     {
-      "uuid": "9cfe8e48-2d0a-43a9-846e-09f5fac8a34c",
-      "groupUuid": "b23905c0-2643-4e22-8914-ace9dd048201",
+      "uuid": "60bf3348-4865-4609-b4eb-31668a0d558c",
+      "groupUuid": "3c41feca-9614-4b23-8b01-380f80f2faf2",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -3930,17 +3930,17 @@
       }
     },
     {
-      "uuid": "d44a47c3-c7d1-4a4e-bdcc-c6eb26f3c3a1",
-      "groupUuid": "fb7bc901-dd51-45dc-8f10-bc9550a9665c",
+      "uuid": "6f6b8798-61a3-4bb7-a3e6-a9854dd1007e",
+      "groupUuid": "6a8b13e7-0a3b-46fe-a88a-70303babf414",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "d83613e9-9a64-4a1e-80f2-264856da8463",
-      "groupUuid": "b3334cb1-abc1-43da-9277-0784fb8db0b2",
+      "uuid": "a481173a-0bab-4c68-9b07-ce609e7662e1",
+      "groupUuid": "dc590943-c349-4037-9748-50807ecb9111",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3948,8 +3948,8 @@
       }
     },
     {
-      "uuid": "be9507c7-e9a2-41fb-8088-cc922bbd8c92",
-      "groupUuid": "239f6d27-f484-4dbb-9e91-5cbddcdd79d1",
+      "uuid": "a05baa85-8d4c-4d06-a3f6-d361a044216e",
+      "groupUuid": "74654792-5854-444f-bc68-d14ee6fb0a5c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3960,8 +3960,8 @@
       }
     },
     {
-      "uuid": "45f9859f-8433-40f2-a94c-96ac03c153e3",
-      "groupUuid": "239f6d27-f484-4dbb-9e91-5cbddcdd79d1",
+      "uuid": "f4f16c7d-ef8e-4df6-a15f-28135a0dc14d",
+      "groupUuid": "74654792-5854-444f-bc68-d14ee6fb0a5c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3972,8 +3972,8 @@
       }
     },
     {
-      "uuid": "28e99c43-3f92-4775-86c8-e3abc7290883",
-      "groupUuid": "239f6d27-f484-4dbb-9e91-5cbddcdd79d1",
+      "uuid": "54570528-e0d0-446e-87a8-64412facc8c9",
+      "groupUuid": "74654792-5854-444f-bc68-d14ee6fb0a5c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -3984,8 +3984,8 @@
       }
     },
     {
-      "uuid": "317e9262-5ed1-4e55-b2a3-9df03b04ef68",
-      "groupUuid": "09041212-e0fe-48a0-ac04-c91aeed299b3",
+      "uuid": "b4bc0ff2-9eb1-41ef-ac1a-10b8de023dff",
+      "groupUuid": "761e1fe4-0e15-4e84-8459-59bee1b76154",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -3993,8 +3993,8 @@
       }
     },
     {
-      "uuid": "1aee4d25-9794-47ee-9f17-e6cccf9338e4",
-      "groupUuid": "f20265f1-5cab-4924-96c2-10b2a07ab34b",
+      "uuid": "d2b0fa49-ffd2-4fee-9cc7-15502ed5dd16",
+      "groupUuid": "69abf7b9-ef29-48ad-ba08-3645b753e5d9",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4003,8 +4003,8 @@
       }
     },
     {
-      "uuid": "a713dbb9-649e-4c89-8876-689f663bf682",
-      "groupUuid": "920b2c4b-4c2d-436e-8b37-f78883fb29ea",
+      "uuid": "7f66a1d2-9ffd-4f9c-b285-555cab7a89e0",
+      "groupUuid": "15a29f2a-0358-4396-868c-0e95c7d4f2f6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4012,8 +4012,8 @@
       }
     },
     {
-      "uuid": "8a2da08a-05e8-4416-a464-850f572f2174",
-      "groupUuid": "6349b1bc-b1a3-4551-a78f-a8c9a4bef3d8",
+      "uuid": "baf0fb05-7dab-43e9-bb5e-f3771d9daca4",
+      "groupUuid": "03c538a8-5b9d-49fc-a82b-c81622955752",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4022,8 +4022,8 @@
       }
     },
     {
-      "uuid": "d465ceef-9a77-46b3-ba17-b2a68ae034ef",
-      "groupUuid": "b1b621f8-d1da-4d10-b465-540ff26e9ae8",
+      "uuid": "1d3a195f-ba1f-4920-9cb9-1f4cfe21bbf5",
+      "groupUuid": "3070c976-96eb-44d3-93e9-1b09e31cb6de",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4031,8 +4031,8 @@
       }
     },
     {
-      "uuid": "ab240d8e-4661-47a9-9a18-d325e2bdf0cb",
-      "groupUuid": "0fba73be-5428-4197-9f2a-70d52d8256b5",
+      "uuid": "16a72a3a-5c2e-4b88-9727-ac6527bd4798",
+      "groupUuid": "b3372847-aa32-45cf-acbe-5eb02dcc7825",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4041,8 +4041,8 @@
       }
     },
     {
-      "uuid": "cd3806b5-00b2-4631-b77d-3f96e0e41f2c",
-      "groupUuid": "c0a111d2-a19a-46ff-8027-a3c6d3a938ff",
+      "uuid": "7a943ba9-1c32-4fac-9ae3-1f47fc95725b",
+      "groupUuid": "39fa1061-c636-4287-af2a-e4d921def9d0",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4050,8 +4050,8 @@
       }
     },
     {
-      "uuid": "3461c920-be5d-4fdf-9ae5-5364bcbfd084",
-      "groupUuid": "86a4fff8-16ae-4a45-8b53-9271e7c5dc11",
+      "uuid": "1a7c5127-1f0c-4f64-b34c-c7f80c9dfdaf",
+      "groupUuid": "56477c54-e8c8-4ef6-b772-4edeee8b7811",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4064,17 +4064,17 @@
       }
     },
     {
-      "uuid": "92906a23-398c-4007-9b01-014fc44cafe7",
-      "groupUuid": "1d162f99-c36e-4251-b040-899f34b740e8",
+      "uuid": "5ae1fff0-dc32-4947-9d3b-d0ebf06d3480",
+      "groupUuid": "6f60e3ed-57d1-4541-a39c-77a2044e613c",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: altered-dominant<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Altered voicing:</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "42f5d33b-8d8f-4a6d-8aff-892af8ad0d9e",
-      "groupUuid": "d3525e7f-f8f7-4015-b263-d371a8f04a12",
+      "uuid": "418fa6d2-4033-480f-a7fa-56a36cf489d5",
+      "groupUuid": "775714b5-a562-4599-8901-485c081ec729",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4082,8 +4082,8 @@
       }
     },
     {
-      "uuid": "e5233241-cc9a-4ed6-ac79-b32fa8348906",
-      "groupUuid": "d8b18563-6834-4f65-bb37-db914206c1f9",
+      "uuid": "3849e3b0-af98-4d40-b595-4d9ea2d8dbd5",
+      "groupUuid": "e4cc92ed-35c8-49b0-90f2-625c0a0d838a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4094,8 +4094,8 @@
       }
     },
     {
-      "uuid": "01753435-4d29-4b69-8b95-417705ef83bd",
-      "groupUuid": "d8b18563-6834-4f65-bb37-db914206c1f9",
+      "uuid": "dc5a333a-e746-46bf-874a-258be3241e7f",
+      "groupUuid": "e4cc92ed-35c8-49b0-90f2-625c0a0d838a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4106,8 +4106,8 @@
       }
     },
     {
-      "uuid": "1c60760c-b2cb-42b5-ae18-6709f2119383",
-      "groupUuid": "d8b18563-6834-4f65-bb37-db914206c1f9",
+      "uuid": "44c16674-6233-48ea-a6e0-3945c42dbb4c",
+      "groupUuid": "e4cc92ed-35c8-49b0-90f2-625c0a0d838a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4118,8 +4118,8 @@
       }
     },
     {
-      "uuid": "24888c4e-f0e9-4ff6-a70d-a66e86d4898a",
-      "groupUuid": "507cf1d7-ff76-4c4e-8296-d1334883fe78",
+      "uuid": "36c83dd1-d215-4802-8680-9298182a8856",
+      "groupUuid": "b7042dbd-28f9-4998-8969-34d2ebe4a6b5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4127,8 +4127,8 @@
       }
     },
     {
-      "uuid": "506672f8-88b1-4fdf-aad0-c870cba80994",
-      "groupUuid": "7855f898-e112-4cf9-bcb9-3508e29af04f",
+      "uuid": "921d77f6-3db4-46f1-8214-b740e9dd82bb",
+      "groupUuid": "64536e52-99aa-441e-a438-a7480e53f8eb",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4137,8 +4137,8 @@
       }
     },
     {
-      "uuid": "411d10f4-f2c3-40ea-931e-14a006c7123a",
-      "groupUuid": "a21e7c6b-fe8b-40be-8a2b-b853490aabc1",
+      "uuid": "feda5aea-9274-45d1-9911-02cf2efe734f",
+      "groupUuid": "ffee5176-fcbb-47b0-acb3-8d0790f7897f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4146,8 +4146,8 @@
       }
     },
     {
-      "uuid": "664e8f78-02dd-4064-9bd9-c9618d938c1f",
-      "groupUuid": "0c1db91b-10dc-438b-b8a1-e3caea41d006",
+      "uuid": "159e98eb-220a-42ac-a3bf-50a1dd41567e",
+      "groupUuid": "cd377616-093c-4f99-ae29-66841843e0ba",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4156,8 +4156,8 @@
       }
     },
     {
-      "uuid": "3c10318e-f498-4d48-819c-6f406b0b3e64",
-      "groupUuid": "1adaa31e-256d-4ecd-b05d-d4e0203efbc5",
+      "uuid": "b5e9dd68-6a33-4faf-91fc-6194f3f95a26",
+      "groupUuid": "3cca6f33-41b9-4052-9dd6-8112458f6383",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4165,8 +4165,8 @@
       }
     },
     {
-      "uuid": "a5b791e7-b172-403a-82ad-21250d8dadcf",
-      "groupUuid": "3619fd32-f765-4724-9c12-6716e808a37b",
+      "uuid": "dc4affe7-c130-45e5-9fba-0d281307926b",
+      "groupUuid": "0400e3e6-9e89-4ce1-860f-bc2fd09b0748",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4175,8 +4175,8 @@
       }
     },
     {
-      "uuid": "88150b73-e887-4913-89fc-4b576d92ab12",
-      "groupUuid": "2454743b-ae62-4e19-b6ca-86ecb5cfb119",
+      "uuid": "f9c896d2-abf7-48ad-b325-de96fde4dcf4",
+      "groupUuid": "72f600e5-3d79-40bc-8c09-e3904e356d34",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4184,8 +4184,8 @@
       }
     },
     {
-      "uuid": "16790705-126f-49bd-a065-51f27f3dbd8a",
-      "groupUuid": "d057204a-1d11-4d17-be5e-182ee294ac49",
+      "uuid": "93ac3029-cd8e-4ce7-841e-d5d9c9e27b69",
+      "groupUuid": "1818f48a-0b60-4369-b909-1cfe7a9c94b4",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4198,17 +4198,17 @@
       }
     },
     {
-      "uuid": "e2d6e111-0568-45c9-ac96-9e210f715070",
-      "groupUuid": "aa0c119b-e175-4b55-8dd0-86502597ddd1",
+      "uuid": "fc660e72-af58-4e3d-abb2-3356a953133d",
+      "groupUuid": "90e3eb7a-efe3-472f-bea3-93712536ebd0",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-2, block<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>Drop-2:</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "11b16fda-6bce-4812-b866-1145cc9397b7",
-      "groupUuid": "b3ddbf2b-61c8-4225-950b-7338ee357196",
+      "uuid": "2972febb-dc95-4c08-b0cd-a74f508ba030",
+      "groupUuid": "3bb33c16-a1ba-47cf-b12a-937da328e527",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4216,8 +4216,8 @@
       }
     },
     {
-      "uuid": "05d5a581-5064-4d52-ba3a-0f6181edfbed",
-      "groupUuid": "d50dc337-4677-4673-aed0-8a0f06e753c0",
+      "uuid": "1c7788e3-619e-4837-be02-578898955e29",
+      "groupUuid": "4bce36d0-b1c6-49f3-a6a8-7b5ee077d150",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4228,8 +4228,8 @@
       }
     },
     {
-      "uuid": "b1ddd00e-c771-4637-bc2a-7277f026361d",
-      "groupUuid": "d50dc337-4677-4673-aed0-8a0f06e753c0",
+      "uuid": "c749b237-784c-4eb7-9319-58911e6b64ba",
+      "groupUuid": "4bce36d0-b1c6-49f3-a6a8-7b5ee077d150",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4240,8 +4240,8 @@
       }
     },
     {
-      "uuid": "0f5678ae-1367-41af-8078-e4d562edb7fa",
-      "groupUuid": "d50dc337-4677-4673-aed0-8a0f06e753c0",
+      "uuid": "f45cbb44-df53-41da-b21d-c811bbe0bcbf",
+      "groupUuid": "4bce36d0-b1c6-49f3-a6a8-7b5ee077d150",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4252,8 +4252,8 @@
       }
     },
     {
-      "uuid": "9b1fd16a-a150-4f53-88b3-c0e46eef4b84",
-      "groupUuid": "4c747dd2-430a-4a0f-b7b6-94d9b24d4a5e",
+      "uuid": "a495d08f-6ebb-44ff-91be-3cfc37afe949",
+      "groupUuid": "383ac66f-4cb0-4a87-b35e-a32730b81205",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4261,8 +4261,8 @@
       }
     },
     {
-      "uuid": "65a8f202-2e19-4206-a333-b233d293294c",
-      "groupUuid": "b2d01d9e-8a03-4b04-91e4-3716558e41f4",
+      "uuid": "5e40258a-2121-415d-9876-b14929defd16",
+      "groupUuid": "5addb254-fa70-46ca-8a21-5f8519e66d31",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4271,8 +4271,8 @@
       }
     },
     {
-      "uuid": "c119c314-82ca-4dd7-b5c3-b3e813cbb23f",
-      "groupUuid": "bc34cfff-efdf-4bb7-bf4f-32c81cf7a487",
+      "uuid": "ce377cba-2d53-491a-beaf-d31a9eba784b",
+      "groupUuid": "67cec606-a393-43f9-b039-06518e5cbf95",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4280,8 +4280,8 @@
       }
     },
     {
-      "uuid": "e55774c0-3db1-47bc-b7cf-f78f06f6e1a4",
-      "groupUuid": "979d2e53-7946-4824-863f-6b8bb6caafcd",
+      "uuid": "8cdf287c-5ef6-4974-86fd-c4a5ae470836",
+      "groupUuid": "41dec756-e240-4157-8653-5c533d2d331d",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4290,8 +4290,8 @@
       }
     },
     {
-      "uuid": "ff1711b1-e698-4ea6-bff4-dc3d77f6f60d",
-      "groupUuid": "50740c00-2dc6-4d44-8bc9-f5cf11a3f653",
+      "uuid": "c802e1e2-1f76-4f2f-b553-a3486d50856c",
+      "groupUuid": "80dc0722-09c1-42dc-a276-0ec1854dcad1",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4299,8 +4299,8 @@
       }
     },
     {
-      "uuid": "e0ffb2f5-899f-4d84-bbb0-3d964e85f611",
-      "groupUuid": "f27322db-9903-4281-aa7f-1a10cb8a8c8f",
+      "uuid": "89e46c94-88db-4b5c-89b5-cf2fcc3c22c3",
+      "groupUuid": "6522d653-708c-44b6-bc54-a3ad2a604e0b",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4309,8 +4309,8 @@
       }
     },
     {
-      "uuid": "25ad9037-c9d1-40e0-87c8-bcc71497ba92",
-      "groupUuid": "07d49550-67c8-4734-94fa-6bf70928bec2",
+      "uuid": "a7b2d789-8209-42f9-b61f-848e00e79a74",
+      "groupUuid": "5acb7f08-66a2-4cfa-bf87-83df66aa26bd",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4318,8 +4318,8 @@
       }
     },
     {
-      "uuid": "746ff797-3d75-412a-ba8e-d007e9ee4cc3",
-      "groupUuid": "fb6fd81a-c83f-4af2-a7ac-d6d19eab754c",
+      "uuid": "acfcbb0e-9d34-4f4c-b4d0-f151fc1248c8",
+      "groupUuid": "5fdbdda5-b47d-4190-8a70-87b209fe0c8b",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4332,17 +4332,17 @@
       }
     },
     {
-      "uuid": "abfc74fe-bfad-458e-899b-ab4369bff91c",
-      "groupUuid": "32936ef1-85e6-47c3-8719-3af54534bff9",
+      "uuid": "e2e7bf6c-fbb5-4a36-92a5-76761c29259a",
+      "groupUuid": "02892a2b-cc3a-48f8-b3c5-e769dfd6a025",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: drop-3, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "2a6ac9ea-2dcf-40e4-8eb8-672e3555838a",
-      "groupUuid": "bd32da2a-7a44-462a-83bf-13866e94791c",
+      "uuid": "21fcf33e-d65d-4eaf-9041-318da8ba59fb",
+      "groupUuid": "fa37324d-03e1-4919-b0c9-6a65a41b8d49",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4350,8 +4350,8 @@
       }
     },
     {
-      "uuid": "fe46b267-9721-4140-8fe1-4a4f028490bd",
-      "groupUuid": "fcbd104f-5873-4d52-91ab-34377ba9367e",
+      "uuid": "c47165e7-9549-4a50-8ca6-5e82b13c0fd3",
+      "groupUuid": "9ac078ba-d562-43f0-8087-dc0d21aee43c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4362,8 +4362,8 @@
       }
     },
     {
-      "uuid": "6ffa8c41-bfc8-46c0-b57d-dabdc1d30c22",
-      "groupUuid": "fcbd104f-5873-4d52-91ab-34377ba9367e",
+      "uuid": "e7118af7-3444-4651-ae53-ce53c73bf581",
+      "groupUuid": "9ac078ba-d562-43f0-8087-dc0d21aee43c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4374,8 +4374,8 @@
       }
     },
     {
-      "uuid": "afcdde41-7acb-42dc-a4f4-c525f5c2937c",
-      "groupUuid": "fcbd104f-5873-4d52-91ab-34377ba9367e",
+      "uuid": "73b83519-3b52-4b2a-bcd5-3957ceab4538",
+      "groupUuid": "9ac078ba-d562-43f0-8087-dc0d21aee43c",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4386,8 +4386,8 @@
       }
     },
     {
-      "uuid": "81b47524-d5c0-4ef6-b8e2-dd244157f2d6",
-      "groupUuid": "ce9760d4-3605-49d7-b461-74b2c9a71edf",
+      "uuid": "9b4dfbd1-c153-48be-95f8-e544f89be7fd",
+      "groupUuid": "9eaf6234-ec14-413e-be63-e9e30e53d407",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4395,8 +4395,8 @@
       }
     },
     {
-      "uuid": "aa83d95d-377c-44ff-9b25-55a88fccc631",
-      "groupUuid": "b382813b-03de-465b-9f91-8ced4b07eca4",
+      "uuid": "3d8e3fbd-22e5-4e22-903c-47824751d76b",
+      "groupUuid": "eb26e22b-b145-48e9-8a9b-22a5989e0e3d",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4405,8 +4405,8 @@
       }
     },
     {
-      "uuid": "fa7c1897-cd62-4478-bda6-30f50295fff6",
-      "groupUuid": "4957cf7c-2a8f-472a-833e-463854af0f94",
+      "uuid": "780360bc-c379-44e5-b4a7-28bd9dbd1f5b",
+      "groupUuid": "2ec5b7ba-0615-4f61-93c4-fd4851c8ecf7",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4414,8 +4414,8 @@
       }
     },
     {
-      "uuid": "2e4475ff-4d69-4194-ab3e-6f3b231474e6",
-      "groupUuid": "a880c370-5a72-451d-b466-d72f73180e7b",
+      "uuid": "9da00c62-4944-4502-9636-849b1d8c4e8e",
+      "groupUuid": "1148b31e-8e47-4841-9556-ec578824c88c",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4424,8 +4424,8 @@
       }
     },
     {
-      "uuid": "490de3c6-3b65-43a8-823b-f05c19a7f448",
-      "groupUuid": "fa1c0c00-66e2-434d-ac29-8fa55a087944",
+      "uuid": "0c09b23e-fa1b-4d44-a22c-15381028d423",
+      "groupUuid": "a56f49f9-4ba4-40fa-b2db-16cccc9c7804",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4433,8 +4433,8 @@
       }
     },
     {
-      "uuid": "2c0dccd5-ea8e-4198-b531-417752dcfd42",
-      "groupUuid": "d95ee9ea-fe9a-4801-8c5f-6de25e6b39bb",
+      "uuid": "b6d443ee-54f0-46ae-89cf-a6b6f7cf0ca3",
+      "groupUuid": "9022674a-d2af-493c-86ec-a162c034b26a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4443,8 +4443,8 @@
       }
     },
     {
-      "uuid": "0c90ae11-c5a5-4eb6-85a4-74f7c8c23f59",
-      "groupUuid": "51f71be1-435b-47d5-87e5-6c194b4e4d44",
+      "uuid": "854f2bcd-c869-4bf1-9cd3-ff1fb29563c1",
+      "groupUuid": "5562fe3e-a5b9-4218-a32c-967e4f8ff61f",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4452,8 +4452,8 @@
       }
     },
     {
-      "uuid": "a36de668-3455-4dc8-ab25-80f0cf91c3aa",
-      "groupUuid": "300e3cf0-c43c-403d-a0b6-bea433d76d52",
+      "uuid": "9d158a95-8094-4f22-8099-0579da012ae3",
+      "groupUuid": "098f5038-b7d4-44b9-a257-ed559d97ce80",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4466,17 +4466,17 @@
       }
     },
     {
-      "uuid": "58dab944-17f9-4f9a-a060-9a43471f9765",
-      "groupUuid": "e5e999c9-ec7e-44f1-ba66-f7945bee261d",
+      "uuid": "97fc39e0-55b5-4e7c-811b-c3891ac489ad",
+      "groupUuid": "00fdbf5d-1a43-461c-8de6-30de0962b982",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-3<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</p>"
       }
     },
     {
-      "uuid": "9e2ad76f-483c-4207-a97c-981e994d41cb",
-      "groupUuid": "437b6b4a-0c9c-4a6f-83e6-4c72ced3f863",
+      "uuid": "dbb728b6-cd4e-422e-9d15-a2df1e9bc4ac",
+      "groupUuid": "e9e2d39b-05f0-4fe2-9209-c66a9b544ba4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4484,8 +4484,8 @@
       }
     },
     {
-      "uuid": "fe11dda3-5ecd-4137-926c-4ab32562319b",
-      "groupUuid": "1dc76600-eb76-463f-bbc7-d3cc4a3f0347",
+      "uuid": "e462caad-78b6-43fa-88bc-51d3966edc9b",
+      "groupUuid": "915319a7-dc01-433e-abea-b8eb1ec90484",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4496,8 +4496,8 @@
       }
     },
     {
-      "uuid": "e0cee4b8-5e78-42d2-980f-2c5f1f2955c9",
-      "groupUuid": "1dc76600-eb76-463f-bbc7-d3cc4a3f0347",
+      "uuid": "f895ffc8-8258-49c3-8067-86a03569c8ab",
+      "groupUuid": "915319a7-dc01-433e-abea-b8eb1ec90484",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4508,8 +4508,8 @@
       }
     },
     {
-      "uuid": "eb7c7650-8a70-4bbe-9bb0-62cf521aa569",
-      "groupUuid": "1dc76600-eb76-463f-bbc7-d3cc4a3f0347",
+      "uuid": "c8b5cf0c-6508-4211-90c8-97d46c4c484f",
+      "groupUuid": "915319a7-dc01-433e-abea-b8eb1ec90484",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4520,8 +4520,8 @@
       }
     },
     {
-      "uuid": "13836698-91d3-4d7a-84f8-fcf01b1cc1bb",
-      "groupUuid": "00cc27c8-d393-4282-8e4a-7c5bf3b9b662",
+      "uuid": "a3026f6d-bca0-4cbc-a978-5db0ffd18cf5",
+      "groupUuid": "9a8e30b3-a5a2-4d5c-ba1b-ed6a7651f14d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4529,8 +4529,8 @@
       }
     },
     {
-      "uuid": "e9820153-ca59-4a98-9e74-c119b04132ed",
-      "groupUuid": "aa60c86a-cd87-4fda-bc68-2bae1bdda50c",
+      "uuid": "d64ed929-463e-4205-a8b7-c05dab3a6540",
+      "groupUuid": "9a4cea4b-c00a-4e65-b002-a13df61539ea",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4539,8 +4539,8 @@
       }
     },
     {
-      "uuid": "466fb8bf-0d36-4b0d-af09-b6d2c99e4833",
-      "groupUuid": "c4c89059-2a8d-4329-9f93-ca50e8e51e71",
+      "uuid": "6760f110-7c1a-4cfb-b36e-51d060371a65",
+      "groupUuid": "1f738d0b-2b3b-4c06-92c1-f124060d1003",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4548,8 +4548,8 @@
       }
     },
     {
-      "uuid": "cfcf491f-d383-46ab-8140-995413e02f23",
-      "groupUuid": "e166e22b-76e3-456e-b995-466b51c3c3b4",
+      "uuid": "c684bf79-2f3f-43cf-8d8e-512f499744e6",
+      "groupUuid": "1684ef92-7c82-4c98-ad04-cdec83c45b8f",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4558,8 +4558,8 @@
       }
     },
     {
-      "uuid": "0a3f5eb8-cdcf-40b5-b9c0-8583ee8ea7ad",
-      "groupUuid": "62be65bb-1df4-42d8-9f80-7c7905c30436",
+      "uuid": "f3729cdc-7df1-4a47-bbf8-acb2ca5eb975",
+      "groupUuid": "429f1fbe-da9e-4916-8c26-6c5f09f49083",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4567,8 +4567,8 @@
       }
     },
     {
-      "uuid": "68df2ec8-b3c0-407a-93f3-b8bee8594584",
-      "groupUuid": "f22db7b4-706c-41ca-b4df-069ebc6e195d",
+      "uuid": "67bd63a7-070c-4959-aa29-f70cd9386cfd",
+      "groupUuid": "7655d54f-69d3-4bb7-9601-d7d35833222c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4577,8 +4577,8 @@
       }
     },
     {
-      "uuid": "3a1686fc-6b82-41b8-a14c-b76ca1fd8b38",
-      "groupUuid": "d53bbdb9-de2b-4c3e-8307-d48f455ae1e4",
+      "uuid": "54bdb7fb-8d7e-4576-ab56-50758741f16a",
+      "groupUuid": "3e3c352b-c786-47f2-9f8c-0902625aea4c",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4586,8 +4586,8 @@
       }
     },
     {
-      "uuid": "3c01f7a6-1567-4022-ba37-fbdd67e76f8f",
-      "groupUuid": "fe2c5357-750c-40f9-86ec-f0cb304a6b91",
+      "uuid": "dd64a1e2-1006-4408-b1bc-48d455cde40e",
+      "groupUuid": "34ef3535-b256-443e-902b-5cf94c1cb53a",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4600,17 +4600,17 @@
       }
     },
     {
-      "uuid": "ab9014a7-d613-439f-b255-62a27e30aa10",
-      "groupUuid": "84052375-8c4f-4196-ba6e-5703beb23338",
+      "uuid": "8fe58931-0322-4195-b558-c39eb72c80f8",
+      "groupUuid": "d38f7bbe-bf82-43a7-a9b3-c52e2c872ac0",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "0b69c4eb-2c39-43bc-942a-a836f7765e15",
-      "groupUuid": "2cd842f0-e1ca-4280-82bb-32c7bc0af104",
+      "uuid": "faee0e6b-6d39-4b01-a4ce-f16a7b9765bf",
+      "groupUuid": "dd43f607-7067-42de-bdca-f1e696a6dd7f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4618,8 +4618,8 @@
       }
     },
     {
-      "uuid": "d8a73666-82ed-49ab-aaf6-5a5e02d7e522",
-      "groupUuid": "fc3e73be-ff47-4a98-8986-1d9161a58fce",
+      "uuid": "fdcc2ff6-3ed0-4ebf-b6fd-5504a0c13fe9",
+      "groupUuid": "7b6019b1-9f93-4121-aaa7-df89d062a4cd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4630,8 +4630,8 @@
       }
     },
     {
-      "uuid": "74a7416f-5ca5-4ed0-81f6-138421822f77",
-      "groupUuid": "fc3e73be-ff47-4a98-8986-1d9161a58fce",
+      "uuid": "0410ef32-303e-4682-aba9-540f26604658",
+      "groupUuid": "7b6019b1-9f93-4121-aaa7-df89d062a4cd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4642,8 +4642,8 @@
       }
     },
     {
-      "uuid": "3ad5e2a1-012b-4a76-85f0-d79454f3f1e0",
-      "groupUuid": "fc3e73be-ff47-4a98-8986-1d9161a58fce",
+      "uuid": "36c654f1-d449-46c7-b3d2-6baf134d545b",
+      "groupUuid": "7b6019b1-9f93-4121-aaa7-df89d062a4cd",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4654,8 +4654,8 @@
       }
     },
     {
-      "uuid": "37223fe3-af15-4e09-8abc-5e6111a90e0d",
-      "groupUuid": "377b842a-e969-497f-a256-a8a05cb75c1f",
+      "uuid": "25312503-c92c-43dd-b85e-e279dee29137",
+      "groupUuid": "d5f65d3b-7386-4925-9ee8-aa2668da98d2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4663,8 +4663,8 @@
       }
     },
     {
-      "uuid": "c4ea283a-bd36-4dd5-9ff2-223e19ff358b",
-      "groupUuid": "4f9ce44b-1d75-4606-9eea-1dc7de02fe5c",
+      "uuid": "8dd1f61a-897d-4681-897c-c8127ddaedba",
+      "groupUuid": "86b5d77a-4510-4e37-b031-d20b5b69158f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4673,8 +4673,8 @@
       }
     },
     {
-      "uuid": "353976f0-9522-4c71-91dc-fe089b22ffc6",
-      "groupUuid": "c0f4f57b-26a5-4eee-8ee0-bd02450b0d60",
+      "uuid": "3106aa29-f7b3-48fd-a985-497a52ac802f",
+      "groupUuid": "72aa394e-f1fd-4441-a26b-bcfd5b5ed61d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4682,8 +4682,8 @@
       }
     },
     {
-      "uuid": "1b065373-f6be-4be8-9d5c-180beed8734c",
-      "groupUuid": "e97495f7-f7a1-480f-bc12-c1638a102eeb",
+      "uuid": "91339dc5-7443-47a4-945a-611551a2daf8",
+      "groupUuid": "8ad97c09-32fe-4170-9f75-0164e1982968",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4692,8 +4692,8 @@
       }
     },
     {
-      "uuid": "6a053db5-9b27-4eee-b6a1-20670993152f",
-      "groupUuid": "3f88b509-72a8-4a29-88e7-b971720d3dd8",
+      "uuid": "faa3441f-aa74-4d70-a1a4-976f2751972e",
+      "groupUuid": "f73c40bb-21b7-49dc-a998-32fde28b4d16",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4701,8 +4701,8 @@
       }
     },
     {
-      "uuid": "863c6e43-cfb2-49af-9312-677dd848a740",
-      "groupUuid": "24eb47d9-2f34-4e77-bd5e-4700240ee299",
+      "uuid": "335c7fd4-9449-4c83-aefc-eb5de3cbbaa0",
+      "groupUuid": "193189e4-9cb8-4cb0-a24d-2f533e7411dc",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4711,8 +4711,8 @@
       }
     },
     {
-      "uuid": "c0d1e360-7d44-4bc8-a420-6125518eb618",
-      "groupUuid": "a164c7a6-3d9b-49d3-ad12-c125e0498e09",
+      "uuid": "7a12e71f-2254-4e72-b1d2-a277d9bd7185",
+      "groupUuid": "06fa3a3f-780d-49df-9379-61d0f5d943b1",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4720,8 +4720,8 @@
       }
     },
     {
-      "uuid": "7bb802e6-e9a5-412f-821d-3f14310c5641",
-      "groupUuid": "71affffd-73d8-4551-8f45-5aba1fb18b30",
+      "uuid": "74fc4c51-19c2-4b05-97c1-953b3644e205",
+      "groupUuid": "10622235-c1f5-42c8-afc5-50aa49f07372",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4734,17 +4734,17 @@
       }
     },
     {
-      "uuid": "b63043c9-aa69-46cf-b69a-b9f09673e06c",
-      "groupUuid": "acb4f4ad-e77c-435e-ad03-912000de426b",
+      "uuid": "475e8c61-857e-4ce9-abb3-297d7521735e",
+      "groupUuid": "3a001fac-cfe6-4619-a8c2-0e9c71057df8",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "8207d948-0ebd-4740-bbc0-d49b0f7295de",
-      "groupUuid": "8d74fc05-8fb7-4c2a-bc18-2c9b3c50da40",
+      "uuid": "c539d067-a24e-429f-a2b4-a82b995a65aa",
+      "groupUuid": "b5983a95-df5d-4014-8164-eb0a859bc6b3",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4752,8 +4752,8 @@
       }
     },
     {
-      "uuid": "0df40b0d-81c5-43e0-8df4-24df9422cf07",
-      "groupUuid": "cd2944f4-ac45-469c-bbbc-cadb06292995",
+      "uuid": "de1dd6d2-b8d3-46c8-a710-b52b1e7c2c18",
+      "groupUuid": "84ef29b7-19c1-4ea1-a5d0-c3b2a9125af0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4764,8 +4764,8 @@
       }
     },
     {
-      "uuid": "1bb94431-fdf8-4c7d-a732-a4fd645f4e9c",
-      "groupUuid": "cd2944f4-ac45-469c-bbbc-cadb06292995",
+      "uuid": "b8f5a6b0-64ac-4407-970b-164fad4887da",
+      "groupUuid": "84ef29b7-19c1-4ea1-a5d0-c3b2a9125af0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4776,8 +4776,8 @@
       }
     },
     {
-      "uuid": "1fd9aba4-cd4f-4127-91b4-dcba7e58ebb6",
-      "groupUuid": "cd2944f4-ac45-469c-bbbc-cadb06292995",
+      "uuid": "67d08a9c-f63c-42b9-bf89-abde76102f30",
+      "groupUuid": "84ef29b7-19c1-4ea1-a5d0-c3b2a9125af0",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4788,8 +4788,8 @@
       }
     },
     {
-      "uuid": "0ca27988-43bc-46ce-ae92-7e12b28be0a1",
-      "groupUuid": "668e4e7a-ba38-49ba-a59f-24730d99b132",
+      "uuid": "3d3b6d62-8df2-4687-95a1-ecc7283e72d6",
+      "groupUuid": "885967c8-2c94-494a-9a5e-0b6103b3bed7",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4797,8 +4797,8 @@
       }
     },
     {
-      "uuid": "d458dff5-fdd3-4546-9a65-843610e3fb6b",
-      "groupUuid": "990eff4f-1aa7-49b3-9a8f-3b20c15a199f",
+      "uuid": "0356d37d-6462-422a-9348-828efcad28a2",
+      "groupUuid": "bdb63e00-522e-480f-825f-63e8426a0bd7",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4807,8 +4807,8 @@
       }
     },
     {
-      "uuid": "55490013-d6c3-41d5-a876-a76356492e26",
-      "groupUuid": "52c22eca-2efc-4df8-a995-010531bd290a",
+      "uuid": "64ed1812-ad41-4832-a311-afac97d20032",
+      "groupUuid": "9d4a298a-0841-459c-977d-94524c817ef0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4816,8 +4816,8 @@
       }
     },
     {
-      "uuid": "40198c1f-7a27-4a1c-8d79-38ef38c41008",
-      "groupUuid": "b30f3eaa-26a1-4ca6-a0b4-ba7279863734",
+      "uuid": "ae1bb063-a2f8-4700-81d8-e10719ff104e",
+      "groupUuid": "938eab5d-72f2-4380-b24f-a7d7fd634a08",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4826,8 +4826,8 @@
       }
     },
     {
-      "uuid": "28651ea8-b7d6-48a5-9827-afa0f2b41d68",
-      "groupUuid": "d9af0262-ec42-4477-896c-4cad5b27b1a4",
+      "uuid": "f9232880-fd34-4043-a926-5f2de43a3711",
+      "groupUuid": "d2f36318-7229-424f-b84e-7e1c19fe0b8b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4835,8 +4835,8 @@
       }
     },
     {
-      "uuid": "4e48a36a-4bd2-4933-aab8-9591290a160b",
-      "groupUuid": "76fe64a5-ad83-4a56-bad1-d3418dd82169",
+      "uuid": "f6e2a35f-c849-4d18-9f7c-0b7c4ae70a88",
+      "groupUuid": "9d33e246-9f57-4fbe-9774-c7e21df1b6ce",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4845,8 +4845,8 @@
       }
     },
     {
-      "uuid": "1fb55ac4-9ab8-4715-b42a-a396e90d921b",
-      "groupUuid": "b1628805-e982-4f55-ae0c-8f7efd3418b2",
+      "uuid": "a6a51b19-9264-41af-87fe-8e13c265b3fd",
+      "groupUuid": "87def636-dde6-4f07-a01f-f42c100a6c9e",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4854,8 +4854,8 @@
       }
     },
     {
-      "uuid": "78868799-9261-4d53-8c11-447cb919bbd8",
-      "groupUuid": "d21272e1-969c-43cf-aa37-14b4c16250b3",
+      "uuid": "c7a291e5-a9b1-4391-9bec-1a8c7e39d040",
+      "groupUuid": "66a5729f-040d-470d-ab38-18e66b89bf58",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -4868,17 +4868,17 @@
       }
     },
     {
-      "uuid": "48af34e6-ecb5-4d8c-b445-b20195873d14",
-      "groupUuid": "fc36abf4-ca5f-4796-9b2b-0427cd26a791",
+      "uuid": "0234b2d0-dfa8-4adf-a9d4-25b43b2259f5",
+      "groupUuid": "b7074b8f-16af-4aeb-9621-3f6d14bdf2cd",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: quartal<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>Quartal voicing:</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>quartal</b> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</p>"
       }
     },
     {
-      "uuid": "64589f36-8dc1-4d48-94aa-b080af3f4bfa",
-      "groupUuid": "bc0f1e8c-bd6b-4f23-a2ce-deb02fb3b474",
+      "uuid": "29da1c71-cedd-4f45-baa5-1dfff2fee121",
+      "groupUuid": "27839f9d-39ef-43d1-ad7f-f600b17d02c0",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4886,8 +4886,8 @@
       }
     },
     {
-      "uuid": "dfefc5b6-bddc-452b-aa7d-5ef27646b9ee",
-      "groupUuid": "29d9ba45-0467-4852-bfdf-e967ad6e1957",
+      "uuid": "378fdfc8-1959-4184-a0a4-fd9df846a9a8",
+      "groupUuid": "115fb70f-315a-4b73-b780-e6b6f28b15c2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4898,8 +4898,8 @@
       }
     },
     {
-      "uuid": "b826b30b-5c8d-4fc4-a418-7d87fcc0935a",
-      "groupUuid": "29d9ba45-0467-4852-bfdf-e967ad6e1957",
+      "uuid": "d54b6f7f-cddc-4919-acee-24b0db22e686",
+      "groupUuid": "115fb70f-315a-4b73-b780-e6b6f28b15c2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4910,8 +4910,8 @@
       }
     },
     {
-      "uuid": "e30e9e0d-0004-440c-841b-a22237c50be7",
-      "groupUuid": "29d9ba45-0467-4852-bfdf-e967ad6e1957",
+      "uuid": "130d274a-b183-4d10-89bc-1c034d343389",
+      "groupUuid": "115fb70f-315a-4b73-b780-e6b6f28b15c2",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -4922,8 +4922,8 @@
       }
     },
     {
-      "uuid": "fd453882-2867-452d-8ce6-d3f4cdf7bd82",
-      "groupUuid": "672500e5-ea43-4a35-8a02-7fe3716d673d",
+      "uuid": "fa152610-6ae2-411b-9455-5cf64e57dfdd",
+      "groupUuid": "e505dd30-f89c-4df5-bec4-fed9c40c5d5f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4931,8 +4931,8 @@
       }
     },
     {
-      "uuid": "7fde6a4a-91e0-429c-af62-33487d91bb43",
-      "groupUuid": "772bb8d5-c9d7-42d5-b84c-40c7c7454c8c",
+      "uuid": "2c0e378a-337c-4a0c-b643-107e3ac2a209",
+      "groupUuid": "87d2151a-87d5-44aa-a0d8-8528db29a70d",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4941,8 +4941,8 @@
       }
     },
     {
-      "uuid": "0fb98255-2172-4432-837b-d0a29a98e310",
-      "groupUuid": "dc906de9-a641-4c86-be7e-efee4aca577a",
+      "uuid": "4c223262-de9f-4cfa-85d7-d095e62225b7",
+      "groupUuid": "e35fae5c-cc46-4b22-8728-460f522306ed",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4950,8 +4950,8 @@
       }
     },
     {
-      "uuid": "c3a53426-16a3-416a-89d4-7b5b39630d3b",
-      "groupUuid": "0f6e12e9-e427-465f-bb58-330659d0553c",
+      "uuid": "8189d049-40cd-47f9-ba07-3755fd7fb50e",
+      "groupUuid": "a699332c-4fae-4919-865d-0479fd0767eb",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -4960,8 +4960,8 @@
       }
     },
     {
-      "uuid": "5e2dfc5e-f4e7-48eb-8ec1-0a0f83913c7b",
-      "groupUuid": "040aaf27-4515-4306-bc02-a11d60fd6ed4",
+      "uuid": "167f34f8-ce17-48a5-983f-ac05dc7e5c3e",
+      "groupUuid": "6d2ea963-8b96-48dd-88ba-4e405f48b24b",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -4969,8 +4969,8 @@
       }
     },
     {
-      "uuid": "4c6e7de2-d4ae-46c8-868c-8400b3df1769",
-      "groupUuid": "07f21e76-50d4-4041-aea3-adae8320ea4a",
+      "uuid": "99bf529c-ed73-4060-ac9d-fc878f4d2e62",
+      "groupUuid": "65b9e5d1-1cf4-4348-bb1c-358402f27639",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -4979,8 +4979,8 @@
       }
     },
     {
-      "uuid": "83a78ca6-f5f0-4319-9797-751da9ad36dd",
-      "groupUuid": "3c0f18be-1b38-40aa-9ae4-56eae2c8cb3f",
+      "uuid": "5333ed0b-f424-407a-adf6-5152fdd63a31",
+      "groupUuid": "520f6cbb-b2b8-49b8-9021-2670c168ef99",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -4988,8 +4988,8 @@
       }
     },
     {
-      "uuid": "7b9cada4-202b-4e8c-b1b5-940d76188d06",
-      "groupUuid": "c61f6484-416e-4c29-ad09-329096b4c6cd",
+      "uuid": "4a999bb3-fed9-47a2-8f72-b3b0747b763d",
+      "groupUuid": "914529b5-08cb-4e3c-a875-063216917fd3",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5002,17 +5002,17 @@
       }
     },
     {
-      "uuid": "ae631272-59a3-4465-99cd-1b3361216e2b",
-      "groupUuid": "29688d5d-a2ae-4a79-8a0b-f03c0e1c3ac4",
+      "uuid": "d9352b95-5aca-47f7-aab8-db7814b83db9",
+      "groupUuid": "ccd1d208-a343-41bd-8110-ee839d0d0e9f",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "ceedcd6f-b638-413d-b4eb-84b507b57a7b",
-      "groupUuid": "216c78be-52bb-43cc-b09f-051f93745a37",
+      "uuid": "54d104b5-d7fd-4ed6-89a6-5aac57c10b8b",
+      "groupUuid": "6880553b-c86a-4b2e-a1e6-0fd348166935",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5020,8 +5020,8 @@
       }
     },
     {
-      "uuid": "035c858d-c1ff-422f-99fd-d98c87fb65fa",
-      "groupUuid": "eb4e2d00-e014-4acb-bf1f-cf32b86f375d",
+      "uuid": "a76c7351-78c9-471d-ad48-752f12c109fb",
+      "groupUuid": "6e9b5acb-b65b-4818-bad8-f333dbfc53e7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5032,8 +5032,8 @@
       }
     },
     {
-      "uuid": "6ae12a7e-06a3-4e89-99eb-923e7cb12112",
-      "groupUuid": "eb4e2d00-e014-4acb-bf1f-cf32b86f375d",
+      "uuid": "d7c5dbd0-3db1-49a9-8deb-58b5ab64922b",
+      "groupUuid": "6e9b5acb-b65b-4818-bad8-f333dbfc53e7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5044,8 +5044,8 @@
       }
     },
     {
-      "uuid": "02970e56-cb98-4ca8-a448-c81fca20d66c",
-      "groupUuid": "eb4e2d00-e014-4acb-bf1f-cf32b86f375d",
+      "uuid": "7ce2856e-c38a-4dc0-8418-34110be2422a",
+      "groupUuid": "6e9b5acb-b65b-4818-bad8-f333dbfc53e7",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5056,8 +5056,8 @@
       }
     },
     {
-      "uuid": "cb9da38b-76f7-4c1e-850b-10bf16d2c1e6",
-      "groupUuid": "88b255c9-f02a-4232-bddd-8a78581cb688",
+      "uuid": "44901641-6ca2-4c9b-9c37-57da4a9666fb",
+      "groupUuid": "3b70423a-4ffd-4e81-990b-980964c5c965",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5065,8 +5065,8 @@
       }
     },
     {
-      "uuid": "afe6ffeb-af65-4234-a8a1-e69f0351b80d",
-      "groupUuid": "343ffd28-38a9-47c9-b30a-6f5205e97908",
+      "uuid": "51ad5503-6d14-4be4-bcc2-ac6515615c39",
+      "groupUuid": "896192e9-89e2-4d61-9c7d-a57b1ffec9e8",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5075,8 +5075,8 @@
       }
     },
     {
-      "uuid": "6ccd287d-c951-424c-b7bf-d288cecc002e",
-      "groupUuid": "df59a9c5-0eb8-4b67-9e3e-b3e8ec249606",
+      "uuid": "1529cb71-154c-4969-a845-9dd25eff97b0",
+      "groupUuid": "bdf77565-3f80-4dbc-9276-65d54ca4de18",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5084,8 +5084,8 @@
       }
     },
     {
-      "uuid": "87360e97-347f-4a90-9e54-73c971f55589",
-      "groupUuid": "82d037ae-b44b-4a5b-bd10-c9b61429d830",
+      "uuid": "35c7d1b3-0c1b-4b6a-b172-0dc644434ba3",
+      "groupUuid": "afa47840-7bbb-490e-92c7-b97d3af302f5",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5094,8 +5094,8 @@
       }
     },
     {
-      "uuid": "08bc456c-e2b7-4fec-b090-e973f3af190b",
-      "groupUuid": "efaa767a-7c30-49fc-a015-499815033e41",
+      "uuid": "83a18b26-4630-48f9-9e1c-341d7abe4cc3",
+      "groupUuid": "f116b7c2-ebd6-431f-9baa-ee1a46c68f00",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5103,8 +5103,8 @@
       }
     },
     {
-      "uuid": "2f9dd37e-f360-4ab6-8bf6-92c2e26c2fb7",
-      "groupUuid": "305e5511-040a-474f-8088-07c17b5cdc37",
+      "uuid": "e3049fd8-d6c6-4191-9de7-827addfc9b5e",
+      "groupUuid": "3e1a6c70-5e51-42f9-922d-eaae2f68d60c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5113,8 +5113,8 @@
       }
     },
     {
-      "uuid": "5a9faa25-951a-4eeb-bd29-3dc0c5b9d7fa",
-      "groupUuid": "96c9a1a4-2467-4088-8dd5-91c6607b2536",
+      "uuid": "76363844-88e5-49a8-a845-445ccc64ac23",
+      "groupUuid": "fcc10401-4e53-4711-9684-a9e094d7c0a0",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5122,8 +5122,8 @@
       }
     },
     {
-      "uuid": "2d854235-5524-481a-9e53-9ecd5956aceb",
-      "groupUuid": "76848fec-f91b-4824-8bbf-235c353f0540",
+      "uuid": "25c3bb53-0c96-4787-afb4-9ace34e5f01f",
+      "groupUuid": "42efe9de-6fc0-42e2-b921-dd9ec70e144d",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5136,17 +5136,17 @@
       }
     },
     {
-      "uuid": "ab67d033-89b5-4766-ae32-301324e65585",
-      "groupUuid": "04ad5882-e26c-42dd-a9c1-ffc657fb920c",
+      "uuid": "583345ff-5300-4734-86b7-2f9208ab6909",
+      "groupUuid": "3cd0e869-752f-4a4e-a22e-bc9151f9ea7d",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</p>"
       }
     },
     {
-      "uuid": "a6d79c59-d8aa-40c5-a28a-f71bbfaf7a1e",
-      "groupUuid": "0c1c00a3-fb9c-442d-9d3e-1ede4753639c",
+      "uuid": "f073b3f2-c445-4fc7-a810-956576f124d2",
+      "groupUuid": "4225324f-67a0-49df-822b-baa3f3b4d043",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5154,8 +5154,8 @@
       }
     },
     {
-      "uuid": "0968e5b0-8893-46de-8762-66d5ce09a3b4",
-      "groupUuid": "53e0b35f-aef8-431f-9ccc-53a3db47efdd",
+      "uuid": "54459e5d-7a11-49f7-a1b2-beaba73b3366",
+      "groupUuid": "a626d8ac-261e-4cbe-9e0e-6f3b4effc633",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5166,8 +5166,8 @@
       }
     },
     {
-      "uuid": "e118727a-2815-41c4-b4dc-be724263319b",
-      "groupUuid": "53e0b35f-aef8-431f-9ccc-53a3db47efdd",
+      "uuid": "0978ece2-dc96-4103-a395-8074d181e39c",
+      "groupUuid": "a626d8ac-261e-4cbe-9e0e-6f3b4effc633",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5178,8 +5178,8 @@
       }
     },
     {
-      "uuid": "a994c38a-1018-450b-81e6-5b121b3bcc8b",
-      "groupUuid": "53e0b35f-aef8-431f-9ccc-53a3db47efdd",
+      "uuid": "0e547adb-b555-49f0-a43f-64a4cb133deb",
+      "groupUuid": "a626d8ac-261e-4cbe-9e0e-6f3b4effc633",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5190,8 +5190,8 @@
       }
     },
     {
-      "uuid": "92fe496b-3969-4319-89aa-8cc0d82f4d2e",
-      "groupUuid": "30f75880-40f3-4b4d-a30a-9f4c65a2ee3a",
+      "uuid": "1ef4ff38-62e5-4848-b265-5358e4bc0054",
+      "groupUuid": "2d863bba-3359-43b7-a4aa-7a1b7863bdee",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5199,8 +5199,8 @@
       }
     },
     {
-      "uuid": "269269b2-4e4b-43f1-9df6-5ccea876ec6e",
-      "groupUuid": "87b8cbf8-b405-4aa0-b0c9-d9947014ccc9",
+      "uuid": "6a4eab30-ec76-4f0a-b03a-94a8e9e3062c",
+      "groupUuid": "03594e5b-237d-48a4-b9f6-1fe858f6a1a9",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5209,8 +5209,8 @@
       }
     },
     {
-      "uuid": "40a97c95-beb9-4d8f-a22a-16ef25af915b",
-      "groupUuid": "dda82317-fa6c-4ce0-94fc-249ddf3fbc3b",
+      "uuid": "5fe1b380-1bf7-4774-8590-5d7f22583e59",
+      "groupUuid": "82903585-14cf-4ae2-80f0-0895f1b677d2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5218,8 +5218,8 @@
       }
     },
     {
-      "uuid": "fd39f73a-5c12-4bd1-be4d-7b3503fb02be",
-      "groupUuid": "10f0ce19-4a86-4263-ba74-d6b74e124041",
+      "uuid": "bf0690ac-9b11-4051-b978-f6facb26367e",
+      "groupUuid": "6922a0a7-f174-4974-9e6d-34e6a823b6fb",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5228,8 +5228,8 @@
       }
     },
     {
-      "uuid": "24218b1e-df09-4fd5-8508-7789c047f202",
-      "groupUuid": "ec748780-ce4c-4f8a-87c9-6d7acb7f1f81",
+      "uuid": "44a321ba-a33a-4d38-981f-fce11467c450",
+      "groupUuid": "790ac4d8-6d47-43d8-9e3f-0f0c5ee3531c",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5237,8 +5237,8 @@
       }
     },
     {
-      "uuid": "181cfe44-5cb4-4b15-ab22-d4658084ee1a",
-      "groupUuid": "4e4f43b7-c2ba-4deb-bb44-311388019712",
+      "uuid": "669c4718-f28d-4355-854a-e939d3ee832a",
+      "groupUuid": "ae9e8f95-9718-4493-8cb9-1b16589ae386",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5247,8 +5247,8 @@
       }
     },
     {
-      "uuid": "0b71f850-0116-4e56-8971-b61043961b62",
-      "groupUuid": "8e9eb49b-db65-4bd0-abc3-4a13b0fac82b",
+      "uuid": "db91ee3c-7331-49e4-86a5-6159360f68a1",
+      "groupUuid": "9f9e0dd6-f86d-42ca-913f-80d54180fcd2",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5256,8 +5256,8 @@
       }
     },
     {
-      "uuid": "616ed4bb-738c-4914-91fe-edff25782b82",
-      "groupUuid": "0ab242ed-2318-4ac6-9806-7e14c357c4d2",
+      "uuid": "bc0bb6e3-ae91-43c5-9ffa-db5040ae53e0",
+      "groupUuid": "10adf617-de90-4562-a0f2-927057b1e500",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5270,17 +5270,17 @@
       }
     },
     {
-      "uuid": "e89b3588-30c5-40c3-81bb-7a34da3d0a43",
-      "groupUuid": "42735189-19e6-4397-bf3e-327cce0e3336",
+      "uuid": "221c18ab-57bc-4a18-8a3b-cbf9ddb37e12",
+      "groupUuid": "e9fb4642-5275-494f-b7e8-35c4dde125ba",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "d58f4b8c-0406-4ea2-b77f-3f1d00f9f907",
-      "groupUuid": "82a0fa71-96e9-4aa2-b0ed-a11ee532f256",
+      "uuid": "6b75babb-70ac-4182-b62c-ea1e344b822a",
+      "groupUuid": "a241ab95-8ac8-4aa3-8646-180f64b967ec",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5288,8 +5288,8 @@
       }
     },
     {
-      "uuid": "3f2a0220-5253-45cd-8ed0-88195b44fe8b",
-      "groupUuid": "e6e2894c-03c4-4897-9492-7aca22036c37",
+      "uuid": "690abf3f-6b20-4070-a5f1-68042e16a9a9",
+      "groupUuid": "c084a9eb-a046-46db-9846-472ec18dcd35",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5300,8 +5300,8 @@
       }
     },
     {
-      "uuid": "93f32082-8bf6-43e4-910a-3c684ba193eb",
-      "groupUuid": "e6e2894c-03c4-4897-9492-7aca22036c37",
+      "uuid": "48724b2d-e631-4ab6-9e41-fbd24ec2fee6",
+      "groupUuid": "c084a9eb-a046-46db-9846-472ec18dcd35",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5312,8 +5312,8 @@
       }
     },
     {
-      "uuid": "65fc68c1-ef7c-47b3-a034-b9765ae50d6a",
-      "groupUuid": "e6e2894c-03c4-4897-9492-7aca22036c37",
+      "uuid": "6d8009d9-2add-4c03-9727-d9c4ec8e722b",
+      "groupUuid": "c084a9eb-a046-46db-9846-472ec18dcd35",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5324,8 +5324,8 @@
       }
     },
     {
-      "uuid": "20a9994b-824f-4f4c-93f5-a84da5379a63",
-      "groupUuid": "73a8b9c1-91a6-449b-b257-3c6cc828891a",
+      "uuid": "e2abae2b-8a78-436c-84cb-4e51498af3be",
+      "groupUuid": "6a6faa63-5f30-4b5c-9055-eaf50b724ee5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5333,8 +5333,8 @@
       }
     },
     {
-      "uuid": "2cd97c16-0f01-47db-8d54-178727b37d6c",
-      "groupUuid": "5e1cd4ce-c3e3-4d5d-90d5-73cfea079707",
+      "uuid": "b2795540-9f71-4fdf-8686-5082251bf9d3",
+      "groupUuid": "50ddec67-46f2-4aa9-ba48-ce2fb06966ab",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5343,8 +5343,8 @@
       }
     },
     {
-      "uuid": "05e3098a-9799-473e-a9ec-c41d9369d71f",
-      "groupUuid": "ab3ce43f-3c5b-44b4-987b-05f2a3ce706d",
+      "uuid": "21696e5b-4171-4752-9112-70482185c1c3",
+      "groupUuid": "ba47ec78-09df-401a-873f-76501f77edc7",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5352,8 +5352,8 @@
       }
     },
     {
-      "uuid": "12ca7157-8216-484e-b4c9-1c6d210b825c",
-      "groupUuid": "efc84b19-f14e-45cc-a1ac-a7f4dace286b",
+      "uuid": "41d5fb94-4b37-41c3-90e1-84b1a1866acf",
+      "groupUuid": "39481929-138f-498a-ab3e-93b114639272",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5362,8 +5362,8 @@
       }
     },
     {
-      "uuid": "41f4a69e-bc18-4e78-b6d3-7bda914a0b3b",
-      "groupUuid": "b01f1a1d-9073-488b-b3dd-4b4aa560233e",
+      "uuid": "671f7d00-edaa-43f3-93b3-0b2a2151f14d",
+      "groupUuid": "b569654b-fa07-45d7-8955-b500432d3d9f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5371,8 +5371,8 @@
       }
     },
     {
-      "uuid": "d33cfb1f-7882-4384-93af-945b4aefd77e",
-      "groupUuid": "05e0d3f3-272e-4df2-a43e-f2ad71b22b0f",
+      "uuid": "53eacb77-1f3b-424b-ab9d-77ab13e748e7",
+      "groupUuid": "06c2eed0-193c-48b2-9e47-7f692a7b6d20",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5381,8 +5381,8 @@
       }
     },
     {
-      "uuid": "03420e98-1fe5-4645-8534-dd4a1359775c",
-      "groupUuid": "4b522e22-4a80-482f-9130-b280ca309861",
+      "uuid": "b161d817-fe34-4f29-94c2-4366410419b9",
+      "groupUuid": "061bb93f-1391-4b90-944c-796ef33104bf",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5390,8 +5390,8 @@
       }
     },
     {
-      "uuid": "a9d52eac-4f5c-4e6c-a8eb-765c50aa829a",
-      "groupUuid": "e61c9e10-4c17-419f-8cc4-bb52528ca32d",
+      "uuid": "b4a42fb5-dfdb-433d-9133-cce22a1f88d5",
+      "groupUuid": "03678ed2-7c96-4313-bc4a-09ca6ed03f7f",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5404,17 +5404,17 @@
       }
     },
     {
-      "uuid": "55bc0b52-8683-4bd3-9690-cf6401e61ae7",
-      "groupUuid": "9261c17a-1a8a-4433-8dd3-019fcf52e3c6",
+      "uuid": "811a2047-32ea-4d40-bd02-dc95ed40a12b",
+      "groupUuid": "e12ae3f2-a51c-4a25-b3bd-7e0e3dc68c12",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>altered-dominant</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Altered voicing?</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: altered-dominant<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Altered voicing:</b> A dominant-7 voicing with one or more altered tensions: b5, #5, b9, #9, #11, b13. <i>Tense, leaning hard toward resolution. The Tristano / Coltrane language.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "0b5ec2c7-321b-40cc-9247-dabba689e919",
-      "groupUuid": "a303adc1-dbb0-49f8-8a64-5f7e7ecddd2b",
+      "uuid": "04d9e6ff-940c-42c2-a4a1-ec7abc8c96dd",
+      "groupUuid": "f89cb95c-973b-494c-a01f-a7d6cd2aa925",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5422,8 +5422,8 @@
       }
     },
     {
-      "uuid": "3737ef36-6ed7-46f1-83f1-465368652ef2",
-      "groupUuid": "be72e1b6-67f9-4b09-a140-955879dbc4ac",
+      "uuid": "34a8ed92-c2ad-4b07-b942-de3b4a9c5931",
+      "groupUuid": "4db86c30-73df-42a2-af71-53173e1f71da",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5434,8 +5434,8 @@
       }
     },
     {
-      "uuid": "09fe4db8-3565-41f0-b461-2f93375e6f67",
-      "groupUuid": "be72e1b6-67f9-4b09-a140-955879dbc4ac",
+      "uuid": "4eb9598e-4310-4b9d-b530-79fc2e43cada",
+      "groupUuid": "4db86c30-73df-42a2-af71-53173e1f71da",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5446,8 +5446,8 @@
       }
     },
     {
-      "uuid": "754759c3-1025-4719-b7bd-3c14fa4ee61e",
-      "groupUuid": "be72e1b6-67f9-4b09-a140-955879dbc4ac",
+      "uuid": "aed09dcd-88d2-4b9e-9e19-cde8e511ddf8",
+      "groupUuid": "4db86c30-73df-42a2-af71-53173e1f71da",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5458,8 +5458,8 @@
       }
     },
     {
-      "uuid": "3ffe6596-2c62-437c-80b0-a821b7844828",
-      "groupUuid": "761ac5fb-23d5-4d04-a821-b4926539f604",
+      "uuid": "aa3f2c05-27d5-4854-aff7-211002d0dfca",
+      "groupUuid": "ca00a0ee-a8a7-46e2-a47b-304f56a6027d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5467,8 +5467,8 @@
       }
     },
     {
-      "uuid": "1ab81e18-0b03-416b-9977-5b7c7633b403",
-      "groupUuid": "2bee07a0-abba-4eb3-b01b-eb0166ea667a",
+      "uuid": "0ff9e4bf-17a1-483b-a5ee-4d9426e2e0f0",
+      "groupUuid": "5b630942-c018-4779-ac3e-cfc8da2d2e47",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5477,8 +5477,8 @@
       }
     },
     {
-      "uuid": "09af395b-c5e8-4045-883d-582688147784",
-      "groupUuid": "a6d152e4-4325-4cc3-a308-7f70640a84d6",
+      "uuid": "f83571f3-a112-438b-b386-32a1f35bf443",
+      "groupUuid": "06ec32a6-7105-423e-9bd7-971eb53b34e6",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5486,8 +5486,8 @@
       }
     },
     {
-      "uuid": "9050b937-0d96-497a-af38-c7beda0473e4",
-      "groupUuid": "39fd65c1-ba8c-4742-9252-8040bd2efeb2",
+      "uuid": "aef5b607-97fd-4eba-80d1-eceb3e328c38",
+      "groupUuid": "12e80e60-3867-48e9-80fa-e4a48997f284",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5496,8 +5496,8 @@
       }
     },
     {
-      "uuid": "4f858130-55f9-4790-81e2-27d37a8531b2",
-      "groupUuid": "97f5a6b5-b081-48bc-ba54-7db3f11d9af9",
+      "uuid": "4b88b06a-df43-4bbe-b309-456ad939c023",
+      "groupUuid": "6b3a93f0-f3e5-4f36-8d71-eb93c99e0108",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5505,8 +5505,8 @@
       }
     },
     {
-      "uuid": "d0936bb6-3871-4bc1-81f8-ebf9a1f8de71",
-      "groupUuid": "65c4e669-0e51-4456-9d43-fdbeb3ea49f8",
+      "uuid": "1e3eac76-1ad8-42c3-a0c0-5added6d4e54",
+      "groupUuid": "12aeb885-899c-4b21-b481-44dc0f448073",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5515,8 +5515,8 @@
       }
     },
     {
-      "uuid": "36c00d42-7466-4da2-882c-2abae8747ecb",
-      "groupUuid": "caeac7d8-240f-43da-8cd6-0bbf111eedeb",
+      "uuid": "4769e9b1-1f21-4763-814d-c7f775f28fe9",
+      "groupUuid": "885eb38c-10d8-458b-8ed6-b2e98e6c7f61",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5524,8 +5524,8 @@
       }
     },
     {
-      "uuid": "1d886c80-f891-4064-ac02-cbae11a0aedd",
-      "groupUuid": "7463f1fa-07e1-4da1-834d-2a1e4fa2642b",
+      "uuid": "864480c0-3a45-494b-a688-6c9b2cb821de",
+      "groupUuid": "c0b6d261-797f-4225-adba-0f69d05d9d39",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5538,17 +5538,17 @@
       }
     },
     {
-      "uuid": "b5dbf919-5b28-4dd3-9ad6-d0bfa59dcba2",
-      "groupUuid": "d7beb072-9066-41de-b708-7a7f9fffef88",
+      "uuid": "d3b56e45-3f8e-4554-b4c9-0136917c3d4c",
+      "groupUuid": "d0053c5b-1f3f-4c56-9297-438c7ecdc2cb",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-2, block</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>What's a Drop-2?</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-2, block<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-2 (MED): derived from category='drop2' | block (MED): derived from category='drop2'</p><p><b>Drop-2:</b> A 4-note voicing built by taking a close-position chord and dropping the second-highest note an octave. <i>The bread-and-butter chord-melody and comping shape \u2014 clean, balanced, easy to voice-lead. Most jazz chord-solo arrangements live here.</i></p>"
       }
     },
     {
-      "uuid": "08e44e9b-b212-43c6-9887-dc908c364784",
-      "groupUuid": "5ad229b2-d16a-4ea5-ab1b-802191cf9f30",
+      "uuid": "5a9827c0-760b-4ba3-81e1-03497b144399",
+      "groupUuid": "4473be68-bfeb-485a-bf6f-a9e10a4f85c5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5556,8 +5556,8 @@
       }
     },
     {
-      "uuid": "29bde560-36a8-45ee-95a8-164bb46ea4d3",
-      "groupUuid": "c4bda2d6-a3cb-4a2d-a871-651850b867ca",
+      "uuid": "ebc5f149-8b67-46d7-811d-67966c4496da",
+      "groupUuid": "6faf0ead-4455-45db-a75c-7a2a901b0aab",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5568,8 +5568,8 @@
       }
     },
     {
-      "uuid": "abbf70ba-be90-4a03-b155-66d572238b7a",
-      "groupUuid": "c4bda2d6-a3cb-4a2d-a871-651850b867ca",
+      "uuid": "83a9e334-29c2-421a-8fb4-ca21111c9e22",
+      "groupUuid": "6faf0ead-4455-45db-a75c-7a2a901b0aab",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5580,8 +5580,8 @@
       }
     },
     {
-      "uuid": "41571d23-da16-4b6a-926f-97a7fc3c91ba",
-      "groupUuid": "c4bda2d6-a3cb-4a2d-a871-651850b867ca",
+      "uuid": "576e4954-4564-4d23-a3bb-9ab6662e54be",
+      "groupUuid": "6faf0ead-4455-45db-a75c-7a2a901b0aab",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5592,8 +5592,8 @@
       }
     },
     {
-      "uuid": "faa65171-2671-4a9c-9bee-e0baee873359",
-      "groupUuid": "177f496c-b078-4485-8857-10f7147205fd",
+      "uuid": "b2e89e86-32bb-4e0a-81c7-2e9e966cecef",
+      "groupUuid": "48c4e2b5-90f5-481c-8901-ed143af58733",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5601,8 +5601,8 @@
       }
     },
     {
-      "uuid": "9c3fe8a4-55bf-4500-aa9f-d16eb2e13b14",
-      "groupUuid": "07d2f48b-ee23-4f59-a732-063475669328",
+      "uuid": "11fbfbf3-798b-4bea-b212-b5b108195273",
+      "groupUuid": "12303571-f40a-414b-8b57-617659d434e8",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5611,8 +5611,8 @@
       }
     },
     {
-      "uuid": "09820335-5954-4e41-9b00-c7b712041849",
-      "groupUuid": "9f21dd31-ea4d-4e66-8842-27ebc7e1a632",
+      "uuid": "90d14761-8ebf-45b4-a2a5-c2bf268a2cd9",
+      "groupUuid": "03d9b604-04e2-430f-9e69-50b121d7fb26",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5620,8 +5620,8 @@
       }
     },
     {
-      "uuid": "ec4f41c7-10d8-4ec5-8658-60bc2f63555e",
-      "groupUuid": "96f974de-c060-4af3-832f-835c8b18d6a3",
+      "uuid": "86931574-d82d-4eb6-b45f-ef0a24cb1c19",
+      "groupUuid": "5cc9ba42-7f02-4e7d-8b2c-a482a48bdf25",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5630,8 +5630,8 @@
       }
     },
     {
-      "uuid": "55db9ad8-9d2c-4e65-92a1-be71f9703479",
-      "groupUuid": "07361fc1-be56-4a24-a364-833bcb291047",
+      "uuid": "709a662f-08d0-463e-9b9a-d5cdb6e8ed02",
+      "groupUuid": "eebc8714-1679-44c4-8e3b-7058d00e01df",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5639,8 +5639,8 @@
       }
     },
     {
-      "uuid": "63f4bf27-7b65-48d7-85c7-ff2ab96b613b",
-      "groupUuid": "9957ff05-c250-429e-a560-d4e20c74926a",
+      "uuid": "7d6d2802-5f7b-4ffd-baf7-c102404e3baa",
+      "groupUuid": "058e5f27-7218-4d8e-983b-c278d5eb776f",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5649,8 +5649,8 @@
       }
     },
     {
-      "uuid": "5014f0c5-4305-47a1-8ba1-53806d953b10",
-      "groupUuid": "45a4e31f-9431-439d-bb38-dc507b688fc9",
+      "uuid": "8b750c28-6bfd-4ee3-832e-a359a9593b75",
+      "groupUuid": "5b76215a-eefd-4afe-b358-039a49a460f2",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5658,8 +5658,8 @@
       }
     },
     {
-      "uuid": "8930519d-f411-459e-9dba-c4962d1b18b0",
-      "groupUuid": "a94dbdf6-6695-48a7-ac56-4476f7c4d5e9",
+      "uuid": "cdfe0d30-a8e2-4877-9eb1-ae1bd4c08ed9",
+      "groupUuid": "f56566ab-ecd1-4c24-9b13-3562a5c41feb",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5672,17 +5672,17 @@
       }
     },
     {
-      "uuid": "8a36a1f6-c79f-4e19-82f2-03109380faa0",
-      "groupUuid": "86fed215-65a3-4e42-a766-ced8fd28dbef",
+      "uuid": "19ae1122-16e7-461b-aabf-56cb7100f9f4",
+      "groupUuid": "31521380-6d95-4638-a64e-0aba72683407",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>drop-3, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: drop-3, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> drop-3 (MED): existing tag 'drop-3' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['jody-fisher', 'joe-pass'] | van-eps (HIGH): existing voi\u2026</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "eca3a963-1cd7-4e5c-bd79-c87830fce9ea",
-      "groupUuid": "a9998ede-2633-46ad-81ae-fa8dd38125a6",
+      "uuid": "ceaf49db-4b78-428c-852e-3437db3abd18",
+      "groupUuid": "d6dce634-23d6-411c-9259-767c08e0e387",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5690,8 +5690,8 @@
       }
     },
     {
-      "uuid": "f86421be-0f12-4933-b372-839916939e13",
-      "groupUuid": "7590e0f1-fb7a-4a98-865e-288697f04cf3",
+      "uuid": "4986e2a7-0a34-45ad-a0ea-8142f9476124",
+      "groupUuid": "5ce4ec03-ae1d-4ccd-bc40-96a9dc737615",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5702,8 +5702,8 @@
       }
     },
     {
-      "uuid": "1768aa45-ffe0-4632-ad17-8bb689d4609c",
-      "groupUuid": "7590e0f1-fb7a-4a98-865e-288697f04cf3",
+      "uuid": "bb2dff53-e251-4752-a183-5a2422616779",
+      "groupUuid": "5ce4ec03-ae1d-4ccd-bc40-96a9dc737615",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5714,8 +5714,8 @@
       }
     },
     {
-      "uuid": "337d3c92-9ccc-44fc-a088-87d09053add1",
-      "groupUuid": "7590e0f1-fb7a-4a98-865e-288697f04cf3",
+      "uuid": "dcacda22-6a6c-4e13-a7b1-00c90ba7ded2",
+      "groupUuid": "5ce4ec03-ae1d-4ccd-bc40-96a9dc737615",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5726,8 +5726,8 @@
       }
     },
     {
-      "uuid": "3ce5b78f-5bd8-49e8-bf02-10da3c0d0e01",
-      "groupUuid": "43418907-33e2-4f8f-9fb3-cb24db1e9dca",
+      "uuid": "03e16a0f-d553-4a04-986e-0b18e4c44d43",
+      "groupUuid": "443d3cf9-4c92-4573-b409-1e05c8521286",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5735,8 +5735,8 @@
       }
     },
     {
-      "uuid": "6e572a18-2268-4e8a-aaa0-51f6360935e2",
-      "groupUuid": "7aaf18c2-4934-49b5-904a-acc7768d08e0",
+      "uuid": "a574965a-6310-486a-b0b8-622ef4e283f7",
+      "groupUuid": "845f39fa-e660-48d3-bfd6-e09670318a4b",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5745,8 +5745,8 @@
       }
     },
     {
-      "uuid": "7ba21ae9-e25a-45ba-90e9-3bf5b59e0653",
-      "groupUuid": "8f6cb847-6161-489a-a695-432ee8abbaa1",
+      "uuid": "554a6c96-2b05-4b01-a9d1-ac05e29e99ca",
+      "groupUuid": "1cf06ea6-a04a-42e7-afea-744f4807a8b1",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5754,8 +5754,8 @@
       }
     },
     {
-      "uuid": "e12434cb-907d-4b58-98a8-2a42fced6929",
-      "groupUuid": "8e09e398-edde-4728-97fd-6a86f001281e",
+      "uuid": "2af9505e-72f7-47f1-837d-3c2b999d9f07",
+      "groupUuid": "b9b0ef5d-ef7a-4646-90a2-6127daae051c",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5764,8 +5764,8 @@
       }
     },
     {
-      "uuid": "024453ac-c6df-44cc-983c-d0945311a0f5",
-      "groupUuid": "140ce1ed-3194-4e6f-a609-1f6dd0f7e455",
+      "uuid": "dc039a4a-01d8-4c8a-a4e4-a2e95ac6737c",
+      "groupUuid": "114d2392-e168-48e5-932a-d1e4e1556397",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5773,8 +5773,8 @@
       }
     },
     {
-      "uuid": "7a94ed82-15ac-4957-ad01-2de8fdeb5377",
-      "groupUuid": "fb2d944b-7227-4535-80c5-4200ad0c1934",
+      "uuid": "329552ed-1370-403c-b617-9fbcf333b6df",
+      "groupUuid": "7668cd28-6d2b-4507-b914-95b8c5507c59",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5783,8 +5783,8 @@
       }
     },
     {
-      "uuid": "7a6a2a46-6217-4d46-a0e3-1f46996c7346",
-      "groupUuid": "07d119ce-e072-41a0-b47d-ed69d172439c",
+      "uuid": "936e2a42-f588-4d79-8472-b00b59f49a69",
+      "groupUuid": "ad623214-a6e1-44f5-9f3a-7385dc8aac38",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5792,8 +5792,8 @@
       }
     },
     {
-      "uuid": "0c47a87b-4292-4a83-9d57-f32c4f5061a7",
-      "groupUuid": "6dbe987e-59d0-4b9f-a745-d6c920cceece",
+      "uuid": "480b04c7-6a63-453c-b702-b2e0352d48ee",
+      "groupUuid": "8aed139d-1b60-47df-9411-2a771a4a2c0c",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5806,17 +5806,17 @@
       }
     },
     {
-      "uuid": "7227c6b5-5a8a-4145-901e-d711fb723b5b",
-      "groupUuid": "c7e15df4-0c77-463b-9e22-b32558dd57c1",
+      "uuid": "d5fe6287-6ff2-414d-bb96-3c56049976fc",
+      "groupUuid": "4cec79bc-d9ce-43d0-a713-4a52446d6f69",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>drop-3</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>What's a Drop-3?</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b></p><ul><li><code>drop-3</code> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: drop-3<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> drop-3 (MED): derived from category='drop3'</p><p><b>Drop-3:</b> Like drop-2, but the THIRD-highest voice is dropped an octave \u2014 producing a wider, more open spread across the strings. <i>Bigger sound, more piano-like. Common when you want a bass note to ring under a chord-melody phrase.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>drop-3</b> \u2014 Pass's typical chord-melody technique harmonizes the melody with drop-2 and drop-3 voicings. Drop-2 keeps melody on top of a 4-note voicing on adjacent strings; drop-3 spreads the voicing wider with a 'skip' in the middle.</p>"
       }
     },
     {
-      "uuid": "201f3526-b062-4bce-9700-129b389d3f98",
-      "groupUuid": "ae22d6d6-f6ed-4777-8dac-97e542cb33bc",
+      "uuid": "878c6c97-6bec-4fdf-b2fe-c7448560bf79",
+      "groupUuid": "b0f3ca72-eaa0-4a66-886a-e1438fe30a82",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5824,8 +5824,8 @@
       }
     },
     {
-      "uuid": "ac25c8f3-ff23-4457-8f80-8a454597f8b2",
-      "groupUuid": "5e96655f-8a87-44cd-8929-dac5ac8d13ed",
+      "uuid": "461e53b8-6aff-442d-8133-3bef543db62c",
+      "groupUuid": "4ce25941-d3a6-4692-b722-ca1d2e6c0d9a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5836,8 +5836,8 @@
       }
     },
     {
-      "uuid": "f30c1985-6349-4d9e-ad96-6db0bf376c9a",
-      "groupUuid": "5e96655f-8a87-44cd-8929-dac5ac8d13ed",
+      "uuid": "de1906f8-f5c2-4a67-bc32-047be6b505cc",
+      "groupUuid": "4ce25941-d3a6-4692-b722-ca1d2e6c0d9a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5848,8 +5848,8 @@
       }
     },
     {
-      "uuid": "2b6cb2dd-4ad0-4b3e-92d9-b181a9472516",
-      "groupUuid": "5e96655f-8a87-44cd-8929-dac5ac8d13ed",
+      "uuid": "80d3536e-909b-4269-b6d2-083c62d5c9cf",
+      "groupUuid": "4ce25941-d3a6-4692-b722-ca1d2e6c0d9a",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5860,8 +5860,8 @@
       }
     },
     {
-      "uuid": "724e60d4-d1d9-474d-a146-d1f5435dab5b",
-      "groupUuid": "0ff436e3-4386-4144-ae70-d0b7e330aa7c",
+      "uuid": "425b1552-b3d0-4ad0-a1d4-1e92583fc4b4",
+      "groupUuid": "ef3d12a3-36b8-4ae4-a5f6-01713fed24a4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5869,8 +5869,8 @@
       }
     },
     {
-      "uuid": "6ddfb77d-ef35-469f-be66-a10e980d07e6",
-      "groupUuid": "b6867300-cbda-4d0c-a2ea-b999b218e6d0",
+      "uuid": "04a0d5ac-7483-4fba-b68c-d7a0259ae989",
+      "groupUuid": "427188f0-4a73-40c9-a0b6-3ccc3e41eaf9",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5879,8 +5879,8 @@
       }
     },
     {
-      "uuid": "5e4eadd4-4306-426d-bbc2-75320d54d887",
-      "groupUuid": "7010b88a-2f79-4223-8317-c2c780140f61",
+      "uuid": "93a09c6a-7d95-4c30-b201-1ba3fd135f9b",
+      "groupUuid": "7497269d-f5ea-4d24-b034-5f3cd5a91784",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5888,8 +5888,8 @@
       }
     },
     {
-      "uuid": "dba2df71-e99d-4161-985e-dbe0000fc685",
-      "groupUuid": "5ce5a50e-316c-45b4-b80c-75b7b3328645",
+      "uuid": "e0d7447a-f2d8-47b6-8d3f-039299b01878",
+      "groupUuid": "1f99912a-a917-454b-945c-3966c4f81827",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -5898,8 +5898,8 @@
       }
     },
     {
-      "uuid": "c38a38fa-4d38-4cee-97ae-4401df21829e",
-      "groupUuid": "4a53bf3f-8916-49cf-ba8c-0d44cc088785",
+      "uuid": "58e2d90e-4a61-47d6-a980-6cb42945c13c",
+      "groupUuid": "bf32827a-803c-4055-a90c-9e5e636e2f4f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5907,8 +5907,8 @@
       }
     },
     {
-      "uuid": "6d6f34fd-8fef-400c-aad7-fd3fb7d0d579",
-      "groupUuid": "b5221a10-1849-4057-a7e0-d532ed0070ab",
+      "uuid": "612e669e-3179-40e4-979c-974e66a5ad31",
+      "groupUuid": "85b4d341-2782-41de-a756-24ca135b17e6",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -5917,8 +5917,8 @@
       }
     },
     {
-      "uuid": "545934d4-4d49-407f-9836-be8bdc9a1907",
-      "groupUuid": "da1af38a-8c4e-40ca-a795-dd9a986741d2",
+      "uuid": "d640a381-5ce1-4032-bfc6-6e2059c919bb",
+      "groupUuid": "9e6f6fa5-c48c-4f1f-9842-29bc4da54207",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -5926,8 +5926,8 @@
       }
     },
     {
-      "uuid": "ee7ee4aa-ec6d-4b2d-8221-9e9eeded2538",
-      "groupUuid": "7f292128-5c27-45ad-970f-250a9a0f9962",
+      "uuid": "a5cbd23b-934a-471d-a9ae-24586740fe8b",
+      "groupUuid": "dcaee47b-20f5-4e70-845a-adb8ef0a01a7",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -5940,17 +5940,17 @@
       }
     },
     {
-      "uuid": "7bb665c3-5422-44bc-a664-c14838523497",
-      "groupUuid": "6a050cb4-6e6c-429c-8a8c-7d5f4acc291b",
+      "uuid": "c8f2ad72-c734-4042-806d-2dc943fcabe2",
+      "groupUuid": "a4440ba5-df6f-48ea-bad9-73d846e6c2d4",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>dirk-laukens, chord-function-driven, function-assigned, substitution-derivation</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b></p><ul><li><code>dirk-laukens</code> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.</li><li><code>chord-function-driven</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>function-assigned</code> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.</li><li><code>substitution-derivation</code> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: dirk-laukens, chord-function-driven, function-assigned, substitution-derivation<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> dirk-laukens (MED): master 'dirk-laukens' (id-as-tag) | chord-function-driven (MED): discriminating tag 'chord-function-driven' | function-assigned (MED): discriminating tag 'func\u2026</p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>dirk-laukens</b> \u2014 Laukens organizes his entire pedagogy \u2014 across the beginner method, the chord dictionary, the pattern volume, and the lick anthology \u2014 around moveable physical shapes.<br>\u2022 <b>chord-function-driven</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>function-assigned</b> \u2014 Across Laukens's catalog every melodic-vocabulary unit (scale, arpeggio, pattern, lick) is assigned to a chord function rather than to a chord-name-in-a-key.<br>\u2022 <b>substitution-derivation</b> \u2014 Laukens treats substitutions as derivable from a small set of named relations rather than as a memorized catalog.</p>"
       }
     },
     {
-      "uuid": "ba7d2d7a-42bf-4fd3-a7b2-499698af035b",
-      "groupUuid": "90e86a4c-8742-493c-a4fd-303da777dcc2",
+      "uuid": "208bcf71-fe09-4450-9e6c-3a02a3c98957",
+      "groupUuid": "0e1a2a63-e19f-4abe-a7db-b5557c100d49",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -5958,8 +5958,8 @@
       }
     },
     {
-      "uuid": "fd474796-60fc-4159-ae0e-dd66ae9505f3",
-      "groupUuid": "fc6eef54-2c64-45a5-bd9c-6b7a044ef126",
+      "uuid": "82e894bc-6079-4c79-8045-17bdacf99606",
+      "groupUuid": "fa879e3f-ef17-4ef6-a21d-d44315658d15",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5970,8 +5970,8 @@
       }
     },
     {
-      "uuid": "5e1c5c33-4a93-4ffd-94c9-93f64fa73b8c",
-      "groupUuid": "fc6eef54-2c64-45a5-bd9c-6b7a044ef126",
+      "uuid": "ac8d3950-cb88-48e7-88f8-8ea7f818da3d",
+      "groupUuid": "fa879e3f-ef17-4ef6-a21d-d44315658d15",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5982,8 +5982,8 @@
       }
     },
     {
-      "uuid": "24f0c243-1a11-47f8-af65-c10e10d1a2e9",
-      "groupUuid": "fc6eef54-2c64-45a5-bd9c-6b7a044ef126",
+      "uuid": "0edd31ce-5426-46ea-92e4-59cd8526b30b",
+      "groupUuid": "fa879e3f-ef17-4ef6-a21d-d44315658d15",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -5994,8 +5994,8 @@
       }
     },
     {
-      "uuid": "ec34fb62-92b9-4a53-8023-710c639b78d4",
-      "groupUuid": "ad89b391-e8e3-4164-a0ad-2aaba6dc777c",
+      "uuid": "bbb52e0e-67ed-40dc-bfef-529986bf5273",
+      "groupUuid": "25a971bf-7382-4115-a727-4b1b0410ea0f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6003,8 +6003,8 @@
       }
     },
     {
-      "uuid": "4d0a30a9-7461-43b1-8947-237c811a6d09",
-      "groupUuid": "ad37d2bc-b102-4441-9740-7552430d410a",
+      "uuid": "06a50699-b98a-40dc-a19c-78f88f04b611",
+      "groupUuid": "5fc0484d-a4c4-499a-a8b2-cee734c03aae",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6013,8 +6013,8 @@
       }
     },
     {
-      "uuid": "13baaed6-a364-439c-a0c3-3e78c5dfbc22",
-      "groupUuid": "4f7c1efe-e256-4aa4-8281-498a0ffa66de",
+      "uuid": "3844f4c5-10b7-457d-b74a-424160ffa15e",
+      "groupUuid": "f47ddb27-e17d-46d6-b002-51bfe89a61cb",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6022,8 +6022,8 @@
       }
     },
     {
-      "uuid": "db0ed09a-3c14-42cf-93dd-fb71c9f4a01f",
-      "groupUuid": "becdd511-75af-43b3-b95f-78cbab57b440",
+      "uuid": "f0169cca-235b-4256-a9cf-a891b6e25063",
+      "groupUuid": "6d438742-ef63-424b-b710-a6ce4814605b",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6032,8 +6032,8 @@
       }
     },
     {
-      "uuid": "81a8d3d3-d537-4803-909d-c4319ecb579c",
-      "groupUuid": "38cb7e7a-24fb-4e10-b509-0677e159929e",
+      "uuid": "4018d10d-4f10-409a-8b05-cc7830981494",
+      "groupUuid": "14145baf-f86f-4edb-8e75-ac65378779e9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6041,8 +6041,8 @@
       }
     },
     {
-      "uuid": "fae5b538-b09c-4211-bc2a-7829342c3738",
-      "groupUuid": "260aa4ab-c0ab-4e29-bc3b-6fff9918be36",
+      "uuid": "922c9d65-6d2b-4bbe-a625-792affc83ce4",
+      "groupUuid": "d041bd61-438b-47cf-836d-0aa1ac1b4070",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6051,8 +6051,8 @@
       }
     },
     {
-      "uuid": "a551a216-b895-497d-b031-3c78e2518691",
-      "groupUuid": "09660ddb-24d0-4560-a978-63e8288c9a02",
+      "uuid": "e7f45b69-58d5-4699-9732-f34ffeed8234",
+      "groupUuid": "a70e3a3a-d79f-466e-b867-7ed56d48e5b7",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6060,8 +6060,8 @@
       }
     },
     {
-      "uuid": "6a0e09aa-46c5-47a7-86c1-6f2b992b4372",
-      "groupUuid": "9fc9615f-360e-47fd-83e1-f97c466c2caa",
+      "uuid": "1dbb7722-b553-4449-bb33-866cf73f52bb",
+      "groupUuid": "b2684bc2-7be3-4acd-aa3a-519505e63718",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6074,17 +6074,17 @@
       }
     },
     {
-      "uuid": "f11ad451-5aff-4966-8191-41d5021800a6",
-      "groupUuid": "552bd68d-47d6-420c-aed6-90e2bcf4bca6",
+      "uuid": "8da4138e-99f3-4bee-95c2-b7a20da7a900",
+      "groupUuid": "f72cd882-7656-4c3c-8348-b2e49a467e85",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Extended voicing?</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Extended voicing:</b> A voicing that includes upper-structure extensions: 9th, 11th, 13th. <i>Rich, modern, harmonically saturated. Sounds 'jazzy' on a Cmaj7 vamp; sounds 'wrong' on a country progression.</i></p>"
       }
     },
     {
-      "uuid": "909dba01-bf7b-4795-9eac-d9940a9f2c1d",
-      "groupUuid": "9a82adb7-f7e2-467e-a22a-899afc9bd34b",
+      "uuid": "653a6710-416d-4b38-a214-75c128815579",
+      "groupUuid": "d64f4be9-bc36-486e-ad6f-958a8425176a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6092,8 +6092,8 @@
       }
     },
     {
-      "uuid": "fff1c901-c1cf-487e-9e68-9038ff9d1a06",
-      "groupUuid": "f1d57823-f3ee-4aa2-9cf1-ff7e9149a58c",
+      "uuid": "c60d606d-6c90-4b84-8787-a21ca0b46786",
+      "groupUuid": "ca3d6bd1-4824-47c9-9b72-76ff8a904aa4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6104,8 +6104,8 @@
       }
     },
     {
-      "uuid": "cb5ca320-bd54-4d64-a022-82edded71827",
-      "groupUuid": "f1d57823-f3ee-4aa2-9cf1-ff7e9149a58c",
+      "uuid": "8208ff15-dcca-4208-95ed-22648f4e39a0",
+      "groupUuid": "ca3d6bd1-4824-47c9-9b72-76ff8a904aa4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6116,8 +6116,8 @@
       }
     },
     {
-      "uuid": "7ce0ae3c-7849-4b0d-9f26-8f37de359b5f",
-      "groupUuid": "f1d57823-f3ee-4aa2-9cf1-ff7e9149a58c",
+      "uuid": "7d172894-ce8f-4968-a6ca-fa3327000547",
+      "groupUuid": "ca3d6bd1-4824-47c9-9b72-76ff8a904aa4",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6128,8 +6128,8 @@
       }
     },
     {
-      "uuid": "4c436030-17b6-4a40-a62f-1b4dde6bcc11",
-      "groupUuid": "6d6b3f6c-04a6-4c46-ba5a-e6de65ea9036",
+      "uuid": "0d2c4d8c-9d87-47ba-9b09-e180260e8ceb",
+      "groupUuid": "5adb08c9-3ecc-4c7d-b7a3-9a0c1b2509a4",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6137,8 +6137,8 @@
       }
     },
     {
-      "uuid": "b54aed9f-6531-4f5a-9ecb-bcfda7e40f4d",
-      "groupUuid": "bd1830e8-ac1d-4c24-bca2-de3644dbbe9c",
+      "uuid": "63684f95-d16c-44e2-87be-87139e490098",
+      "groupUuid": "687a3416-d241-4ea0-817d-b3b86e6a3b94",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6147,8 +6147,8 @@
       }
     },
     {
-      "uuid": "ad46080c-70e0-4642-8dc2-b4f9ec4f14ae",
-      "groupUuid": "7de015e2-6a32-43d6-91f7-be65b821fbee",
+      "uuid": "e19fa8f4-aee8-433b-953b-84399baeaa8a",
+      "groupUuid": "6ea4d04e-9f58-4ddc-8545-3f08fe035bb2",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6156,8 +6156,8 @@
       }
     },
     {
-      "uuid": "64c25568-a468-4ad7-9472-1a39411d3098",
-      "groupUuid": "2e990c04-1ce6-40ac-a2dd-04c382d773ba",
+      "uuid": "822cde7e-e59a-4607-b2eb-e572e3426bda",
+      "groupUuid": "03bcee3b-976a-48c7-8cec-727210140a38",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6166,8 +6166,8 @@
       }
     },
     {
-      "uuid": "ec5a938f-97e3-44ad-bfd4-9e3be8b2e567",
-      "groupUuid": "c159671c-9b66-4ea1-9ff5-b54c4cb5b6c7",
+      "uuid": "c9b0b6d6-ca95-4278-835a-6d6a8040eae1",
+      "groupUuid": "d6039076-8a8b-49d5-932f-fca118abb190",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6175,8 +6175,8 @@
       }
     },
     {
-      "uuid": "840aa818-2b98-4349-af75-525d53841d03",
-      "groupUuid": "a427f415-66f8-4fb3-8fef-c0588b7299b6",
+      "uuid": "aff11913-9a5b-4658-bdac-7d93945ff537",
+      "groupUuid": "cd89d5dd-10a7-4748-9070-0b3fe057852a",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6185,8 +6185,8 @@
       }
     },
     {
-      "uuid": "b1efcdff-5106-4640-85a2-9e2c87bda099",
-      "groupUuid": "05391e58-8d2a-4fc1-8418-8bff585cad1e",
+      "uuid": "f52eaed5-ea47-4e01-9d95-52beed92d641",
+      "groupUuid": "a24a7bf8-b8db-49a4-a374-fa5961b8450d",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6194,8 +6194,8 @@
       }
     },
     {
-      "uuid": "8be39843-5bc0-4e5c-9a58-5fc82302fb12",
-      "groupUuid": "cb4b67d6-6a81-4c68-9f20-ea664f02a870",
+      "uuid": "d62686a1-f032-4a5e-8100-96309dbdabc2",
+      "groupUuid": "98bcd000-0594-4a8b-a57d-a4b6fbaf32b2",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6208,17 +6208,17 @@
       }
     },
     {
-      "uuid": "6bc89d8d-b93b-4bc6-97ff-f92a3ca78709",
-      "groupUuid": "65060685-bb58-4585-bdc2-be8316130729",
+      "uuid": "ae146921-5830-49ac-adc1-b0f7b68a5001",
+      "groupUuid": "db92572b-48c8-4acf-a963-862faeba9ef1",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>quartal</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>What's a Quartal voicing?</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b></p><ul><li><code>quartal</code> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: quartal<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> quartal (HIGH): existing voicing.tags='quartal' matches master voicingStyleTag (attributes to ['jim-hall'])</p><p><b>Quartal voicing:</b> A voicing built by stacking perfect-fourths rather than thirds. <i>Open, ambiguous, modern. Doesn't commit to a single tonality \u2014 perfect for modal contexts and McCoy Tyner / Jim Hall sounds.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>quartal</b> \u2014 Hall's signature 'fourths' sound: voicings built from stacked perfect fourths rather than triadic thirds \u2014 beautiful and harmonically ambiguous, doesn't commit to a single tonality. Often complemented with bass notes for grounding and counter-melodies on top.</p>"
       }
     },
     {
-      "uuid": "a6fd2644-8ae3-4199-8bd4-5eef3a35f500",
-      "groupUuid": "94d4d0c7-e370-48c2-8ce6-431649a467bf",
+      "uuid": "c515b07c-ebd8-491b-a574-1f67e9f1c813",
+      "groupUuid": "34ae0cfa-c7cb-4478-8fa7-7d1cf4b44098",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6226,8 +6226,8 @@
       }
     },
     {
-      "uuid": "0be29414-7d0e-4002-8813-9785d15d4f77",
-      "groupUuid": "704e0633-d4e7-42f9-996f-8a571ed360ef",
+      "uuid": "1482809a-3302-43fa-a16b-78ca488084b3",
+      "groupUuid": "f4539e57-6e7e-4fa5-ac30-9123e7535869",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6238,8 +6238,8 @@
       }
     },
     {
-      "uuid": "6ecb5c6c-7812-47b1-955b-ca6758aeb37f",
-      "groupUuid": "704e0633-d4e7-42f9-996f-8a571ed360ef",
+      "uuid": "4016f4db-5b0a-4a16-9445-ba099ce056ec",
+      "groupUuid": "f4539e57-6e7e-4fa5-ac30-9123e7535869",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6250,8 +6250,8 @@
       }
     },
     {
-      "uuid": "343f863b-077a-41b2-99fb-3c23e4417958",
-      "groupUuid": "704e0633-d4e7-42f9-996f-8a571ed360ef",
+      "uuid": "3881d88a-1246-4c39-813e-e20aa4d7d0ce",
+      "groupUuid": "f4539e57-6e7e-4fa5-ac30-9123e7535869",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6262,8 +6262,8 @@
       }
     },
     {
-      "uuid": "84d93005-a3ae-4cac-a071-071122a1a04d",
-      "groupUuid": "1b6c60ce-9270-4366-b38c-697767d7c2e1",
+      "uuid": "60db93d3-c87f-4798-95e7-75347bb213af",
+      "groupUuid": "69912b2d-b260-42ae-ba8a-8d7ba150d590",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6271,8 +6271,8 @@
       }
     },
     {
-      "uuid": "a183bd6e-87c7-413f-a75b-8c5e21d47844",
-      "groupUuid": "a4dbde33-6fc5-44b1-a1ed-2f724b69765d",
+      "uuid": "8f3a8d17-5ca6-4a6a-b3ed-4f3a3b173fc6",
+      "groupUuid": "f65f1b63-2f5d-405f-bc78-8b5513bc3e9c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6281,8 +6281,8 @@
       }
     },
     {
-      "uuid": "529fc60d-b9db-4a44-b70c-7d04cfb48ae3",
-      "groupUuid": "99fb1604-a407-4995-b1e7-64990938bf04",
+      "uuid": "671729ac-053f-4ec7-ba2a-6eabb0d81652",
+      "groupUuid": "d3a11a1c-f474-40a3-977d-8516eb45c14d",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6290,8 +6290,8 @@
       }
     },
     {
-      "uuid": "c2d81e2f-fb38-4f7d-a656-3a6ba2e1191e",
-      "groupUuid": "c44d20e2-7376-4484-9adc-7b0b90b4a94e",
+      "uuid": "f3168061-de6f-4325-9337-39e5a3ed80a1",
+      "groupUuid": "1fe5887d-98a8-448a-8b5b-897745da24bd",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6300,8 +6300,8 @@
       }
     },
     {
-      "uuid": "48682b63-e86e-471f-9eee-095702696a00",
-      "groupUuid": "6d1aabc3-18d8-4297-802c-9c86a1229720",
+      "uuid": "351ba922-41ae-463f-94e7-a6124b46d0a6",
+      "groupUuid": "70230430-cd27-4561-83f9-eb0985613615",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6309,8 +6309,8 @@
       }
     },
     {
-      "uuid": "af5a2953-a99c-48e6-ad7f-682a85eae722",
-      "groupUuid": "db2a41e3-fdb2-4d15-a512-0ebc185604c7",
+      "uuid": "22496c31-bacc-41c7-a2df-9325c3d290a4",
+      "groupUuid": "610184f7-ba80-44ef-a040-855a6e299a25",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6319,8 +6319,8 @@
       }
     },
     {
-      "uuid": "1e21129f-c7d9-4823-9137-40d43c6111e4",
-      "groupUuid": "8af6d100-8bb0-4c2d-8c13-75bcbe5d836d",
+      "uuid": "e3b2ffd6-832f-4b11-bc7f-31cb17c0b6d4",
+      "groupUuid": "ceda7468-1688-4979-a0ba-64f99c872c42",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6328,8 +6328,8 @@
       }
     },
     {
-      "uuid": "61ccf572-dbca-4def-a666-8a2ec822f60a",
-      "groupUuid": "a2de9bb9-9fba-4646-a261-046ffb2798ae",
+      "uuid": "a667be02-e1a8-461e-8e2c-f5a60ab5a77c",
+      "groupUuid": "11ae52fa-5392-41af-9eb7-12c5f4fbb6ea",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6342,17 +6342,17 @@
       }
     },
     {
-      "uuid": "9b7864ff-7fb1-4dfa-9a1a-e1d76169db80",
-      "groupUuid": "433fd460-d45d-446b-89e2-7d79615cebef",
+      "uuid": "724f7c36-ec83-4b67-9ca3-0c317c6b5531",
+      "groupUuid": "e4464303-1ecc-4f7e-b9e0-9b0e3a3e1024",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell, van-eps</code><br>playStyle: <code>(none)</code><br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li><li><code>van-eps</code> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell, van-eps<br>playStyle: (none)<br>confidence: <b>HIGH</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' (generic descriptor) confirmed by master signal in same voicing; vocab attributes to ['peter-bernstein'] | van-eps (HIGH): existing voicing.tags=\u2026</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.<br>\u2022 <b>van-eps</b> \u2014 Every chord-quality category in Van Eps's method begins by harmonizing the corresponding scale in triads. Major chords (Ex. 1-25) start with the harmonized major scale in triads; minor chords (Ex. 26-32) with the harmonized minor; 7th chords (Ex.</p>"
       }
     },
     {
-      "uuid": "59c1bd16-9003-4478-9dfc-a35e6cc1eb39",
-      "groupUuid": "1c51b7ec-ccef-4f02-aa01-6d3a5a8a7c2f",
+      "uuid": "8241a8a2-4ea5-4db2-b875-bc3ec4d08802",
+      "groupUuid": "6fc155bd-497c-4779-b750-2bd835e4ccce",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6360,8 +6360,8 @@
       }
     },
     {
-      "uuid": "0cfda9df-a9d6-4f18-b075-bdf420d9550e",
-      "groupUuid": "098a2284-1219-4a9d-85e6-a26b79386ea3",
+      "uuid": "fd512863-3663-4ad5-a2be-6d85ee0b89cc",
+      "groupUuid": "33406d61-5506-42c3-a2f7-43c85062f2b8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6372,8 +6372,8 @@
       }
     },
     {
-      "uuid": "0a939a50-18cd-4378-8066-6532f59dddf4",
-      "groupUuid": "098a2284-1219-4a9d-85e6-a26b79386ea3",
+      "uuid": "c6f90671-fa3f-4483-b6f4-a8c82b429db4",
+      "groupUuid": "33406d61-5506-42c3-a2f7-43c85062f2b8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6384,8 +6384,8 @@
       }
     },
     {
-      "uuid": "b0b8896f-7191-4cf5-a766-c9ad58658460",
-      "groupUuid": "098a2284-1219-4a9d-85e6-a26b79386ea3",
+      "uuid": "0a31e1f5-88ce-4fb1-9eeb-5ad1514d696e",
+      "groupUuid": "33406d61-5506-42c3-a2f7-43c85062f2b8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6396,8 +6396,8 @@
       }
     },
     {
-      "uuid": "8e4a538b-efc1-447f-a9cf-47eb9bca26b2",
-      "groupUuid": "c6c9a0ad-69fd-4a2d-95d3-acedfdb06bd8",
+      "uuid": "bda872a1-1930-42a5-8792-d25c57576422",
+      "groupUuid": "c82e6837-0af6-4ad4-afde-f69fa9fadc21",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6405,8 +6405,8 @@
       }
     },
     {
-      "uuid": "b41ce938-ce6c-495a-a31f-4467500f6351",
-      "groupUuid": "b85daed8-c727-430f-9357-5ec6d739a0be",
+      "uuid": "4bf1a0c2-55c2-4882-b87b-637d2685dff1",
+      "groupUuid": "10f0b737-3814-44da-8b13-a0bcc567c163",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6415,8 +6415,8 @@
       }
     },
     {
-      "uuid": "1e7de301-5f48-490f-a87b-caf09cef4610",
-      "groupUuid": "8d9e418a-f6ae-449a-ad7c-5c549365acf8",
+      "uuid": "7eb3be23-559d-480d-9017-55aba503a50b",
+      "groupUuid": "26deb945-c763-40b5-a210-eaba8a9d25b5",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6424,8 +6424,8 @@
       }
     },
     {
-      "uuid": "90b1aaac-f93c-4855-ab63-078991e1bd17",
-      "groupUuid": "516cc31a-91df-4d3a-88db-98ddeecc5928",
+      "uuid": "e64eba5b-9749-4930-a156-de2efe49c462",
+      "groupUuid": "7f31c23b-954d-4e26-8fad-16069925b11f",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6434,8 +6434,8 @@
       }
     },
     {
-      "uuid": "7d4182a0-dc75-42c3-b489-dac3aea9b1b2",
-      "groupUuid": "079ba583-5215-42ca-98cf-d1b61eb333bf",
+      "uuid": "a6af2496-3ab6-4199-b52f-7295d7e9afd5",
+      "groupUuid": "1a18fd68-4ce1-4a55-9f8c-4df75b6c5bf9",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6443,8 +6443,8 @@
       }
     },
     {
-      "uuid": "2f659ca6-2888-4385-9b96-bf315e49b17e",
-      "groupUuid": "94c20900-565a-4a6e-ae46-5f9857546e46",
+      "uuid": "985add9f-85fc-4597-8072-1ce958022a71",
+      "groupUuid": "909906cc-8649-4c2b-8c91-1395a8328ee7",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6453,8 +6453,8 @@
       }
     },
     {
-      "uuid": "abcb3631-5877-4137-8f93-f3c08481dbc1",
-      "groupUuid": "9f7e70ae-ddb1-434c-ae81-b661587bebfa",
+      "uuid": "856f9f68-2e5f-4a1d-a623-868995f0c7ad",
+      "groupUuid": "fd588b83-eca1-440f-89b8-48a580029a8c",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6462,8 +6462,8 @@
       }
     },
     {
-      "uuid": "138d1b2f-d5fe-493a-a4fd-fc713fd2f4d9",
-      "groupUuid": "fef187dd-d37f-4366-9c19-a20f2afbe6cc",
+      "uuid": "0b08c556-d0b8-45f8-bc1d-531fb8830663",
+      "groupUuid": "5fd7f2f3-3ed0-4f39-ba2f-d6062fd4e607",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6476,17 +6476,17 @@
       }
     },
     {
-      "uuid": "ad87620d-c36d-4d7b-b605-629fe65d7fbf",
-      "groupUuid": "767c24a6-e97d-4f0a-b58c-5cc29e34d9a8",
+      "uuid": "3aca20be-9170-4e6e-9f65-b3ae6a756919",
+      "groupUuid": "4cb1ebdd-862b-4a08-89a1-cfbfcda57ae0",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>shell</code><br>playStyle: <code>(none)</code><br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b></p><ul><li><code>shell</code> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</li></ul>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: shell<br>playStyle: (none)<br>confidence: <b>MED</b></p><p><b>Reasoning:</b> shell (MED): existing tag 'shell' + category=shell + quality='dom7' matches bernstein R-3-7 shell principle</p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p><p><b>Tag definitions:</b><br>\u2022 <b>shell</b> \u2014 The melody-first hierarchy applied to accompaniment: comping's job is to give each melody note the right outfit so it feels important.</p>"
       }
     },
     {
-      "uuid": "4cd044ad-2ea6-497e-b4e5-1fc6c156497b",
-      "groupUuid": "9c53ed60-353a-4458-97e9-f0bc288bffb2",
+      "uuid": "c8e2bb3c-9310-46ff-b96e-eb164e817844",
+      "groupUuid": "93fbd306-d9be-4b51-9ee4-4b5f51967f50",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6494,8 +6494,8 @@
       }
     },
     {
-      "uuid": "07ecfc71-2384-4cec-8daf-c5ca21c1d550",
-      "groupUuid": "9899d3a1-f413-4f54-9aa8-97e5c5b422dd",
+      "uuid": "b1f0690c-058c-492b-8974-421e1dd42200",
+      "groupUuid": "78b219dd-12f8-49c3-b87c-ff8860fcbb28",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6506,8 +6506,8 @@
       }
     },
     {
-      "uuid": "2b80989a-5ee1-42b0-b69d-e8c98ad51778",
-      "groupUuid": "9899d3a1-f413-4f54-9aa8-97e5c5b422dd",
+      "uuid": "6b94c1ff-63fe-4ce7-bc3a-277a2967583f",
+      "groupUuid": "78b219dd-12f8-49c3-b87c-ff8860fcbb28",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6518,8 +6518,8 @@
       }
     },
     {
-      "uuid": "8efc7b69-b836-4595-94ee-8dcc5f32cb6f",
-      "groupUuid": "9899d3a1-f413-4f54-9aa8-97e5c5b422dd",
+      "uuid": "2163a011-9405-44af-b988-f3d94aeeac7a",
+      "groupUuid": "78b219dd-12f8-49c3-b87c-ff8860fcbb28",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6530,8 +6530,8 @@
       }
     },
     {
-      "uuid": "0e1d83f7-83ad-4b3b-b886-191edb242730",
-      "groupUuid": "7a025ff3-34d7-43aa-a526-29832302213b",
+      "uuid": "4460418e-c771-4640-872a-5466c94a9fa5",
+      "groupUuid": "092a0981-26ca-492b-809c-ff5ec6301290",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6539,8 +6539,8 @@
       }
     },
     {
-      "uuid": "9fb4f010-3273-4882-9c36-4628f65d190c",
-      "groupUuid": "25c0963d-3129-4d64-af9f-1853aae5f3ca",
+      "uuid": "5e70729a-0084-4c8c-962d-bc438f80096f",
+      "groupUuid": "3ce1a568-3bcb-4308-9d23-1dc73d216437",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6549,8 +6549,8 @@
       }
     },
     {
-      "uuid": "440e175c-4d1b-4cc6-9080-b18d7cedba71",
-      "groupUuid": "3bd825a1-2fe6-4db8-aff5-ebde3daf4df1",
+      "uuid": "0eee1d9f-4143-48c2-9f12-01275f590048",
+      "groupUuid": "cbb5fcba-2e03-4af3-9c16-8477adb42c20",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6558,8 +6558,8 @@
       }
     },
     {
-      "uuid": "4e017148-7f03-4141-ae4b-b615177553f2",
-      "groupUuid": "f39d9170-afd4-4b5d-9e36-727f6b505778",
+      "uuid": "1e5d6333-5433-411d-9799-b7bc43d37d28",
+      "groupUuid": "600d68a4-e21f-4a23-ae23-6f220f783003",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6568,8 +6568,8 @@
       }
     },
     {
-      "uuid": "e9ea24e0-cc1d-484a-9ac2-d9df709806a3",
-      "groupUuid": "148e45db-c000-4718-af66-2ffaaab64e11",
+      "uuid": "671af0c0-55f4-446f-a603-dae6b99b3a01",
+      "groupUuid": "d683af21-0fdc-4b05-b6ba-c7d572f31341",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6577,8 +6577,8 @@
       }
     },
     {
-      "uuid": "76491286-10a2-420c-8199-988bc6c0a5bf",
-      "groupUuid": "2368052b-bd4c-4606-ad9f-4947dce81d10",
+      "uuid": "8675a382-2031-4688-a054-852118d6319f",
+      "groupUuid": "df910712-c896-4eef-b8b9-29570fa448aa",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6587,8 +6587,8 @@
       }
     },
     {
-      "uuid": "bbbeb133-26c9-43b0-a447-0b8af7295629",
-      "groupUuid": "7dd991fc-1672-4db8-96d6-1621ae6c3f91",
+      "uuid": "134941b6-fe93-4dc3-aecd-30669a854fd6",
+      "groupUuid": "5352d965-db77-4f22-8a56-a10959f5c00e",
       "groupType": "TITLE",
       "type": "TITLE",
       "payload": {
@@ -6596,8 +6596,8 @@
       }
     },
     {
-      "uuid": "a4b10f3d-7891-44d5-8ec3-1b8bb77cca75",
-      "groupUuid": "38b69232-4e07-44ee-b804-605142b9faba",
+      "uuid": "2ae7f7cf-6f52-4b00-aa15-ddb7f72dbaa7",
+      "groupUuid": "76720b98-8413-43a9-91ef-4ecd549062dd",
       "groupType": "IMAGE",
       "type": "IMAGE",
       "payload": {
@@ -6610,17 +6610,17 @@
       }
     },
     {
-      "uuid": "b42b974d-c539-498d-8406-960f1a770e17",
-      "groupUuid": "54475ea7-c57f-4cb0-aa27-b60752c72bdc",
+      "uuid": "88af2fbc-a23d-4d46-bd7a-08d6ed495b73",
+      "groupUuid": "08af28b0-a59f-43a5-a747-d40f80f8658c",
       "groupType": "TEXT",
       "type": "TEXT",
       "payload": {
-        "html": "<p><b>Agent proposed:</b><br>voicingStyle: <code>(none)</code><br>playStyle: <code>(none)</code><br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>What's a Shell voicing?</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
+        "html": "<p><b>Agent proposed:</b><br>voicingStyle: (none)<br>playStyle: (none)<br>confidence: <b>NONE</b></p><p><b>Reasoning:</b> </p><p><b>Shell voicing:</b> A skeleton voicing \u2014 usually just the root, third, and seventh (R-3-7) \u2014 with no fifth or extensions. <i>Minimal, dry, leaves space. Common in bebop comping and as a starting point that you 'dress' with extensions and tensions.</i></p>"
       }
     },
     {
-      "uuid": "30f24f85-4886-4c4e-bd07-306c8c2ab38e",
-      "groupUuid": "84ef4ad1-7070-4e78-8933-59d6d3e6c2f9",
+      "uuid": "cf53c91c-3443-4d75-9f99-8b380e40b0a0",
+      "groupUuid": "9c7d10da-9ebb-4586-9084-ecd1159ccf72",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6628,8 +6628,8 @@
       }
     },
     {
-      "uuid": "3dff64be-2aa4-4a63-a47b-e9085158abb3",
-      "groupUuid": "7db5082e-ef48-47f2-a7b2-3b1d07f8523f",
+      "uuid": "d2fe9bb5-4b9c-4fd6-8fd0-0d29a87209d5",
+      "groupUuid": "ebe4d0ab-7336-4d7a-8a0c-16c4f0306ba8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6640,8 +6640,8 @@
       }
     },
     {
-      "uuid": "0caba1d4-9b4c-48e7-a1f5-f222ed574aa4",
-      "groupUuid": "7db5082e-ef48-47f2-a7b2-3b1d07f8523f",
+      "uuid": "0c67be76-4ac1-47bd-8261-45a855455b17",
+      "groupUuid": "ebe4d0ab-7336-4d7a-8a0c-16c4f0306ba8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6652,8 +6652,8 @@
       }
     },
     {
-      "uuid": "46438fbb-444a-4953-a3d8-215744f0b925",
-      "groupUuid": "7db5082e-ef48-47f2-a7b2-3b1d07f8523f",
+      "uuid": "9a935ff0-5d0c-4fd1-a75d-673b87a9066c",
+      "groupUuid": "ebe4d0ab-7336-4d7a-8a0c-16c4f0306ba8",
       "groupType": "MULTIPLE_CHOICE",
       "type": "MULTIPLE_CHOICE_OPTION",
       "payload": {
@@ -6664,8 +6664,8 @@
       }
     },
     {
-      "uuid": "0794669d-7b98-4d56-9848-abdccc7201cf",
-      "groupUuid": "6cb7db04-4c04-4c24-8cf8-1b092110fc5c",
+      "uuid": "20d43338-13ef-4800-8de6-0aaf1579fd5f",
+      "groupUuid": "8f4b2250-3380-469c-b945-d3a7045f162f",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6673,8 +6673,8 @@
       }
     },
     {
-      "uuid": "d3022e43-8f76-4298-8c6e-184157827342",
-      "groupUuid": "82f125f4-954b-45f6-9875-3b4b5d33765f",
+      "uuid": "2e7ec320-b247-4498-9dcc-a092280cfddb",
+      "groupUuid": "2ef57dc0-bead-4c02-9295-5baa4b527269",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {
@@ -6683,8 +6683,8 @@
       }
     },
     {
-      "uuid": "781a5718-573f-464e-9f42-c9548cb0148d",
-      "groupUuid": "42dd7614-9b58-4aeb-928a-dd13e5a9d3d8",
+      "uuid": "1c0b89fb-e85a-40b5-9c43-c48f1f2da219",
+      "groupUuid": "96054515-87a1-456f-aa73-1163bf59894a",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6692,8 +6692,8 @@
       }
     },
     {
-      "uuid": "9ceddba7-d219-41c1-9cec-54909f6cbde1",
-      "groupUuid": "9567b408-bd0e-4499-8fef-8a7f915b326a",
+      "uuid": "d7f7519d-c3b0-4674-8be8-4f9ab616f97f",
+      "groupUuid": "dff5a6c4-7104-453c-a7dd-8d86052fe26f",
       "groupType": "INPUT_TEXT",
       "type": "INPUT_TEXT",
       "payload": {
@@ -6702,8 +6702,8 @@
       }
     },
     {
-      "uuid": "b00f1da1-f4a6-4170-ab0f-85755a14c53c",
-      "groupUuid": "b87d1eee-3c1f-4874-ab20-b96481fea6ab",
+      "uuid": "a124232c-d5a1-4ea6-ad8a-94fbdcc03b4c",
+      "groupUuid": "afc4f318-b74c-4e6b-86f1-acd495d045fa",
       "groupType": "QUESTION",
       "type": "TITLE",
       "payload": {
@@ -6711,8 +6711,8 @@
       }
     },
     {
-      "uuid": "ddf033f6-ed37-451f-932b-667ba2d9910e",
-      "groupUuid": "3e2fa313-e551-4e05-9c05-ce6990138b04",
+      "uuid": "8519b53d-86ac-438f-add9-99a460869671",
+      "groupUuid": "b010066d-8bbd-4df3-b105-638c9868cb6c",
       "groupType": "TEXTAREA",
       "type": "TEXTAREA",
       "payload": {


### PR DESCRIPTION
## Summary

Consolidated PR carrying both **#397 (Tally form builder)** + **#399 (data dictionary)** work. The original stacked PRs were closed during a base-branch cascade when PR #396's diagram branch was deleted on merge. This PR is functionally equivalent and rebased clean on `develop`.

Closes #393, #398, #395 (form-builder + dictionary subtasks). PR #396 already landed (diagrams).

## Stack content

| Commit | Source |
|---|---|
| `tooling(voicing-tags)(#395 subtask 2): Tally form builder + pilot-50 payload` | from closed PR #397 |
| `tooling(voicing-tags)(#395 subtask 2 fixup): match real Tally API block schema` | from closed PR #397 (live-POST debugging) |
| `content(voicing-tags)(#398): reviewer-facing data dictionary + form injection` | from closed PR #399 |
| `content(voicing-tags)(#398 fixup): drop Tally-unsupported HTML from form blocks` | from closed PR #399 |

## What lands

- `scripts/voicing-tags/tally-form-builder.py` — script that reads the pilot CSV + diagrams + dictionary and emits a Tally form payload; optional `--post` flag for live API
- `scripts/voicing-tags/tally-form-payload.json` — generated 50-voicing payload (652 blocks)
- `scripts/voicing-tags/build-data-dictionary.py` — reads `voicings.json` + `masters.json` + `voicings-tag-proposal.json` → emits dictionary
- `scripts/voicing-tags/data-dictionary.md` + `data-dictionary.json` — categories + master tags + principle tags + confidence levels

## Live-tested

Test form was created via the form builder (id `q4zkEG`); 3 voicings with fretboard diagrams + reasoning + tag definitions + YES/NO/REFINE + override-reason. Caught & fixed: Cloudflare-blocked urllib UA, wrong endpoint path, missing payload wrapper, wrong groupType, MULTIPLE_CHOICE-as-groupType, Tally TEXT block stripping `<code>`/`<ul>`/`<li>`.

## Refs

PR #396 (diagrams, merged) · #393 · #395 · #398 · #389/PR #390 · #391/PR #392 · #222 · #275
