### PR TITLE
fix(#459): backfill [stages.s5] section into 44 pre-#423 configs

### DIFF
--- a/pipelines/master-distillation/configs/aebersold-vol-1-how-to-play-jazz.toml
+++ b/pipelines/master-distillation/configs/aebersold-vol-1-how-to-play-jazz.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/baker-jazz-guitar.toml
+++ b/pipelines/master-distillation/configs/baker-jazz-guitar.toml
@@ -41,3 +41,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/baker-vol-2.toml
+++ b/pipelines/master-distillation/configs/baker-vol-2.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/benson-vol-1.toml
+++ b/pipelines/master-distillation/configs/benson-vol-1.toml
@@ -38,3 +38,7 @@ model = "qwen2.5:72b"
 # Use _pending:<kebab> for any engine_payload.kind we're not confident
 # about — until #298 payload-kind glossary lands.
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/benson-vol-2-advanced-harmony.toml
+++ b/pipelines/master-distillation/configs/benson-vol-2-advanced-harmony.toml
@@ -31,3 +31,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/benson-vol-3-technique-arpeggios.toml
+++ b/pipelines/master-distillation/configs/benson-vol-3-technique-arpeggios.toml
@@ -31,3 +31,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/benson-vol-4-approach-tones.toml
+++ b/pipelines/master-distillation/configs/benson-vol-4-approach-tones.toml
@@ -31,3 +31,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/benson-vol-5-melodic-minor.toml
+++ b/pipelines/master-distillation/configs/benson-vol-5-melodic-minor.toml
@@ -31,3 +31,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/benson-vol-6-giant-lines.toml
+++ b/pipelines/master-distillation/configs/benson-vol-6-giant-lines.toml
@@ -31,3 +31,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/benson-vol-7-blues-ideas.toml
+++ b/pipelines/master-distillation/configs/benson-vol-7-blues-ideas.toml
@@ -31,3 +31,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/bergonzi-melodic-rhythms-vol-4.toml
+++ b/pipelines/master-distillation/configs/bergonzi-melodic-rhythms-vol-4.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/bernstein-improvisation-method.toml
+++ b/pipelines/master-distillation/configs/bernstein-improvisation-method.toml
@@ -34,3 +34,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/bertoncini-arrangements-solo-guitar.toml
+++ b/pipelines/master-distillation/configs/bertoncini-arrangements-solo-guitar.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/bruno-art-of-picking.toml
+++ b/pipelines/master-distillation/configs/bruno-art-of-picking.toml
@@ -31,3 +31,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/carter-fingerstyle-jazz.toml
+++ b/pipelines/master-distillation/configs/carter-fingerstyle-jazz.toml
@@ -43,3 +43,7 @@ engine_kind_policy = "pending-when-unsure"
 [notes]
 status = "superseded"
 note = "PDF was mislabeled (filename references Bill Carter; actual content is Alan de Mause, Mel Bay's Complete Fingerstyle Jazz Guitar Book). Salvaged under de-mause-fingerstyle-jazz.toml in PR #372 / #360 audit comments. This config remains as audit trail; do not re-dispatch a worker against it."
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/coker-elements-jazz-language.toml
+++ b/pipelines/master-distillation/configs/coker-elements-jazz-language.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/coker-patterns-for-jazz.toml
+++ b/pipelines/master-distillation/configs/coker-patterns-for-jazz.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/de-mause-fingerstyle-jazz.toml
+++ b/pipelines/master-distillation/configs/de-mause-fingerstyle-jazz.toml
@@ -49,3 +49,7 @@ engine_kind_policy = "pending-when-unsure"
 #   transcript head; "Carter" appears in body but not as author.
 # - Source OCR copied from runs/2026-05-28T15-05-20-carter-fingerstyle-jazz/.
 # - Original wrong-keyed run dir stays as audit trail per #360.
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/dunbar-system-of-tonal-convergence.toml
+++ b/pipelines/master-distillation/configs/dunbar-system-of-tonal-convergence.toml
@@ -50,3 +50,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/faria-brazilian-guitar-book.toml
+++ b/pipelines/master-distillation/configs/faria-brazilian-guitar-book.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/felts-reharmonization-techniques.toml
+++ b/pipelines/master-distillation/configs/felts-reharmonization-techniques.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/fisher-jazz-guitar-method-vol-1.toml
+++ b/pipelines/master-distillation/configs/fisher-jazz-guitar-method-vol-1.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/fisher-jazz-guitar-method-vol-2.toml
+++ b/pipelines/master-distillation/configs/fisher-jazz-guitar-method-vol-2.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/fisher-jazz-guitar-method-vol-3.toml
+++ b/pipelines/master-distillation/configs/fisher-jazz-guitar-method-vol-3.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/galbraith-jazz-solo-guitar.toml
+++ b/pipelines/master-distillation/configs/galbraith-jazz-solo-guitar.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/greenan-jazz-standards-playbook.toml
+++ b/pipelines/master-distillation/configs/greenan-jazz-standards-playbook.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/greene-chord-chemistry.toml
+++ b/pipelines/master-distillation/configs/greene-chord-chemistry.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/greene-modern-chord-progressions.toml
+++ b/pipelines/master-distillation/configs/greene-modern-chord-progressions.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/greene-single-note-soloing-vol-1.toml
+++ b/pipelines/master-distillation/configs/greene-single-note-soloing-vol-1.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/heussenstamm-goldmine-100-jazz-lessons.toml
+++ b/pipelines/master-distillation/configs/heussenstamm-goldmine-100-jazz-lessons.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/larsen-modern-jazz-guitar-concepts.toml
+++ b/pipelines/master-distillation/configs/larsen-modern-jazz-guitar-concepts.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/laukens-jazz-guitar-chord-dictionary.toml
+++ b/pipelines/master-distillation/configs/laukens-jazz-guitar-chord-dictionary.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/laukens-jazz-guitar-patterns-vol-1.toml
+++ b/pipelines/master-distillation/configs/laukens-jazz-guitar-patterns-vol-1.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/laukens-tritone-substitution-licks.toml
+++ b/pipelines/master-distillation/configs/laukens-tritone-substitution-licks.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/martino-linear-expressions.toml
+++ b/pipelines/master-distillation/configs/martino-linear-expressions.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/martino-tonal-convergence.toml
+++ b/pipelines/master-distillation/configs/martino-tonal-convergence.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/orourke-complete-chord-melody.toml
+++ b/pipelines/master-distillation/configs/orourke-complete-chord-melody.toml
@@ -34,3 +34,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/pass-guitar-chords.toml
+++ b/pipelines/master-distillation/configs/pass-guitar-chords.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/pass-guitar-method.toml
+++ b/pipelines/master-distillation/configs/pass-guitar-method.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/taylor-complete-method-compilation.toml
+++ b/pipelines/master-distillation/configs/taylor-complete-method-compilation.toml
@@ -43,3 +43,7 @@ engine_kind_policy = "pending-when-unsure"
 [notes]
 status = "blocked-on-source-pdf"
 note = "PDF on disk is a marketplace decoy (Amazon-style listing page captured as 1 page; not the actual book). Surfaced on #360 wave-3 audit. Cannot distill until a real Martin Taylor source PDF is sourced. martin-taylor master entry in masters.json has empty works[] as a placeholder for when this gets unblocked."
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/vaartstra-jazz-standards-playbook.toml
+++ b/pipelines/master-distillation/configs/vaartstra-jazz-standards-playbook.toml
@@ -48,3 +48,7 @@ engine_kind_policy = "pending-when-unsure"
 #   transcript head; "Greenan" appears 0 times.
 # - Source OCR copied from runs/2026-05-28T15-05-20-greenan-jazz-standards-playbook/.
 # - Original wrong-keyed run dir stays as audit trail per #360.
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/van-eps-1939-method.toml
+++ b/pipelines/master-distillation/configs/van-eps-1939-method.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/van-eps-harmonic-mechanisms-vol-1.toml
+++ b/pipelines/master-distillation/configs/van-eps-harmonic-mechanisms-vol-1.toml
@@ -47,3 +47,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."

--- a/pipelines/master-distillation/configs/warnock-beginners-guide.toml
+++ b/pipelines/master-distillation/configs/warnock-beginners-guide.toml
@@ -39,3 +39,7 @@ book_level_model = "claude-sonnet"
 [stages.s4]
 model = "claude-sonnet"
 engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Backfilled per #459. Granular-levels prompt (#434) in effect; config predates PR #423 (s5_prescriptive stage)."


### PR DESCRIPTION
Closes #459.

s5_prescriptive.py reads cfg['stages']['s5']['model']; pre-#423 configs lack the section so resume errors with KeyError 's5'. Surfaced via #458 (Baker V1 s5 backfill from the #457 umbrella — 41 books in this state).

44 configs patched. Schema A claim: every config in pipelines/master-distillation/configs/ now has '[stages.s5]'.

Unblocks the entire #457 s5-backfill backlog.