### PR TITLE
feat(#471): polarity backfill — Greene Modern Chord Progressions

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -6048,7 +6048,10 @@
               "citation": "ch 10 p.74"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7#9/soprano-exception"
+          ]
         },
         {
           "chord_quality": "dom7#9",
@@ -6062,7 +6065,11 @@
               "citation": "ch 10 p.74"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7#9/raise-third-lower-voice-operation"
+          ]
         },
         {
           "chord_quality": "dom7alt",
@@ -6490,7 +6497,11 @@
               "citation": "ch 10 p.74"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "min7/raise-third-to-dom7-rule"
+          ]
         },
         {
           "chord_quality": "min7",
@@ -6504,7 +6515,10 @@
               "citation": "ch 10 p.74"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/min7-11-soprano-exception"
+          ]
         },
         {
           "chord_quality": "min7",


### PR DESCRIPTION
## Summary

Stage B injection for Ted Greene's *Modern Chord Progressions* (47 usage_notes). Conservative classifier sweep returned 2 proscriptive marks and 2 cross_ref pairs.

## Marks

| idx | quality | function_role | mark |
|---|---|---|---|
| 98 | dom7#9 | soprano-exception | proscriptive |
| 128 | min7 | min7-11-soprano-exception | proscriptive |

## Cross-refs

- 98 ↔ 97 (dom7#9 raise-third-lower-voice-operation)
- 128 ↔ 129 (min7 raise-third-to-dom7-rule)

Both encode the same pedagogical structure as CC's tonic-placement family: prescriptive procedure + scoped proscriptive exception, linked bidirectionally.

## Why so sparse vs CC (14/89)

MCP is procedural/formulaic (ii-V-I voice-leading machinery); CC is prescriptive prose. Both exceptions come from the same passage (Ch.10 p.74 raise-the-third operation).

## Validation

`tests/test_masters_schema.py`: 24/24 pass.

## Tickets

Refs #471.