### PR TITLE
data(styles)(#417): styles.json scaffolding (schemaVersion v1 + bossa+bebop)

### DIFF
--- a/plugin/data/styles.json
+++ b/plugin/data/styles.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "v1",
+  "styles": [
+    {
+      "id": "bossa-nova",
+      "name": "Bossa Nova",
+      "summary": "Brazilian-rooted style fusing samba rhythm with cool-jazz harmonic sensibility. Characterized by syncopated guitar comping (the 'bossa pattern'), gentle harmonic motion through extended chords with 9 and #11 colors, and a soft dynamic that leaves space for the singer / melody line.",
+      "voicing_style_tag_affinity": {
+        "chord-melody": 0.3,
+        "shell": 0.4,
+        "guide-tones": 0.6,
+        "drop-2": 0.5
+      },
+      "rhythmic_signature": {
+        "anticipated_beats": ["upbeat-of-2", "and-of-4"],
+        "accent_pattern": "syncopated-with-bass-anchor-on-1-3",
+        "density": "sparse",
+        "typical_tempo_range_bpm": [120, 160]
+      },
+      "harmonic_signature": {
+        "chromatic_motion_tolerance": "low",
+        "substitution_density": "moderate",
+        "color_tone_preference": ["9", "11", "13", "#11"],
+        "characteristic_progressions": ["ii-V-I with 9-color tonic", "I-VI-ii-V cycle", "descending-ii-V chains"]
+      },
+      "prescriptive_lessons": [
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-with-color",
+          "narrative": "[placeholder] In bossa, maj7 tonic typically lifts to maj9 or maj7(#11). The bossa pattern places the chord on the upbeat of 2 with a sustaining bass on 1 and 3. Real prescriptive content backfilled via #419.",
+          "provenance": "placeholder",
+          "source": "placeholder"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "predominant-with-9",
+          "narrative": "[placeholder] m7 voicings in bossa favor the 9 on top, drop-2 shape across strings 5-2. Backfill via #419.",
+          "provenance": "placeholder",
+          "source": "placeholder"
+        }
+      ],
+      "divergence_notes": [
+        {
+          "vs_style": "bebop",
+          "shared_dimensions": ["ii-V-I as base progression", "extended-chord vocabulary"],
+          "diverging_dimensions": ["density", "onset placement", "chromatic tolerance"],
+          "characteristic_quote": "[placeholder] You're using bebop chords in bossa rhythm — try lifting the density and anticipating the upbeat. Real quote backfilled via curator pass after #419.",
+          "provenance": "placeholder"
+        }
+      ],
+      "example_masters": [
+        {
+          "master_id": "joe-pass",
+          "exemplar_principle_ids": ["three-to-four-note-voicings-with-voice-leading"]
+        }
+      ],
+      "diagnostic_examples": []
+    },
+    {
+      "id": "bebop",
+      "name": "Bebop",
+      "summary": "Post-WWII jazz style centered on dense chromatic improvisation, fast tempos, and intricate harmonic substitution. Comping is rhythmically aggressive with anticipated upbeats and ample chromatic passing chords; voicings emphasize R-3-7 shells dressed with altered tensions on dominants.",
+      "voicing_style_tag_affinity": {
+        "pass": 0.9,
+        "shell": 1.0,
+        "drop-2": 0.8,
+        "drop-3": 0.6,
+        "altered-dominant": 0.9,
+        "tritone-sub": 0.7
+      },
+      "rhythmic_signature": {
+        "anticipated_beats": ["upbeat-of-4", "and-of-2", "and-of-4"],
+        "accent_pattern": "syncopated-eighths-with-chromatic-passing",
+        "density": "dense",
+        "typical_tempo_range_bpm": [180, 280]
+      },
+      "harmonic_signature": {
+        "chromatic_motion_tolerance": "high",
+        "substitution_density": "high",
+        "color_tone_preference": ["b9", "#9", "#11", "b13"],
+        "characteristic_progressions": ["rapid ii-V-I cycles", "tritone-sub V7s", "diminished-passing on every weak beat", "Coltrane-changes (three-tonic substitution)"]
+      },
+      "prescriptive_lessons": [
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-with-alteration-mandate",
+          "narrative": "[placeholder] In bebop, V7 is rarely played 'plain.' Standard prescriptions: voice as V7alt (b9, #9, #5, b5) on string set 6-3 with the b9 or #9 on top, or substitute the tritone bII7 voiced as a shell with the b5 implied. Real prescriptive content via #419 (mickey-baker run is queued as bebop exemplar).",
+          "provenance": "placeholder",
+          "source": "placeholder"
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "predominant-in-minor-ii-V-i",
+          "narrative": "[placeholder] m7b5 in bebop is the ii of minor ii-V-i, typically voiced as drop-2 with the b5 anchored on string 3 and resolving chromatically downward into the altered V7. Backfill via #419.",
+          "provenance": "placeholder",
+          "source": "placeholder"
+        }
+      ],
+      "divergence_notes": [
+        {
+          "vs_style": "bossa-nova",
+          "shared_dimensions": ["ii-V-I as base progression", "extended-chord vocabulary"],
+          "diverging_dimensions": ["density", "onset placement", "chromatic tolerance"],
+          "characteristic_quote": "[placeholder] A bebop player would say: 'You're playing bossa rhythm with bebop chord density — relax the chromatic passing and let the bass breathe.' Backfilled via curator pass after #419.",
+          "provenance": "placeholder"
+        }
+      ],
+      "example_masters": [
+        {
+          "master_id": "joe-pass",
+          "exemplar_principle_ids": ["walking-bass-plus-chord-stabs", "dominant-alteration-substitution-lattice"]
+        },
+        {
+          "master_id": "mickey-baker",
+          "exemplar_principle_ids": ["four-named-substitution-principles-as-lattice"]
+        }
+      ],
+      "diagnostic_examples": []
+    }
+  ]
+}

--- a/schema/styles.schema.json
+++ b/schema/styles.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "styles.json schema",
+  "description": "Schema for plugin/data/styles.json — the second axis catalog (the first being masters.json, the third idioms.json). A 'style' is a TRADITION (bebop, bossa nova, gypsy jazz, ...) characterized by signature voicings, rhythmic conventions, and harmonic vocabulary. Per cross-agent agreement (plugin#417 + ellington-systems/ellington-web), structural fields ship first; prescriptive content (the actual lessons) backfills via the quality-axis distillation pipeline change (#419).",
+  "type": "object",
+  "required": ["schemaVersion", "styles"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "enum": ["v1"],
+      "description": "Schema version string. Consumers (Ellington StylePreset loader, plugin engine, future tools) MUST gate on this. Breaking changes bump the major (v2, v3, ...). Minor-additive changes that stay backward-compatible do not bump."
+    },
+    "styles": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/style" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "style": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+$",
+          "description": "Kebab-case slug. Examples: 'bebop', 'bossa-nova', 'cool-jazz', 'gypsy-jazz', 'hard-bop', 'fusion', 'modal-jazz', 'standards', 'berklee-consensus'."
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "summary": {
+          "type": "string",
+          "description": "1-3 sentences naming the tradition. What you'd tell someone who'd never heard of it."
+        },
+        "voicing_style_tag_affinity": {
+          "type": "object",
+          "additionalProperties": { "type": "number" },
+          "description": "dict[voicingStyleTag → weight] declaring which tags this style favors. Tags should reference master.principles[].voicingStyleTags or voicing.voicingStyle values that exist in the corpus. Weights are relative (consumer normalizes). Example: {'pass': 0.9, 'bebop': 1.0, 'chromatic-cool': 0.4}."
+        },
+        "rhythmic_signature": {
+          "type": "object",
+          "description": "Structured rhythmic characteristics of the style. Free-form by design — Ellington's comparator reads specific keys; new keys can be added without bumping schemaVersion as long as they're additive.",
+          "properties": {
+            "anticipated_beats": { "type": "array", "items": { "type": "string" }, "description": "e.g. ['upbeat-of-4', 'upbeat-of-2'] for bossa." },
+            "accent_pattern": { "type": "string" },
+            "density": { "type": "string", "enum": ["sparse", "moderate", "dense", "very-dense"] },
+            "typical_tempo_range_bpm": { "type": "array", "items": { "type": "number" } }
+          },
+          "additionalProperties": true
+        },
+        "harmonic_signature": {
+          "type": "object",
+          "description": "Structured harmonic characteristics. Same additive-extension pattern as rhythmic_signature.",
+          "properties": {
+            "chromatic_motion_tolerance": { "type": "string", "enum": ["low", "moderate", "high", "extreme"] },
+            "substitution_density": { "type": "string", "enum": ["low", "moderate", "high"] },
+            "color_tone_preference": { "type": "array", "items": { "type": "string" }, "description": "e.g. ['9', '13', '#11'] for cool-jazz; ['b9', '#9', 'b13'] for bebop." },
+            "characteristic_progressions": { "type": "array", "items": { "type": "string" } }
+          },
+          "additionalProperties": true
+        },
+        "prescriptive_lessons": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/prescriptive_lesson" },
+          "description": "Per-chord-quality prescriptive lessons for THIS style. Same shape as masters.usage_notes from #415, but indexed by style instead of master. 'In bossa, m7 is voiced with the 9 on top, anticipated on the upbeat of 4, because [rationale].'"
+        },
+        "divergence_notes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/divergence_note" },
+          "description": "Structured cross-style commentary. Consumed by the Ellington cross-style coach to render 'a bebop player would say...' criticism when audio exhibits one style against another's backing."
+        },
+        "example_masters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["master_id"],
+            "properties": {
+              "master_id": { "type": "string", "description": "References masters[].id." },
+              "exemplar_work_ids": { "type": "array", "items": { "type": "string" }, "description": "Optional: which of the master's works[].id best exemplify this style." },
+              "exemplar_principle_ids": { "type": "array", "items": { "type": "string" }, "description": "Optional: which of the master's principles[].id best exemplify this style." }
+            },
+            "additionalProperties": true
+          },
+          "description": "Which corpus masters exemplify this style. The comparator uses these as canonical references."
+        },
+        "diagnostic_examples": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["voicing_id"],
+            "properties": {
+              "voicing_id": { "type": "string", "description": "References voicings[].id." },
+              "why_canonical": { "type": "string", "description": "1-2 sentences: what about this voicing makes it canonically THIS style." },
+              "provenance": { "type": "string", "enum": ["extracted", "hand-authored", "placeholder"] }
+            },
+            "additionalProperties": true
+          },
+          "description": "5-10 reference voicings that ARE canonically this style. Training signal for the comparator."
+        }
+      },
+      "additionalProperties": true
+    },
+    "prescriptive_lesson": {
+      "type": "object",
+      "required": ["chord_quality", "narrative"],
+      "properties": {
+        "chord_quality": { "type": "string", "minLength": 1, "description": "References voicings.json voicings[].chord_quality vocabulary." },
+        "function_role": { "type": "string" },
+        "narrative": { "type": "string", "minLength": 1, "description": "1-3 sentences explaining how THIS style uses this chord quality. Should be prescriptive enough to guide a player." },
+        "voicing_examples": { "type": "array", "items": { "type": "string" }, "description": "voicings[].id references that exemplify the lesson." },
+        "source": { "type": "string", "description": "Free text: where this lesson is grounded (book + page, principle id, or 'placeholder')." },
+        "provenance": { "type": "string", "enum": ["extracted", "inferred-from-principles", "hand-authored", "placeholder"], "description": "Same enum as masters.usage_notes.provenance — see schema/masters.schema.json $defs/usage_note." }
+      },
+      "additionalProperties": true
+    },
+    "divergence_note": {
+      "type": "object",
+      "required": ["vs_style"],
+      "description": "Structured cross-style commentary. Each entry compares THIS style against vs_style: what's shared, what diverges, and a characteristic quote the coach renders verbatim. Per ellington-systems request.",
+      "properties": {
+        "vs_style": { "type": "string", "description": "References another styles[].id." },
+        "shared_dimensions": { "type": "array", "items": { "type": "string" }, "description": "Examples: 'ii-V-I as base progression', 'guide-tone-driven voice-leading'." },
+        "diverging_dimensions": { "type": "array", "items": { "type": "string" }, "description": "Examples: 'density', 'onset placement', 'chromatic tolerance'." },
+        "characteristic_quote": { "type": "string", "description": "Rendered verbatim by the LLM coach. Format: short quote in the voice of a player from THIS style critiquing usage in vs_style. Example for bossa vs bebop: 'You're using bebop chords in bossa rhythm — try lifting the density and anticipating the upbeat.'" },
+        "provenance": { "type": "string", "enum": ["hand-authored", "extracted", "placeholder"] }
+      },
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
Closes #417. First piece of the three-axis catalog model (`masters × styles × idioms`). Lands the styles schema + structural scaffolding so Ellington's StylePreset loader can bind against a stable contract; prescriptive content backfills via #419.

## What landed

- `schema/styles.schema.json` — top-level `schemaVersion: "v1"`. Style entries carry `voicing_style_tag_affinity`, `rhythmic_signature`, `harmonic_signature`, `prescriptive_lessons[]` (same shape as masters.usage_notes from #415), `divergence_notes[]` with `characteristic_quote` (verbatim render for LLM coach), `example_masters[]`, `diagnostic_examples[]`.
- `plugin/data/styles.json` — 2 entries:
  - **bossa-nova**: anticipated upbeats, sparse density, low chromatic tolerance, 9/11/13/#11 colors. 2 prescriptive_lessons + 1 divergence_note (vs bebop) + 1 example_master (joe-pass via `three-to-four-note-voicings-with-voice-leading`).
  - **bebop**: anticipated eighths, dense, high chromatic + substitution density, b9/#9/#11/b13 colors. 2 prescriptive_lessons + 1 divergence_note (vs bossa-nova) + 2 example_masters (joe-pass via dom-alteration lattice; mickey-baker via four-named-substitutions).

All narrative + quote content carries `provenance: "placeholder"`. The structural shape is stable; only the textual content is awaiting #419's extracted-from-source distillation.

## Why this shape

- **`schemaVersion: "v1"`** — Ellington's loader gates on this; breaking changes bump the major.
- **`prescriptive_lessons[]`** reuses the `usage_notes`/`prescriptive_lesson` shape from #415 so the chapter-loop distillation pipeline change (#419) outputs one shape consumable by both masters and styles.
- **`divergence_notes[].characteristic_quote`** is exactly what the LLM coach renders verbatim ("a bebop player would say…"). Authoring this is curator work, not LLM-generation — keeps the cross-style commentary in human voice.
- **`example_masters[]` + `diagnostic_examples[]`** — the comparator's training signal. Says "this voicing IS canonically this style because [reason]."

## Validation

- JSON parses; `jsonschema.validate(data, schema)` returns OK
- 2 styles × 2 lessons + 1 divergence + 1-2 example masters each
- No new errors in `scripts/validate.py` baseline (validator doesn't yet target `styles`; out of scope for this PR)

## Out of scope

- Populating prescriptive content (gated on #419 chapter-loop pipeline change)
- Curator pass for `divergence_notes[].characteristic_quote` (human-voiced, hand-authored)
- Extending `scripts/validate.py` with `--target styles` (small follow-up; or fold into #419)
- Adding more styles beyond bossa+bebop (cool-jazz, gypsy, hard-bop, etc. — incremental as the distillation pipeline outputs them)

## Refs

#417 (this) · #418 (idioms.json, sibling) · #419 (distillation pipeline change, content source) · #415 / PR #416 (usage_notes shape pattern) · ellington-systems#13 (Style Comparator MVP epic) · ellington-web#27 (StylePreset loader consumer) · #275 (EPIC: data-shape evolution)
