### PR TITLE
queue(#452): backfill .done state markers from orchestrator runs

### DIFF
--- a/pipelines/master-distillation/queue/state_backfill.py
+++ b/pipelines/master-distillation/queue/state_backfill.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Backfill queue daemon `.done` state markers from orchestrator runs.
+
+Why: the bash queue daemon (queue_runner.sh) considers a book eligible if
+no `state/<slug>.done` marker exists. Markers are written ONLY by
+process_one.sh on its own successful completion — runs completed via the
+direct `run.py new-run <config>` orchestration path (the standard manual
+flow) never touch the daemon state dir, so the daemon considers those
+books eligible and would re-OCR them. See #452.
+
+This script scans every stage-state.json under
+`pipelines/master-distillation/runs/<run_id>/` and, for any run whose s1
+stage is `accepted` (s1 has produced the canonical outputs and the
+operator/curator advanced past it), writes a matching `.done` marker into
+the daemon's STATE_DIR so the daemon will skip that book on next poll.
+
+Idempotent. Re-run after every direct orchestrator session.
+
+Usage (on cyberpower):
+    python3 pipelines/master-distillation/queue/state_backfill.py
+
+    # Custom paths:
+    python3 .../state_backfill.py --runs-root /path/to/runs --state-dir /path/to/state
+
+    # Dry run — print what would be written, don't write:
+    python3 .../state_backfill.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _config_slug(config_path_str: str, configs_root: Path) -> str | None:
+    """Derive the queue slug from a config path string.
+
+    The run's `config` field is the repo-relative path to the toml, e.g.
+    `pipelines/master-distillation/configs/laukens-complete-chord-melody.toml`.
+    The slug is the stem of the basename.
+
+    Returns None if the path doesn't look like a config under the
+    expected configs/ tree.
+    """
+    p = Path(config_path_str)
+    if p.suffix != ".toml":
+        return None
+    return p.stem
+
+
+def _read_s1_status(state_file: Path) -> str | None:
+    """Return s1.status from a stage-state.json, or None if unreadable."""
+    try:
+        data = json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    stages = data.get("stages") or {}
+    s1 = stages.get("s1") or {}
+    return s1.get("status")
+
+
+def _read_config_field(state_file: Path) -> str | None:
+    """Return the run's `config` field from a stage-state.json."""
+    try:
+        data = json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    cfg = data.get("config")
+    if isinstance(cfg, str) and cfg:
+        return cfg
+    return None
+
+
+def collect_completed_slugs(runs_root: Path, configs_root: Path) -> dict[str, Path]:
+    """Walk runs_root, return {slug: state_file} for every run whose s1
+    is `accepted`. If the same slug has multiple runs (re-runs), the
+    most-recently-modified state file wins.
+    """
+    out: dict[str, Path] = {}
+    if not runs_root.exists():
+        return out
+    for state_file in sorted(runs_root.glob("*/stage-state.json")):
+        s1 = _read_s1_status(state_file)
+        if s1 != "accepted":
+            continue
+        cfg = _read_config_field(state_file)
+        if not cfg:
+            continue
+        slug = _config_slug(cfg, configs_root)
+        if not slug:
+            continue
+        # Prefer the most-recently-modified record if duplicate slugs.
+        prior = out.get(slug)
+        if prior is None or state_file.stat().st_mtime > prior.stat().st_mtime:
+            out[slug] = state_file
+    return out
+
+
+def write_marker(state_dir: Path, slug: str, source_file: Path) -> Path:
+    """Write `<state_dir>/<slug>.done`. Body is an ISO-8601 timestamp plus
+    the source stage-state.json path for audit. Returns the written path.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    marker = state_dir / f"{slug}.done"
+    body = (
+        datetime.now(timezone.utc).isoformat(timespec="seconds")
+        + "\n"
+        + f"BACKFILLED_FROM: {source_file}\n"
+    )
+    marker.write_text(body)
+    return marker
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--runs-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "runs",
+        help="root of run dirs; default: ../runs/ relative to this script",
+    )
+    p.add_argument(
+        "--configs-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "configs",
+        help="root of config tomls; default: ../configs/ relative to this script",
+    )
+    p.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path(os.environ.get("STATE_DIR")
+                     or Path.home() / "jazz-pipeline" / "state"),
+        help="queue daemon STATE_DIR; default: ~/jazz-pipeline/state",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print what would be written without touching disk",
+    )
+    args = p.parse_args(argv)
+
+    completed = collect_completed_slugs(args.runs_root, args.configs_root)
+    print(f"scanned {args.runs_root}; found {len(completed)} runs with s1=accepted")
+    if not completed:
+        return 0
+
+    written = 0
+    skipped_already = 0
+    for slug, source in completed.items():
+        marker = args.state_dir / f"{slug}.done"
+        if marker.exists():
+            skipped_already += 1
+            print(f"  ALREADY: {slug}.done exists ({marker})")
+            continue
+        if args.dry_run:
+            print(f"  WOULD WRITE: {marker} <- {source}")
+        else:
+            written_path = write_marker(args.state_dir, slug, source)
+            print(f"  WROTE: {written_path} <- {source}")
+            written += 1
+    print(
+        f"backfill complete: wrote {written}, skipped {skipped_already} "
+        f"(already present), total eligible {len(completed)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_queue_state_backfill.py
+++ b/tests/test_queue_state_backfill.py
@@ -1,0 +1,252 @@
+"""Tests for the queue daemon state-marker backfill script (#452).
+
+The backfill scans pipelines/master-distillation/runs/*/stage-state.json and
+writes ~/jazz-pipeline/state/<slug>.done for any run with s1=accepted.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = (
+    REPO_ROOT
+    / "pipelines"
+    / "master-distillation"
+    / "queue"
+    / "state_backfill.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("state_backfill", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+backfill = _load_module()
+
+
+def _write_run_state(
+    run_dir: Path,
+    config_path: str,
+    s1_status: str,
+    run_id: str | None = None,
+) -> Path:
+    """Write a minimal stage-state.json file. Returns its path."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    state_file = run_dir / "stage-state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "run_id": run_id or run_dir.name,
+                "config": config_path,
+                "stages": {
+                    "s1": {"status": s1_status},
+                    "s2": {"status": "pending"},
+                    "s3": {"status": "pending"},
+                    "s4": {"status": "pending"},
+                    "s5": {"status": "pending"},
+                },
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return state_file
+
+
+def test_config_slug_from_canonical_repo_relative_path():
+    assert (
+        backfill._config_slug(
+            "pipelines/master-distillation/configs/laukens-complete-chord-melody.toml",
+            Path("/anything"),
+        )
+        == "laukens-complete-chord-melody"
+    )
+
+
+def test_config_slug_rejects_non_toml():
+    assert backfill._config_slug("foo/bar.yaml", Path("/x")) is None
+
+
+def test_collect_only_returns_s1_accepted_runs(tmp_path):
+    runs_root = tmp_path / "runs"
+    accepted_dir = runs_root / "2026-06-10T15-35-34-laukens-complete-chord-melody"
+    running_dir = runs_root / "2026-06-10T22-47-48-goodrick-almanac-vol-1"
+    pending_dir = runs_root / "2026-06-09T01-02-03-roberts-chord-melody"
+
+    _write_run_state(
+        accepted_dir,
+        "pipelines/master-distillation/configs/laukens-complete-chord-melody.toml",
+        "accepted",
+    )
+    _write_run_state(
+        running_dir,
+        "pipelines/master-distillation/configs/goodrick-almanac-vol-1.toml",
+        "running",
+    )
+    _write_run_state(
+        pending_dir,
+        "pipelines/master-distillation/configs/roberts-chord-melody.toml",
+        "pending",
+    )
+
+    completed = backfill.collect_completed_slugs(runs_root, tmp_path / "configs")
+    assert set(completed.keys()) == {"laukens-complete-chord-melody"}, (
+        "only s1=accepted runs should be in the result"
+    )
+
+
+def test_collect_handles_missing_runs_root(tmp_path):
+    """No runs dir yet (fresh checkout) — should not raise."""
+    assert backfill.collect_completed_slugs(tmp_path / "absent", tmp_path) == {}
+
+
+def test_collect_dedupes_by_slug_keeping_most_recent(tmp_path):
+    """When the same config slug has multiple runs (e.g. a redo), the
+    most-recently-modified state file wins."""
+    runs_root = tmp_path / "runs"
+    older = runs_root / "2026-05-01T00-00-00-laukens-beginners-guide"
+    newer = runs_root / "2026-06-10T00-00-00-laukens-beginners-guide"
+    older_state = _write_run_state(
+        older,
+        "pipelines/master-distillation/configs/laukens-beginners-guide.toml",
+        "accepted",
+    )
+    newer_state = _write_run_state(
+        newer,
+        "pipelines/master-distillation/configs/laukens-beginners-guide.toml",
+        "accepted",
+    )
+    # Force monotonic mtime ordering — touch newer to a later time.
+    import os
+    import time
+
+    os.utime(older_state, (time.time() - 100, time.time() - 100))
+    os.utime(newer_state, (time.time(), time.time()))
+
+    completed = backfill.collect_completed_slugs(runs_root, tmp_path / "configs")
+    assert completed == {"laukens-beginners-guide": newer_state}
+
+
+def test_write_marker_creates_file_with_audit_body(tmp_path):
+    state_dir = tmp_path / "state"
+    src = tmp_path / "stage-state.json"
+    src.write_text("{}")
+    marker = backfill.write_marker(state_dir, "laukens-beginners-guide", src)
+    assert marker == state_dir / "laukens-beginners-guide.done"
+    body = marker.read_text()
+    # Two lines: ISO timestamp + BACKFILLED_FROM
+    lines = body.strip().splitlines()
+    assert len(lines) == 2
+    assert lines[0].startswith("2026-") or lines[0].startswith("20")
+    assert lines[1].startswith("BACKFILLED_FROM: ")
+    assert str(src) in lines[1]
+
+
+def test_main_dry_run_does_not_write(tmp_path, capsys):
+    runs_root = tmp_path / "runs"
+    state_dir = tmp_path / "state"
+    _write_run_state(
+        runs_root / "run-a",
+        "pipelines/master-distillation/configs/example-book.toml",
+        "accepted",
+    )
+    rc = backfill.main(
+        [
+            "--runs-root",
+            str(runs_root),
+            "--state-dir",
+            str(state_dir),
+            "--configs-root",
+            str(tmp_path / "configs"),
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    assert not state_dir.exists(), "dry-run must not create state dir"
+    captured = capsys.readouterr().out
+    assert "WOULD WRITE" in captured
+    assert "example-book.done" in captured
+
+
+def test_main_actual_run_writes_markers(tmp_path):
+    runs_root = tmp_path / "runs"
+    state_dir = tmp_path / "state"
+    _write_run_state(
+        runs_root / "run-a",
+        "pipelines/master-distillation/configs/example-book.toml",
+        "accepted",
+    )
+    rc = backfill.main(
+        [
+            "--runs-root",
+            str(runs_root),
+            "--state-dir",
+            str(state_dir),
+            "--configs-root",
+            str(tmp_path / "configs"),
+        ]
+    )
+    assert rc == 0
+    marker = state_dir / "example-book.done"
+    assert marker.exists()
+    assert "BACKFILLED_FROM" in marker.read_text()
+
+
+def test_main_idempotent_when_marker_already_present(tmp_path, capsys):
+    runs_root = tmp_path / "runs"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "example-book.done").write_text("existing-marker\n")
+    _write_run_state(
+        runs_root / "run-a",
+        "pipelines/master-distillation/configs/example-book.toml",
+        "accepted",
+    )
+    rc = backfill.main(
+        [
+            "--runs-root",
+            str(runs_root),
+            "--state-dir",
+            str(state_dir),
+            "--configs-root",
+            str(tmp_path / "configs"),
+        ]
+    )
+    assert rc == 0
+    # The existing marker is preserved (idempotent — don't clobber).
+    assert (state_dir / "example-book.done").read_text() == "existing-marker\n"
+    out = capsys.readouterr().out
+    assert "ALREADY:" in out
+    assert "wrote 0" in out
+
+
+def test_collect_skips_runs_with_no_config_field(tmp_path):
+    """A malformed stage-state.json with no `config` field should be
+    silently skipped, not crash the script."""
+    runs_root = tmp_path / "runs"
+    run_dir = runs_root / "run-broken"
+    run_dir.mkdir(parents=True)
+    (run_dir / "stage-state.json").write_text(
+        json.dumps({"run_id": "x", "stages": {"s1": {"status": "accepted"}}})
+        + "\n"
+    )
+    assert backfill.collect_completed_slugs(runs_root, tmp_path) == {}
+
+
+def test_collect_skips_malformed_json(tmp_path):
+    """A garbage stage-state.json file should be silently skipped."""
+    runs_root = tmp_path / "runs"
+    run_dir = runs_root / "run-broken"
+    run_dir.mkdir(parents=True)
+    (run_dir / "stage-state.json").write_text("not-json{{{")
+    assert backfill.collect_completed_slugs(runs_root, tmp_path) == {}


### PR DESCRIPTION
Closes #452. Implements Option 1 (lightest touch) from the ticket.

## Why
Daemon's eligible_books() considers any book without a state/<slug>.done marker as eligible. Markers are written only by process_one.sh on its own successful completion — runs completed via direct `run.py new-run` orchestration never touch the daemon state dir, so daemon sees them as eligible and would re-dispatch them.

This bit us tonight: daemon picked up a freshly regenerated manifest with new books and immediately dispatched laukens-complete-chord-melody (already s1-s5 complete via #429, PR #433 merged) for re-OCR. ~5h of GPU waste would have happened plus contention with the in-flight #436 Goodrick V1 OCR. Caught early and killed.

## What
`pipelines/master-distillation/queue/state_backfill.py`:
- Walks runs/*/stage-state.json
- For any run with s1.status == 'accepted', writes state/<config-slug>.done with an ISO timestamp + BACKFILLED_FROM source path (audit trail)
- Idempotent — skips slugs that already have markers (does not clobber)
- Dedupes by slug keeping most-recently-modified state file (handles redos)
- `--dry-run` for inspection
- Robust to missing runs root, missing config field, malformed JSON

## Tests
11/11 pass:
- Slug derivation (canonical path; reject non-toml)
- Collect filters by s1=accepted
- Collect handles missing runs root
- Collect dedupes by slug, most-recent wins
- Marker body has timestamp + BACKFILLED_FROM
- Dry-run doesn't write
- Actual run writes
- Idempotency (existing marker preserved)
- Malformed inputs (no config field, garbage JSON)

## Deployment
Operator runs once on cyberpower after every direct orchestrator session, or wires into cron. Restarting the daemon after backfill skips the already-done books.

## Followups
Option 2 (have eligible_books() query stage-state.json directly) is the cleaner long-term fix — eliminates the dual-source-of-truth class entirely. Tracked separately if and when we want it.