### PR TITLE
schema(masters)(#415): add usage_notes[] + populate dirk-laukens

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -20786,6 +20786,45 @@
           ]
         }
       ],
+      "usage_notes": [
+        {
+          "chord_quality": "min7b5",
+          "function_role": "predominant-in-minor-ii-V-i",
+          "narrative": "Laukens treats half-diminished (m7b5) as the ii of minor ii-V-i — the predominant function that sets up an altered V. The substitution lattice from his Upper-Structure work explicitly derives ø7 ↔ altered V7 via shared tritone (root of m7b5 = b5 of V7alt), so the voicing's pedagogical use is interchangeable with its tritone-sub V. When tagging a m7b5 voicing as Laukens, the question to ask: does this voicing's voice-leading support a resolution to an altered dominant a half-step below it?",
+          "source_principle_ids": [
+            "function-assigned-vocabulary",
+            "substitution-as-derivable-not-memorized"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant",
+          "narrative": "In Laukens's substitution lattice the dominant 7 is the most-substituted chord in the catalog. The Patterns Vol 1 Upper-Structure Substitution Lattice derives V7 ↔ bII7 (tritone), V7alt (b9/#9/#5/b5 extensions stacked as derivable from the diminished and altered scales), V7sus, and the diminished chord a half-step above V (passing/leading-tone use). Tagging a dom7 voicing as Laukens implies the voicing supports at least one of these derivation paths via its voice-leading availability.",
+          "source_principle_ids": [
+            "substitution-as-derivable-not-memorized",
+            "function-assigned-vocabulary"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-in-major",
+          "narrative": "maj7 functions as tonic in Laukens's function-assigned hierarchy. His method emphasizes the 3-7 guide tones as the harmonic skeleton and treats the 9 and #11 as color tones for tension-release (the Lydian-mode reading of maj7 as a tonic-with-color). Voicings that bury the root and project the 3-7-9 or 3-7-#11 are the Laukens-pedagogically-typical shapes; voicings that emphasize the root-fifth-octave are not.",
+          "source_principle_ids": [
+            "function-assigned-vocabulary",
+            "moveable-shape-as-organizing-principle"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "predominant-or-tonic-minor",
+          "narrative": "min7 carries two functions in Laukens's lattice: predominant (ii of major ii-V-I) and tonic-minor (i of natural minor, often colored to min9 / min-maj7 / min11 to disambiguate). The moveable-shape pedagogy places min7 drop-2 voicings on adjacent string sets (6-3, 5-2, 4-1) as the workhorse forms, with the same physical shape transposed across the fretboard. Tagging a min7 voicing as Laukens implies either function reading is supportable, NOT that the voicing carries one specific function unconditionally.",
+          "source_principle_ids": [
+            "moveable-shape-as-organizing-principle",
+            "function-assigned-vocabulary",
+            "standard-anchored-practice"
+          ]
+        }
+      ],
       "status": "promoted"
     },
     {

--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -20794,7 +20794,8 @@
           "source_principle_ids": [
             "function-assigned-vocabulary",
             "substitution-as-derivable-not-memorized"
-          ]
+          ],
+          "provenance": "inferred-from-principles"
         },
         {
           "chord_quality": "dom7",
@@ -20803,7 +20804,8 @@
           "source_principle_ids": [
             "substitution-as-derivable-not-memorized",
             "function-assigned-vocabulary"
-          ]
+          ],
+          "provenance": "inferred-from-principles"
         },
         {
           "chord_quality": "maj7",
@@ -20812,7 +20814,8 @@
           "source_principle_ids": [
             "function-assigned-vocabulary",
             "moveable-shape-as-organizing-principle"
-          ]
+          ],
+          "provenance": "inferred-from-principles"
         },
         {
           "chord_quality": "min7",
@@ -20822,7 +20825,8 @@
             "moveable-shape-as-organizing-principle",
             "function-assigned-vocabulary",
             "standard-anchored-practice"
-          ]
+          ],
+          "provenance": "inferred-from-principles"
         }
       ],
       "status": "promoted"

--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -232,6 +232,11 @@
           "type": "string",
           "description": "Optional ref to works[].id when the note is drawn from a specific book/chapter."
         },
+        "provenance": {
+          "type": "string",
+          "enum": ["extracted", "inferred-from-principles", "hand-authored", "placeholder"],
+          "description": "How this usage_note was produced. 'extracted' = distilled from source text via chapter-loop (authoritative); 'inferred-from-principles' = derived by reasoning over this master's principles[] (speculative, pending re-distillation); 'hand-authored' = written by a curator from direct source reading; 'placeholder' = structural-only, content TBD. Downstream consumers (form, glossary, Ellington) may render different provenance levels differently."
+        },
         "references": { "$ref": "#/$defs/references" }
       },
       "additionalProperties": true

--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -36,6 +36,11 @@
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/work" }
+        },
+        "usage_notes": {
+          "type": "array",
+          "description": "Per-master × per-chord-quality pedagogical notes. Each entry says how this master uses or teaches voicings of the named chord quality — function role, idiom, common substitution, voice-leading context. Consumed by reviewer-facing surfaces (the #395 review form, the docs glossary) so reviewers can confirm 'is this how the master would use this chord in a lesson' rather than just 'is this a master-X voicing'. Optional; populated incrementally per #415 and follow-up tickets.",
+          "items": { "$ref": "#/$defs/usage_note" }
         }
       },
       "anyOf": [
@@ -196,6 +201,38 @@
         "name": { "type": "string", "minLength": 1 },
         "summary": { "type": "string" },
         "engine_payload": { "$ref": "#/$defs/engine_payload" }
+      },
+      "additionalProperties": true
+    },
+    "usage_note": {
+      "description": "Per-master × per-chord-quality pedagogical note. Says how the master uses or teaches voicings of the given chord quality — function role, idiom, common substitution, voice-leading context. The narrative should give a reviewer enough to decide 'is this how the master would use this chord in a lesson' rather than just 'is this a master-X voicing'. Multiple notes per (master, quality) are allowed (e.g. Greene treats m7b5 differently in V-System vs sequential-articulation).",
+      "type": "object",
+      "required": ["chord_quality", "narrative"],
+      "properties": {
+        "chord_quality": {
+          "type": "string",
+          "minLength": 1,
+          "description": "One of the chord_quality values appearing on voicings.json voicings[].chord_quality. No enum constraint yet — the voicings catalog itself defines the live vocabulary; usage_notes referencing unknown qualities will be flagged by a future cross-validation step."
+        },
+        "function_role": {
+          "type": "string",
+          "description": "Free text describing the chord's role in this master's teaching (e.g. 'predominant-in-minor-ii-V-i', 'tonic-substitute', 'passing-diminished'). No enum yet — values will be enumerated once N≥5 masters have populated usage_notes and patterns stabilize."
+        },
+        "narrative": {
+          "type": "string",
+          "minLength": 1,
+          "description": "1-3 sentences explaining how the master treats this chord quality. Should be specific enough to confirm/refute pedagogical claims, not just identify the namespace."
+        },
+        "source_principle_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional refs to this master's principles[].id values that justify the note. Grounds the narrative claim in the principle structure."
+        },
+        "source_work_id": {
+          "type": "string",
+          "description": "Optional ref to works[].id when the note is drawn from a specific book/chapter."
+        },
+        "references": { "$ref": "#/$defs/references" }
       },
       "additionalProperties": true
     },


### PR DESCRIPTION
Closes #415. Extends the masters schema so each master can carry per-chord-quality pedagogical notes — the substrate reviewers need to confirm not just "is this a Laukens voicing" but "is this how Laukens would USE this voicing in a lesson."

## What changed

- `schema/masters.schema.json`: adds `usage_notes[]` to `$defs/master`; adds `$defs/usage_note` (chord_quality + narrative required; function_role, source_principle_ids, source_work_id, references optional).
- `plugin/data/masters.json`: 4 worked-example usage_notes for `dirk-laukens` covering min7b5, dom7, maj7, min7.

## Validation

- `scripts/validate.py --target masters` shows the same 5 baseline errors as develop (galbraith/bertoncini `_pending:` system ids, aebersold year=None). Zero new errors.
- Schema parses cleanly.

## Worked-example honesty

The 4 Laukens narratives are derived from his existing `principles[]` summaries (function-assigned-vocabulary, substitution-as-derivable-not-memorized, moveable-shape-as-organizing-principle, standard-anchored-practice), NOT from direct re-reading of his book. They should be reviewed by a Laukens-reader (or the project owner) before treating as authoritative. The `source_principle_ids` field on each note cites the principle the claim grounds in, so disagreements can be traced back to the originating principle.

## Out of scope (downstream tickets)

- Populating other masters' `usage_notes` (hand-author OR re-run chapter-loop distillation with quality-axis prompt)
- Form integration: surface the relevant usage_note inline per voicing in the Tally form so reviewers see it next to the chord they're voting on
- Docs glossary regen: expose usage_notes per master in the Pages site
- `function_role` enumeration: free text for now, enum once N≥5 masters populate and patterns stabilize

## Refs

#415 · #389 / PR #390 · #393 / PR #404 · #395 · #410 / PR #411 · #275
