### PR TITLE
pipeline(#426): heal stage-state.json for missing STAGE_ORDER entries on load

### DIFF
--- a/pipelines/master-distillation/lib/state.py
+++ b/pipelines/master-distillation/lib/state.py
@@ -94,12 +94,20 @@ class RunState:
     @classmethod
     def load(cls, path: Path) -> RunState:
         data = json.loads(path.read_text())
+        stages = {
+            k: StageRecord.from_dict(v) for k, v in data["stages"].items()
+        }
+        # Heal: backfill any STAGE_ORDER entry missing from this run's
+        # state. Lets STAGE_ORDER grow (e.g. s5 added in #423) without
+        # requiring hand-edits to every in-flight run's state file.
+        # New stages default to pending; existing accepted/awaiting-review
+        # statuses are preserved untouched. See #426.
+        for stage in STAGE_ORDER:
+            stages.setdefault(stage, StageRecord())
         return cls(
             run_id=data["run_id"],
             config=data["config"],
-            stages={
-                k: StageRecord.from_dict(v) for k, v in data["stages"].items()
-            },
+            stages=stages,
         )
 
     def save(self, path: Path) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -198,6 +198,34 @@ def test_state_save_load_roundtrip(tmp_path):
     assert reloaded.stages["s2"].outputs == ["a.txt", "b.txt"]
 
 
+def test_state_load_heals_missing_stage(tmp_path):
+    """#426: STAGE_ORDER may grow over time (s5 added in #423).
+    Loading a state file written when STAGE_ORDER was smaller should
+    backfill the missing stages with status='pending' and preserve
+    existing stage statuses."""
+    # Hand-roll a state file that's missing the LAST stage in current
+    # STAGE_ORDER — simulating a pre-extension state file.
+    legacy_stages = state.STAGE_ORDER[:-1]
+    last_stage = state.STAGE_ORDER[-1]
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({
+        "run_id": "legacy-run",
+        "config": "config.toml",
+        "stages": {
+            s: {"status": "accepted" if s == "s1" else "pending",
+                "started_at": None, "ended_at": None,
+                "outputs": [], "error_message": None}
+            for s in legacy_stages
+        },
+    }))
+    reloaded = state.RunState.load(path)
+    # Existing stage status preserved
+    assert reloaded.stages["s1"].status == "accepted"
+    # Missing stage backfilled with pending
+    assert last_stage in reloaded.stages
+    assert reloaded.stages[last_stage].status == "pending"
+
+
 # === lib/paths.py ===
 
 


### PR DESCRIPTION
Closes #426. Unblocks #419 first-run on laukens-beginners-guide.

PR #423 added s5 to STAGE_ORDER but did not migrate the 24 in-flight runs whose stage-state.json was written when STAGE_ORDER was [s1..s4]. Loading those state files would have left s5 missing from the stages dict, and resume would KeyError.

Fix: `RunState.load()` backfills any missing STAGE_ORDER entry with status=pending. Existing accepted/awaiting-review statuses are preserved.

Added `test_state_load_heals_missing_stage` covering the backfill semantics.

## Refs

#426 · #419 · PR #423 · #275