### PR TITLE
data(idioms)(#418): idioms.json scaffolding (schemaVersion v1 + chord-melody+comping)

### DIFF
--- a/plugin/data/idioms.json
+++ b/plugin/data/idioms.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "v1",
+  "idioms": [
+    {
+      "id": "chord-melody",
+      "name": "Chord Melody",
+      "description": "Solo-guitar idiom where the player carries the melody on top of the voicing while the lower notes provide harmony (and sometimes bass). The guitarist plays the role of the entire ensemble — melody, harmony, bass — within a single instrument. Most exemplified in the unaccompanied solo-guitar repertoire (Pass, Van Eps, Greene, Galbraith, Bertoncini).",
+      "characteristic_voicing_density": "moderate",
+      "characteristic_rhythmic_role": "melody on top with sustaining harmony underneath; bass anchors on downbeats; interior chord rhythm aligns with melodic phrasing rather than running 8ths/quarters independently",
+      "compatible_styles": ["bossa-nova", "cool-jazz", "standards", "ballad"],
+      "prescriptive_lessons": [
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-with-melody-on-top",
+          "narrative": "[placeholder] In chord-melody, maj7 voicings are typically drop-2 or drop-3 shapes with the melody note as the topmost voice. When the melody is the 3rd, voice the chord as R-7-3 closed; when the melody is the 9, lift to maj9. Real prescriptive content via #419 (bertoncini or galbraith run as the chord-melody exemplar).",
+          "provenance": "placeholder",
+          "source": "placeholder"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-with-melody-leading-chromatically",
+          "narrative": "[placeholder] V7 in chord-melody often supports the melody through 3-7 guide-tone resolution. When the melody resolves down a half-step into the I, the V7 typically carries altered tensions (b9 or #9) to create the chromatic pull. Backfill via #419.",
+          "provenance": "placeholder",
+          "source": "placeholder"
+        }
+      ],
+      "divergence_notes": [
+        {
+          "vs_idiom": "comping",
+          "shared_dimensions": ["voicing-tradition vocabulary", "voice-leading principles"],
+          "diverging_dimensions": ["who-carries-melody", "rhythmic-independence", "ensemble-role"],
+          "characteristic_quote": "[placeholder] A chord-melody player would say: 'You're playing comping rhythms — but there's no one else playing the melody. Lift the top voice up to the melody and let the comping be the interior.' Backfilled via curator pass after #419.",
+          "provenance": "placeholder"
+        }
+      ],
+      "example_masters": [
+        {
+          "master_id": "joe-pass",
+          "exemplar_principle_ids": ["drop-2-and-drop-3-chord-melody"]
+        },
+        {
+          "master_id": "van-eps",
+          "exemplar_principle_ids": ["harmonized-scale-foundation", "outer-voice-anchor-inner-motion"]
+        },
+        {
+          "master_id": "gene-bertoncini",
+          "exemplar_principle_ids": ["open-string-as-orchestrational-resource"]
+        }
+      ],
+      "diagnostic_examples": []
+    },
+    {
+      "id": "comping",
+      "name": "Comping (Accompaniment)",
+      "description": "Rhythm-section idiom where the guitarist plays harmony in support of a separate melody player (singer, horn, lead guitarist, pianist). The comping player's role is to outline the harmony rhythmically and provide forward motion without competing with the melody. Most exemplified in small-group jazz comping traditions (Bernstein, Baker, Warnock pedagogy, walking-bass-and-chords tradition).",
+      "characteristic_voicing_density": "moderate",
+      "characteristic_rhythmic_role": "off-beat or continuous-pattern chord stabs in support of a melody player elsewhere; voicings often shells (R-3-7) dressed with extensions; rhythmic independence from the melody is the defining feature",
+      "compatible_styles": ["bebop", "hard-bop", "bossa-nova", "cool-jazz", "standards"],
+      "prescriptive_lessons": [
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-supporting-melody",
+          "narrative": "[placeholder] In comping, V7 voicings stay small (3-4 notes max) so they don't crowd the melody. The R-3-7 shell with an added b9 or 13 on top is the workhorse; rhythm is anticipated on the upbeat of 4 of the preceding bar. Backfill via #419 (mickey-baker run is queued as the comping exemplar).",
+          "provenance": "placeholder",
+          "source": "placeholder"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-with-rhythmic-support",
+          "narrative": "[placeholder] Comping maj7 is voiced as a shell (R-3-7) or guide-tone pair (3-7) so the singer/horn has room. The 9 or 6/9 is added when the melody allows. Backfill via #419.",
+          "provenance": "placeholder",
+          "source": "placeholder"
+        }
+      ],
+      "divergence_notes": [
+        {
+          "vs_idiom": "chord-melody",
+          "shared_dimensions": ["voicing vocabulary", "voice-leading principles"],
+          "diverging_dimensions": ["who-carries-melody", "voicing-density-relative-to-melody", "rhythmic-independence"],
+          "characteristic_quote": "[placeholder] A comping player would say: 'You're playing chord-melody density behind a horn solo — drop the top voice and let the horn live up there.' Backfilled via curator pass after #419.",
+          "provenance": "placeholder"
+        }
+      ],
+      "example_masters": [
+        {
+          "master_id": "peter-bernstein",
+          "exemplar_principle_ids": ["dressing-the-notes-comping-aesthetic"]
+        },
+        {
+          "master_id": "mickey-baker",
+          "exemplar_principle_ids": ["numbered-finite-vocabulary-with-transposition-mandate", "four-named-substitution-principles-as-lattice"]
+        }
+      ],
+      "diagnostic_examples": []
+    }
+  ]
+}

--- a/schema/idioms.schema.json
+++ b/schema/idioms.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "idioms.json schema",
+  "description": "Schema for plugin/data/idioms.json — the third axis catalog. An 'idiom' is a PERFORMANCE CONTEXT / ROLE (chord-melody, comping, single-line, walking-bass-with-chords, ...). Orthogonal to masters (who) and styles (tradition); answers 'what role is the guitarist playing in this passage.' Per cross-agent agreement (plugin#418 + ellington-web), structural fields ship first; prescriptive content backfills via the quality-axis distillation pipeline change (#419).",
+  "type": "object",
+  "required": ["schemaVersion", "idioms"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "enum": ["v1"],
+      "description": "Schema version string. Consumers MUST gate on this. Breaking changes bump the major (v2, v3, ...)."
+    },
+    "idioms": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/idiom" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "idiom": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+$",
+          "description": "Kebab-case slug. Examples: 'chord-melody', 'comping', 'single-line', 'walking-bass-with-chords', 'counterpoint-arrangement', 'rubato-rhapsody'."
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "description": {
+          "type": "string",
+          "description": "2-3 sentences on what playing IN this idiom means."
+        },
+        "characteristic_voicing_density": {
+          "type": "string",
+          "enum": ["sparse", "moderate", "dense", "very-dense"],
+          "description": "Typical number of simultaneous notes. Single-line is sparse (1 note); chord-melody is moderate-dense (3-4); walking-bass-with-chords is moderate (2-3 in chord + 1 bass)."
+        },
+        "characteristic_rhythmic_role": {
+          "type": "string",
+          "description": "Free text describing the rhythmic responsibility carried in this idiom. Examples: 'melody on top + supporting bass + interior chord rhythm' (chord-melody); 'rhythm-section accompaniment on off-beats or in continuous comping pattern' (comping)."
+        },
+        "compatible_styles": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "References styles[].id that naturally pair with this idiom. Examples: chord-melody compatible with cool-jazz, ballad-context; comping compatible with bebop, hard-bop, bossa-nova."
+        },
+        "prescriptive_lessons": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/prescriptive_lesson" },
+          "description": "Per-chord-quality teaching specific to this idiom. Same shape as masters.usage_notes from #415 and styles.prescriptive_lessons from #417."
+        },
+        "divergence_notes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/divergence_note" },
+          "description": "Structured cross-idiom commentary. 'A comping player would say...' when audio exhibits one idiom inside a passage that called for another."
+        },
+        "example_masters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["master_id"],
+            "properties": {
+              "master_id": { "type": "string" },
+              "exemplar_work_ids": { "type": "array", "items": { "type": "string" } },
+              "exemplar_principle_ids": { "type": "array", "items": { "type": "string" } }
+            },
+            "additionalProperties": true
+          }
+        },
+        "diagnostic_examples": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["voicing_id"],
+            "properties": {
+              "voicing_id": { "type": "string" },
+              "why_canonical": { "type": "string" },
+              "provenance": { "type": "string", "enum": ["extracted", "hand-authored", "placeholder"] }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "prescriptive_lesson": {
+      "type": "object",
+      "required": ["chord_quality", "narrative"],
+      "properties": {
+        "chord_quality": { "type": "string", "minLength": 1 },
+        "function_role": { "type": "string" },
+        "narrative": { "type": "string", "minLength": 1 },
+        "voicing_examples": { "type": "array", "items": { "type": "string" } },
+        "source": { "type": "string" },
+        "provenance": { "type": "string", "enum": ["extracted", "inferred-from-principles", "hand-authored", "placeholder"] }
+      },
+      "additionalProperties": true
+    },
+    "divergence_note": {
+      "type": "object",
+      "required": ["vs_idiom"],
+      "properties": {
+        "vs_idiom": { "type": "string" },
+        "shared_dimensions": { "type": "array", "items": { "type": "string" } },
+        "diverging_dimensions": { "type": "array", "items": { "type": "string" } },
+        "characteristic_quote": { "type": "string" },
+        "provenance": { "type": "string", "enum": ["hand-authored", "extracted", "placeholder"] }
+      },
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
Closes #418. Second piece of the three-axis catalog model. Mirrors styles.json (#417 / PR #421) but with idiom-specific semantics (performance contexts: chord-melody, comping).

Stacked logically on #417 — the two schemas reuse the same prescriptive_lesson and divergence_note shapes so the chapter-loop distillation pipeline change (#419) produces one output shape consumed by both.

## What landed

- schema/idioms.schema.json (schemaVersion v1)
- plugin/data/idioms.json with chord-melody + comping

## Refs

#418 · #417 / PR #421 (sibling) · #415 / PR #416 · #419 · ellington-systems#13 · ellington-web#27 · #275