### PR TITLE
data(masters)(#471): backfill polarity on Baker usage_notes (2 proscriptive)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -35573,7 +35573,8 @@
               "citation": "lesson 7 p.26"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive"
         },
         {
           "chord_quality": "dim7",
@@ -35668,7 +35669,8 @@
               "citation": "lesson 3 p.9"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive"
         },
         {
           "chord_quality": "dom7",


### PR DESCRIPTION
Sub-#471 sweep 1 of 4. Adds polarity='proscriptive' tags to 2 Baker entries (aug7 elimination + plain dom7 condemnation). Remaining 35 default-prescriptive (field omitted).