### PR TITLE
feat(#457): Stage B — Benson Vol 1 usage_notes (66 entries)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -32349,7 +32349,895 @@
           ]
         }
       ],
-      "status": "corpus_only"
+      "status": "corpus_only",
+      "usage_notes": [
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-i",
+          "narrative": "On the I degree, freely interchange C6 and Cmaj7 almost all the time. 'We can replace C6 by Cmaj7 or vice-versa almost all the time.' (Ch. 6, p. 200). Use C6 instead when the melody is the octave to avoid a b9 conflict between melody and chord.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 200, 'Ist degree: C6 vs Cmaj7'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "tonic-i",
+          "narrative": "'We can replace C6 by Cmaj7 or vice-versa almost all the time. The only exception is when the melody is the octave. In this case we must use C6, in order to not create a conflict between the melody and the chord (a b9 interval).' (Ch. 6, p. 200). The maj6 voicing is the preferred choice specifically when the melody sits on the octave of the root.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 200, 'Ist degree: C6 vs Cmaj7'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-iv-lydian",
+          "narrative": "'We do not have to put the (#4) in the chord all the time, but in a few cases it might work. In theory, G/F can be considered an F Lydian chord, including G7(13) or G7(9).' (Ch. 6, p. 209). The #4 (augmented 11th) is optional on the IV Lydian maj7 chord and need not appear in every voicing.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 209, 'IV degree lydian #4 rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7#11",
+          "function_role": "tonic-iv-lydian",
+          "narrative": "For major chords functioning in a Lydian context, the augmented 11th (#4) is the characteristic note of the mode. 'For major chords and dominant 7th chords, most of the time we use the #11th (#4) to prevent unwanted dissonance with the major 3rd.' (Ch. 4, p. 126). Apply #11 freely on major chords to preserve Lydian modal color.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 126, '11th chord 3rd-vs-4th dissonance rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "upper-structure-iiim-phrygian",
+          "narrative": "On the IIIm (Phrygian) degree, recast Em7 as the slash voicing Cmaj7/E or C/E. 'Em7 can be replaced by Em7(b6), Cmaj7/E or even C/E, which are the same chords.' (Ch. 6, p. 207). This slash approach reinterprets the maj7 chord as an upper structure over the phrygian bass.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 207, 'IIIm degree phrygian options'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "upper-structure-vim-aeolian",
+          "narrative": "On the VIm (Aeolian) degree, every Fmaj7/A can be considered an Aeolian chord. 'In theory, every Dm7/A or Fmaj7/A can be considered as an Aeolian chord.' (Ch. 6, p. 217). Use the Fmaj7/A slash voicing to supply an aeolian color over the vi bass note.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 217, 'VIm degree aeolian options'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "enharmonic-identity-sixth-chord",
+          "narrative": "'Cm(b6) is exactly the same as Abmaj7 first inversion.' (Ch. 4, p. 83). When a Cm(b6) voicing appears, recognize it as Abmaj7 in first inversion and choose the label that best fits the harmonic context.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 83, 'Sixth-chord/seventh-chord equivalence'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj9",
+          "function_role": "tonic-i-extended",
+          "narrative": "Extended notes on the Ionian (I) chord include the major 9th, perfect 11th, and major 13th as tensions, but 'not all extended notes of a chord must be in it. Many of them should only be played as the passing tones of a melody on the chord.' (Ch. 5, p. 182). Add the major 9th to the I voicing for color, but treat it as a melodic option rather than a required component.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5 — Harmonic Fields & Scale Modes",
+              "citation": "p. 182, 'Extended notes usage rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "supertonic-iim-dorian",
+          "narrative": "On the IIm (Dorian) degree, the base min7 voicing can be freely replaced with its Dorian extensions. 'We can replace Dm7(9) dorian by Dm7(11) or even Dm7(13).' (Ch. 6, p. 204). Begin from the Dm7 shape and add the 9th, 11th, or 13th depending on the melodic context.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 204, 'IIm degree dorian replacements'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "mediant-iiim-phrygian",
+          "narrative": "On the IIIm (Phrygian) degree, Em7 can be enriched or replaced with a flat-6 addition or equivalent slash voicings. 'Em7 can be replaced by Em7(b6), Cmaj7/E or even C/E, which are the same chords. However, as a phrygian chord, Em7 can also be replaced by Esus(b9).' (Ch. 6, p. 207).",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 207, 'IIIm degree phrygian options'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "submediant-vim-aeolian",
+          "narrative": "On the VIm (Aeolian) degree, replace Am7 with Am7(9), Am7(11), or Am7(b6) for extended color, or use the slash voicings Dm7/A or Fmaj7/A. 'We can replace Am7(9) Aeolian with Am7(11) or even Am7(b6). But just like any degree, the characteristic notes do not have to be in the chord all the time.' (Ch. 6, p. 217).",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 217, 'VIm degree aeolian options'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min9",
+          "function_role": "supertonic-iim-dorian",
+          "narrative": "The 9th is a standard Dorian extension on the IIm degree. 'We can replace Dm7(9) dorian by Dm7(11) or even Dm7(13).' (Ch. 6, p. 204). Dm7(9) is the primary Dorian voicing recommended as the starting point before adding the 11th or 13th.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 204, 'IIm degree dorian replacements'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min6",
+          "function_role": "supertonic-iim-dorian",
+          "narrative": "'In theory, we could also use Dm6, but minor 6th chords are more complex than they look, so we will come back to them later. For now, let us consider that they can sometimes replace a minor 7th chord.' (Ch. 6, p. 204). Defer the min6 on the IIm degree until the simpler Dorian extensions are mastered.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 204, 'IIm degree dorian replacements'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-v",
+          "narrative": "On the V degree, the dominant 7th can always be replaced with a sus chord. 'We can replace the V chord (dominant) with a sus chord. Example: G7 can be replaced by Gsus9 or Gsus13.' (Ch. 6, p. 213).",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 213, 'V degree dominant sus substitution'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "sharp11-extension-rule",
+          "narrative": "'For major chords and dominant 7th chords, most of the time we use the #11th (#4) to prevent unwanted dissonance with the major 3rd. Only in some specific cases do we use the major 3rd and the perfect 11th (4th) together.' (Ch. 4, p. 126). On dominant 7th chords prefer #11 over natural 11 except in deliberate cases.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 126, '11th chord 3rd-vs-4th dissonance rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom11",
+          "function_role": "dominant-natural-11-avoid",
+          "narrative": "The perfect 11th (natural 4th) is listed as an avoid note for the Mixolydian (V) chord: 'Avoid notes: perfect 4th' (Ch. 5, p. 182). For dominant chords, avoid placing the natural 11th in the voicing because it clashes with the major 3rd; use #11 instead on major and dominant qualities.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7#11/dominant-v"
+          ],
+          "references": [
+            {
+              "source": "Ch. 5 — Harmonic Fields & Scale Modes",
+              "citation": "p. 182, 'Mixolydian characteristics'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7#11",
+          "function_role": "dominant-v",
+          "narrative": "Prefer the #11 on dominant chords functioning as the V or in a Lydian Dominant context. 'For major chords and dominant 7th chords, most of the time we use the #11th (#4) to prevent unwanted dissonance with the major 3rd.' (Ch. 4, p. 126). The Lydian Dominant scale (IV of Melodic Minor) is the primary source for this color on the V chord.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom11/dominant-natural-11-avoid"
+          ],
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 126, '11th chord 3rd-vs-4th dissonance rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom13",
+          "function_role": "dominant-v-omit-5th",
+          "narrative": "'Notice that in this type of chord, the 5th is almost always omitted.' (Ch. 4, p. 126). When voicing a 13th chord on guitar, drop the 5th to keep the voicing practical; the essential tones are the root, 3rd, 7th, and 13th.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 126, '13th chords almost omit the 5th'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom13",
+          "function_role": "subdominant-iv-lydian-implied",
+          "narrative": "A G7(13) or G7(9) voicing over an F bass implies F Lydian. 'In theory, G/F can be considered an F Lydian chord, including G7(13) or G7(9).' (Ch. 6, p. 209). Use the dom13 chord as an upper-structure slash to evoke the Lydian color on the IV degree.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 209, 'IV degree lydian #4 rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "altered-dominant-definition",
+          "narrative": "'Every dominant chord with more than one altered extended note is called an altered chord.' (Ch. 4, p. 126). When applying alterations to a dominant chord, ensure at least two altered extensions (e.g., b9 and b5, or #9 and #5) are present to qualify it as altered; a single alteration simply modifies the dominant without crossing into the altered category.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 126, 'Altered chord definition'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "color-source-melodic-minor-vii",
+          "narrative": "The VII Altered Scale (Root/min 2nd/aug 2nd/maj 3rd/aug 4th/min 6th/min 7th) from Melodic Minor is the primary theoretical source for altered dominant voicings. 'We cannot use the chord families derived from these three groups of scale modes to guide us through songs, we can only use them to add more colors to the chords.' (Ch. 7, p. 224). Apply Altered Scale colors on top of an existing dominant chord rather than as a structural replacement.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7 — Leading Tone & How Other Scales Appeared",
+              "citation": "p. 224, 'Function of derived chord families'; p. 251, 'Altered Scale intervals'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "dominant-v-b9-between-bass-top-avoid",
+          "narrative": "'For major and minor chords, we should avoid intervals of a flat 9th between the bass note and the top note of the chord.' (Ch. 4, p. 77). This prohibition applies broadly to any voicing where the interval from bass to top note spans a minor 9th, so when building dom7b9 shapes take care not to position the b9 as the top note against the bass.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 77, 'Flat-9 between bass and top to avoid'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "viim-locrian-9th-forbidden",
+          "narrative": "'The VII degree cannot use the 9th in the chord, because it would be flat 9th, which does not work properly for this type of chord. Remember that the flat 9th is an avoid note on locrian chord.' (Ch. 6, p. 221). Never add the 9th to the half-diminished VII chord when reinterpreted as a dominant-7 slash voicing over the leading tone.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 221, 'VIIm locrian avoid-note rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "dominant-v-substitution",
+          "narrative": "'We can replace the V chord (dominant) with a sus chord. Example: G7 can be replaced by Gsus9 or Gsus13.' (Ch. 6, p. 213). The sus4 substitution for the V dominant is a primary Mixolydian color move; keep the perfect 4th in place of the 3rd and leave the minor 7th intact.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 213, 'V degree dominant sus substitution'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "sus-definition-3rd-replacement",
+          "narrative": "'Suspended chords are those where the 3rd is replaced by the 4th or 2nd. We call these chords sus2 and sus4. Although the two instances exist, the most common is to replace the 3rd by the 4th.' (Ch. 4, p. 108). Always treat the sus4 as a 3rd-replacement voicing, not as an added-tone chord.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 108, 'Suspended chord definition'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "visualization-from-dom7",
+          "narrative": "'In order to visualize this type of chord properly, it is recommended to consider them as dominant 7th chords using some different tension notes. In other words, for the sus chords visualization, we will use the simple dominant 7th chord shapes we already know to guide us.' (Ch. 4, p. 109). Build every sus4 shape by starting from a known dominant-7 shape and replacing the 3rd with the 4th.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 109, 'Sus chord visualization tip'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "iiim-phrygian-sus-b9",
+          "narrative": "'As a phrygian chord, Em7 can also be replaced by Esus(b9) and sometimes Em7(b9), which was often used by composers such as Antonio Carlos Jobim and also Heitor Villa Lobos.' (Ch. 6, p. 207). On the IIIm Phrygian degree the sus(b9) voicing is a characteristic coloristic substitution with a strong Brazilian art-music precedent.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 207, 'IIIm degree phrygian options'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "viim-locrian-recast-as-slash",
+          "narrative": "'Bø can be replaced with G7/B or even G/B. This happens frequently because we consider the Bø as being G7(9)/B.' (Ch. 6, p. 221). The half-diminished VII chord should routinely be recast as a slash voicing of the dominant a minor 7th below, making its locrian function explicit through the bass note alone.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 221, 'VIIm locrian avoid-note rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "viim-locrian-b9-avoid",
+          "narrative": "The minor 2nd (b9) is the primary avoid note for Locrian: 'Avoid notes: minor 2nd' (Ch. 5, p. 182). On the half-diminished VII chord, 'the VII degree cannot use the 9th in the chord, because it would be flat 9th, which does not work properly for this type of chord.' (Ch. 6, p. 221). Never voice the 9th on a Locrian half-diminished chord.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 5 — Harmonic Fields & Scale Modes",
+              "citation": "p. 182, 'Locrian characteristics'"
+            },
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 221, 'VIIm locrian avoid-note rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "symmetric-no-inversion",
+          "narrative": "'There is no inversion to diminished or augmented chords, because they are symmetric. Symmetric chords are those that repeat themselves in a predetermined intervallic cycle. The diminished chord, for example, repeats itself each minor 3rd.' (Ch. 4, p. 75). Do not apply root/first/second inversion analysis to dim7 shapes; instead navigate them via their enharmonic minor-3rd equivalences.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 75, 'Symmetric chords - no inversion'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "enharmonic-dominant-relationship",
+          "narrative": "Dominant 7th chords 'have a strong relationship with diminished, half diminished and major 7th (#4) chords.' (Ch. 4, p. 128). Use the dim7 as an enharmonic substitute for a dominant-7 chord a half-step above any of its chord tones, exploiting the four-way symmetric identity to access distant tonal regions.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 128, 'Dominant 7 to diminished/half-dim/maj7#4 web'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "color-from-harmonic-major-viim-locrian-bb7",
+          "narrative": "The Harmonic Major VIIm Locrian (bb7) mode (Root/min 2nd/min 3rd/perf 4th/dim 5th/min 6th/dim 7th) is the theoretical source for diminished 7th colors including o7(b13) and (11) textures (Ch. 7, p. 277). 'We cannot use the chord families derived from these three groups of scale modes to guide us through songs, we can only use them to add more colors to the chords.' (Ch. 7, p. 224). Apply these dim7 colors as tension layers over existing chords, never as structural substitutes.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7 — Leading Tone & How Other Scales Appeared",
+              "citation": "p. 277, 'Harmonic Major VIIm Locrian bb7'; p. 224, 'Function of derived chord families'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "triad-shape-for-improvisation",
+          "narrative": "'The diminished triad will use a left shape using 3 consecutive strings. Actually this type of diminished shape is not as common as the real diminished chord. We use this shape to create phrases (licks) when improvising, or even when we play a solo guitar piece.' (Ch. 4, p. 64). Reserve the triadic diminished left-side shape for melodic/improvisational use rather than comping.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 64, 'Diminished triad shape rationale'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "aug7",
+          "function_role": "symmetric-no-inversion",
+          "narrative": "'There is no inversion to diminished or augmented chords, because they are symmetric... the augmented chords repeat themselves every major 3rd.' (Ch. 4, p. 75). Do not label augmented chord shapes as root, first, or second inversions; treat the three enharmonic positions as equivalent.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 75, 'Symmetric chords - no inversion'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "aug7",
+          "function_role": "color-source-lydian-augmented",
+          "narrative": "The bIII Lydian Augmented scale from Melodic Minor (Root/maj 2nd/maj 3rd/aug 4th/aug 5th/maj 6th/maj 7th) is the primary color source for augmented dominant tones (Ch. 7, p. 251). Apply the augmented color over a dominant chord as a tension device, not as a structural harmonic move. 'We can only use them to add more colors to the chords.' (Ch. 7, p. 224).",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7 — Leading Tone & How Other Scales Appeared",
+              "citation": "p. 251, 'bIII Lydian Augmented intervals'; p. 224, 'Function of derived chord families'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "tonic-harmonic-minor-im",
+          "narrative": "The Im Harmonic Minor mode yields a min-maj7 chord (Root/min 3rd/perf 5th/maj 7th). Its characteristic note is the major 7th and its avoid note is the minor 6th when the chord is Am(maj7): 'Avoid notes: minor 6th when the chord is Am(maj7). Characteristic notes: major 7th.' (Ch. 7, p. 226). Emphasize the major 7th as the defining tension and keep the minor 6th out of the voicing when holding on the chord.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7 — Leading Tone & How Other Scales Appeared",
+              "citation": "p. 226, 'Avoid/characteristic notes for Am(maj7)'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "color-not-progression",
+          "narrative": "'It is important to understand that we cannot use the chord families derived from these three groups of scale modes to guide us through songs, we can only use them to add more colors to the chords.' (Ch. 7, p. 224). The min-maj7 voicing sourced from Harmonic Minor is a coloristic tension device layered over an existing minor chord, not a progression-guiding substitution.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 7 — Leading Tone & How Other Scales Appeared",
+              "citation": "p. 224, 'Function of derived chord families'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "minor6-avoid-on-chord",
+          "narrative": "When voicing Am(maj7), avoid the minor 6th as a chord tone: 'Avoid notes: minor 6th when the chord is Am(maj7).' (Ch. 7, p. 226). The minor 6th is usable as a passing tone in the melody over the chord but must never land as a resting note within the voicing.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 7 — Leading Tone & How Other Scales Appeared",
+              "citation": "p. 226, 'Avoid/characteristic notes for Am(maj7)'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "no-b9-bass-to-top-major-minor",
+          "narrative": "'For major and minor chords, we should avoid intervals of a flat 9th between the bass note and the top note of the chord.' (Ch. 4, p. 77). This voicing prohibition also applies to inversions and slash voicings: check that the outer-voice interval between bass and melody is never a minor 9th when the chord is major or minor.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 77, 'Flat-9 between bass and top to avoid'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "no-b9-bass-to-top",
+          "narrative": "'For major and minor chords, we should avoid intervals of a flat 9th between the bass note and the top note of the chord.' (Ch. 4, p. 77). When building maj7 voicings in any inversion, verify that the interval spanning from the lowest sounding note to the highest is not a minor 9th.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 77, 'Flat-9 between bass and top to avoid'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "no-b9-bass-to-top",
+          "narrative": "'For major and minor chords, we should avoid intervals of a flat 9th between the bass note and the top note of the chord.' (Ch. 4, p. 77). On min7 shapes the most common trigger is a 3rd-inversion voicing where the b7 bass sits a minor 9th below the root on top; revoice to eliminate that span.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 77, 'Flat-9 between bass and top to avoid'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "enharmonic-identity-min7",
+          "narrative": "'C6 is exactly the same as Am7 first inversion and Cm(b6) is exactly the same as Abmaj7 first inversion. We can call them by both names, but depending on the harmonic situation one of them will work better.' (Ch. 4, p. 83). Choose the C6 or Am7/first-inversion label that best fits the harmonic context; neither is universally preferable.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 83, 'Sixth-chord/seventh-chord equivalence'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "enharmonic-identity-maj6",
+          "narrative": "'C6 is exactly the same as Am7 first inversion.' (Ch. 4, p. 83). When encountering Am7 in first inversion, recognize it as functionally equivalent to a C6 voicing; select whichever label serves the local harmonic analysis.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 83, 'Sixth-chord/seventh-chord equivalence'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "drop2-drop3-tetrad-only",
+          "narrative": "'It is very important to understand that drop chord voicings can only be used with tetrads, leaving behind the tensions 9th, 11th and 13th that will be used later with the extended chords.' (Ch. 4, p. 84). Apply Drop 2 and Drop 3 transformations only to four-note dominant 7th shapes; never apply them to extended (9, 11, 13) voicings.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 84, 'Drop 2 and Drop 3'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "drop2-drop3-tetrad-only",
+          "narrative": "'Drop chord voicings can only be used with tetrads.' (Ch. 4, p. 84). Drop 2 and Drop 3 apply to the four-note maj7 chord exclusively; do not carry these transformations into maj9 or maj7#11 voicings.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 84, 'Drop 2 and Drop 3'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "drop2-drop3-tetrad-only",
+          "narrative": "'Drop chord voicings can only be used with tetrads.' (Ch. 4, p. 84). Use Drop 2 / Drop 3 on the four-note min7 chord shape only, not on min9 or min7(11) extensions.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 84, 'Drop 2 and Drop 3'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "left-side-minor-shape-avoid-6th-string",
+          "narrative": "'It is important to understand that some chords using the left side shape might not work properly because they are almost impossible to play. The 5th string/left side shape works better than the 6th string/left side shape, which we do not use with a minor chord.' (Ch. 4, p. 58). When building Chord Skeleton shapes for any quality on the 6th string, avoid the left-side shape; prefer 5th-string or right-side alternatives.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 58, 'Left-side shape caveat'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "left-side-skeleton-6th-string-avoid",
+          "narrative": "'The 6th string/left side shape... we do not use with a minor chord.' (Ch. 4, p. 58). For minor chord skeletons rooted on the 6th string, always use the right-side or 5th-string skeleton rather than the left-side shape.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 58, 'Left-side shape caveat'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "guitar-must-edit-and-omit",
+          "narrative": "'It is important to remember that many of the chords on the guitar have to be edited. This is totally different from the piano which is a complete harmonic instrument, where we can have many chord voicing possibilities without having to omit any note.' (Ch. 4, p. 112). On guitar, freely omit chord tones — especially the 5th — to make voicings physically playable; this is not a compromise but the instrument defining constraint.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 112, 'Guitar must omit notes; not piano'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "guitar-must-edit-and-omit",
+          "narrative": "'Many of the chords on the guitar have to be edited... unlike the piano which is a complete harmonic instrument.' (Ch. 4, p. 112). For maj7 voicings, omit the 5th when needed to make the shape playable; the root, major 3rd, and major 7th carry the essential identity.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 112, 'Guitar must omit notes; not piano'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "natural-11-freely-used",
+          "narrative": "'However, for minor chords the perfect 11th (4th) can be used freely.' (Ch. 4, p. 126). Unlike major and dominant chords where the natural 11 clashes with the major 3rd, the minor 11th is an unrestricted tension on any minor 7th voicing and may be added at will.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 126, '11th chord 3rd-vs-4th dissonance rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "voice-leading-smallest-movement",
+          "narrative": "'The choice of notes for a chord sequence, most of the time must keep the smallest possible movement between the notes from one chord to another. Certainly, sometimes there may be deliberate leaps, but the smallest movement will almost always be the best way.' (Ch. 4, p. 84). When moving between dominant 7th voicings (or any chord pair), choose the inversion and string set that minimizes total voice movement.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 84, 'Smallest movement voice-leading'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "voice-leading-smallest-movement",
+          "narrative": "'The choice of notes for a chord sequence, most of the time must keep the smallest possible movement between the notes from one chord to another.' (Ch. 4, p. 84). Select maj7 inversions (root, 1st, 2nd, 3rd position) to minimize melodic step size when moving to or from the chord.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 84, 'Smallest movement voice-leading'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "4th-string-derived-from-6th-5th",
+          "narrative": "'The extended chords will be learned by rooting them on the 5th and 6th strings. The 4th string will be used to play the 6th and 5th string chords without the bass note. Usually, a 4th string chord is derived from a 6th string chord. It will start from the 7th or 6th of the chord.' (Ch. 4, p. 127). When moving a dominant 7th voicing to the 4th string, begin from the shape 7th or 6th degree rather than attempting an independent fingering.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 127, '4th-string chords derived from 5th/6th'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "ionian-perfect-4th-avoid",
+          "narrative": "'We rarely use the perfect 4th over an Ionian chord. However we have some exceptions, where we can find chords with 4ths and 3rds or even omitted 3rd chords.' (Ch. 6, p. 200). On a maj7 Ionian chord, treat the natural 4th as an avoid note except in specific open-voicing or quartal contexts.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 200, 'Ist degree: C6 vs Cmaj7'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "mixolydian-perfect-4th-avoid",
+          "narrative": "'Avoid notes: perfect 4th' on the Mixolydian (V) chord (Ch. 5, p. 182). The natural 11th/4th creates a characteristic half-step clash with the major 3rd in dominant 7th voicings; use #11 instead or omit the 11th entirely.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "references": [
+            {
+              "source": "Ch. 5 — Harmonic Fields & Scale Modes",
+              "citation": "p. 182, 'Mixolydian characteristics'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "drop2-drop3-tetrad-only",
+          "narrative": "'Drop chord voicings can only be used with tetrads.' (Ch. 4, p. 84). The half-diminished (min7b5) is a tetrad and may be subjected to Drop 2 / Drop 3 transformations; do not apply these to any extension-bearing version of the chord.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 84, 'Drop 2 and Drop 3'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "altered-dominant-color",
+          "narrative": "A dominant chord carrying both a #9 and any other alteration qualifies as an altered chord: 'Every dominant chord with more than one altered extended note is called an altered chord.' (Ch. 4, p. 126). Apply the #9 in combination with at least one other alteration (b5, b9, #5, or b13) and source the resulting color from the VII Altered Scale of Melodic Minor.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 126, 'Altered chord definition'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "enharmonic-dominant-diminished-web",
+          "narrative": "Dominant 7th chords 'have a strong relationship with diminished, half diminished and major 7th (#4) chords.' (Ch. 4, p. 128). The dom7b5 participates in this web of enharmonic identities; use the relationship to navigate between a dom7b5 and a diminished or half-diminished voicing on the same set of strings.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 128, 'Dominant 7 to diminished/half-dim/maj7#4 web'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj9",
+          "function_role": "extensions-as-passing-tones-not-voicing",
+          "narrative": "'VERY IMPORTANT: Not all extended notes of a chord must be in it. Many of them should only be played as the passing tones of a melody on the chord.' (Ch. 7, p. 227). The major 9th on a maj9 chord is primarily a melodic passing-tone resource; omitting it from the voicing is standard practice and does not undermine the chord identity.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7 — Leading Tone & How Other Scales Appeared",
+              "citation": "p. 227, 'Rule: extensions as passing tones'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min9",
+          "function_role": "extensions-as-passing-tones-not-voicing",
+          "narrative": "'Not all extended notes of a chord must be in it. Many of them should only be played as the passing tones of a melody on the chord.' (Ch. 5, p. 182). On a min9 chord the 9th belongs primarily to the melody line over the chord; it need not appear in the comping voicing.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5 — Harmonic Fields & Scale Modes",
+              "citation": "p. 182, 'Extended notes usage rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom13",
+          "function_role": "extensions-as-passing-tones-not-voicing",
+          "narrative": "'Not all extended notes of a chord must be in it. Many of them should only be played as the passing tones of a melody on the chord.' (Ch. 5, p. 182). On a dom13, the 9th and 11th layers in particular serve as melodic ornaments rather than mandatory voicing components; voice only the root, 3rd, 7th, and 13th on the guitar.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5 — Harmonic Fields & Scale Modes",
+              "citation": "p. 182, 'Extended notes usage rule'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "study-6th-5th-strings-before-4th",
+          "narrative": "'To make visualization easier, choose chords that are close to each other, using only the 6th and 5th string chords. The 4th string chords should be studied only after you are comfortable with the others.' (Ch. 6, p. 187). Master all dominant 7th voicings rooted on the 6th and 5th strings before attempting 4th-string positions.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 187, 'Study Devices for Harmonic Fields'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "study-6th-5th-strings-before-4th",
+          "narrative": "'To make visualization easier, choose chords that are close to each other, using only the 6th and 5th string chords. The 4th string chords should be studied only after you are comfortable with the others.' (Ch. 6, p. 187). Learn all maj7 voicings rooted on the 6th and 5th strings as a prerequisite to studying 4th-string maj7 positions.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 187, 'Study Devices for Harmonic Fields'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "study-6th-5th-strings-before-4th",
+          "narrative": "'To make visualization easier, choose chords that are close to each other, using only the 6th and 5th string chords. The 4th string chords should be studied only after you are comfortable with the others.' (Ch. 6, p. 187). Build min7 fluency first on the 6th and 5th strings in a single key before moving to 4th-string positions or modulating.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6 — How to Study the Harmonic Fields",
+              "citation": "p. 187, 'Study Devices for Harmonic Fields'"
+            }
+          ]
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "sus9-sus13-chord-symbol-decoding",
+          "narrative": "'Gsus9: means that we have chord tones: root, perfect 4th, minor 7th and major 9th. Gsus13: means that we have chord tones: root, perfect 4th, minor 7th and major 13th. (It can also mean: root, perfect 4th, minor 7th major 9th and major 13th).' (Ch. 4, p. 108). Always decode sus9/sus13 symbols by stripping the 3rd and substituting the 4th within the dominant-7 parent shape before adding the named extension.",
+          "source_work_id": "method-vol-1-chord-construction",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4 — Chord Structures",
+              "citation": "p. 108, 'Sus9 / Sus13 chord-symbol semantics'"
+            }
+          ]
+        }
+      ]
     },
     {
       "id": "jimmy-bruno",


### PR DESCRIPTION
## Summary

First of 7 Benson volumes through s5_prescriptive backfill. 66 usage_notes covering 20 chord qualities. 15 carry polarity:proscriptive; 2 cross_ref pairs.

## Highlights

- **maj7** (10) — Ionian I-degree + #11 / 4-avoid restrictions
- **dom7** (10) — sus substitution, voicing edits, #11 vs 11 rule
- **min7** (8) — Dorian extensions, drop2/3 tetrad-only, b9 avoid
- **sus4** (5) — sus(b9) Phrygian + sus9/sus13 semantic decoding
- **min-maj7** (3, 2 proscriptive) — Harmonic Minor color-only discipline
- **dim7/aug7** — symmetric-no-inversion rule (proscriptive)

## Pipeline

Run `2026-05-22T21-15-00-benson-vol-1` on cyberpower; s5 advanced to accepted. Extraction model: sonnet. Source artifacts:
- `prescriptive-lessons-draft.json` (66 entries)
- `PRESCRIPTIVE.md` (review surface)

## Validation

Schema 24/24 pass.

## Tickets

Refs #457 (umbrella), #459 (pre-#423 config), #471 (polarity).