### PR TITLE
data(masters)(#475): inject Laukens jazz-guitar-chord-dictionary usage_notes (35 notes, 13 chord_qualities)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -25109,6 +25109,496 @@
             }
           ],
           "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "color-tone-requirement",
+          "narrative": "Altered extensions (#11/b5, b9/#9) are available color tones over any dom7. New players directed to begin in minor key contexts: 'These chords can be used over any dominant 7th chord in your comping to create extra tension' (ch. 5, p. 35).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 35"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "harmonic-family-membership",
+          "narrative": "dom7 introduced as core four-note drop 2 / drop 3 type, parent type for all altered dominant extensions in Chapter 5: 'These chords can be used over any dominant 7th chord in your comping to create extra tension' (ch. 5, p. 35).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 35"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "inversion-comping-substitution",
+          "narrative": "All four inversions of dom7 presented systematically. Ear-based selection: 'some voicings will work better than others' and 'putting the root or the 3rd in the bass causes the chord to have a slightly different flavor' (ch. 6, p. 45).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 6 p. 45"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "shell-voicing-floor",
+          "narrative": "dom7 shell: root, major 3rd, minor 7th — three-note harmonic floor on lower string sets. The tritone between 3rd and 7th is preserved without the 5th (ch. 3, p. 14).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 3 p. 14"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "harmonic-family-membership",
+          "narrative": "dom7alt = b5/b9 or b5/#9 voicing family from altered scale (7th mode of melodic minor). Categorically separated from the Lydian dominant (#11) family (ch. 5, p. 36).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 36"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "minor-ii-V-I-application",
+          "narrative": "Canonical context: minor ii-V-I. 'if you have a minor ii V I chord progression (Dm7b5-G7-Cm7), you can use altered extensions over the G7 chord' (ch. 5, p. 35), V7alt resolving to Im7 or Imaj7. New players deploy in minor keys first.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 35"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "color-tone-requirement",
+          "narrative": "b5 voicing co-occurs with b9 or #9 — not natural 9 — because of altered scale derivation. Natural 9 would signal Lydian dominant (ch. 5, p. 36).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 36"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "harmonic-family-membership",
+          "narrative": "dom7b5 from altered scale family: 'A C7 with a b5 contains a b9 or #9 because this chord is derived from the altered scale (7th mode of melodic minor)' (ch. 5, p. 36). b5 and #11 enharmonically identical pitches but signal different scale contexts.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 36"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "harmonic-resolution-target",
+          "narrative": "dom7b5 (paired with b9 or #9) functions as V7alt resolving to Im7 or Imaj7. 'A C7(b5,b9) often functions as a V7alt going to Im7 or Imaj7 (C7b5b9 going to Fm7 or Fm9, for example)' (ch. 5, p. 36). Canonical minor ii-V-I dominant function.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 36"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "minor-ii-V-I-application",
+          "narrative": "Minor ii-V-I is the canonical entry point for altered dominants: 'if you have a minor ii V I chord progression (Dm7b5-G7-Cm7), you can use altered extensions over the G7 chord' (ch. 5, p. 35). New players start here before extending to major-key contexts.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 35"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom9#11",
+          "function_role": "color-tone-requirement",
+          "narrative": "The #11 voicing characteristically includes a natural 9 — scale-derived co-requirement that distinguishes this voicing from the b5 family. 'A C7 with a #11 usually contains a natural 9' (ch. 5, p. 36).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 36"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom9#11",
+          "function_role": "harmonic-family-membership",
+          "narrative": "dom9#11 belongs to Lydian dominant scale family: 'A C7 with a #11 usually contains a natural 9 (d) because this chord is derived from the Lydian dominant scale (4th mode of the melodic minor scale)' (ch. 5, p. 36). Outside the altered-scale dominant family.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 36"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom9#11",
+          "function_role": "harmonic-resolution-target",
+          "narrative": "Canonical function: bVII7 resolving to Imaj7. 'A C9#11 often functions as a bVII7 going to Imaj7 (C7#11 to Dmaj7, for example)' (ch. 5, p. 36). Backdoor/Lydian dominant approach, not V7.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 5 p. 36"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj13",
+          "function_role": "harmonic-family-membership",
+          "narrative": "maj13 distinguished from maj6 by co-presence of 7th and 6th: 'When a 6 and a 7 are both present in a major chord, it becomes a major 13 chord' (ch. 4, p. 19). The 13 is enharmonically the 6; the 7th's presence is the diagnostic criterion.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 4 p. 19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj13",
+          "function_role": "note-omission-policy",
+          "narrative": "Guitarists cannot voice all available intervals simultaneously: 'guitarists have to leave some notes out when adding extended notes to their chord shapes. Keep that in mind, and notice which notes are replaced' (ch. 4, p. 19). The 7th and 6/13 must both be retained; other tones (e.g., 5th) are candidates for omission.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 4 p. 19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "harmonic-family-membership",
+          "narrative": "maj6 is its own sub-category within extended chords, distinguished by absence of the 7th: 'Major 6 chords and major 6(9) chords are different from the extended chords that follow because they don't contain a 7' (ch. 4, p. 19). The 6 substitutes for the 7 as the defining interval.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 4 p. 19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "note-omission-policy",
+          "narrative": "Strict interval-substitution rule: 'In a major 6 chord, the 6 replaces the 7' (ch. 4, p. 19). The 7th must be absent; if both 7 and 6 are present, the chord becomes a major 13. Definitional, not optional.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 4 p. 19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj69",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Laukens groups major 6(9) alongside major 6 as one of two extended chord types that omit the 7th (ch. 4, p. 19). The 6(9) adds the 9th atop the 6-replaces-7 structure.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 4 p. 19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "ensemble-register-tone-constraint",
+          "narrative": "Shell voicings on lower string sets require active tone management in ensemble contexts: 'you need to keep your tone in mind so you don't clash with the bass player.' With soft tone these voicings are 'highly effective when comping in a duo, trio, or larger ensembles' (ch. 3, p. 14).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 3 p. 14"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Laukens introduces maj7 as a foundational chord type in Chapter 2, presented in drop 2 and drop 3 root-position voicings (ch. 2, p. 8). The movable-shape system: a single Cmaj7 fingering transposed two frets up becomes Dmaj7 (ch. 1, p. 7).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 2 p. 8"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "inversion-comping-substitution",
+          "narrative": "Any inversion of a maj7 chord symbol — root, 3rd, 5th, or 7th in the bass — may be freely substituted: 'if you see a Cmaj7 chord symbol you can play any inversion of Cmaj7' (ch. 6, p. 45). Ear-based selection: 'each inversion will have a slightly different sound.'",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 6 p. 45"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "shell-voicing-floor",
+          "narrative": "For maj7, the shell chord reduces to root/3rd/7th on the lower string sets: 'These three-note chords contain the root, 3rd, 7th (or the 6th) of each chord' (ch. 3, p. 14).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 3 p. 14"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj9",
+          "function_role": "harmonic-family-membership",
+          "narrative": "maj9 is the paradigm example of an extended chord that retains the 7th: 'All the other extended chords (such as maj9), contain the 7th in their construction' (ch. 4, p. 19). The 9 adds color but does not displace the 7.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 4 p. 19"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "harmonic-family-membership",
+          "narrative": "min7 introduced in Chapter 2 as foundational, taught in drop 2 and drop 3 root-position voicings alongside maj7 and dom7. Learn one shape per chord type before applying it to a real jazz tune (ch. 2, p. 8).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 2 p. 8"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "inversion-comping-substitution",
+          "narrative": "Any inversion of a min7 chord symbol may be freely used. Inversions presented in systematic order: 'Notice that for each group of chords, the root is in the bass for the first chord shape, then the 3rd, 5th, and the 7th after that' (ch. 6, p. 45).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 6 p. 45"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "shell-voicing-floor",
+          "narrative": "Shell chord for min7: root/m3/m7 on lower string sets. The minor 3rd and minor 7th are the identity-defining intervals retained (ch. 3, p. 14).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 3 p. 14"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "harmonic-family-membership",
+          "narrative": "min7b5 (Half-Diminished) — both names interchangeable. Core drop 2/3 voicing type, explicitly named as the ii chord in the minor ii-V-I example (Dm7b5, ch. 5, p. 35; also ch. 2, p. 12).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 2 p. 12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "lead-sheet-reading-convention",
+          "narrative": "Players must recognize both names: 'Minor 7b5' label and 'Half-Diminished' symbol (ø) are equivalent — prerequisite for correctly parsing chord charts (ch. 2, p. 12).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 2 p. 12"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "open",
+          "function_role": "enharmonic-reading-convention",
+          "narrative": "Complex open voicings must be readable from multiple harmonic perspectives: 'Bm11(b6) = Gmaj7(add 6)/B' (ch. 7, p. 57). Students must master polychord notation to parse open-chord symbols.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 7 p. 57"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "open",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Open chords are structurally distinct: 'Open chords use open strings in their construction' (ch. 7, p. 54). Not transposable by the two-fret rule like other shapes in the dictionary.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 7 p. 54"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "open",
+          "function_role": "key-center-deployment-constraint",
+          "narrative": "Open chords prescribed for specific guitar-friendly key centers only: 'Though they are limited to a few keys, these shapes add new flavor to your comping in particular key centers. Open chords have a specific sound that is unique to the guitar' (ch. 7, p. 54). Unique resonant quality justifies learning them despite key restriction.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 7 p. 54"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "quartal",
+          "function_role": "context-universality-prescription",
+          "narrative": "Unlike altered dominants or open chords, quartal chords are universally applicable: they 'can be used over any jazz standard in your comping and solos' (ch. 8, p. 59). No harmonic context restriction.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 8 p. 59"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "quartal",
+          "function_role": "harmonic-family-membership",
+          "narrative": "Quartal chords are structurally distinct from tertian harmony: 'built by stacking 4th intervals above the lowest note of the chord' (ch. 8, p. 59). Outside the extended-chord taxonomy; characteristically open, modern sound.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 8 p. 59"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "quartal",
+          "function_role": "solo-guitar-application",
+          "narrative": "Quartal chords prescribed for both comping AND soloing: 'can be used over any jazz standard in your comping and solos' (ch. 8, p. 59). Distinguishes them from shell voicings (ensemble comping focus) and drop 2/3 (comping-primary).",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 8 p. 59"
+            }
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "quartal",
+          "function_role": "string-set-voicing-position",
+          "narrative": "Two fretboard implementations of quartal voicings derived from C Dorian: string set 2-3-4-5 (ch. 8, p. 59) and string set 1-2-3-4 (ch. 8, p. 60). Same harmonic material at different registers via direct position transfer.",
+          "source_principle_ids": [],
+          "source_work_id": "jazz-guitar-chord-dictionary",
+          "references": [
+            {
+              "source": "jazz-guitar-chord-dictionary",
+              "citation": "chapter 8 p. 59"
+            }
+          ],
+          "provenance": "extracted"
         }
       ],
       "status": "promoted"


### PR DESCRIPTION
Closes #475. Sub-#457.

35 new notes appended to dirk-laukens.usage_notes (was 59, now 94).
Voicing-catalog reference. s1-s4 pre-#423; s5 unblocked by #460.