### PR TITLE
data(masters)(#467): inject Ted Greene Chord Chemistry usage_notes (89 notes, 23 chord_qualities)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -4574,6 +4574,1314 @@
             }
           ]
         }
+      ],
+      "usage_notes": [
+        {
+          "chord_quality": "aug",
+          "function_role": "family-membership",
+          "narrative": "Greene places augmented chords outside the three main families: 'The diminished and augmented chords do not really fit in any of the families but they are most like the dominant chords in the way that they are used.' (Ch6 p.12). Functionally treated as altered dominants.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 6 p.12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "aug",
+          "function_role": "fret-interval-movement",
+          "narrative": "Greene establishes the symmetry rule for augmented chords: 'Augmented chords repeat every 4 frets' (Ch8 p.52) and reconfirms in Ch12: 'Augmented chords repeat themselves every 4 frets the same way diminished chords repeat every 3 frets.' (Ch12 p.63). Any aug voicing shifted 4 frets is enharmonically equivalent.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.52"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.63"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "aug",
+          "function_role": "note-omission-policy",
+          "narrative": "As a chord with an altered (#5) tone, the augmented chord's raised 5th may never be omitted. Greene states: 'if the 5th is altered, that is, sharped or flatted, you may not leave it out as it is essential to the chord.' (Ch5 p.10). The root could still be dropped.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "aug",
+          "function_role": "shell-voicing-floor",
+          "narrative": "Greene advises thinking of the augmented chord reductively: 'It is wise to think of the + chord as a 7+ with no b7.' (Ch12 p.63). This framing makes the augmented triad a shell of the dominant 7#5, with the b7 as the only missing element.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.63"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "blues-passing-application",
+          "narrative": "Greene specifically identifies '#IVo is used as a passing chord following a IV or IV7 type chord and then leading to a I or I7 type chord' (Ch19 p.98) as a standard blues-form passing motion. This chromatic diminished passing move is a defining blues-harmony idiom.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 19 p.98"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "family-membership",
+          "narrative": "Greene notes that 'The diminished and augmented chords do not really fit in any of the families but they are most like the dominant chords in the way that they are used.' (Ch6 p.12). Functionally, dim7 behaves as an altered dominant despite its structural independence.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 6 p.12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "fret-interval-movement",
+          "narrative": "Greene establishes the symmetry rule: 'any form of the diminished chord repeats itself every 3 frets.' (Ch11 p.62). This means any dim7 voicing can be moved in 3-fret intervals without changing chord identity, enabling fluid passing motion anywhere on the neck.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.62"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "idiom-specific-application",
+          "narrative": "Greene introduces the 'resolving diminished chord' concept: 'This chord will now replace the V7 chord, and will be called a RESOLVING DIMINISHED CHORD.' (Ch20 p.106). 'Resolving diminished chords also work well in place of m(maj7) type of chords, as long as the 7th tone of the m(maj7) is in the resolving dim chord.' (Ch20 p.107)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.106"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.107"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "passing-chord-usage",
+          "narrative": "Greene prescribes the primary role explicitly: 'Diminished chords are used as 'passing' chords usually; that is, they go IN BETWEEN other chords.' (Ch11 p.62). A specific passing use: '#IVo is used as a passing chord following a IV or IV7 type chord and then leading to a I or I7 type chord.' (Ch19 p.98)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.62"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 19 p.98"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "substitution-rules",
+          "narrative": "Greene articulates the dim7-as-dom7b9 relationship: 'a VII diminished triad sounds like a dominant 7th chord whose root is 2 whole steps lower.' (Ch16 p.86). More precisely, 'For an interesting sounding resolution of V7 to I, you may try putting together any 3 notes of a diminished 7th chord whose root is one fret higher than the root of the V7 chord, with the root of the I chord.' (Ch20 p.106)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 16 p.86"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.106"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "synonym-application",
+          "narrative": "Because dim7 repeats every 3 frets, Greene notes via the synonyms chapter that 'There are some chords with different names but the same notes, and they may be used in place of each other.' (Ch8 p.17). Each dim7 chord has four enharmonic names, quadrupling its substitution potential.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.17"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom11",
+          "function_role": "color-tone-requirement",
+          "narrative": "Greene highlights the expressive power of 11th chords: 'The dominant 11th chords (especially with no 3rd) are some of the prettiest chords when used properly.' (Ch11 p.61). Proper use requires avoiding the 3rd to prevent the clash that destroys the chord's characteristic openness.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.61"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom11",
+          "function_role": "note-omission-policy",
+          "narrative": "Greene prescribes omitting the 3rd in 11th chords: 'In chords that have the 11th tone, the 3rd is often omitted, particularly in the 11th chord itself.' (Ch5 p.10). The 3rd clashes with the 11th, making this omission structural rather than optional.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom11b9",
+          "function_role": "function-role-restriction",
+          "narrative": "Greene explicitly restricts the 11b9 chord to authentic V7 function: 'The 11b9 chords are usually used for the V7 chord of a key, but not often for others.' (Ch12 p.64). This chord's strong tension profile limits it to the primary dominant in a key.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.64"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom13b9",
+          "function_role": "note-omission-policy",
+          "narrative": "Greene specifies flexible omission for the 13b9: 'Sometimes 13b9 chords are played with no b7 or no 3rd - not both.' (Ch8 p.17). Either the b7 or the 3rd may be dropped, but never simultaneously, as both are critical to the chord's identity.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.17"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "back-cycling-application",
+          "narrative": "Greene defines back-cycling using dom7: 'this technique of putting in V chords right before another chord will be called back-cycling.' For dominant chains: 'For a dominant type chord, you may play another dominant type chord whose root is a 5th higher.' (Ch14 p.79, Ch10 p.60)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 14 p.79"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 10 p.60"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "blues-form-application",
+          "narrative": "Greene notes that the III7 chord substitutes for the I chord at measure 7: 'The IIIm7 and/or III7 chord are used often in place of the I chord in measure 7 of blues progressions.' (Ch19 p.101). The dom7 quality of the III gives a brighter, more aggressive substitute.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 19 p.101"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "blues-idiom-application",
+          "narrative": "Greene declares: 'the blues sound is usually associated with the dominant 7th family.' (Ch18 p.93). In blues, dominant chords appear on I, IV, and V, and 'in 99.9999% of all cases, some form of I chord will be in bar 1 to start the progression, and some form of a IV chord will be in bar 5.' (Ch18 p.93)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 18 p.93"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "common-tone-voice-leading",
+          "narrative": "Greene prescribes common-tone technique for smooth dominant progressions: 'COMMON TONES on the top notes of the chords will sometimes help smooth out the transitions' and 'Notice the use of common tones on top of some of these chords. This is one aid to smooth chord resolutions.' (Ch12 p.68, Ch11 p.62)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.68"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.62"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "cycle-of-fourths-voice-leading",
+          "narrative": "Greene describes a chromatic voice-leading technique: 'if you take any 7th chord and lower the 3rd and 7th 1 fret each, you will get a 9th chord built on the IV.' (Ch20 p.105). 'In any progression that has a series of dominant chords based on the cycle, you may progressively lower the 3rd and b7th, one fret at a time.' (Ch20 p.106)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.105"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.106"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "family-membership",
+          "narrative": "The dominant 7th is one of the three foundational chord 'fathers': 'The MAJOR, MINOR, and DOMINANT 7TH chords are the 'fathers' of the 3 families.' Greene also notes 'There are more dominant chords, by far, than major or minor types.' (Ch5 p.10, Ch8 p.17)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.17"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "fret-interval-movement",
+          "narrative": "Greene prescribes that 'Almost any dominant type chord can be moved in intervals of 3 frets as long as the LAST chord resolves into wherever you are going next.' (Ch12 p.65). Free chromatic movement of dominant chords is permitted so long as the final chord resolves correctly.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.65"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "i-iv-i-sandwich-application",
+          "narrative": "Greene describes a rock-specific rhythmic cell: 'each measure the IV chord of each basic chord is sandwiched between two I chords' (Ch20 p.110). In a rock I7 context, the IV7 is inserted mid-measure creating a rhythmic I7-IV7-I7 sandwich pattern.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.110"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "mixolydian-modal-application",
+          "narrative": "Greene observes that 'The harmonies of this scale seem to lend themselves towards the blues and rock field more than the other scales' regarding the mixolydian scale (Ch17 p.90), and because 'The notes and chords of these scales are the same: C major = G mixolydian,' the dom7 is the characteristic tonic chord of mixolydian.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 17 p.88"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 17 p.90"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "rhythmic-placement",
+          "narrative": "In chord melody contexts, dominant 7th chords are typically placed on 'the 1ST NOTE IN EACH MEASURE' rather than on every melody note. (Ch14 p.77). Greene emphasizes that 'chords are generally played every few notes, not on every note.' (Ch14 p.76)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 14 p.76"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 14 p.77"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "rock-idiom-application",
+          "narrative": "Greene prescribes that 'for a rock sound, quite often for a major chord you can substitute the dominant 7th and its extensions.' (Ch20 p.110). This establishes a blanket major-to-dom7 substitution specifically for rock contexts.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.110"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "secondary-dominant-application",
+          "narrative": "Greene states: 'Whenever a major or minor type chord is followed by a major, minor, or dominant type chord whose root is a 4th higher, you may divide the duration of the 1st chord in 1/2 and play a dominant chord with the same root for the 2nd 1/2 of the allotted time.' (Ch10 p.59). This creates secondary dominant motion on any chord.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 10 p.59"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "shell-voicing-floor",
+          "narrative": "Greene states 'When a 7th chord triad is desired, it is usually best to leave out the root or 5th.' (Ch16 p.84). The 3rd and b7th form the essential tritone shell; the root and 5th are the standard omission candidates for dom7 voicings.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 16 p.84"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "substitution-rules",
+          "narrative": "Greene establishes the tritone substitution framework: 'all dominant chords a 5th apart are related.' (Ch11 p.61). 'You can also use chords a b5th higher than those in the cycle if you like the sound.' (Ch15 p.81). This means any dom7 may be replaced by the dom7 a tritone away.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.61"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 15 p.81"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "turnaround-placement",
+          "narrative": "Greene mandates that 'The last chord of a turnaround is almost always a V7 type or its b5 (b11).' (Ch19 p.99). The dom7 (or its tritone sub) is the required final chord in any turnaround, regardless of the starting chord.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 19 p.99"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "voice-leading-melodic",
+          "narrative": "In chord melody, Greene emphasizes listening for top notes: 'When choosing the inversions, pay particular attention to the melody note (the highest pitch — the top note) in each chord.' (Ch18 p.95). For dom7 voicings in chord melody, the inversion is chosen to place the melody note on top.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 18 p.95"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7#11",
+          "function_role": "family-membership",
+          "narrative": "The augmented 11th dominant belongs to the dominant family. Greene states: 'Augmented 11th type chords can be used in place of dominant chords that are followed by a chord a 4th higher (just like other altered dominants).' (Ch11 p.61). It is classified as an altered dominant.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.61"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7#11",
+          "function_role": "practical-preference",
+          "narrative": "Greene notes a preference hierarchy among related chord types: 'It is actually more common to play a 9b5 than a +11.' (Ch11 p.61). The 9b5 is described as having 'a less muddy sound and are more easily used.' (Ch8 p.52). The +11 is the more complex alternative.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.61"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.52"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7#11",
+          "function_role": "tonic-placement-restriction",
+          "narrative": "Greene explicitly restricts +11 from tonic function: 'the +11 does not assume a tonic function; that is, you wouldn't REPLACE a I7 at the beginning of a song with it.' (Ch11 p.61). This chord is V7 function only.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.61"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7#11",
+          "function_role": "voicing-placement",
+          "narrative": "Greene prescribes the internal register of the #11: 'the +11 is usually put above the 5th in a chord (assuming there is a 5th being played) as in chords like the +11, 13+11, etc.' (Ch5 p.10). The 5th must be present if the #11 is to be placed above it.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "tonic-placement-exception",
+          "narrative": "Unlike other altered dominants, Greene grants the 7#9 an exception: 'the 7#9 chord can also be used as a direct replacement for the 7th chord in other cases too, when a 'bluesy' sound is desired' and it is the only altered chord that may replace a I7 at the start of a song. (Ch10 p.58-59)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 10 p.58"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 10 p.59"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "voicing-placement",
+          "narrative": "Greene specifies the internal voicing order: 'when using the #9, it is usually put above the 3rd in a chord, not below (such as in chords like 7#9, 7#9#5, etc.).' (Ch5 p.10). The #9 must sit higher than the 3rd in the voicing stack.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "color-tone-requirement",
+          "narrative": "Greene specifies the voicing priority: 'The most critical factor in an altered tone is often its top note (highest pitch).' (Ch10 p.59). When building altered dominant voicings, the altered tone should be placed on top to project its color.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 10 p.59"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "fret-interval-movement",
+          "narrative": "Greene prescribes specific intervallic movement for altered dominants: 'Dominant chords that have b5ths and/or #5ths may be used in 2 FRET INTERVALS effectively, still being careful to resolve nicely.' (Ch12 p.66). This is distinct from the 3-fret diminished movement.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.66"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "function-role-restriction",
+          "narrative": "Greene prescribes that altered dominants are contextually restricted: 'Dominant chords with altered tones (b5th, #5th, both, #9th) can be used effectively for dominant chords when the next chord is: 1-one whose root is a 4th higher, 2-one whose root is a 1/2 step lower, and 3-a minor type chord with the same root.' (Ch10 p.58)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 10 p.58"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "note-omission-policy",
+          "narrative": "Altered 5ths are non-negotiable: 'if the 5th is altered, that is, sharped or flatted, you may not leave it out as it is essential to the chord. You could still leave out the root though.' (Ch5 p.10). For dom7alt voicings, the altered tone is the most structurally critical note.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "tonic-placement-restriction",
+          "narrative": "Greene restricts altered dominants from opening a song: 'One important point is that you couldn't always replace a I7 at the beginning of a song with an altered chord (except for a 7#9); you might first play the I7 (or extension) and then you could play the altered chord.' (Ch10 p.59)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 10 p.59"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "practical-preference",
+          "narrative": "Greene prefers the 9b5 over the +11 for practical use: '9b5's have a less muddy sound and are more easily used.' (Ch8 p.52). The 9b5 and +11 differ only in that the +11 retains the 5th while the 9b5 omits it: 'the only difference is that the 5th and the +11th (b5th) are in the +11 chord while just the +11th (b5th) is in the 9b5.' (Ch8 p.52)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.52"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "substitution-rules",
+          "narrative": "Dom7b5 participates in tritone substitution at the chord level: 'Almost any dominant type chord can be moved in intervals of 3 frets as long as the LAST chord resolves into wherever you are going next.' (Ch12 p.63). The b5 chord is also the direct tritone sub of the plain dominant.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.63"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "formula-definition",
+          "narrative": "Greene defines the b9 altered dominant explicitly: 'a C7b9b5 would be a C7 chord with the 5th flatted and a b9th added — in other words the formula would be 1,3,b5,b7,b9.' (Ch6 p.12). The b9 is treated as an additive extension on the dom7 structure.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 6 p.12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "voice-leading",
+          "narrative": "Greene notes that common tones aid smooth resolution: 'Notice the use of common tones on top of some of these chords. This is one aid to smooth chord resolutions.' (Ch11 p.62). For dom7b9, smooth voice leading into the target I chord is the primary concern.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.62"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom9",
+          "function_role": "blues-idiom-application",
+          "narrative": "Greene notes the expressive impact of 9th chords in blues: 'This progression has a much bluesier sound to most ears due to the abundance of 9th chords.' (Ch18 p.95). Dominant 9th chords are the primary upgrade from plain dom7 for achieving a more sophisticated blues sound.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 18 p.95"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom9",
+          "function_role": "cycle-voice-leading",
+          "narrative": "Greene shows how dom9 arises from dom7 through voice leading: 'if you take any 7th chord and lower the 3rd and 7th 1 fret each, you will get a 9th chord built on the IV.' (Ch20 p.106). This creates a stepwise chromatic motion that generates the IV9 naturally from any I7.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.106"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom9#5b5",
+          "function_role": "voicing-limitation",
+          "narrative": "Greene flags a structural constraint unique to this chord: 'There seems to be only one inversion of this amazing chord [9#5b5].' (Ch8 p.52). Its intervallic density makes it one of the most voicing-restricted chords in the book.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.52"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj",
+          "function_role": "color-tone-requirement",
+          "narrative": "Greene recommends experimenting with 3rd omission: 'Try leaving out the 3rd in major type chords for a different type of sound (especially if you replace the 3rd with a 2nd).' (Ch11 p.62). The sus2 substitution of the 3rd is highlighted as a particularly effective major color.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.62"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj",
+          "function_role": "picardy-third-application",
+          "narrative": "Greene prescribes the Picardy third technique in chord melody: 'Ending on a major is an often used technique in minor songs.' (Ch14 p.77). A minor song's final chord is replaced by the parallel major for a brightened cadential effect.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 14 p.77"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj",
+          "function_role": "triad-omission-policy",
+          "narrative": "For major triads used as 4-note chords, Greene specifies: 'To make triads into 4 note chords, you may double a root, 3rd, or 5th.' (Ch16 p.85). In open triad voicings: 'WHEN USING OPEN TRIADS, THE ROOT IS USUALLY PUT IN THE BASS FOR THE LAST CHORD IN A PHRASE.' (Ch16 p.85)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 16 p.85"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "chord-melody-placement",
+          "narrative": "In chord melody contexts, the melody must sit above the maj7 voicing: 'the melody is always played ABOVE the chord, not in the middle or in the bass.' (Ch14 p.76). Chords are typically placed on 'the 1ST NOTE IN EACH MEASURE,' not every melody note.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 14 p.76"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "color-tone-requirement",
+          "narrative": "Greene notes that 'Try leaving out the 3rd in major type chords for a different type of sound (especially if you replace the 3rd with a 2nd),' indicating that the major 7th chord's 3rd is optional and a sus2 color can substitute. (Ch11 p.63)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.63"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "family-membership",
+          "narrative": "The major 7th chord belongs to the Major family, derived from the foundational major chord. Greene states 'The MAJOR, MINOR, and DOMINANT 7TH chords are the 'fathers' of the 3 families, and all the other chords, with a few exceptions, are derived from them.' (Ch5 p.10)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "iv-chord-application",
+          "narrative": "Major 7th and major 9th voicings with root on top or 7th in bass are 'good passing chords to a major type chord a 4th higher' (Ch11 p.63), making maj7 a natural IV approach chord in major-key progressions.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.63"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "learning-sequence",
+          "narrative": "Greene prescribes a specific learning order: 'Learn the major and minor chords first, then the major 6th and minor 6th, then the major 7th, minor 7th, and dominant 7th, etc.' (Ch7 p.13). The maj7 is the third tier of major-family study.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 7 p.13"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "note-omission-policy",
+          "narrative": "Greene notes 'if you lower ONE root in a major chord that has TWO roots, you will get a major 7th chord,' showing that doubling roots is the natural precursor to omitting one. (Ch13 p.73). Leaving out the 5th in a I maj7 chord is explicitly called 'acceptable.' (Ch13 p.69)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 13 p.73"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 13 p.69"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "passing-chord-usage",
+          "narrative": "Greene specifies that 'Major 7ths and major 9ths that have the root on top or 7th in the bass can be used as good passing chords to a major type chord a 4th higher.' (Ch11 p.63). This gives maj7 a specific half-step approach function in progressions.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.63"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "shell-voicing-floor",
+          "narrative": "In five-note major 7th voicings, the root or 5th may be omitted. Greene writes 'in any chord with 5 tones in the formula, the root OR 5th is often omitted and possibly one of the remaining tones DOUBLED.' (Ch5 p.10). The 5th is the preferred omission since it is not essential when unaltered.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "synonym-application",
+          "narrative": "Greene emphasizes exploiting chord synonyms for substitution discovery: 'The main benefit of knowing chord synonyms is that you can use them to come up with substitute chords you wouldn't have come up with otherwise.' (Ch8 p.17). Maj7 chords frequently share notes with min7 chords whose roots are a minor 3rd lower.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.17"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "voice-leading",
+          "narrative": "Greene prescribes that 'the 3rd of the V7 chord moves up to the root of the I chord in each example; this is common procedure for V7 to I,' making the major 7th chord the resolution target of this half-step voice leading motion. (Ch13 p.69)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 13 p.69"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7#11",
+          "function_role": "family-membership",
+          "narrative": "The maj7#11 belongs to the major family as an extension. Greene states '#11 is usually put above the 5th in a chord (assuming there is a 5th being played) as in chords like the +11, 13+11, etc.' (Ch5 p.10)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min",
+          "function_role": "harmonic-minor-application",
+          "narrative": "Greene allows plain minor as a simplification in harmonic minor contexts: 'When using chord progressions with the harmonic minor scale, you may substitute a plain minor for the Im(maj7).' (Ch17 p.88). This reduces the complexity while maintaining minor tonality.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 17 p.88"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min",
+          "function_role": "relative-substitution",
+          "narrative": "Greene notes: 'The technique of substituting the relative minor is often used on the IV chord of a key.' (Ch16 p.84). The relative minor shares most tones and provides a darker color alternative to the diatonic IV.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 16 p.84"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "family-membership",
+          "narrative": "The m(maj7) chord belongs to the minor family as a chromatic color variant. Greene notes it as one of the chord types that 'almost necessitate the use of voice leading principles,' signaling its inherently transitional character. (Ch13 p.73)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 13 p.73"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "harmonic-minor-application",
+          "narrative": "In harmonic minor contexts, Greene provides a relaxation option: 'When using chord progressions with the harmonic minor scale, you may substitute a plain minor for the Im(maj7).' (Ch17 p.88). This makes m(maj7) the default Im chord in harmonic minor, with plain minor as the simplified alternative.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 17 p.88"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "resolving-diminished-relationship",
+          "narrative": "Greene connects m(maj7) directly to the resolving diminished technique: 'Resolving diminished chords also work well in place of m(maj7) type of chords, as long as the 7th tone of the m(maj7) is in the resolving dim chord.' (Ch20 p.107). The shared major-7th tone is the functional link.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 20 p.107"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "substitution-rules",
+          "narrative": "Greene allows m(maj7) as a dom7 substitute in specific contexts: 'm(maj7) type chords can be used in place of dominant chords whose roots are 1 fret lower (like Cm(maj7)/9 for B7). This will only work if the dominant chord is being used as a V7 or V7 function.' (Ch12 p.66)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.66"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "voice-leading",
+          "narrative": "Greene is explicit: 'when using m(maj7) type chords with m7 type chords of the same root, the 7 TONE SHOULD MOVE UP 1 FRET or DOWN 1 FRET INTO A ROOT OR b7 TONE.' (Ch14 p.75). This half-step resolution of the major 7th to the root or b7 is the defining voice-leading rule for this chord.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 14 p.75"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min6",
+          "function_role": "function-role-restriction",
+          "narrative": "Greene imposes a hard restriction: 'Minor 6th type chords usually should not be used for a minor chord that is followed by a dominant chord a 4th higher, because the m6 type chord will sound too much like the next dominant chord.' (Ch11 p.61). The m6 contains tones of the approaching dom7, creating premature resolution.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.61"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "back-cycling-application",
+          "narrative": "The min7 is the standard II chord in back-cycling: 'a smooth transition can be achieved if the new key is preceded by a IIm7 V7 progression OF THAT NEW KEY.' (Ch12 p.66). Back-cycling preceding any target chord with its IIm7-V7 creates forward momentum.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 12 p.66"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "blues-form-application",
+          "narrative": "In blues progressions, Greene prescribes: 'The IIIm7 and/or III7 chord are used often in place of the I chord in measure 7 of blues progressions.' (Ch19 p.101). The min7 variant of the III chord provides a softer, jazzier color at the measure-7 position.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 19 p.101"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "dorian-modal-application",
+          "narrative": "Greene establishes modal equivalence: 'The notes and chords of these scales are the same: C major = G mixolydian = A natural minor = D dorian minor.' (Ch17 p.88). The min7 is the characteristic chord of the dorian mode, which shares its harmonic content with the relative major.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 17 p.88"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "family-membership",
+          "narrative": "The minor 7th chord belongs to the Minor family. Greene identifies the minor chord as one of the three 'fathers' and notes that 'the major and major 7th chords are closely related, and also the minor and minor 7th chords.' (Ch9 p.55)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 9 p.55"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "learning-sequence",
+          "narrative": "Greene places min7 in the third tier of the prescribed learning order: 'Learn the major and minor chords first, then the major 6th and minor 6th, then the major 7th, minor 7th, and dominant 7th, etc.' (Ch7 p.13)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 7 p.13"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "shell-voicing-floor",
+          "narrative": "The min7 chord follows the same omission policy as all five-note chords: 'in any chord with 5 tones in the formula, the root OR 5th is often omitted and possibly one of the remaining tones DOUBLED.' (Ch5 p.10). The 5th is the preferred candidate since it is unaltered.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "substitution-rules",
+          "narrative": "Greene establishes the IIm7-V7 relationship as foundational: 'Quite often following a minor 7th type chord a dominant chord whose root is a 4th higher will be used.' (Ch13 p.71). Furthermore, 'IF YOU HEAR IIm TO I, YOU MAY THINK IIm V7 TO I INSTEAD.' (Ch15 p.80)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 13 p.71"
+            },
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 15 p.80"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "upper-structure-application",
+          "narrative": "For dominant 7th chord substitution, Greene prescribes: 'you may play a m7 type chord whose root is a 5th higher than the root of the dominant chord, but you do not only play this m7 type chord; you play it for part of the duration of the dominant chord and then play the dominant chord (or extension).' (Ch10 p.58)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 10 p.58"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "voice-leading",
+          "narrative": "When moving from m(maj7) to m7 on the same root, Greene prescribes: 'when using m(maj7) type chords with m7 type chords of the same root, the 7 TONE SHOULD MOVE UP 1 FRET or DOWN 1 FRET INTO A ROOT OR b7 TONE.' (Ch14 p.75). This half-step motion is the defining voice-leading event.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 14 p.75"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "diatonic-scale-application",
+          "narrative": "Greene lists Im7b5 as a diatonic chord in specific modal scale contexts, noting the harmonized scale produces 'I+ m7 IIm7 IV# V7 VIm7 VII Im7b5 VIII#.' (Ch16 p.87). This confirms m7b5 as a structural diatonic chord, not merely a passing color.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 16 p.87"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "family-membership",
+          "narrative": "The m7b5 (half-diminished) belongs to the minor family as the only widely used altered minor type. Greene states: 'The only altered minor chord that is widely used is the m7b5 type.' (Ch11 p.61). It appears naturally as the VII chord of the harmonic minor scale.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.61"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "note-omission-policy",
+          "narrative": "As an altered minor chord, the b5th of m7b5 must be retained in any voicing. Greene is explicit: 'if the 5th is altered, that is, sharped or flatted, you may not leave it out as it is essential to the chord. You could still leave out the root though.' (Ch5 p.10)",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min9",
+          "function_role": "shell-voicing-floor",
+          "narrative": "The min9 chord follows the five-tone omission policy: 'in any chord with 5 tones in the formula, the root OR 5th is often omitted and possibly one of the remaining tones DOUBLED.' (Ch5 p.10). The unaltered 5th is the standard omission candidate, leaving root, m3, b7, and 9.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "formula-definition",
+          "narrative": "Greene defines the suspended chord categorically: 'any chord that has the 3RD replaced by a 4TH is called a SUSPENDED chord.' (Ch5 p.10). The 3rd is not added to but fully displaced by the 4th.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 5 p.10"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "function-role-restriction",
+          "narrative": "Greene restricts sus4 primarily to dominant preparation: 'Dominant suspended chords are usually used as partial replacements for dominant 7th chords.' (Ch11 p.62). They precede the resolved dom7 but do not typically replace it outright.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.62"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "synonym-application",
+          "narrative": "Greene notes that when the 3rd is omitted from the 9th chord, 'this chord is also called a 9 suspended.' (Ch8 p.17). This establishes a synonym bridge between 9sus4 and dom9-no-3 voicings, enabling cross-substitution.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 8 p.17"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "unresolved-usage",
+          "narrative": "Greene allows for unresolved sus4 usage: 'Sometimes suspended chords are left unresolved; in other words, they may directly replace the dominant 7th chord.' (Ch11 p.62). This is the exception rather than the norm, and context determines acceptability.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.62"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "voice-leading",
+          "narrative": "The sus4's resolution to the 3rd is the normative voice-leading destination: 'Dominant suspended chords are usually used as partial replacements for dominant 7th chords' (Ch11 p.62), implying the 4th resolves down a semitone to the 3rd of the following dom7, providing smooth stepwise motion.",
+          "source_principle_ids": [],
+          "source_work_id": "chord-chemistry",
+          "references": [
+            {
+              "source": "chord-chemistry",
+              "citation": "ch 11 p.62"
+            }
+          ],
+          "provenance": "extracted"
+        }
       ]
     },
     {


### PR DESCRIPTION
Closes #467. Sub-#457 (s5-backfill).

s1-s4 already accepted from pre-#423 era. s5 unblocked by #460 + #469 (work_id rename). Inline-driven with #434 granular-levels + Ellington 12-quality steer.

## Result
**89 usage_notes across 23 chord_qualities** — densest single-book extraction in the project. Hits all 12 Ellington comparator-bearing qualities plus 11 bonus qualities Greene addresses.

- Distribution: maj7=9, min7=10, min7b5=3, dom7=17, dom7alt=5, dim7=7, dom7b9=2, sus4=4, min-maj7=5, maj7#11=1, min9=1, dom7#11=4; bonus dom7#9=2, dom11=2, dom11b9=1, dom13b9=1, aug=4, dom7b5=2, min6=1, dom9=2, dom9#5b5=1, maj=3, min=2
- Captures Greene's characteristic structural rules: 3-fret-symmetry on dim7, 4-fret-symmetry on aug, m(maj7)→m7 half-step descent rule, 'altered tone on top' projection rule, the 7#9 tonic-placement exception
- Full granularity matrix per quality: family / voicing-floor / omission / color / substitution / voice-leading / idiom-specific

ted-greene master + chord-chemistry work already existed. usage_notes[] filled with 89 new entries.