### PR TITLE
data(masters)(#458): inject Mickey Baker Vol 1 usage_notes (37 notes, 15 chord_qualities)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -31512,7 +31512,635 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "chord_quality": "aug7",
+          "function_role": "substitution-rule-replaced-by-min7-pair",
+          "narrative": "Chapter 7 (p.26) shows the aug7 (G+7) appearing in the 'Standard' progression (C7 / Fmi / G7 / G+7 / C) but being fully replaced in the 'New' version by a Dmi7-Dmi6 cell. Baker's prescription eliminates aug7 from modern usage in favor of the relative-minor substitution pair.",
+          "source_principle_ids": [
+            "cycle-no-1-ii-v-recipe",
+            "dominant-to-relative-minor"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.26"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "idiom-specific-application",
+          "narrative": "Baker includes a diminished run in the Chapter 9 exercise vocabulary (Lessons 27-31), grouping it with scale, minor, and dominant runs as a foundational solo building block; the run is transposed chromatically up and down the neck using identical fingering (p.30).",
+          "source_principle_ids": [],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom11",
+          "function_role": "extended-dominant-menu",
+          "narrative": "Chapter 3 (p.9) includes G11 in the extended dominant substitution menu: 'G13, G9, G7#5+9, G13#5+9, G7b5, G11, G13b9 and so on.' G11 is listed as one of the available dominant substitutes, though Baker offers no further specification of its voice-leading or placement within the excerpted material.",
+          "source_principle_ids": [
+            "extended-dominant-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom13",
+          "function_role": "cycle-no-1-ii-v-recipe",
+          "narrative": "Chapter 4 (p.12) shows G13 as an explicit resolution target within the ii-V cell: 'I may use Dmi7 to Dmi6, or Dmi7 to G13, or something like that.' G13 (unaltered) and G13b9 (altered) are both available endpoints for the Dmi7 lead-in depending on context.",
+          "source_principle_ids": [
+            "cycle-no-1-ii-v-recipe"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 4 p.12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom13",
+          "function_role": "extended-dominant-menu",
+          "narrative": "Chapter 3 (p.9) lists G13 as the first item in the extended dominant substitution menu: 'you could use G13, G9, G7#5+9...' G13 is Baker's go-to dominant extension — the least altered form in the menu and a direct substitute for any plain dom7.",
+          "source_principle_ids": [
+            "extended-dominant-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom13",
+          "function_role": "root-omitted-tritone-equivalent",
+          "narrative": "Chapter 7 (p.26) shows 'G13b5b9' in the Cycle No. 1 reharmonization as a root-omitted dominant form. Baker's tritone equivalence principle (Chapter 7, p.19) applies to these 13-chord shapes as well, enabling the same root-omitted voicing to serve as either G13b5b9 or the enharmonic tritone substitute.",
+          "source_principle_ids": [
+            "root-omitted-tritone-equivalent"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.26"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "color-tone-requirement",
+          "narrative": "Chapter 3 (p.9) explicitly condemns the plain major triad as lacking 'enough color' and sounding 'corny.' By extension, an unaltered dom7 in a progression heading to a tonic is insufficient — Baker's standard requires at minimum an extension (9, 11, 13) or alteration (#5, b5, b9) to 'add color.'",
+          "source_principle_ids": [
+            "extended-dominant-menu",
+            "plain-triad-expansion-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "extended-dominant-menu",
+          "narrative": "Chapter 3 (p.9) enumerates the full substitution menu for any dom7: 'G13, G9, G7#5+9, G13#5+9, G7b5, G11, G13b9 and so on.' The student may choose any of these in place of a plain G7 depending on progression context.",
+          "source_principle_ids": [
+            "extended-dominant-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Baker declares in Chapter 3 (p.9): 'With dominant chords there is no limit to what can be done.' The plain dom7 is the minimum entry point for an open-ended menu of substitutions and alterations; using an unadorned dom7 is acceptable only as a baseline, not as a destination.",
+          "source_principle_ids": [
+            "extended-dominant-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "leading-chord-principle",
+          "narrative": "Chapter 5 (p.15) calls the dominant 'the key to all of the other lessons' and 'the best possible way to connect one chord to another using the dominant as leading chord.' Baker categorizes all dominant usage into three connection types: dominant-to-dominant, dominant-to-minor, and dominant-to-major.",
+          "source_principle_ids": [
+            "extended-dominant-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 5 p.15"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "progression-dependency-rule",
+          "narrative": "Chapter 3 (p.9) warns: 'It all depends on how the chords are progressing. You just can't throw these chords in any place, they have to be part of some kind of progression.' Dominant substitutions from the extended menu are context-sensitive, not free-floating.",
+          "source_principle_ids": [
+            "extended-dominant-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "substitution-rule-relative-minor",
+          "narrative": "Chapter 4 (p.12) states: 'The fifth of any dominant chord can be substituted in place of the Dominant itself.' For G7, the fifth is D, so Dmi7 (or Dmi7-Dmi6) replaces G7. Chapter 11 (p.42) reaffirms: 'The 5th of a dominant chord can be substituted in the dominant place, because they are closely related.'",
+          "source_principle_ids": [
+            "dominant-to-relative-minor"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 4 p.12"
+            },
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 11 p.42"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "always-alter-the-v-before-major",
+          "narrative": "Chapter 10 (p.34) prescribes: 'when connecting a dominant chord to a major the dominant in most of the time altered, (G7#5+9 to Cma or G13b5+9 to Cma). By altering chords like this they blend together perfectly. This same thing applies to solo work.' G7#5+9 and G13b5+9 are the two canonical altered forms before a major tonic.",
+          "source_principle_ids": [
+            "always-alter-the-v"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 10 p.34"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "idiom-specific-application",
+          "narrative": "Chapter 10 (p.34) explicitly extends the altered-dominant rule to solo work: 'This same thing applies to solo work.' Baker treats G7#5+9 and G13b5+9 as mandatory before tonic arrival regardless of whether the guitarist is comping or playing chord-melody.",
+          "source_principle_ids": [
+            "always-alter-the-v"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 10 p.34"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "root-omitted-tritone-equivalent",
+          "narrative": "Chapter 7 (p.19) provides the diagram annotation: 'G7#5 Db9b5 - Root omitted Root omitted,' establishing that these two root-omitted shapes are identical. The student may label the same fingering as either G7#5 or Db9b5 depending on harmonic context, giving dom7alt a built-in tritone substitution identity.",
+          "source_principle_ids": [
+            "root-omitted-tritone-equivalent"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "chromatic-passing-dominant",
+          "narrative": "Chapter 7 (p.26) shows 'Gmi7 C7b5' as a voice-leading pass within the Cycle No. 1 reharmonization of the Fmi bar. C7b5 (dom7b5) appears as a chromatic passing dominant resolving to Fmi7, distinct from its role as a tritone substitute, demonstrating dom7b5 in an inner-voice passing function.",
+          "source_principle_ids": [
+            "root-omitted-tritone-equivalent"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.26"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "extended-dominant-menu",
+          "narrative": "Chapter 3 (p.9) lists G7b5 within the extended dominant substitution menu. Chapter 7 (p.19) further identifies Db9b5 as the root-omitted tritone equivalent of G7#5 ('G7#5 Db9b5 - Root omitted Root omitted'), establishing dom7b5 as both a direct dominant substitute and a tritone substitution form.",
+          "source_principle_ids": [
+            "extended-dominant-menu",
+            "root-omitted-tritone-equivalent"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            },
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "cycle-no-1-ii-v-recipe",
+          "narrative": "Chapter 7 (p.26) places G13b9 as the resolution target in Cycle No. 1: 'Replace G7 with Dmi7-G13b9.' The b9 alteration is built into the prescribed ii-V cell — G13b9 is the specific dom7b9 form Baker recommends at the V before I in this cycle.",
+          "source_principle_ids": [
+            "cycle-no-1-ii-v-recipe"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.26"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "extended-dominant-menu",
+          "narrative": "Chapter 3 (p.9) lists G13b9 within the extended dominant substitution menu alongside G13, G9, G7#5+9, G13#5+9, G7b5, and G11. G13b9 is available as a drop-in replacement for any plain G7 chord within an appropriate progression.",
+          "source_principle_ids": [
+            "extended-dominant-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom9",
+          "function_role": "extended-dominant-menu",
+          "narrative": "Chapter 3 (p.9) lists G9 as the second item in the extended dominant substitution menu: 'you could use G13, G9, G7#5+9...' G9 is available as a drop-in for any plain dom7 within an appropriate progression, representing the unaltered ninth extension of the dominant.",
+          "source_principle_ids": [
+            "extended-dominant-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Chapter 3 (p.9) places Cma6 within the major-mode substitution family alongside Cma7 and Cma9: 'any chord on a major mode can be used in place of the major triad.' Chapter 10 (p.34) further confirms: 'Emi7 and Gma6 are the same (relatives), so it can be used as a major run.'",
+          "source_principle_ids": [
+            "plain-triad-expansion-menu",
+            "two-names-principle"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            },
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 10 p.34"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "two-names-principle",
+          "narrative": "Chapter 7 (p.19) establishes: 'When we are in one key a chord may be Gma7 while still in another key — the same chord has a different name, Emi7.' The specific two-name pairs given are Gma6 = Emi7 and Ama6 = Fmi7. The student must 'learn both names of these chords in all keys,' making maj6 a dual-identity voicing.",
+          "source_principle_ids": [
+            "two-names-principle"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Baker places maj7 within the major-mode substitution family. Chapter 3 (p.9) states: 'any chord on a major mode can be used in place of the major triad,' explicitly listing Cma7 alongside Cma6 and Cma9 as interchangeable tonic-side options.",
+          "source_principle_ids": [
+            "plain-triad-expansion-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "relative-run-substitution",
+          "narrative": "Chapter 10 (p.34) states that 'Emi7 and Gma6 are the same (relatives), so it can be used as a major run. The same rule that applies to chords applies to runs.' A Bmi7 run substitutes freely for Gma7 in the final two bars of a blues head (Chapter 10, p.41).",
+          "source_principle_ids": [
+            "relative-run-substitution",
+            "two-names-principle"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 10 p.34"
+            },
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 10 p.41"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-arrival-target",
+          "narrative": "Cma7 is the prescribed tonic arrival chord in Cycle No. 1 (Chapter 7, p.26): the reharmonized progression lands on 'Cma7 Ebmi7' rather than a plain C major, establishing maj7 as the minimum tonic color in Baker's modern vocabulary.",
+          "source_principle_ids": [
+            "cycle-no-1-ii-v-recipe"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.26"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "two-names-principle",
+          "narrative": "Baker teaches that Gma7 and Bmi7 are 'such close relatives that one can be used for the other at any time' (Chapter 10, p.41). Separately, Gma6 = Emi7 and Ama6 = Fmi7 are presented as the same chord shape under two names (Chapter 7, p.19); the student must 'learn both names of these chords in all keys.'",
+          "source_principle_ids": [
+            "two-names-principle"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.19"
+            },
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 10 p.41"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj9",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Chapter 3 (p.9) lists Cma9 as one of the three primary major-mode substitutes: 'any chord on a major mode can be used in place of the major triad,' explicitly naming Cma7, Cma6, and Cma9 as interchangeable tonic options. Cma9 is the most coloristically rich of the three.",
+          "source_principle_ids": [
+            "plain-triad-expansion-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min6",
+          "function_role": "cycle-no-1-ii-v-recipe",
+          "narrative": "Chapter 7 (p.26) prescribes min6 as the second chord in the relative-minor substitution cell: 'Replace C7 with Gmi7-Gmi6; Replace G7 with Dmi7-G13b9.' The min7-to-min6 descent within the cell provides voice-leading motion (the seventh steps down to the sixth) before resolving to the next harmony.",
+          "source_principle_ids": [
+            "cycle-no-1-ii-v-recipe"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.26"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min6",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Chapter 3 (p.9) places Dmi6 within the minor-mode substitution family: 'Dmi6, Dmi7 and Dmi9 are adaptable, because they are all on the same mode.' Chapter 4 (p.12) confirms: 'I may use Dmi7 to Dmi6,' showing min6 as the preferred minor resolution within the Dmi7 cell.",
+          "source_principle_ids": [
+            "plain-triad-expansion-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            },
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 4 p.12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "blues-bars-9-10-application",
+          "narrative": "Chapter 10 (p.34) prescribes min7 runs specifically at bars 9-10 of a blues: 'we use the V7 for one bar (D7) and the IV7 for one bar (C7), this allows you to use an Ami7 run for one bar and a Gmi7 run for one bar.' The min7 substitution applies equally to chord voicings and melodic runs.",
+          "source_principle_ids": [
+            "dominant-to-relative-minor",
+            "relative-run-substitution"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 10 p.34"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "cycle-no-1-ii-v-recipe",
+          "narrative": "In Cycle No. 1 (Chapter 7, p.26) Baker prescribes pairing min7 with min6 in a descending two-chord cell: 'Replace C7 with Gmi7-Gmi6; Replace G7 with Dmi7-G13b9.' The min7 always precedes either a min6 resolution or a dom13b9 resolution.",
+          "source_principle_ids": [
+            "cycle-no-1-ii-v-recipe"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.26"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Baker places min7 within the minor-mode substitution family. Chapter 3 (p.9) specifies: 'any minor chord can be used on the minor mode — Dmi6, Dmi7 and Dmi9 are adaptable, because they are all on the same mode.'",
+          "source_principle_ids": [
+            "plain-triad-expansion-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "leading-chord-function",
+          "narrative": "Chapter 5 (p.15) identifies the dominant as 'leading chord' for all connections, but min7 substitutes for it in dominant-to-minor and dominant-to-major contexts. Chapter 4 (p.12) confirms: 'most of the time when we have a seventh chord, we substitute minor chords in their place... Dmi7 to Dmi6, or Dmi7 to G13.'",
+          "source_principle_ids": [
+            "dominant-to-relative-minor",
+            "cycle-no-1-ii-v-recipe"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 5 p.15"
+            },
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 4 p.12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "substitution-rule-dominant-to-relative-minor",
+          "narrative": "Chapter 4 (p.12) lays down the core rule: 'if you have a dominant 7 chord you can substitute its relative minor which is the 5th of the chord.' G7 is replaced by Dmi7; D7 is replaced by Ami7. Baker calls this the dominant-to-relative-minor substitution and it is the most frequently applied move in the book.",
+          "source_principle_ids": [
+            "dominant-to-relative-minor"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 4 p.12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "two-names-principle",
+          "narrative": "Chapter 7 (p.19) establishes that Gma6 and Emi7 are the same chord shape — 'the same chord has a different name.' The student is instructed to 'learn both names of these chords in all keys,' making min7 identity context-dependent: the same voicing functions as either a minor ii chord or a major tonic surrogate.",
+          "source_principle_ids": [
+            "two-names-principle"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 7 p.19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "voice-leading-into-major",
+          "narrative": "Chapter 10 (p.34) prescribes a specific voice-leading chain: 'Whenever you have one or two bars of D7 going into G major, you may use an Ami7 run to a Cmi7 run which will blend right into a G major run.' The min7 (Ami7) initiates the chain, a b7-minor7 (Cmi7) passes through, and G major arrives — always altered at the V.",
+          "source_principle_ids": [
+            "always-alter-the-v",
+            "dominant-to-relative-minor"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 10 p.34"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min9",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Chapter 3 (p.9) includes Dmi9 in the minor-mode substitution family alongside Dmi6 and Dmi7: 'Dmi6, Dmi7 and Dmi9 are adaptable, because they are all on the same mode.' Dmi9 is available as a drop-in replacement for any minor chord in the appropriate modal context.",
+          "source_principle_ids": [
+            "plain-triad-expansion-menu"
+          ],
+          "source_work_id": "complete-course-in-jazz-guitar",
+          "references": [
+            {
+              "source": "complete-course-in-jazz-guitar",
+              "citation": "lesson 3 p.9"
+            }
+          ],
+          "provenance": "extracted"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #458. Sub-#457 (s5-backfill umbrella).

## Why now
Baker Vol 1 had s1-s4 already accepted from the pre-#423 era. s5 was unblocked by PR #460 (#459 config backfill). Driven inline with #434 granular-levels prompt + Ellington's 12-quality chord_quality steer (260607-sunny-ember).

## Result
- **37 usage_notes across 15 chord qualities** — broader coverage than prior extractions
- Distribution: min7=7, dom7=6, maj7=4, dom7alt=3, dom13=3, dom7b9=2, dom7b5=2, maj6=2, min6=2, aug7=1, dim7=1, dom9=1, dom11=1, maj9=1, min9=1
- Captures Baker's characteristic moves: cycle no. 1 ii-V recipe (Dmi7-G13b9), dominant-to-relative-minor substitution, root-omitted tritone equivalence (G7#5=Db9b5), two-names principle, always-alter-the-V before major, relative-run substitution carrying chord moves into single-note lines

## DoD
- 37 ≥ 23 (Laukens beginners-guide bar) ✅
- All `provenance: extracted` ✅
- Every narrative cites lesson + page ✅
- Schema validation: 24/24 pass on masters_schema ✅
- 15 chord qualities — high granularity per Ellington's prioritization ✅

## Mickey Baker entry in masters.json
- Master and complete-course-in-jazz-guitar work already existed
- This PR fills `usage_notes[]` from 0 to 37
- complete-course-vol-2 work entry remains; that's #457 backlog (separate s5 run)