### PR TITLE
fix(#430): resolve remote $HOME before quoting OCR inbox path

### DIFF
--- a/pipelines/master-distillation/stages/s1_extract.py
+++ b/pipelines/master-distillation/stages/s1_extract.py
@@ -315,13 +315,29 @@ def _extract_with_ocr(
     output_dir = book.run_dir / "ocr-output"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    remote_inbox = f"~/jazz-ocr/inbox/{book.run_id}/"
+    # #430: resolve the remote $HOME once and use absolute paths everywhere.
+    # Earlier code passed `~`-prefixed paths through shlex.quote, which wraps
+    # the path in single quotes — bash does not expand `~` or `$HOME` inside
+    # single quotes, so `mkdir -p '$HOME/jazz-ocr/inbox/...'` silently
+    # created a literal `$HOME` directory in the remote cwd. Resolving once
+    # eliminates that whole class of bug.
+    remote_home_probe = subprocess.run(
+        ["ssh", remote, "printf %s \"$HOME\""],
+        capture_output=True, text=True, check=True,
+    )
+    remote_home = remote_home_probe.stdout.strip()
+    if not remote_home or not remote_home.startswith("/"):
+        raise RuntimeError(
+            f"could not resolve remote $HOME on {remote}: "
+            f"got {remote_home!r}"
+        )
+    remote_inbox = f"{remote_home}/jazz-ocr/inbox/{book.run_id}/"
 
     if src.is_remote:
         # 1+2 combined: ssh-run pdftoppm on cyberpower writing directly
         # into the inbox. No local image dir; no rsync-up step. Symmetric
         # with the OCR-runner being on cyberpower already.
-        remote_inbox_quoted = shlex.quote(remote_inbox.replace("~", "$HOME"))
+        remote_inbox_quoted = shlex.quote(remote_inbox)
         ppm_cmd = (
             f"mkdir -p {remote_inbox_quoted} && "
             f"pdftoppm -png -r {cfg['render_dpi']} "
@@ -388,7 +404,7 @@ def _extract_with_ocr(
     # orchestrator polls indefinitely. On timeout we raise — the remote
     # runner may still complete, in which case `reingest.py <run_id>` is
     # the recovery path.
-    remote_outbox = f"~/jazz-ocr/outbox/{book.run_id}"
+    remote_outbox = f"{remote_home}/jazz-ocr/outbox/{book.run_id}"
     poll_interval = 30
     max_wait_seconds = cfg["max_wait_minutes"] * 60
     poll_start = time.monotonic()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -455,6 +455,72 @@ def test_ocr_defaults_max_wait_minutes_is_positive():
     assert s1_extract.OCR_DEFAULTS["max_wait_minutes"] > 0
 
 
+def test_ocr_orchestrator_does_not_pass_unexpanded_HOME_to_ssh(monkeypatch, tmp_path):
+    """#430 regression: pre-fix code wrapped `~/jazz-ocr/inbox/...` through
+    shlex.quote after replacing `~` with `$HOME`. Single-quoted `$HOME`
+    is not expanded by bash, so `mkdir -p '$HOME/...'` created a literal
+    `$HOME` directory in cwd. Fix resolves `$HOME` via an ssh probe and
+    uses absolute paths everywhere.
+
+    This test captures every ssh command the orchestrator emits during
+    setup and asserts none of them contain an unexpanded `$HOME` token
+    in places where the shell would not expand it.
+    """
+    import subprocess as _sp
+    import shutil as _sh
+
+    src = s1_extract.SourceLocator({
+        "pdf": "/remote/path/to/book.pdf",
+        "host": "stub-host",
+        "user": "stub-user",
+    })
+    assert src.is_remote
+
+    captured: list[list[str]] = []
+    home_probe_response = _sp.CompletedProcess(
+        args=[], returncode=0, stdout="/home/stub-user\n", stderr=""
+    )
+
+    def fake_run(argv, *a, **kw):
+        captured.append(list(argv))
+        # First ssh call is the $HOME probe; return a realistic absolute
+        # path. After that, abort to skip the rest of the orchestrator.
+        if len(argv) >= 3 and "printf" in argv[-1]:
+            return home_probe_response
+        raise RuntimeError("ABORT_AFTER_PDFTOPPM")
+
+    monkeypatch.setattr(_sp, "run", fake_run)
+    monkeypatch.setattr(s1_extract.subprocess, "run", fake_run)
+    monkeypatch.setattr(_sh, "which", lambda b: f"/usr/bin/{b}")
+    monkeypatch.setattr(s1_extract.shutil, "which", lambda b: f"/usr/bin/{b}")
+
+    book = type("Book", (), {
+        "run_id": "2026-01-02T03-04-05-stub",
+        "run_dir": tmp_path,
+    })()
+
+    try:
+        s1_extract._extract_with_ocr(src, book, {})
+    except RuntimeError as e:
+        assert "ABORT_AFTER_PDFTOPPM" in str(e)
+
+    # Skip the $HOME probe (it intentionally contains `"$HOME"` for the
+    # remote bash to expand). Every OTHER ssh argv must not contain a
+    # literal `$HOME` — pre-fix code shlex.quoted `$HOME/...`, which bash
+    # does NOT expand inside single quotes; `mkdir -p '$HOME/...'`
+    # created a literal `$HOME` directory in cwd.
+    non_probe = [a for a in captured if not (len(a) >= 3 and "printf" in a[-1])]
+    for argv in non_probe:
+        joined = " ".join(argv)
+        assert "$HOME" not in joined, (
+            f"#430 regression: ssh argv leaked '$HOME': {joined!r}"
+        )
+    # And the resolved absolute home must appear in the mkdir+pdftoppm
+    # call, anchoring the fix.
+    assert non_probe, "expected at least one non-probe ssh call"
+    assert "/home/stub-user/jazz-ocr/inbox/" in " ".join(non_probe[0])
+
+
 # ---------------------------------------------------------------------------
 # SourceLocator (#331 remote-source refactor)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #430.

## Symptom
s1 OCR on #429 (Laukens Complete Chord Melody) silently extracted page images into `~/$HOME/jazz-ocr/inbox/<run_id>/` (a literal `$HOME` directory in cwd) instead of `~/jazz-ocr/inbox/<run_id>/`. OCR runner died with "inbox not found". Orchestrator never detected the failure because the polling pgrep matches its own argv.

## Root cause
`shlex.quote()` around a string containing `$HOME` produces single-quoted `'$HOME/...'`. Bash does not expand `$HOME` inside single quotes, so `mkdir -p '$HOME/...'` creates a literal `$HOME` directory.

## Fix
- Resolve remote `$HOME` once via `ssh remote 'printf %s "$HOME"'` at the start of `_extract_with_ocr`.
- Use the resolved absolute path for both `remote_inbox` and `remote_outbox`.
- No more `~` or `$HOME` strings in paths fed to `shlex.quote()`.

## Class-of-bug claim
Affects every run with `src.is_remote = true` AND `needs_ocr = true`. Pre-existing runs (from May) predate the broken refactor (per git blame on the bad line).

## Tests
- New `test_ocr_orchestrator_does_not_pass_unexpanded_HOME_to_ssh` captures every ssh argv the orchestrator emits during setup and asserts none contain a literal `$HOME`. Pre-fix code fails the test with the exact broken `mkdir -p '$HOME/...'` in the assertion output. 50/50 pipeline tests pass.

## #429 recovery
Pages already extracted to `~/\$HOME/...` were manually moved to the correct inbox; OCR runner is now running directly on them (PID 2520207 on cyberpower). #429 resumes via `reingest.py` once the runner completes.