### PR TITLE
feat(#400): engine_dump.js shim + js_runner refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@ __pycache__/
 .venv/
 venv/
 
+# Override the user-level ~/.gitignore rule `test_*.py` (line 84) which
+# silently drops pytest files from staging. The plugin's tests/ tree is
+# tracked; this negation makes that explicit for any new test file.
+# See siege-analytics/ellington-systems#1 post-error revision 2026-06-08
+# for the originating incident.
+!tests/test_*.py
+
 # OS
 .DS_Store
 Thumbs.db

--- a/scripts/engine_dump.js
+++ b/scripts/engine_dump.js
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+// engine_dump.js — Headless ranked-voicings emitter (#400).
+//
+// Loads the plugin's engine JS modules (ChordSelector + MastersStore +
+// ExclusionEngine) into a Node vm sandbox and invokes them to emit a
+// ranked-voicings JSON for one (chord × tuning × master) request to
+// stdout. Designed as the canonical oracle harness for the Ellington
+// Python port at siege-analytics/ellington-systems; also useful here as
+// a regression / smoke tool whenever _scoreCandidate or
+// MastersStore.collectVoicingStyleTags is edited.
+//
+// Loader semantics shared with tests/js_runner.js via tests/_jsLoader.js.
+//
+// USAGE
+//
+//   node scripts/engine_dump.js \
+//       --chord Cmaj7 \
+//       --tuning EADGBE \
+//       --master joe-pass \
+//       [--style chord-melody] \
+//       [--n-strings 6] \
+//       [--position-preference low] \
+//       [--no-master] \
+//       [--masters-path plugin/data/masters.json] \
+//       [--voicings-path plugin/data/voicings.json] \
+//       [--output -|FILE]
+//
+// EXIT CODES
+//
+//   0 — success; ranked_voicings JSON on stdout (or written to FILE)
+//   2 — argument error (unknown flag, missing required, parse failure)
+//   3 — corpus / file error (missing JSON file, malformed wrapper shape)
+//   4 — invalid master id (not present in masters.json)
+//
+// OUTPUT (one JSON object per invocation)
+//
+//   {
+//     "request": { "chord_symbol", "tuning", "master_id", "style_filter", "context" },
+//     "ranked_voicings": [
+//       { "voicing_id", "rank", "score",
+//         "score_components": { "base", "master_boost", "tolerance_match" },
+//         "payload_kind": null, "applied_principles": [] },
+//       ...
+//     ],
+//     "engine_version":   { "sha": "<short>", "clean": <bool> },
+//     "masters_version":  { "sha": "<short>", "clean": <bool> },
+//     "voicings_version": { "sha": "<short>", "clean": <bool> }
+//   }
+//
+// "payload_kind" and "applied_principles" are always null / [] because
+// the plugin's JS does not implement an engine_payload.kind dispatcher.
+// The Ellington Python port populates those fields on its own side.
+
+'use strict';
+
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+const { execSync } = require('child_process');
+const { createSandbox, loadModules } = require('../tests/_jsLoader');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_MASTERS = path.join('plugin', 'data', 'masters.json');
+const DEFAULT_VOICINGS = path.join('plugin', 'data', 'voicings.json');
+const MODEL_DIR = path.join(REPO_ROOT, 'plugin', 'model');
+
+// --------------------------------------------------------------------- argv
+
+function printUsageAndExit(code) {
+    process.stderr.write(
+        'Usage: node scripts/engine_dump.js --chord SYMBOL --tuning STR --master ID [opts]\n' +
+        '  --chord SYMBOL        (e.g. Cmaj7)\n' +
+        '  --tuning STR          (e.g. EADGBE)\n' +
+        '  --master ID           master id from masters.json\n' +
+        '  --no-master           score without master boost\n' +
+        '  --style ID            optional voicingStyleTag filter\n' +
+        '  --n-strings N         default 6\n' +
+        '  --position-preference low|mid|high   informational; not used in scoring today\n' +
+        '  --masters-path PATH   default plugin/data/masters.json\n' +
+        '  --voicings-path PATH  default plugin/data/voicings.json\n' +
+        '  --output FILE         "-" or omitted writes to stdout\n'
+    );
+    process.exit(code);
+}
+
+function parseArgs(argv) {
+    const out = {
+        chord: null,
+        tuning: null,
+        master: null,
+        noMaster: false,
+        style: null,
+        nStrings: 6,
+        positionPreference: null,
+        mastersPath: DEFAULT_MASTERS,
+        voicingsPath: DEFAULT_VOICINGS,
+        output: '-',
+    };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        const next = argv[i + 1];
+        switch (a) {
+            case '--chord':
+            case '--chord-symbol':
+                out.chord = next; i++; break;
+            case '--tuning':
+                out.tuning = next; i++; break;
+            case '--master':
+            case '--master-id':
+                out.master = next; i++; break;
+            case '--no-master':
+                out.noMaster = true; break;
+            case '--style':
+            case '--style-filter':
+                out.style = next; i++; break;
+            case '--n-strings':
+                out.nStrings = parseInt(next, 10); i++; break;
+            case '--position-preference':
+                out.positionPreference = next; i++; break;
+            case '--masters-path':
+                out.mastersPath = next; i++; break;
+            case '--voicings-path':
+                out.voicingsPath = next; i++; break;
+            case '--output':
+                out.output = next; i++; break;
+            case '--help':
+            case '-h':
+                printUsageAndExit(0); break;
+            default:
+                process.stderr.write('Unknown flag: ' + a + '\n');
+                printUsageAndExit(2);
+        }
+    }
+    if (!out.chord) { process.stderr.write('Missing --chord\n'); printUsageAndExit(2); }
+    if (!out.tuning) { process.stderr.write('Missing --tuning\n'); printUsageAndExit(2); }
+    if (!out.master && !out.noMaster) { process.stderr.write('Missing --master (or use --no-master)\n'); printUsageAndExit(2); }
+    if (out.master && out.noMaster) { process.stderr.write('Cannot combine --master with --no-master\n'); printUsageAndExit(2); }
+    if (isNaN(out.nStrings) || out.nStrings < 4 || out.nStrings > 12) {
+        process.stderr.write('--n-strings must be 4-12 inclusive\n');
+        printUsageAndExit(2);
+    }
+    return out;
+}
+
+// -------------------------------------------------------------------- chord
+
+// Mirror of Ellington's parse_chord_symbol — root is one of A-G plus
+// optional b/#, rest is quality. Lives here separately to keep the shim
+// dependency-free; if drift emerges the diff harness will catch it.
+function parseChordSymbol(symbol) {
+    if (!symbol || symbol.length === 0) return { root: '', quality: '' };
+    const head = symbol[0];
+    if ('ABCDEFG'.indexOf(head) < 0) return { root: '', quality: symbol };
+    if (symbol.length >= 2 && (symbol[1] === 'b' || symbol[1] === '#')) {
+        return { root: symbol.slice(0, 2), quality: symbol.slice(2) };
+    }
+    return { root: symbol[0], quality: symbol.slice(1) };
+}
+
+// ------------------------------------------------------------------- corpus
+
+function loadJsonOrExit(filePath, what) {
+    const abs = path.isAbsolute(filePath) ? filePath : path.join(REPO_ROOT, filePath);
+    if (!fs.existsSync(abs)) {
+        process.stderr.write(what + ' not found at ' + abs + '\n');
+        process.exit(3);
+    }
+    let doc;
+    try {
+        doc = JSON.parse(fs.readFileSync(abs, 'utf8'));
+    } catch (e) {
+        process.stderr.write('Failed to parse ' + what + ': ' + e.message + '\n');
+        process.exit(3);
+    }
+    return doc;
+}
+
+function unwrapMasters(doc) {
+    if (!doc || typeof doc !== 'object' || !Array.isArray(doc.masters)) {
+        process.stderr.write("masters.json must be a wrapper {masters: [...]} object\n");
+        process.exit(3);
+    }
+    return doc.masters;
+}
+
+function unwrapVoicings(doc) {
+    if (!doc || typeof doc !== 'object' || !Array.isArray(doc.voicings)) {
+        process.stderr.write("voicings.json must be a wrapper {voicings: [...]} object\n");
+        process.exit(3);
+    }
+    return doc.voicings;
+}
+
+// --------------------------------------------------------------------- git
+
+function gitShortSha(targetPath) {
+    try {
+        const out = execSync(
+            'git log -1 --format=%h -- ' + JSON.stringify(targetPath),
+            { cwd: REPO_ROOT, encoding: 'utf8' }
+        );
+        return out.trim() || 'unknown';
+    } catch (e) {
+        return 'unknown';
+    }
+}
+
+function gitClean(targetPath) {
+    try {
+        const out = execSync(
+            'git status --porcelain -- ' + JSON.stringify(targetPath),
+            { cwd: REPO_ROOT, encoding: 'utf8' }
+        );
+        return out.trim().length === 0;
+    } catch (e) {
+        return false;
+    }
+}
+
+function versionObject(targetPath) {
+    return { sha: gitShortSha(targetPath), clean: gitClean(targetPath) };
+}
+
+// ---------------------------------------------------------------- sandbox
+
+function loadEngineSandbox() {
+    const sandbox = createSandbox({ collectAssertions: false, exposeFs: false });
+    vm.createContext(sandbox);
+    loadModules(sandbox, [
+        path.join(MODEL_DIR, 'ChordSelector.js'),
+        path.join(MODEL_DIR, 'MastersStore.js'),
+        path.join(MODEL_DIR, 'ExclusionEngine.js'),
+    ]);
+    return sandbox;
+}
+
+// ------------------------------------------------------------------- main
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    const mastersDoc = loadJsonOrExit(args.mastersPath, 'masters.json');
+    const voicingsDoc = loadJsonOrExit(args.voicingsPath, 'voicings.json');
+    const masters = unwrapMasters(mastersDoc);
+    const voicings = unwrapVoicings(voicingsDoc);
+
+    let master = null;
+    if (args.master) {
+        for (let i = 0; i < masters.length; i++) {
+            if (masters[i].id === args.master) { master = masters[i]; break; }
+        }
+        if (master === null) {
+            process.stderr.write("master_id='" + args.master + "' not found in masters.json\n");
+            process.exit(4);
+        }
+    }
+
+    const sandbox = loadEngineSandbox();
+    // Compute master tag set via the actual JS implementation (so any
+    // future change to collectVoicingStyleTags surfaces in shim output
+    // without needing a Python rewrite).
+    sandbox._master = master;
+    vm.runInContext('_masterTags = (typeof collectVoicingStyleTags === "function") ? collectVoicingStyleTags(_master) : [];', sandbox);
+    const masterTags = args.noMaster ? [] : (sandbox._masterTags || []);
+
+    const parsed = parseChordSymbol(args.chord);
+    if (!parsed.root) {
+        process.stderr.write("Could not parse chord symbol '" + args.chord + "' (root must be A-G plus optional b/#)\n");
+        process.exit(2);
+    }
+
+    // Build opts shared by score + base computation. Callbacks
+    // (topNoteFn, bassNoteFn, distanceFn) are intentionally absent —
+    // melodyMidi/bassMidi default to -1 in the spike shim, so the
+    // callback-gated terms in _scoreCandidate contribute 0.
+    const baseOpts = {
+        maxStrings: args.nStrings,
+        filterCategory: args.style || null,
+        melodyMidi: -1,
+        bassMidi: -1,
+        melodyLocked: false,
+        bassLocked: false,
+        lastInsertedVoicing: null,
+    };
+    const optsWithMaster = Object.assign({}, baseOpts, { masterVoicingStyleTags: masterTags });
+    const optsBase       = Object.assign({}, baseOpts, { masterVoicingStyleTags: [] });
+
+    // Pipe everything into the sandbox so the JS engine code can act on it.
+    sandbox._voicings = voicings;
+    sandbox._targetRoot = parsed.root;
+    sandbox._quality = parsed.quality;
+    sandbox._optsWith = optsWithMaster;
+    sandbox._optsBase = optsBase;
+
+    // Drive findAllVoicings and per-row dual-_scoreCandidate.
+    vm.runInContext([
+        'if (typeof findAllVoicings !== "function") throw new Error("findAllVoicings not loaded");',
+        'if (typeof _scoreCandidate !== "function") throw new Error("_scoreCandidate not loaded");',
+        '_ranked = findAllVoicings(_voicings, _targetRoot, _quality, _optsWith);',
+        '_rows = [];',
+        'for (var i = 0; i < _ranked.length; i++) {',
+        '  var v = _ranked[i];',
+        '  var score = _scoreCandidate(v, _targetRoot, _quality, -1, -1, null, _optsWith);',
+        '  var base  = _scoreCandidate(v, _targetRoot, _quality, -1, -1, null, _optsBase);',
+        '  _rows.push({',
+        '    voicing_id: v.id,',
+        '    rank: i + 1,',
+        '    score: score,',
+        '    score_components: { base: base, master_boost: score - base, tolerance_match: 0 },',
+        '    payload_kind: null,',
+        '    applied_principles: []',
+        '  });',
+        '}',
+    ].join('\n'), sandbox);
+
+    const rankedVoicings = sandbox._rows || [];
+
+    const out = {
+        request: {
+            chord_symbol: args.chord,
+            tuning: args.tuning,
+            master_id: args.noMaster ? null : args.master,
+            style_filter: args.style || null,
+            context: {
+                n_strings: args.nStrings,
+                position_preference: args.positionPreference,
+            },
+        },
+        ranked_voicings: rankedVoicings,
+        engine_version:   versionObject('plugin/model/'),
+        masters_version:  versionObject(args.mastersPath),
+        voicings_version: versionObject(args.voicingsPath),
+    };
+
+    const payload = JSON.stringify(out, null, 2);
+    if (args.output && args.output !== '-') {
+        fs.writeFileSync(args.output, payload);
+    } else {
+        process.stdout.write(payload + '\n');
+    }
+}
+
+main();

--- a/scripts/engine_dump.js
+++ b/scripts/engine_dump.js
@@ -17,13 +17,24 @@
 //       --chord Cmaj7 \
 //       --tuning EADGBE \
 //       --master joe-pass \
-//       [--style chord-melody] \
+//       [--category drop2] \
 //       [--n-strings 6] \
 //       [--position-preference low] \
 //       [--no-master] \
 //       [--masters-path plugin/data/masters.json] \
 //       [--voicings-path plugin/data/voicings.json] \
 //       [--output -|FILE]
+//
+// FILTER FLAGS
+//
+//   --category ID   filter candidates by voicing.category enum value
+//                   (drop2 / shell / quartal / extended / altered / drop3).
+//                   The originating ticket #400 body referred to this as
+//                   --style-filter / "voicingStyleTag filter"; that was a
+//                   misnomer — see Post-error revision on #400. True
+//                   voicingStyleTag pre-filter is filed as a follow-up
+//                   (#408) and gated until voicing-tag crowdsourcing
+//                   (#389/#393/#395) yields tagged voicings to filter on.
 //
 // EXIT CODES
 //
@@ -35,7 +46,7 @@
 // OUTPUT (one JSON object per invocation)
 //
 //   {
-//     "request": { "chord_symbol", "tuning", "master_id", "style_filter", "context" },
+//     "request": { "chord_symbol", "tuning", "master_id", "category_filter", "context" },
 //     "ranked_voicings": [
 //       { "voicing_id", "rank", "score",
 //         "score_components": { "base", "master_boost", "tolerance_match" },
@@ -73,7 +84,8 @@ function printUsageAndExit(code) {
         '  --tuning STR          (e.g. EADGBE)\n' +
         '  --master ID           master id from masters.json\n' +
         '  --no-master           score without master boost\n' +
-        '  --style ID            optional voicingStyleTag filter\n' +
+        '  --category ID         optional voicing.category filter\n' +
+        '                        (drop2 / shell / quartal / extended / altered / drop3)\n' +
         '  --n-strings N         default 6\n' +
         '  --position-preference low|mid|high   informational; not used in scoring today\n' +
         '  --masters-path PATH   default plugin/data/masters.json\n' +
@@ -89,7 +101,7 @@ function parseArgs(argv) {
         tuning: null,
         master: null,
         noMaster: false,
-        style: null,
+        category: null,
         nStrings: 6,
         positionPreference: null,
         mastersPath: DEFAULT_MASTERS,
@@ -110,9 +122,9 @@ function parseArgs(argv) {
                 out.master = next; i++; break;
             case '--no-master':
                 out.noMaster = true; break;
-            case '--style':
-            case '--style-filter':
-                out.style = next; i++; break;
+            case '--category':
+            case '--category-filter':
+                out.category = next; i++; break;
             case '--n-strings':
                 out.nStrings = parseInt(next, 10); i++; break;
             case '--position-preference':
@@ -275,7 +287,7 @@ function main() {
     // callback-gated terms in _scoreCandidate contribute 0.
     const baseOpts = {
         maxStrings: args.nStrings,
-        filterCategory: args.style || null,
+        filterCategory: args.category || null,
         melodyMidi: -1,
         bassMidi: -1,
         melodyLocked: false,
@@ -329,7 +341,7 @@ function main() {
             chord_symbol: args.chord,
             tuning: args.tuning,
             master_id: args.noMaster ? null : args.master,
-            style_filter: args.style || null,
+            category_filter: args.category || null,
             context: {
                 n_strings: args.nStrings,
                 position_preference: args.positionPreference,

--- a/scripts/engine_dump.js
+++ b/scripts/engine_dump.js
@@ -296,7 +296,16 @@ function main() {
     vm.runInContext([
         'if (typeof findAllVoicings !== "function") throw new Error("findAllVoicings not loaded");',
         'if (typeof _scoreCandidate !== "function") throw new Error("_scoreCandidate not loaded");',
+        'if (typeof _resetDifficultyMemo !== "function") throw new Error("_resetDifficultyMemo not loaded");',
         '_ranked = findAllVoicings(_voicings, _targetRoot, _quality, _optsWith);',
+        // Defensive reset before per-row dual-scoring. findAllVoicings already
+        // resets internally (ChordSelector.js:421) and our opts pass
+        // difficultyFn=null so the memo is never populated for this shim's
+        // workload — but resetting explicitly here documents the per-row
+        // intent and protects against a future runner that batches or
+        // reuses sandbox state across invocations. Per MuseScore plugin agent
+        // (session 260528-neat-forest) review note, 2026-06-08.
+        '_resetDifficultyMemo();',
         '_rows = [];',
         'for (var i = 0; i < _ranked.length; i++) {',
         '  var v = _ranked[i];',

--- a/tests/_jsLoader.js
+++ b/tests/_jsLoader.js
@@ -1,0 +1,156 @@
+// _jsLoader.js — Shared loader for QML .pragma library JavaScript modules.
+//
+// Provides:
+//   createSandbox(options)  — build a vm sandbox with common globals + an
+//                              optional assertion collector
+//   loadModules(sandbox, modulePaths) — load + strip QML directives + eval
+//                              each module into the sandbox
+//
+// Used by:
+//   tests/js_runner.js          — test harness (uses the assertion collector)
+//   scripts/engine_dump.js      — engine-dump shim (#400; doesn't use the
+//                                  assertion collector, only the loader)
+//
+// Refactored out of js_runner.js per ticket #400 so the loading semantics
+// stay in one place and any future consumers (more shim scripts, headless
+// diagram renderers, etc.) get the same behaviour for free.
+
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+/**
+ * Build a vm sandbox seeded with the common ECMAScript globals every
+ * QML .pragma library module needs. Suppresses `console.log` from
+ * loaded modules so it doesn't interleave with the harness's own
+ * JSON-on-stdout output.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.collectAssertions=false] — when true, the
+ *   sandbox exposes `assert`, `assertEqual`, `assertNotEqual`,
+ *   `assertContains`, `assertThrows`, and `_results` / `_pass`. Tests
+ *   use this; the shim does not.
+ * @param {boolean} [options.exposeFs=false] — when true, the sandbox
+ *   exposes `readFileSync(path)` for tests that load fixture data.
+ * @returns {Object} an unfrozen object suitable for vm.createContext.
+ */
+function createSandbox(options) {
+    options = options || {};
+    const sandbox = {
+        console: {
+            log: function() {},   // suppress module console.log
+            error: function() {},
+            warn: function() {}
+        },
+        JSON: JSON,
+        Math: Math,
+        parseInt: parseInt,
+        parseFloat: parseFloat,
+        isNaN: isNaN,
+        isFinite: isFinite,
+        String: String,
+        Number: Number,
+        Array: Array,
+        Object: Object,
+        Date: Date,
+        RegExp: RegExp,
+        Error: Error,
+        TypeError: TypeError,
+        RangeError: RangeError,
+        undefined: undefined
+    };
+
+    if (options.collectAssertions) {
+        sandbox._results = [];
+        sandbox._pass = true;
+        sandbox.assert = function(condition, message) {
+            if (!condition) {
+                sandbox._pass = false;
+                sandbox._results.push({ pass: false, message: message || "Assertion failed" });
+            } else {
+                sandbox._results.push({ pass: true, message: message || "OK" });
+            }
+        };
+        sandbox.assertEqual = function(actual, expected, message) {
+            const actualStr = JSON.stringify(actual);
+            const expectedStr = JSON.stringify(expected);
+            if (actualStr !== expectedStr) {
+                sandbox._pass = false;
+                sandbox._results.push({
+                    pass: false,
+                    message: (message || "assertEqual") + ": expected " + expectedStr + ", got " + actualStr
+                });
+            } else {
+                sandbox._results.push({ pass: true, message: message || "OK" });
+            }
+        };
+        sandbox.assertNotEqual = function(actual, notExpected, message) {
+            if (JSON.stringify(actual) === JSON.stringify(notExpected)) {
+                sandbox._pass = false;
+                sandbox._results.push({
+                    pass: false,
+                    message: (message || "assertNotEqual") + ": values should differ but both are " + JSON.stringify(actual)
+                });
+            } else {
+                sandbox._results.push({ pass: true, message: message || "OK" });
+            }
+        };
+        sandbox.assertContains = function(arr, item, message) {
+            const found = Array.isArray(arr) && arr.indexOf(item) >= 0;
+            if (!found) {
+                sandbox._pass = false;
+                sandbox._results.push({
+                    pass: false,
+                    message: (message || "assertContains") + ": " + JSON.stringify(item) + " not in " + JSON.stringify(arr)
+                });
+            } else {
+                sandbox._results.push({ pass: true, message: message || "OK" });
+            }
+        };
+        sandbox.assertThrows = function(fn, message) {
+            try {
+                fn();
+                sandbox._pass = false;
+                sandbox._results.push({ pass: false, message: (message || "assertThrows") + ": expected exception but none thrown" });
+            } catch(e) {
+                sandbox._results.push({ pass: true, message: message || "OK" });
+            }
+        };
+    }
+
+    if (options.exposeFs) {
+        sandbox.readFileSync = function(p) {
+            return fs.readFileSync(path.resolve(p), 'utf8');
+        };
+    }
+
+    return sandbox;
+}
+
+/**
+ * Load each .js module into an already-contextified sandbox.
+ *
+ * Strips the QML `.pragma library` directive (Qt's marker for a
+ * library module) before evaluation so `vm.runInContext` doesn't
+ * reject the syntax. The original line is preserved as a comment for
+ * readability when debugging stack traces.
+ *
+ * @param {Object} sandbox — must already have been passed through
+ *   vm.createContext() by the caller.
+ * @param {string[]} modulePaths — absolute or working-directory-
+ *   relative paths to .js modules to evaluate.
+ */
+function loadModules(sandbox, modulePaths) {
+    for (const modPath of modulePaths) {
+        const absPath = path.resolve(modPath);
+        let code = fs.readFileSync(absPath, 'utf8');
+        // Strip QML-specific directive (one per file, at top of file).
+        code = code.replace(/^\.pragma\s+library\s*$/m, '// .pragma library (stripped)');
+        vm.runInContext(code, sandbox, { filename: path.basename(absPath) });
+    }
+}
+
+module.exports = {
+    createSandbox: createSandbox,
+    loadModules: loadModules
+};

--- a/tests/js_runner.js
+++ b/tests/js_runner.js
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 // js_runner.js — Test harness for QML .pragma library JavaScript modules.
-// Strips QML-specific directives and evaluates modules in a Node.js context,
-// then runs test code passed as the last argument.
+// Evaluates modules in a Node.js vm context and runs test code passed
+// as the last argument (or via stdin when `-` is the last arg).
 //
 // Usage: node js_runner.js <module_path> [<module_path2> ...] -- <test_code>
+//         node js_runner.js <module_path> [...] -- -            # read test code from stdin
 //
-// The test code runs in a context where all module vars/functions are global.
 // Output JSON: { "pass": true/false, "results": [...], "error": "..." }
+//
+// Loading + sandbox semantics live in tests/_jsLoader.js (#400 refactor)
+// so engine_dump.js and any future shim consumer share the same
+// behaviour without duplicating the loader.
 
 const fs = require('fs');
 const vm = require('vm');
 const path = require('path');
+const { createSandbox, loadModules } = require('./_jsLoader');
 
 // Parse arguments: module paths before --, test code after --
 const args = process.argv.slice(2);
@@ -32,108 +37,13 @@ if (tail.length === 0 || (tail.length === 1 && tail[0] === '-')) {
     testCode = tail.join(' ');
 }
 
-// Create a sandbox context with common globals
-const sandbox = {
-    console: {
-        log: function() {},  // suppress module console.log
-        error: function() {},
-        warn: function() {}
-    },
-    JSON: JSON,
-    Math: Math,
-    parseInt: parseInt,
-    parseFloat: parseFloat,
-    isNaN: isNaN,
-    isFinite: isFinite,
-    String: String,
-    Number: Number,
-    Array: Array,
-    Object: Object,
-    Date: Date,
-    RegExp: RegExp,
-    Error: Error,
-    TypeError: TypeError,
-    RangeError: RangeError,
-    undefined: undefined,
-    // Test results collector
-    _results: [],
-    _pass: true,
-    assert: function(condition, message) {
-        if (!condition) {
-            sandbox._pass = false;
-            sandbox._results.push({ pass: false, message: message || "Assertion failed" });
-        } else {
-            sandbox._results.push({ pass: true, message: message || "OK" });
-        }
-    },
-    assertEqual: function(actual, expected, message) {
-        const actualStr = JSON.stringify(actual);
-        const expectedStr = JSON.stringify(expected);
-        if (actualStr !== expectedStr) {
-            sandbox._pass = false;
-            sandbox._results.push({
-                pass: false,
-                message: (message || "assertEqual") + ": expected " + expectedStr + ", got " + actualStr
-            });
-        } else {
-            sandbox._results.push({ pass: true, message: message || "OK" });
-        }
-    },
-    assertNotEqual: function(actual, notExpected, message) {
-        if (JSON.stringify(actual) === JSON.stringify(notExpected)) {
-            sandbox._pass = false;
-            sandbox._results.push({
-                pass: false,
-                message: (message || "assertNotEqual") + ": values should differ but both are " + JSON.stringify(actual)
-            });
-        } else {
-            sandbox._results.push({ pass: true, message: message || "OK" });
-        }
-    },
-    assertContains: function(arr, item, message) {
-        const found = Array.isArray(arr) && arr.indexOf(item) >= 0;
-        if (!found) {
-            sandbox._pass = false;
-            sandbox._results.push({
-                pass: false,
-                message: (message || "assertContains") + ": " + JSON.stringify(item) + " not in " + JSON.stringify(arr)
-            });
-        } else {
-            sandbox._results.push({ pass: true, message: message || "OK" });
-        }
-    },
-    assertThrows: function(fn, message) {
-        try {
-            fn();
-            sandbox._pass = false;
-            sandbox._results.push({ pass: false, message: (message || "assertThrows") + ": expected exception but none thrown" });
-        } catch(e) {
-            sandbox._results.push({ pass: true, message: message || "OK" });
-        }
-    },
-    // File reading for test data
-    readFileSync: function(p) {
-        return fs.readFileSync(path.resolve(p), 'utf8');
-    }
-};
-
+const sandbox = createSandbox({ collectAssertions: true, exposeFs: true });
 vm.createContext(sandbox);
 
 try {
-    // Load each module into the sandbox
-    for (const modPath of modulePaths) {
-        const absPath = path.resolve(modPath);
-        let code = fs.readFileSync(absPath, 'utf8');
-        // Strip QML-specific directives
-        code = code.replace(/^\.pragma\s+library\s*$/m, '// .pragma library (stripped)');
-        // Replace console.error/log with sandbox versions (already done via context)
-        vm.runInContext(code, sandbox, { filename: path.basename(absPath) });
-    }
-
-    // Run the test code
+    loadModules(sandbox, modulePaths);
     vm.runInContext(testCode, sandbox, { filename: 'test' });
 
-    // Output results
     console.log(JSON.stringify({
         pass: sandbox._pass,
         results: sandbox._results,

--- a/tests/test_engine_dump.py
+++ b/tests/test_engine_dump.py
@@ -141,7 +141,7 @@ class TestResponseShape:
         assert req["chord_symbol"] == "Cmaj7"
         assert req["tuning"] == "EADGBE"
         assert req["master_id"] == "joe-pass"
-        assert req["style_filter"] is None
+        assert req["category_filter"] is None
         assert req["context"]["n_strings"] == 6
 
     def test_version_objects_have_sha_and_clean(

--- a/tests/test_engine_dump.py
+++ b/tests/test_engine_dump.py
@@ -1,0 +1,332 @@
+"""Tests for scripts/engine_dump.js — the ranked-voicings shim (#400).
+
+Uses the same Python-subprocess pattern as tests/test_js_modules.py:
+invoke the Node CLI, parse its JSON output, assert shape + invariants.
+
+Fixture battery matches the 12 masters Ellington uses for its Goal A
+oracle diff (see ellington-systems#1 design note for the choice of
+each master).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHIM = REPO_ROOT / "scripts" / "engine_dump.js"
+
+
+# 12-master fixture battery from ellington-systems#1
+ENGINE_STRESSERS = [
+    "nelson-faria",
+    "peter-bernstein",
+    "mickey-baker",
+    "ted-dunbar",
+    "brent-vaartstra",
+]
+DHEERAJ_HEROES = [
+    "joe-pass",
+    "van-eps",
+    "wes-montgomery",
+    "jim-hall",
+    "lenny-breau",
+]
+MELODIC_AXIS = ["pat-martino", "jens-larsen"]
+FIXTURE_BATTERY = ENGINE_STRESSERS + DHEERAJ_HEROES + MELODIC_AXIS
+assert len(FIXTURE_BATTERY) == 12
+
+
+def run_shim(*args: str, expect_exit: int = 0) -> dict[str, Any] | str | None:
+    """Invoke the shim with the given args, assert exit code, return parsed JSON.
+
+    On non-zero expected exit, returns stderr string instead of JSON.
+    When `--output` points at a real file (not `-`), stdout is empty by
+    design; caller reads the file directly and we return None.
+    """
+    cmd = ["node", str(SHIM)] + list(args)
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=REPO_ROOT, timeout=30
+    )
+    assert result.returncode == expect_exit, (
+        f"Exit code {result.returncode} (expected {expect_exit}); "
+        f"stderr=\n{result.stderr}\nstdout=\n{result.stdout[:500]}"
+    )
+    if expect_exit != 0:
+        return result.stderr
+    # Detect "--output FILE" (FILE != "-") and skip stdout parse.
+    args_list = list(args)
+    if "--output" in args_list:
+        idx = args_list.index("--output")
+        if idx + 1 < len(args_list) and args_list[idx + 1] != "-":
+            return None
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Help + argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestArguments:
+    def test_help_exits_zero(self) -> None:
+        # --help prints to stderr and exits 0
+        cmd = ["node", str(SHIM), "--help"]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0
+        assert "Usage:" in result.stderr
+
+    def test_missing_chord_exits_2(self) -> None:
+        run_shim("--tuning", "EADGBE", "--master", "joe-pass", expect_exit=2)
+
+    def test_missing_tuning_exits_2(self) -> None:
+        run_shim("--chord", "Cmaj7", "--master", "joe-pass", expect_exit=2)
+
+    def test_missing_master_exits_2(self) -> None:
+        run_shim("--chord", "Cmaj7", "--tuning", "EADGBE", expect_exit=2)
+
+    def test_master_and_no_master_conflict_exits_2(self) -> None:
+        run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--no-master",
+            expect_exit=2,
+        )
+
+    def test_unknown_master_exits_4(self) -> None:
+        stderr = run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "definitely-not-a-real-master-id",
+            expect_exit=4,
+        )
+        assert isinstance(stderr, str)
+        assert "definitely-not-a-real-master-id" in stderr
+
+    def test_n_strings_out_of_range_exits_2(self) -> None:
+        run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--n-strings", "20",
+            expect_exit=2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Response shape — every field the contract names must be present
+# ---------------------------------------------------------------------------
+
+
+class TestResponseShape:
+    @pytest.fixture()
+    def cmaj7_joepass(self) -> dict[str, Any]:
+        return run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--n-strings", "6",
+        )
+
+    def test_top_level_keys(self, cmaj7_joepass: dict[str, Any]) -> None:
+        assert set(cmaj7_joepass.keys()) == {
+            "request",
+            "ranked_voicings",
+            "engine_version",
+            "masters_version",
+            "voicings_version",
+        }
+
+    def test_request_echoed_back(self, cmaj7_joepass: dict[str, Any]) -> None:
+        req = cmaj7_joepass["request"]
+        assert req["chord_symbol"] == "Cmaj7"
+        assert req["tuning"] == "EADGBE"
+        assert req["master_id"] == "joe-pass"
+        assert req["style_filter"] is None
+        assert req["context"]["n_strings"] == 6
+
+    def test_version_objects_have_sha_and_clean(
+        self, cmaj7_joepass: dict[str, Any]
+    ) -> None:
+        for key in ("engine_version", "masters_version", "voicings_version"):
+            ver = cmaj7_joepass[key]
+            assert isinstance(ver, dict), f"{key} should be an object"
+            assert "sha" in ver
+            assert "clean" in ver
+            assert isinstance(ver["clean"], bool)
+
+    def test_ranked_voicings_nonempty(
+        self, cmaj7_joepass: dict[str, Any]
+    ) -> None:
+        rows = cmaj7_joepass["ranked_voicings"]
+        assert len(rows) > 0, "Cmaj7/joe-pass should return SOME voicings"
+
+    def test_each_row_has_required_fields(
+        self, cmaj7_joepass: dict[str, Any]
+    ) -> None:
+        for row in cmaj7_joepass["ranked_voicings"]:
+            assert set(row.keys()) == {
+                "voicing_id",
+                "rank",
+                "score",
+                "score_components",
+                "payload_kind",
+                "applied_principles",
+            }
+            assert set(row["score_components"].keys()) == {
+                "base",
+                "master_boost",
+                "tolerance_match",
+            }
+            assert row["payload_kind"] is None
+            assert row["applied_principles"] == []
+
+
+# ---------------------------------------------------------------------------
+# Score invariants — base + master_boost + tolerance_match == score
+# ---------------------------------------------------------------------------
+
+
+class TestScoreInvariants:
+    def test_score_equals_components_sum(self) -> None:
+        resp = run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--n-strings", "6",
+        )
+        for row in resp["ranked_voicings"]:
+            sc = row["score_components"]
+            total = sc["base"] + sc["master_boost"] + sc["tolerance_match"]
+            assert abs(total - row["score"]) < 1e-6, (
+                f"score-components-sum mismatch on {row['voicing_id']}: "
+                f"score={row['score']} but base+master_boost+tolerance_match={total}"
+            )
+
+    def test_ranks_are_one_indexed_dense(self) -> None:
+        resp = run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--n-strings", "6",
+        )
+        ranks = [r["rank"] for r in resp["ranked_voicings"]]
+        assert ranks == list(range(1, len(ranks) + 1))
+
+    def test_scores_descending(self) -> None:
+        resp = run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--n-strings", "6",
+        )
+        scores = [r["score"] for r in resp["ranked_voicings"]]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_tolerance_match_is_zero_from_js(self) -> None:
+        # The JS engine doesn't run a payload-kind dispatcher; the shim
+        # always emits tolerance_match=0. Ellington's Python port populates
+        # this on its own side.
+        resp = run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--n-strings", "6",
+        )
+        for row in resp["ranked_voicings"]:
+            assert row["score_components"]["tolerance_match"] == 0
+
+
+# ---------------------------------------------------------------------------
+# master_boost behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestMasterBoost:
+    def test_no_master_yields_zero_master_boost(self) -> None:
+        resp = run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--no-master", "--n-strings", "6",
+        )
+        for row in resp["ranked_voicings"]:
+            assert row["score_components"]["master_boost"] == 0
+
+    def test_with_master_master_boost_is_zero_today(self) -> None:
+        """Per Investigation Fact Sheet Entity 4: 0/820 voicings are tagged
+        at SHA 628ed30. Master boost gate requires BOTH master tags AND
+        voicing tags to be non-empty; with the corpus's current state,
+        boost is always 0 even when --master is set. When voicing-tag
+        crowdsourcing (plugin #389/#393/#395) lands first batches, this
+        test SHOULD fail — that's the trigger to re-snapshot the oracle.
+        """
+        resp = run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--n-strings", "6",
+        )
+        for row in resp["ranked_voicings"]:
+            assert row["score_components"]["master_boost"] == 0, (
+                f"Expected master_boost=0 (untagged corpus); "
+                f"got {row['score_components']['master_boost']} on {row['voicing_id']}. "
+                f"If voicings now carry voicingStyle tags, this is the signal "
+                f"to refresh the oracle snapshot."
+            )
+
+
+# ---------------------------------------------------------------------------
+# 12-fixture battery — every master in Ellington's spike runs cleanly
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureBattery:
+    @pytest.mark.parametrize("master_id", FIXTURE_BATTERY)
+    def test_master_runs_cmaj7(self, master_id: str) -> None:
+        resp = run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", master_id, "--n-strings", "6",
+        )
+        assert resp["request"]["master_id"] == master_id
+        assert len(resp["ranked_voicings"]) > 0
+        # Smoke invariant on every row.
+        for row in resp["ranked_voicings"]:
+            assert row["rank"] >= 1
+            assert row["voicing_id"]
+
+    @pytest.mark.parametrize("master_id", FIXTURE_BATTERY)
+    def test_master_runs_dom7(self, master_id: str) -> None:
+        resp = run_shim(
+            "--chord", "G7", "--tuning", "EADGBE",
+            "--master", master_id, "--n-strings", "6",
+        )
+        assert len(resp["ranked_voicings"]) > 0
+
+    @pytest.mark.parametrize("master_id", FIXTURE_BATTERY)
+    def test_master_runs_minor(self, master_id: str) -> None:
+        resp = run_shim(
+            "--chord", "Dm7", "--tuning", "EADGBE",
+            "--master", master_id, "--n-strings", "6",
+        )
+        # Some quality variants may yield empty under the shim's filter;
+        # the contract is that the response is well-formed even if empty.
+        assert isinstance(resp["ranked_voicings"], list)
+
+
+# ---------------------------------------------------------------------------
+# Output to file
+# ---------------------------------------------------------------------------
+
+
+class TestOutputDestination:
+    def test_output_to_file(self, tmp_path: Path) -> None:
+        outfile = tmp_path / "result.json"
+        run_shim(
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--output", str(outfile),
+        )
+        assert outfile.exists()
+        data = json.loads(outfile.read_text())
+        assert data["request"]["master_id"] == "joe-pass"
+
+    def test_output_dash_writes_stdout(self) -> None:
+        # Default behaviour also; this just makes the contract explicit.
+        cmd = [
+            "node", str(SHIM),
+            "--chord", "Cmaj7", "--tuning", "EADGBE",
+            "--master", "joe-pass", "--output", "-",
+        ]
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=REPO_ROOT, timeout=30
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "ranked_voicings" in data


### PR DESCRIPTION
## Summary

Implements [#400](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/400) — the Node.js CLI shim that the Ellington Python port at [ellington-systems#1](https://github.com/siege-analytics/ellington-systems/issues/1) consumes as its Goal A oracle harness. Also useful in-repo as a regression / smoke tool whenever \`_scoreCandidate\` or master-boost logic is edited.

- **\`tests/_jsLoader.js\`** — shared loader extracted from \`js_runner.js\`. Exposes \`createSandbox({collectAssertions?, exposeFs?})\` and \`loadModules(sandbox, paths)\`.
- **\`tests/js_runner.js\`** — refactored to import \`_jsLoader\`. 149 → 59 lines; semantics preserved (220 existing \`test_js_modules.py\` tests pass unchanged).
- **\`scripts/engine_dump.js\`** — Node CLI emitting ranked-voicings JSON. Loads ChordSelector + MastersStore + ExclusionEngine, calls \`findAllVoicings\`, then \`_scoreCandidate\` twice per row (with + without master tags) to derive \`{base, master_boost}\`. \`tolerance_match\` always 0 (JS doesn't run \`engine_payload.kind\` dispatch; Ellington populates that on its own side). \`engine_version\` / \`masters_version\` / \`voicings_version\` are \`{sha, clean}\` objects per the design-comment refinement.
- **\`tests/test_engine_dump.py\`** — 56 tests: argument validation, response shape, score invariants (base+master_boost+tolerance_match==score within 1e-6, ranks 1-indexed dense, scores descending), master_boost behaviour, **12-master fixture battery × 3 chord qualities** (the Ellington spike battery), output-to-file vs stdout.
- **\`.gitignore\`** — \`!tests/test_*.py\` negation to override the user-level global \`~/.gitignore:84\` that silently drops pytest files.

## Smoke run

\`\`\`
\$ node scripts/engine_dump.js --chord Cmaj7 --tuning EADGBE --master joe-pass --n-strings 6 | jq '.ranked_voicings | length'
29
\`\`\`

\`master_boost = 0\` everywhere is consistent with the Investigation Fact Sheet finding that 0/820 voicings carry \`voicingStyle[]\` tags at SHA \`628ed30\`. When voicing-tag crowdsourcing (#389/#393/#395) lands, \`test_with_master_master_boost_is_zero_today\` will fail loudly — that's the re-snapshot signal.

## Pipeline trail

- Design note: [comment on #400](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/400#issuecomment-4651090519)
- Post-error revision (gitignore-test-file silent-drop, caught pre-push): [comment on #400](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/400#issuecomment-4651167262)
- Cross-reference Fact Sheet + Pre-mortem: [ellington-systems#1 comments](https://github.com/siege-analytics/ellington-systems/issues/1)
- Self-review artifact: \`sessions/260607-sunny-ember/plans/008-self-review-plugin-shim.md\` (Craft Agent session-local; gates inline)

## Test plan

- [x] Gate 1: \`node --check\` + \`ast.parse\` — 4 of 4 modified files clean
- [x] Gate 2: \`pytest tests/test_engine_dump.py\` — 56 passed; \`pytest tests/test_js_modules.py\` — 220 passed (refactor regression check)
- [x] Gate 2 extension (files-in-tree): \`git show HEAD --name-status\` lists all 5 files; \`tests/test_engine_dump.py\` is tracked (recovered via amend after the gitignore incident — see Post-error revision)
- [x] Gate 3: N/A (no docs/ changes)
- [x] Gate 4: N/A (no notebook changes)

## Pre-existing failures NOT introduced by this PR

5 develop-baseline failures verified by checkout + run-on-develop comparison: 4 in \`TestClipboardPipeline\` (clipboard/launchd integration) + 1 in \`test_masters_schema\` (\`test_existing_masters_json_validates\`). They carry forward unchanged.

## Ellington-side follow-up (separate PR there, not blocking)

Ellington's \`EngineResponse.engine_version\` is currently \`str\`. The richer \`{sha: str, clean: bool}\` shape from this shim needs a Pydantic-model adjustment on Ellington's side. Small PR; will land after this one merges so we're not chasing two contracts at once.

Refs #400, ellington-systems#1.

@MuseScore-29-May-2026 — tagging per our cross-agent agreement; happy to iterate on any of the choices above.