### PR TITLE
fix(#413): permalink: pretty on Pages site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,7 @@ description: >-
 theme: jekyll-theme-cayman
 show_downloads: false
 markdown: kramdown
+permalink: pretty
 plugins:
   - jekyll-relative-links
 defaults:


### PR DESCRIPTION
Closes #413. One-line addition to docs/_config.yml so trailing-slash internal links (/glossary/, /how-to-help/, etc.) resolve instead of 404. Verified rendering correctly via curl after the rebuild.