### PR TITLE
feat(#471): polarity backfill — Laukens (5 works)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -24358,7 +24358,10 @@
               "citation": "chapter 4 p.48"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/sub-family-discrimination"
+          ]
         },
         {
           "chord_quality": "dom7",
@@ -24425,7 +24428,11 @@
               "citation": "chapter 3 p.23"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/harmonic-family-membership"
+          ]
         },
         {
           "chord_quality": "dom7",
@@ -24519,7 +24526,10 @@
               "citation": "chapter 3 p.23"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/sub-family-discrimination"
+          ]
         },
         {
           "chord_quality": "dom7alt",
@@ -24568,7 +24578,11 @@
               "citation": "chapter 3 p.23"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7alt/altered-dominant-sub-family"
+          ]
         },
         {
           "chord_quality": "dom7b9",
@@ -24622,7 +24636,10 @@
               "citation": "chapter 3 p.23"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/sub-family-discrimination"
+          ]
         },
         {
           "chord_quality": "dom7b9",
@@ -24672,7 +24689,10 @@
               "citation": "chapter 4 p.61"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/sub-family-discrimination"
+          ]
         },
         {
           "chord_quality": "dom7b9",
@@ -24688,7 +24708,12 @@
               "citation": "chapter 3 p.23"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7b9/altered-dominant-sub-family",
+            "dom7b9/minor-ii-V-i-V-chord-role"
+          ]
         },
         {
           "chord_quality": "maj7",
@@ -24958,7 +24983,11 @@
               "citation": "chapter 3 p.23"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "min7/ii-chord-role-in-ii-V-I"
+          ]
         },
         {
           "chord_quality": "min7",
@@ -24975,7 +25004,10 @@
               "citation": "chapter 4 p.48"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/harmonic-family-membership"
+          ]
         },
         {
           "chord_quality": "min7",
@@ -25136,7 +25168,10 @@
               "citation": "chapter 4 p.61"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7b5/sub-family-discrimination"
+          ]
         },
         {
           "chord_quality": "min7b5",
@@ -25152,7 +25187,11 @@
               "citation": "chapter 3 p.23"
             }
           ],
-          "provenance": "extracted"
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "min7b5/minor-ii-chord-role"
+          ]
         },
         {
           "chord_quality": "dom7",


### PR DESCRIPTION
## Summary

Stage B injection across Dirk Laukens' 5 works (163 usage_notes). Conservative classifier sweep returned 5 proscriptive marks and 6 cross_ref pairs — all concentrated in Complete Chord Melody Ch.3 p.23 sub-family discrimination section.

## Marks

| idx | quality | function_role | mark |
|---|---|---|---|
| 17 | dom7 | sub-family-discrimination | proscriptive |
| 25 | dom7alt | sub-family-discrimination | proscriptive |
| 32 | dom7b9 | sub-family-discrimination | proscriptive |
| 47 | min7 | harmonic-family-membership | proscriptive |
| 58 | min7b5 | sub-family-discrimination | proscriptive |

## Cross-refs (all complete-chord-melody)

- 17 ↔ 13 (dom7 natural-dominant home)
- 25 ↔ 22 (dom7alt altered sub-family)
- 32 ↔ 28 / 32 ↔ 31 (dom7b9 altered classification + minor ii-V-i V role)
- 47 ↔ 48 (min7 ii in major ii-V-I)
- 58 ↔ 57 (min7b5 ii in minor ii-V-i)

## Other 4 works

`jazz-guitar-patterns-vol-1`, `jazz-guitar-chord-dictionary`, `beginners-guide`, `tritone-substitution-licks` — 0 proscriptive marks each (procedural/pattern catalogs, no explicit negative prescriptions).

## Closes originally-planned sweep set

Baker (PR #482), Pass (0 hits, no PR), Greene CC (#483), Greene MCP (#484), Laukens (this PR). After merge, ready to switch focus to #474 naming convergence rename.

## Validation

`tests/test_masters_schema.py`: 24/24 pass.

Refs #471.