### PR TITLE
feat(#457): Stage B — Benson Vols 2-7 usage_notes (361 entries)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -33236,6 +33236,5309 @@
               "citation": "p. 108, 'Sus9 / Sus13 chord-symbol semantics'"
             }
           ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-i",
+          "narrative": "Major 7th chords on the I degree belong to the Root Region and carry the sense of 'resolution, rest or being home' (Ch. 1, p. 1). Available voicing palette includes Cmaj7, Cmaj7(9), C6, C6(9), Cmaj7(#11), C6(#11), C6(9)#11, Cmaj7(6), Cmaj7(6)9 (Ch. 1, p. 2). When comping, the melody determines which tension is chosen from this palette.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melody-governs-voicing",
+            "same-region-interchangeability"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 1–2"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-i-lydian-color",
+          "narrative": "Over a Cmaj7 chord, modal interchange may be used 'to make it a lydian chord for a moment,' using quartal chords from B minor pentatonic or D major pentatonic scale. 'It gives a very tasty flavor to the major 7th or major 6th chords' (Ch. 6, p. 263). This superimposition is an option, not a requirement, and is separate from the foundational tonic function.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "pentatonic-quartal-scale-choice",
+            "modal-interchange"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, p. 263"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-i-quartal-voicing",
+          "narrative": "Over a Cmaj7 chord, use 'G major pentatonic quartal voicings,' 'C major pentatonic quartal voicings,' or a 'mixture of both' (Ch. 6, p. 210). The F major pentatonic is excluded because 'it has the avoid note F' (Ch. 6, p. 202). These quartal voicings are particularly apt for static-harmony or single-chord compositions.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "pentatonic-quartal-scale-choice"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, pp. 202, 210"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-iii",
+          "narrative": "Em7 (IIIm) belongs to the Root Region alongside Cmaj7 and Am7 and may be substituted for any other Root Region chord (Ch. 1, p. 1). The same complete voicing palette available to Im (ninth, eleventh, sixth variants) applies when IIIm assumes a tonic function. When comping, melody governs the specific tension chosen.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 1"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "subdominant-iv",
+          "narrative": "Fmaj7 (IV) is the flagship major subdominant chord, providing 'movement and distancing' from the tonic (Ch. 1, p. 1). It may be freely replaced by Dm7 (IIm) or the minor subdominant chords because they share the same harmonic region: 'any chord of a given Harmonic Region may be replaced by another of the same region' (Ch. 1, p. 3). Subdominant chords function to delay the dominant and add harmonic color.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability",
+            "subdominant-delays-dominant"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 1, 3, 8"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "subdominant-bvii",
+          "narrative": "Bbmaj7 (bVII) is listed as a major subdominant chord and thus belongs to the same harmonic region as Fmaj7 (IV) and Dm7 (IIm) (Ch. 1, p. 1). It may substitute for any other major subdominant chord and serves the same delaying function before the dominant. Melody governs which tension variant is chosen when comping.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 1"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "subdominant-bvi",
+          "narrative": "Abmaj7 (bVI) is a minor subdominant chord available in both major and minor keys for modal interchange and re-harmonization color (Ch. 1, p. 1; Ch. 2, p. 28). It belongs to the subdominant region and is therefore interchangeable with IV, IIm, and the other minor subdominant chords. Its use is prescribed as a re-harmonization resource: 'a tremendous asset for re-harmonizing songs, creating new colors to the harmony' (Ch. 2, p. 28).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability",
+            "modal-interchange"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 1; Ch. 2, p. 28"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "subdominant-bii",
+          "narrative": "Dbmaj7 (bII) is listed as a minor subdominant chord (Ch. 1, p. 1), making it interchangeable with other minor subdominant chords for delaying the dominant. It appears prominently in minor key harmonic regions and modal interchange tables. Its tritone relationship to the major VII degree also makes it a tritone-substitution resource for the dominant in certain progressions.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability",
+            "tritone-sub-traversal"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 1"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj9",
+          "function_role": "tonic-i",
+          "narrative": "Cmaj7(9) is explicitly listed as a valid voicing tension for the I degree major chord (Ch. 1, p. 2). When comping, the melody determines whether the 9th is available: 'the most important thing when comping is to follow the melody, which will tell us what the best chord options are' (Ch. 1, p. 4). When improvising, any of these tensions may be applied freely.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melody-governs-voicing"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 4"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7#11",
+          "function_role": "tonic-i",
+          "narrative": "Cmaj7(#11) and C6(#11) are explicitly listed in the voicing palette for the I degree (Ch. 1, p. 2). The #11 tension produces a Lydian color over the tonic. The method prescribes superimposing quartal chords from B minor pentatonic or D major pentatonic over Cmaj7 to create this Lydian sound: 'it gives a very tasty flavor to the major 7th or major 6th chords' (Ch. 6, p. 263).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "pentatonic-quartal-scale-choice"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 2; Ch. 6, p. 263"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "tonic-i",
+          "narrative": "C6 and C6(9) are listed as valid voicings for the I degree alongside maj7 variants (Ch. 1, p. 2). The method notes the theoretical equivalence: 'the third inversion of Dm6 is Bø which is the II degree from the Am cadence. So we conclude that both II degrees are the same' (Ch. 1, p. 6), linking major 6th chords to the broader II/V/I substitution logic. Melody governs which tension is chosen when comping.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melody-governs-voicing"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 6"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "subdominant-ii",
+          "narrative": "Dm7 (IIm) is the canonical subdominant chord in the II/V/I cadence, substituting for IV because they share the same harmonic region: 'we had to replace the IVth degree by the IIm, which belongs to the same region' (Ch. 1, p. 3). Available tensions include Cm7, Cm7(9), Cm7(11), Cm7(9)11 (Ch. 1, p. 2). The dorian mode is implied: 'II degree = Dm7 is a dorian chord, which means that it could be Dm6 as well' (Ch. 1, p. 6).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2–3, 6"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "tonic-vi",
+          "narrative": "Am7 (VIm) belongs to the Root Region alongside Cmaj7 and Em7 and carries the same sense of rest (Ch. 1, p. 1). It is freely interchangeable with any other Root Region chord. In modal interchange substitution, the VI degree allows substitution from columns 6, 1, and 3 of the modal interchange table (Ch. 2, p. 29).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability",
+            "modal-interchange-column-traversal"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 1; Ch. 2, p. 29"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "tonic-i-minor",
+          "narrative": "Cm7 (Im) heads the minor key Root Region alongside Ebmaj7 (bIII) (Ch. 1, p. 4). In the minor II/V/I cadence, the tonic minor 7th chord almost always receives V7 chords with altered tensions leading into it: 'the dominant seventh chords almost always use altered tensions such as: b9, #9, #11, b13' (Ch. 1, p. 4). The minor Im is the resolution target of all minor cadence motion.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "altered-tensions-minor-v7"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 4"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "subdominant-ivm",
+          "narrative": "Fm7(6) (IVm) is the cornerstone of the minor subdominant region and appears in both major and minor harmonic field tables (Ch. 1, pp. 1, 4). It may be replaced by any other minor subdominant chord. The method notes it 'can be considered melodic minor if we want,' linking it to the melodic minor substitution apparatus (Ch. 2, p. 40).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 1, 4; Ch. 2, p. 40"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min9",
+          "function_role": "subdominant-ii",
+          "narrative": "Cm7(9) is listed as a valid tension for the minor II degree (Ch. 1, p. 2). The method demonstrates that when applying tritone substitution over the dominant in a minor II/V/I, the voicing of the preceding IIm chord may need to be adjusted: '|| Gm7(11) | Gb7(#11) | Fmaj7 ||' shows the IIm upgraded to the 11th tension to accommodate the tritone sub (Ch. 1, p. 14).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "tritone-sub-voicing-adjustment"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 14"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min6",
+          "function_role": "subdominant-ii",
+          "narrative": "Cm6 and Cm6(9) are listed in the voicing palette for the minor II chord (Ch. 1, p. 2). The method notes their theoretical equivalence to the half-diminished: 'the third inversion of Dm6 is Bø which is the II degree from the Am cadence. So we conclude that both II degrees are the same' (Ch. 1, p. 6), authorizing min6 as a substitute for the half-diminished in II/V/I contexts.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 6"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "subdominant-ii-melodic-minor",
+          "narrative": "Cm(maj7)9 is listed among the voicing tensions for minor II chords (Ch. 1, p. 2). More broadly, melodic minor chords—of which min(maj7) is the characteristic I degree sound—may substitute for dominant region chords: 'the chords derived from the melodic minor scale can replace the dominant region chords with the subdominant region chords' (Ch. 2, p. 40). The V degree of melodic minor is the one exception to this freedom (see proscriptive note).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melodic-minor-dual"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 2; Ch. 2, p. 40"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/subdominant-ii-melodic-minor-v-prohibition"
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "subdominant-ii-melodic-minor-v-prohibition",
+          "narrative": "The V degree chord of a melodic minor scale must not substitute for the dominant chord when it shares the same root as the tonic chord. 'If we have a cadence Dm7, G7, Cmaj7 we could not use the C7(9/b13){V degree of F melodic minor} to replace G7, because it has the same root note as the key (Cmaj7), and the cadence would disappear' (Ch. 2, p. 40). This prohibition protects cadential function.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melodic-minor-v-degree-prohibition"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 2, p. 40"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/subdominant-ii-melodic-minor"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-v",
+          "narrative": "G7 (V) is the primary dominant chord, providing tension that 'wants to resolve to the tonic' (Ch. 1, p. 1). Available tensions for the V degree leading to major include G7, G7(9), G7(b9), G7(#9), G7(13), G7(b13), G7(b9)b13, G7(#9)b13, G7(9)13, G7(b9)13, G7(#11), G7(b9)#11, Gsus9, Gsus13, Gsus(b9) (Ch. 1, p. 2). 'The melody will always determine what we can and can not use' (Ch. 1, p. 10).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melody-governs-voicing"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 1–2, 10"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-v-minor",
+          "narrative": "On the V degree of a minor cadence, dominant 7th chords 'almost always use altered tensions such as: b9, #9, #11, b13. The major 13th can be used with some regularity in the chords, but it is still an exception' (Ch. 1, p. 4). Mixolydian (unaltered) quartal voicings are specifically prohibited on this degree; see proscriptive note below.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "altered-tensions-minor-v7"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v-minor-mixolydian-prohibition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-v-minor-mixolydian-prohibition",
+          "narrative": "Mixolydian quartal voicings may not be used on the V chord of a minor cadence: 'we can use all the possibilities we have learned for dominant 7th chords, except with the mixolydian chord voicings, which can only be used when they are leading to major chords' (Ch. 7, p. 279). This restriction distinguishes minor-cadence V7 treatment from its major-cadence counterpart.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "mixolydian-quartal-major-cadence-only"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 279"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v-minor",
+            "dom7/dominant-v-mixolydian-major-only"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-v-mixolydian-major-only",
+          "narrative": "Mixolydian quartal voicings on the V chord are permitted only when resolving to a major tonic: 'mixolydian chord voicings can only be used when they are leading to major chords' (Ch. 7, p. 279). This is the affirmative counterpart to the minor-cadence prohibition and defines the precise context in which unaltered mixolydian color is safe to deploy.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "mixolydian-quartal-major-cadence-only"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 279"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v-minor-mixolydian-prohibition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "non-functional-lydian-dominant",
+          "narrative": "Any dominant 7th that is neither the V degree nor a tritone substitution 'is always considered lydian dominant. In other words, we can use the following tensions on them: 9, 13, or #11. Even though this is a rule, remember that it can be broken, mainly when we have modal harmonies' (Ch. 1, p. 2). This is the default tension palette for all non-resolving dominant chords.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "lydian-dominant-tension-rule"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 2"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "all-dominant-turnaround",
+          "narrative": "In a turnaround progression in Brazilian or blues contexts, every chord 'become[s] dominant with different voicings. Each dominant chord is leading to the next chord until it finally leads to the tonic key (I)' (Ch. 4, p. 83). This all-dominant technique is a structural rule for a specific genre context, not a general substitution. Each dominant chord uses varied voicings to maintain forward motion.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "all-dominant-turnaround-traversal"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 3, p. 69; Ch. 4, p. 83"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "tritone-substitution",
+          "narrative": "A dominant 7th may be replaced by the dominant 7th a tritone away: 'if the chord is G7, the replacement will be Db7. The reason we can do this exchange is that both have the same tritone' (Ch. 1, p. 13). When the substitute does not sound well, both the substitute's tension and the preceding II chord's voicing must be adjusted together (Ch. 1, p. 14).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "tritone-sub-traversal",
+            "tritone-sub-voicing-adjustment"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 13–14"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom13",
+          "function_role": "dominant-v-major",
+          "narrative": "G7(13) and G7(9)13 are explicitly listed in the palette for the V degree leading to major chords (Ch. 1, p. 2). The major 13th is the characteristic unaltered tension for dominant chords in major-key cadences. In minor cadences, the major 13th 'can be used with some regularity in the chords, but it is still an exception' (Ch. 1, p. 4), making it primarily a major-cadence dominant color.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "altered-tensions-minor-v7"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 4"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "dominant-v-minor",
+          "narrative": "G7(b9) and G7(b9)13 and G7(b9)b13 are prescribed tensions for the V degree in minor-key cadences, where 'altered tensions such as: b9, #9, #11, b13' almost always apply (Ch. 1, pp. 2, 4). The method also notes: 'dominant 7th chords such as 7(b9), 7(#9), and 7(b13), can be considered as being the same, therefore they have the same function' (Ch. 1, p. 14). Used as a Fake Diminished (inverted dom7b9) it substitutes for V7.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "altered-tensions-minor-v7",
+            "fake-diminished"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 4, 14"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "fake-diminished-substitute",
+          "narrative": "A dom7(b9) chord with its root removed is the structural basis of the Fake Diminished category: 'This type of diminished chord can be analyzed as an inverted dominant 7th (b9) chord' (Ch. 2, p. 19). The root note is omitted because 'there is no need for it,' and the remaining notes form a diminished chord that substitutes directly for V7. All four inversions are available due to diminished symmetry.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "fake-diminished",
+            "diminished-minor-third-traversal"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 2, p. 19"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "dominant-v-minor",
+          "narrative": "G7(#9) is prescribed for minor-key V degree chords, where altered tensions 'almost always' apply (Ch. 1, pp. 2, 4). The method further equates the #9 function with b9 and b13: 'dominant 7th chords such as 7(b9), 7(#9), and 7(b13), can be considered as being the same, therefore they have the same function' (Ch. 1, p. 14). The Db major quartal family reframes Dø as D7(#9) via a blues/tritone substitution chain (Ch. 7, p. 275).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "altered-tensions-minor-v7"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 4, 14; Ch. 7, p. 275"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7#11",
+          "function_role": "non-functional-lydian-dominant",
+          "narrative": "The #11 tension (alongside 9 and 13) is prescribed for non-functional dominant 7th chords treated as lydian dominant: 'Dominant 7th chords that are not the Vth degree or a tritone substitution, are always considered lydian dominant. In other words, we can use the following tensions on them: 9, 13, or #11' (Ch. 1, p. 2). When a tritone sub sounds wrong, the solution is often to convert it to a 7(#11) voicing (Ch. 1, p. 14).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "lydian-dominant-tension-rule",
+            "tritone-sub-voicing-adjustment"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 14"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7#11",
+          "function_role": "lydian-dominant-unresolved-only",
+          "narrative": "Lydian dominant (dom7#11 / mixolydian #4) voicings 'can only be used over dominant 7th chords that are not leading to any other chord. The only exception is when we have a sequence of many dominant 7th chords one after another' (Ch. 7, p. 279). This restricts lydian dominant to terminal or chained dominant contexts and prohibits it on resolving V7 chords.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "lydian-dominant-restriction-quartal"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 279"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/lydian-dominant-on-resolving-v-prohibition"
+          ]
+        },
+        {
+          "chord_quality": "dom7#11",
+          "function_role": "lydian-dominant-on-resolving-v-prohibition",
+          "narrative": "Lydian dominant (mixolydian #4) voicings must not be used on a dominant 7th chord that is resolving to another chord, as this creates an incorrect application: 'A dominant chord that is used incorrectly most of the time is the lydian dominant (also called mixolydian #4). It can only be used over dominant 7th chords that are not leading to any other chord' (Ch. 7, p. 279).",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "lydian-dominant-restriction-quartal"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 279"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/lydian-dominant-unresolved-only"
+          ]
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "dominant-v-minor",
+          "narrative": "Altered dominant chords are the prescribed voicing for the V degree in minor cadences: 'the dominant seventh chords almost always use altered tensions such as: b9, #9, #11, b13' (Ch. 1, p. 4). The G7 chord 'as being altered' is the VIIth degree of Ab melodic minor, enabling the full melodic minor substitution family: 'subdominant, dominant, root' substitutions are available (Ch. 3, p. 47).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "altered-tensions-minor-v7",
+            "melodic-minor-dual"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 4; Ch. 3, p. 47"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "tritone-substitution-minor",
+          "narrative": "In a minor II/V/I such as '|| Aø | D7(b9) | Gm7 ||, if we use a tritone substitution over the dominant 7th chord, the voicings work perfect and we do not have to change anything. Example: || Aø | Ab7(#11) | Gm7 ||' (Ch. 2, p. 17). Unlike major-cadence tritone subs, no adjustment to the preceding chord is required in the minor case.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "tritone-sub-traversal"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 2, p. 17"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7b5",
+          "function_role": "tritone-substitution",
+          "narrative": "The tritone substitution of a V7 chord (e.g., Db7 replacing G7) contains an implied b5 relationship to the original chord. The method warns that 'depending on the dominant chord we apply the tritone substitution to, it may not sound correct or great. Example: C7(9) using a tritone substitution would be Gb7(b13), which most of time does not work. So we replace the Gb7(b13) by Gb7(#11)' (Ch. 1, p. 14), pointing toward the #11/b5 variant as the practical correction.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "tritone-sub-voicing-adjustment"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 14"
+            }
+          ]
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "dominant-v",
+          "narrative": "Gsus9 and Gsus13 and Gsus(b9) are listed in the complete V-degree palette for dominant chords leading to major (Ch. 1, p. 2). Suspended dominant voicings thus belong to the dominant region and carry tension function. Melody governs which suspension tension is available when comping: 'the melody will always determine what we can and can not use' (Ch. 1, p. 10).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melody-governs-voicing"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 10"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "subdominant-ii-minor",
+          "narrative": "Dø (half-diminished) is the VII degree of the major harmonic field and the II degree of the minor II/V/I cadence (Ch. 1, pp. 1, 4). Available tensions include Dø, Dø(9), Dø(11), Dø(9)11, Dm7(b6) (Ch. 1, p. 2). In the minor II/V/I, 'if we consider Dø chord as being locrian major 2nd we will have the VIth degree of F melodic minor,' unlocking F melodic minor substitution options (Ch. 3, p. 47).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melodic-minor-dual"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 1–2, 4; Ch. 3, p. 47"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "subdominant-ii-quartal-voicing",
+          "narrative": "Over a D half-diminished chord, three quartal chord families are available: 'Two of them are derived from two different major scales: Eb major and Db major, and the last one is derived from a melodic minor scale: F melodic minor' (Ch. 7, p. 275). The Db major family requires a harmonic reframing of Dø as D7(#9) via blues/tritone substitution logic before its mixolydian quartal voicings apply.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melodic-minor-dual"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 275"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "subdominant-ii-lower-note-caution",
+          "narrative": "When applying quartal voicings over a half-diminished chord, 'be careful of the lower notes. They can make the chord sound undesirable' (Ch. 7, p. 275). When lower notes cause muddiness, the remedy is to 'take out the lower note and play a 3 note quartal voicing' (Ch. 7, p. 276).",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "register-floor-3rd-string",
+            "tetrad-to-triad-reduction"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, pp. 275–276"
+            }
+          ],
+          "cross_ref": [
+            "min7b5/subdominant-ii-quartal-voicing"
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "dominant-substitute",
+          "narrative": "Diminished chords substitute for V7 in two categories. Fake Diminished is 'an inverted dominant 7th (b9) chord' (Ch. 2, p. 19). Hybrid Diminished functions 'as a connecting chord, and second as a substitute chord for the V7 degree of a cadence' (Ch. 2, p. 20). Due to diminished symmetry, 'for every diminished chord, we will always have four options' that are equivalent and interchangeable (Ch. 2, p. 19).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "diminished-minor-third-traversal",
+            "fake-diminished",
+            "hybrid-diminished"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 2, pp. 19–20"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "bass-pedal-dominant-substitute",
+          "narrative": "A diminished chord built on the tonic root (e.g., C˚ resolving to C6) substitutes for the dominant via the bass pedal point technique: 'the bass stays the same and the chords move around. Therefore we have: C˚ resolving to C6. Below we have 2 possibilities of diminished chords replacing dominant 7th chords (G7 | C6 replaced by C˚ | C6)' (Ch. 2, p. 21).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "fake-diminished",
+            "hybrid-diminished"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 2, p. 21"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "subdominant-bvii-minor",
+          "narrative": "Bb7 (bVII) is listed as a minor subdominant chord in both major and minor harmonic region tables (Ch. 1, pp. 1, 4). As a subdominant-region chord it functions to delay the dominant: 'subdominant chords are a way to delay the dominant chord, that is why subdominant chords and dominant chords are interchangeable' (Ch. 1, p. 8). It is freely interchangeable with other minor subdominant chords.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "subdominant-delays-dominant",
+            "same-region-interchangeability"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 1, 4, 8"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "secondary-dominant",
+          "narrative": "Secondary dominants are 'dominant chords that resolve to the other harmonic field degrees. They don't belong to the harmonic field and have nothing to do with it, except for the chord that they were assigned to resolve to' (Ch. 1, p. 7). Any dominant 7th acting as a secondary dominant that is not the V degree or a tritone substitution defaults to lydian dominant tensions (9, 13, #11) unless melody overrides.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "secondary-dominant",
+            "lydian-dominant-tension-rule"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 7, 2"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "quartal-register-caution",
+          "narrative": "When voicing dominant 7th chords using quartal structures from the 6th string or in low positions, muddiness is likely: 'the chords rooted from the 6th string might not work. Sometimes, even the chords starting from the 5th string might not work if used in low areas of the instrument' (Ch. 6, p. 204). The remedy is to reduce to 3-note quartal voicings or to shift to the 3rd–5th strings.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "register-floor-3rd-string",
+            "tetrad-to-triad-reduction"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, p. 204"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v-quartal-register-prescriptive"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dominant-v-quartal-register-prescriptive",
+          "narrative": "For quartal dominant voicings during comping, use voicings starting from the 3rd, 4th, or 5th strings: 'we most often use the chords starting from the 3rd, 4th and 5th strings, because the chords rooted from the 6th string might not work' (Ch. 6, p. 204). When tetrads in this range still sound muddy, replace them with 3-note quartal voicings (Ch. 7, p. 276).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "register-floor-3rd-string"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, p. 204; Ch. 7, p. 276"
+            }
+          ],
+          "cross_ref": [
+            "dom7/quartal-register-caution"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "dorian-static-harmony",
+          "narrative": "Dorian (minor 7th) quartal voicings are prescribed for static harmonies: 'Usually the dorian chords are related to static harmonies. However, they can be a tremendous asset when used over non traditional harmonic situations, giving a dorian modal vibe to the chord' (Ch. 7, p. 279). Minor 7th quartal voicings are therefore the primary tool for modal/static chord progressions as well as modal interchange colorings.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "bass-note-selects-mode"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 279"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "quartal-comping-register",
+          "narrative": "Minor 7th (dorian) quartal voicings for comping should favor the 3rd–5th string range. 'Many quartal tetrad chords presented above might not work well, not only because they are voiced too low, but also because they contain too many notes' (Ch. 6, p. 208). Fretboard visualization is the learning goal for all positions; performance use should default to the middle register.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "register-floor-3rd-string"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, p. 208"
+            }
+          ]
+        },
+        {
+          "chord_quality": "aug7",
+          "function_role": "dominant-v-altered",
+          "narrative": "Augmented dominant sounds are implied within the dom7alt palette (G7(b13) contains an augmented 5th/b13 quality). G7(b13) and G7(b9)b13 and G7(#9)b13 are listed among valid V-degree tensions (Ch. 1, p. 2). In minor cadences, b13 is one of the 'almost always' altered tensions (Ch. 1, p. 4). The method treats b13 and b9/#9 as effectively the same functional category: 'dominant 7th chords such as 7(b9), 7(#9), and 7(b13), can be considered as being the same' (Ch. 1, p. 14).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "altered-tensions-minor-v7"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 4, 14"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom11",
+          "function_role": "dominant-v-suspended",
+          "narrative": "Gsus9, Gsus13, and Gsus(b9) (suspended dominant 7th/11th colors) are listed in the complete V-degree palette for chords leading to major (Ch. 1, p. 2). They belong to the dominant region and function identically to unsuspended V7 chords for cadential purposes: 'the tension notes (7, 9, 11, 13) used over the chords below do not affect their function in any way' (Ch. 2, p. 22).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "cadence-tensions-do-not-alter-function"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 2; Ch. 2, p. 22"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "dominant-vii",
+          "narrative": "Bø (VII) is the second dominant-region chord alongside G7 (V) in the major harmonic field (Ch. 1, p. 1). In the leading-tone substitution tradition, 'jazz musicians used to substitute the V, I progression (G7, C6) by VII7, I (B7, C6). The reason why we can do this is quite simple: all the notes of B7 can work as leading tones to the notes of C6, because they are half step from each other' (Ch. 2, p. 20). The half-diminished VII shares this dominant function.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "vii7-leading-tone-substitution"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 1; Ch. 2, p. 20"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "tonic-biii-minor",
+          "narrative": "Ebmaj7 (bIII) belongs to the Root Region in minor keys alongside Cm7 (Im) (Ch. 1, p. 4). As a Root Region chord it may substitute for any other Root Region minor chord. The parallel-mode exercise rule applies: the first chord must always be from the major key, so bIII-as-tonic substitution applies only in minor-key contexts (Ch. 2, p. 33).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "same-region-interchangeability",
+            "parallel-mode-exercise-major-anchor"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 4; Ch. 2, p. 33"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "parallel-mode-anchor",
+          "narrative": "In parallel-mode exercises, the first chord of the sequence 'will always be from the major key, and all the other chords will be the degrees belonging to the parallel minor key' (Ch. 2, p. 33). This means a major 7th chord anchors the opening of every parallel-mode exercise sequence. Violating this anchor—by opening with a borrowed minor chord—collapses the major-to-minor color contrast the exercise is designed to produce.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "parallel-mode-exercise-major-anchor"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 2, p. 33"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "tritone-sub-tension-adjustment",
+          "narrative": "When a tritone substitution produces an undesirable sound—as when C7(9) substituted by Gb7(b13) 'most of time does not work'—the tension of the tritone chord must be changed and the preceding II chord's voicing updated: '|| Gm7(11) | Gb7(#11) | Fmaj7 ||' (Ch. 1, p. 14). Both chords must be adjusted together; adjusting only one is insufficient.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "tritone-sub-voicing-adjustment"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 14"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "tritone-sub-b13-prohibition",
+          "narrative": "A tritone substitute with a b13 tension often does not work: 'C7(9) using a tritone substitution would be Gb7(b13), which most of time does not work' (Ch. 1, p. 14). When this occurs, the b13 must be replaced by #11 on the tritone chord, and the preceding II chord's voicing must also be updated. Using the raw Gb7(b13) tritone substitute without adjustment is proscribed.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "tritone-sub-voicing-adjustment"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 14"
+            }
+          ],
+          "cross_ref": [
+            "dom7/tritone-sub-tension-adjustment"
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "subdominant-ii-f-melodic-minor",
+          "narrative": "F melodic minor quartal voicings may be used over a D half-diminished chord because 'the Dø chord is the VI degree of F melodic minor. Therefore, we can use the F melodic minor quartal chord voicings over it' (Ch. 7, p. 277). The first degree of the F melodic minor quartal family—Fm(maj7)add4—may additionally be replaced by D#/E (F#7(13)b9 over E) when voice-leading demands it.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melodic-minor-dual",
+            "non-family-chord-voice-leading-override"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, pp. 277"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "tonic-i-melodic-minor-quartal",
+          "narrative": "Fm(maj7)add4 is the I degree of the F melodic minor quartal chord family used over Dø. The method permits substituting it with a non-family chord when voice-leading logic is compelling: 'sometimes can be replaced by a chord not belonging to that family: D#/E, which is actually a F#7(13)b9 over E. This is not a rule, it is just a chord voicing that works well' (Ch. 7, p. 277). Family membership is preferred but not absolute.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "non-family-chord-voice-leading-override"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 277"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "quartal-comping-register-caution",
+          "narrative": "Quartal tetrad voicings rooted on the 6th string must not be used for comping major 7th chords: 'the chords rooted from the 6th string might not work. Sometimes, even the chords starting from the 5th string might not work if used in low areas of the instrument. Also, sometimes the 4 note quartal chords must be replaced by the 3 note quartal chords' (Ch. 6, p. 204). Register correctness takes precedence over theoretical completeness.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "register-floor-3rd-string",
+            "tetrad-to-triad-reduction"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, p. 204"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i-quartal-voicing"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "locrian-pentatonic-prohibition",
+          "narrative": "The minor pentatonic scale must not be used to improvise over Locrian quartal chord voicings because 'the perfect 5th of the scale does not belong to this mode' (Ch. 6, p. 226). Instead, 'we can play the Minor Blues scale over Locrian chord voicings emphasizing the #4.' This proscription applies whenever the minor chord voicing is specifically Locrian-mode quartal.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "locrian-pentatonic-blues-scale-exception"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, p. 226"
+            }
+          ],
+          "cross_ref": [
+            "min7/locrian-blues-scale-substitute"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "locrian-blues-scale-substitute",
+          "narrative": "Over Locrian quartal chord voicings, the minor blues scale with #4 emphasis is the prescribed improvisation scale: 'we can play the Minor Blues scale over Locrian chord voicings emphasizing the #4' (Ch. 6, p. 226). This is the specific remedy for the minor pentatonic's incompatibility with the Locrian mode's b5 (lack of perfect 5th).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "locrian-pentatonic-blues-scale-exception"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, p. 226"
+            }
+          ],
+          "cross_ref": [
+            "min7/locrian-pentatonic-prohibition"
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "quartal-eb-major-family",
+          "narrative": "The Eb major quartal chord family 'brings the locrian sound to Dø' and is one of the three prescribed quartal families over a D half-diminished chord (Ch. 7, p. 275). The Locrian modal color this family produces is appropriate for the half-diminished II chord function in a minor II/V/I. The locrian-as-altered substitution principle further unlocks the Ab major scale over any G7alt that accompanies it (Ch. 6, p. 254).",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "locrian-as-altered-scale-unlock"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 275; Ch. 6, p. 254"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "tritone-sub-blues-reframing",
+          "narrative": "The Db major quartal family over Dø requires a two-step transformation: 'we transformed the Dø into D7(#9) chord, giving it a blues vibe. Then using the tritone substitution for D7(#9), we can find Ab7(13), that we can consider mixolydian. Therefore, having this mixolydian chord, we can find the Db major scale quartal chord voicings' (Ch. 7, p. 275). This reframing is necessary before the Db family can be applied.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "tritone-sub-traversal"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 7, p. 275"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "minor-blues-quartal-top-voice",
+          "narrative": "When harmonizing the minor blues scale with quartal shape (1, 4, b7), scale tones must always appear in the top voice: 'the scale notes will always be on the top voice of each chord. By doing this, we give strength to the chord melody, since they sound like power chords' (Ch. 6, p. 244). Non-scale notes are permitted in inner voices as a consequence of the fixed quartal shape.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "minor-blues-scale-top-voice-rule"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 6, p. 244"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "comping-melody-constraint",
+          "narrative": "When comping with any major 7th voicing, the melody must guide chord selection: 'the most important thing when comping is to follow the melody, which will tell us what the best chord options are. However, when improvising we can be more free because we will create the melodies' (Ch. 1, p. 4). This overrides all other voicing preference rules during accompaniment.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melody-governs-voicing"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, p. 4"
+            }
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "comping-melody-constraint",
+          "narrative": "Over minor 7th chords when comping, the melody determines which of the available tensions—m7, m7(9), m7(11), m7(9)11, m(maj7)9, m6, m6(9)—is appropriate: 'the melody will always determine what we can and can not use' (Ch. 1, p. 10). When soloing, all tensions are available regardless of the written melody.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melody-governs-voicing"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 2, 10"
+            }
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "comping-melody-constraint",
+          "narrative": "Dominant 7th chord tension selection during comping is governed by melody: 'we can never forget that the most important thing when comping is to follow the melody' (Ch. 1, p. 4), and 'the melody will always determine what we can and can not use' (Ch. 1, p. 10). Altered tensions are applied pedagogically for minor degrees but 'actually, we can use any alteration to any dominant chord leading to major or minor' as long as melody permits.",
+          "polarity": "prescriptive",
+          "provenance": "extracted",
+          "source_work_id": "method-vol-2-advanced-harmony",
+          "source_principle_ids": [
+            "melody-governs-voicing"
+          ],
+          "references": [
+            {
+              "source": "method-vol-2-advanced-harmony",
+              "citation": "Ch. 1, pp. 4, 10"
+            }
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-i",
+          "narrative": "The perfect 4th is an avoid note over Cmaj7 and must be omitted as a default melodic choice: \"Be careful with the avoid notes of both scales (perfect 4th in the Ionian mode)\" (Ch. 6, p. 244). Contextual exceptions exist: \"there are always exceptions and at times the avoid note works fine depending on the situation\" (Ch. 6, p. 244).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "Be careful with the avoid notes of both scales (perfect 4th in the Ionian mode)"
+            },
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "there are always exceptions and at times the avoid note works fine depending on the situation"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-lydian-superimposition",
+            "min7/relative-vim"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "tonic-lydian-superimposition",
+          "narrative": "Over Cmaj7, melodies that avoid the perfect 4th can also fit Lydian context via superimposition: \"we will create melodies for Cmaj7 that can fit over Ionian or Lydian chords\" (Ch. 7, p. 269). The strategy employs descending Cmaj7 arpeggios with added color tones drawn from transcribed Benson solos: \"Cmaj7 and Am7 descending chord arpeggios with added notes\" (Ch. 7, p. 269).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "we will create melodies for Cmaj7 that can fit over Ionian or Lydian chords"
+            },
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "Cmaj7 and Am7 descending chord arpeggios with added notes"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i",
+            "min7/relative-vim"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "zone-anchor",
+          "narrative": "The Cmaj7 chord shape serves as a navigational anchor for Ionian-side fretboard zones, functioning purely as a positional landmark rather than a harmonic instruction: \"Each zone will be related with a chord shape (Cmaj7 or Am7). The chords will guide us\" (Ch. 6, p. 246). The guide chord's root orients the player within the zone, not to the surrounding harmony.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 246",
+              "citation": "Each zone will be related with a chord shape (Cmaj7 or Am7). The chords will guide us"
+            },
+            {
+              "source": "Ch. 3, p. 110",
+              "citation": "they are only to guide us into the 5 zones, nothing else"
+            }
+          ],
+          "cross_ref": [
+            "min7/zone-anchor"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "arpeggio-root-position",
+          "narrative": "Maj7 tetrad arpeggios are organized by root-string group—5th string or 6th string—with three distinct shapes per group, all played from root position: \"All the following arpeggio examples are divided into two groups\" (Ch. 2, p. 26). Ascending arpeggios define the fretboard zone while descending ones span two zones: \"ascending arpeggios will define the fretboard zones, because the descending arpeggios will almost always use two zones\" (Ch. 7, p. 275).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 26",
+              "citation": "All the following arpeggio examples are divided into two groups"
+            },
+            {
+              "source": "Ch. 7, p. 275",
+              "citation": "ascending arpeggios will define the fretboard zones, because the descending arpeggios will almost always use two zones"
+            }
+          ],
+          "cross_ref": [
+            "min7/arpeggio-root-position",
+            "dom7/arpeggio-root-position"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "major-blues-target",
+          "narrative": "The major blues scale can be played over any individual major chord including the major 7th: \"The major blues scale can be played over any individual major chord, including the major 7th and dominant 7th chords\" (Ch. 4, p. 141). However, alone it risks sounding unbluesy—it must be mixed with the minor blues scale to achieve the blues vibe: \"this scale can sound not bluesy, so the trick is to mix it with the minor blues scale\" (Ch. 4, p. 141).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 141",
+              "citation": "The major blues scale can be played over any individual major chord, including the major 7th and dominant 7th chords"
+            },
+            {
+              "source": "Ch. 4, p. 141",
+              "citation": "this scale can sound not bluesy, so the trick is to mix it with the minor blues scale"
+            }
+          ],
+          "cross_ref": [
+            "dom7/major-blues-target",
+            "maj6/pentatonic-identity"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "relative-vim",
+          "narrative": "The flat 6th is an avoid note over Am7 (VIm7) and must be defaulted away from: \"Be careful with the avoid notes of both scales...flat 6th in the Aeolian mode\" (Ch. 6, p. 244). Melodies for Am7 are constructed to fit Dorian or Aeolian contexts using descending Am7 scale arpeggios with added color tones: \"melodies for Am7 that can fit over Dorian or Aeolian chords\" (Ch. 7, p. 269).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "Be careful with the avoid notes of both scales...flat 6th in the Aeolian mode"
+            },
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "melodies for Am7 that can fit over Dorian or Aeolian chords"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i",
+            "min7/zone-anchor"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "zone-anchor",
+          "narrative": "The Am7 chord shape anchors Aeolian-side fretboard zones as a navigational landmark: \"Each zone will be related with a chord shape (Cmaj7 or Am7)\" (Ch. 6, p. 246). The Am7 guide chord also appears explicitly in the Chapter 3 pentatonic zone system: \"C6 and Am7 serve as fretboard landmarks\" enabling \"we visualize vertically but play horizontally\" (Ch. 6, p. 246).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 246",
+              "citation": "Each zone will be related with a chord shape (Cmaj7 or Am7)"
+            },
+            {
+              "source": "Ch. 6, p. 246",
+              "citation": "we visualize vertically but play horizontally most of the time"
+            }
+          ],
+          "cross_ref": [
+            "maj7/zone-anchor"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "minor-pentatonic-home",
+          "narrative": "The minor pentatonic scale creates a minor 7th chord identity (Am7) and lines built purely from minor pentatonic without major pentatonic mixture are preferentially deployed over the minor chord family: \"our preference is to use the lines over minor chords or chord sequences belonging to the 'minor chord family'\" (Ch. 5, p. 210). This preference is non-absolute: \"This is not a rule. Melodic lines using only the minor pentatonic scale will often work perfectly over major chords\" (Ch. 5, p. 210).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 210",
+              "citation": "our preference is to use the lines over minor chords or chord sequences belonging to the minor chord family"
+            },
+            {
+              "source": "Ch. 5, p. 210",
+              "citation": "This is not a rule. Melodic lines using only the minor pentatonic scale will often work perfectly over major chords"
+            }
+          ],
+          "cross_ref": [
+            "min7/relative-vim",
+            "maj7/tonic-i"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "arpeggio-root-position",
+          "narrative": "Minor 7th tetrad arpeggios follow the same two-group (5th-string root / 6th-string root) organizational system as all other tetrad types, with three shapes per group played from root position: \"All the following arpeggio examples are divided into two groups\" (Ch. 2, p. 26). Inverted Am7 arpeggios may be visualized from either a 5th-string or 6th-string guide root: \"The inverted arpeggios can be visualized many ways, depending on the guide root we [choose]\" (Ch. 2, p. 80).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 26",
+              "citation": "All the following arpeggio examples are divided into two groups"
+            },
+            {
+              "source": "Ch. 2, p. 80",
+              "citation": "The inverted arpeggios can be visualized many ways, depending on the guide root we"
+            }
+          ],
+          "cross_ref": [
+            "maj7/arpeggio-root-position"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "minor-blues-substitution",
+          "narrative": "In a minor blues context, minor 7th chords require substitution tricks because the minor blues form mixes minor and dominant chord types: \"the minor blues form has two different types of chords (minor and dominant), so we must learn some substitution tricks before we start\" (Ch. 5, p. 195). These substitutions must be memorized before their theory is understood: \"it is not necessary to understand the theory behind it, just memorize them\" (Ch. 5, p. 195).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 195",
+              "citation": "the minor blues form has two different types of chords (minor and dominant), so we must learn some substitution tricks before we start"
+            },
+            {
+              "source": "Ch. 5, p. 195",
+              "citation": "it is not necessary to understand the theory behind it, just memorize them"
+            }
+          ],
+          "cross_ref": [
+            "dom7/minor-blues-context"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "blues-primary",
+          "narrative": "The minor blues scale unifies all dominant 7th chords in a blues form as a single summarizing scale: \"Normally we use this scale from the key we are in rather than over an individual chord. Because it can be used over all the blues chords at once\" (Ch. 4, p. 140). Overreliance on this convenience is explicitly proscribed: \"Be careful not to rely on this technique. It will make you sound like a 'lazy' improviser\" (Ch. 4, p. 140).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 140",
+              "citation": "Normally we use this scale from the key we are in rather than over an individual chord"
+            },
+            {
+              "source": "Ch. 4, p. 140",
+              "citation": "Be careful not to rely on this technique. It will make you sound like a lazy improviser"
+            }
+          ],
+          "cross_ref": [
+            "dom7/major-blues-target",
+            "dom7/minor-blues-context"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "major-blues-target",
+          "narrative": "The major blues scale applies over dominant 7th chords as individual chord targets: \"The major blues scale can be played over any individual major chord, including the major 7th and dominant 7th chords\" (Ch. 4, p. 141). When mixing both blues scales, scale choice must follow harmony chord-by-chord rather than collapsing all changes: \"we cannot summarize all the chords into one scale anymore, we must follow the harmony\" (Ch. 4, p. 151).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 141",
+              "citation": "The major blues scale can be played over any individual major chord, including the major 7th and dominant 7th chords"
+            },
+            {
+              "source": "Ch. 4, p. 151",
+              "citation": "we cannot summarize all the chords into one scale anymore, we must follow the harmony"
+            }
+          ],
+          "cross_ref": [
+            "dom7/blues-primary",
+            "maj7/major-blues-target"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "minor-blues-context",
+          "narrative": "When the minor blues scale is used over a dominant 7th chord—mixed with the major blues scale in the same key—the major 3rd must be played quickly to avoid melodic clash: \"when mixed with the major blues scale in the same key, we can use it over any dominant 7th chord, bringing a blues vibe to it. (Make sure to play the major 3rd quickly in the phrase, otherwise the melody can sound wrong)\" (Ch. 4, p. 141).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 141",
+              "citation": "Make sure to play the major 3rd quickly in the phrase, otherwise the melody can sound wrong"
+            }
+          ],
+          "cross_ref": [
+            "dom7/blues-primary",
+            "min7/minor-blues-substitution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "arpeggio-root-position",
+          "narrative": "Dominant 7th tetrad arpeggios follow the two-group (5th-string / 6th-string root) organizational system with three shapes per group from root position: \"All the following arpeggio examples are divided into two groups\" (Ch. 2, p. 26). Simple arpeggios over extended chords use root-position only: \"SIMPLE ARPEGGIOS: We use this technique over chords as the way they are presented\" (Ch. 2, p. 25).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 26",
+              "citation": "All the following arpeggio examples are divided into two groups"
+            },
+            {
+              "source": "Ch. 2, p. 25",
+              "citation": "SIMPLE ARPEGGIOS: We use this technique over chords as the way they are presented"
+            }
+          ],
+          "cross_ref": [
+            "maj7/arpeggio-root-position",
+            "min7/arpeggio-root-position"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "harmonic-field-avoid-note-safe",
+          "narrative": "Unlike Imaj7 and VIm7, the dominant 7th chord (G7/Mixolydian) in the harmonic field tolerates the natural major scale's perfect 4th without melodic problems: \"this scale works perfectly when played over...G7 (mixolydian)...even while using the avoid note\" (Ch. 7, p. 269). This justifies the two-chord narrowing strategy that focuses avoid-note work only on Cmaj7 and Am7.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "this scale works perfectly when played over...G7 (mixolydian)...even while using the avoid note"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i",
+            "min7/relative-vim"
+          ]
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "pentatonic-identity",
+          "narrative": "The major pentatonic scale creates a major 6th chord identity: \"The major pentatonic scale creates a major 6th chord (C, E, G, A)\" (Ch. 3, p. 108). C6 and Am7 share identical notes, establishing their relative relationship: \"C6 is an inverted Am7 (1st inversion)\" (Ch. 3, p. 108). The two pentatonic forms must nevertheless be visualized separately for five-zone navigation.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 108",
+              "citation": "The major pentatonic scale creates a major 6th chord (C, E, G, A)"
+            },
+            {
+              "source": "Ch. 3, p. 108",
+              "citation": "C6 is an inverted Am7 (1st inversion)"
+            }
+          ],
+          "cross_ref": [
+            "min7/minor-pentatonic-home",
+            "maj7/major-blues-target"
+          ]
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "minor-pentatonic-extension",
+          "narrative": "Pure minor pentatonic lines work over C6 as well as Cmaj7 and C7, since the minor pentatonic preference for the minor family is non-absolute: \"Melodic lines using only the minor pentatonic scale will often work perfectly over major chords such as C6, Cmaj7 and of course C7\" (Ch. 5, p. 210). This cross-family applicability is a characteristic feature of blues language.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 210",
+              "citation": "Melodic lines using only the minor pentatonic scale will often work perfectly over major chords such as C6, Cmaj7 and of course C7"
+            }
+          ],
+          "cross_ref": [
+            "maj6/pentatonic-identity",
+            "maj7/tonic-i"
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "harmonic-field-avoid-note-safe",
+          "narrative": "Bø (Locrian/min7b5) within the harmonic field tolerates the natural major scale's perfect 4th without the melodic clash it creates over Imaj7: \"this scale works perfectly when played over...Bø (locrian), even while using the avoid note\" (Ch. 7, p. 269). Like the dominant 7th, this chord does not require the two-chord avoid-note strategy.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "this scale works perfectly when played over...Bø (locrian), even while using the avoid note"
+            }
+          ],
+          "cross_ref": [
+            "dom7/harmonic-field-avoid-note-safe",
+            "maj7/tonic-i"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "harmonic-field-avoid-note-safe",
+          "narrative": "Dm7 (Dorian) and Em7 (Phrygian) within the harmonic field both tolerate the natural major scale's perfect 4th: \"this scale works perfectly when played over Dm7 (Dorian), Em7 (Phrygian)...even while using the avoid note\" (Ch. 7, p. 269). These chords therefore do not need the two-chord avoid-note descending arpeggio approach reserved for Am7.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "this scale works perfectly when played over Dm7 (Dorian), Em7 (Phrygian)...even while using the avoid note"
+            }
+          ],
+          "cross_ref": [
+            "min7/relative-vim",
+            "maj7/tonic-i"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "harmonic-field-avoid-note-safe",
+          "narrative": "Fmaj7 (Lydian) within the harmonic field tolerates the natural major scale's perfect 4th, making it safe for key improvisation without the two-chord arpeggio strategy: \"this scale works perfectly when played over...Fmaj7 (Lydian)...even while using the avoid note\" (Ch. 7, p. 269). Lydian's raised 4th means the scale's perfect 4th functions as a color tone rather than a clash.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "this scale works perfectly when played over...Fmaj7 (Lydian)...even while using the avoid note"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i",
+            "maj7/tonic-lydian-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "superimposition-arpeggiation",
+          "narrative": "Superimposed dominant 7th stacks cannot be voiced simultaneously on guitar as on piano; they must be arpeggiated sequentially: \"it is difficult to play these superimposed chords correctly on the guitar. The only instrument that can apply this harmonic concept correctly is the piano. To achieve this on the guitar, we must arpeggiate two chords\" (Ch. 7, p. 275). A bass note unrelated to the stacked chords may also be selected freely.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 275",
+              "citation": "it is difficult to play these superimposed chords correctly on the guitar...we must arpeggiate two chords"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-lydian-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "superimposition-lydian-stack",
+          "narrative": "Stacking Gmaj7 over Cmaj7 produces a Lydian melodic and harmonic sound through superimposition: \"If we play Gmaj7 (G, B, D, F#) over the Cmaj7, we would have a 'C' Lydian sound melodically, and a Lydian chord harmonically\" (Ch. 7, p. 275). This is realized on guitar through arpeggiation of both chords in sequence rather than simultaneous voicing.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 275",
+              "citation": "If we play Gmaj7 (G, B, D, F#) over the Cmaj7, we would have a 'C' Lydian sound melodically, and a Lydian chord harmonically"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-lydian-superimposition",
+            "dom7/superimposition-arpeggiation"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "scale-arpeggio-descending",
+          "narrative": "Descending Cmaj7 scale arpeggios with added notes are the primary device for melodic lines over the I chord, derived directly from transcribed Benson solos and organized zone-by-zone: \"For each fretboard zone we will have a 'guide idea' starting from the highest note and ending in the lowest note. All the ideas presented below were taken from George Benson solos\" (Ch. 7, p. 269). Descending arpeggios span two zones; ascending ones define a single zone.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "For each fretboard zone we will have a guide idea starting from the highest note and ending in the lowest note. All the ideas presented below were taken from George Benson solos"
+            },
+            {
+              "source": "Ch. 7, p. 275",
+              "citation": "ascending arpeggios will define the fretboard zones, because the descending arpeggios will almost always use two zones"
+            }
+          ],
+          "cross_ref": [
+            "min7/scale-arpeggio-descending",
+            "maj7/arpeggio-root-position"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "scale-arpeggio-descending",
+          "narrative": "Descending Am7 scale arpeggios with added color tones are the primary device for avoiding the flat 6th over the VIm7 chord, organized zone-by-zone: \"Cmaj7 and Am7 descending chord arpeggios with added notes\" (Ch. 7, p. 269). These lines are built to cover both Dorian and Aeolian melodic contexts: \"melodies for Am7 that can fit over Dorian or Aeolian chords\" (Ch. 7, p. 269).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "Cmaj7 and Am7 descending chord arpeggios with added notes"
+            },
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "melodies for Am7 that can fit over Dorian or Aeolian chords"
+            }
+          ],
+          "cross_ref": [
+            "maj7/scale-arpeggio-descending",
+            "min7/relative-vim"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "blues-scale-chord-by-chord",
+          "narrative": "When minor and major blues scales are mixed, each dominant 7th chord in the progression must be addressed individually with its appropriate scale rather than summarized: \"the combination of both blues scales will work for each dominant 7th chord individually\" (Ch. 4, p. 151). This chord-by-chord discipline does not apply to the minor blues form.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 151",
+              "citation": "the combination of both blues scales will work for each dominant 7th chord individually"
+            },
+            {
+              "source": "Ch. 4, p. 151",
+              "citation": "This will not work for minor blues form"
+            }
+          ],
+          "cross_ref": [
+            "dom7/blues-primary",
+            "dom7/major-blues-target"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "scale-arpeggio-rhythmic-displacement",
+          "narrative": "Intervallic patterns applied over Cmaj7 arpeggios must be offset with rhythmic motifs to prevent mechanical predictability: \"DO NOT rely on these. They are exercises and can begin to sound very predictable and extremely boring\" (Ch. 7, p. 270). Rhythmic displacement requires every intervallic pattern to use rhythmic motifs with motif-overlap: \"Every intervallic pattern should be applied using them\" (Ch. 7, p. 270).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 270",
+              "citation": "DO NOT rely on these. They are exercises and can begin to sound very predictable and extremely boring"
+            },
+            {
+              "source": "Ch. 7, p. 270",
+              "citation": "Every intervallic pattern should be applied using them"
+            }
+          ],
+          "cross_ref": [
+            "min7/scale-arpeggio-rhythmic-displacement"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "scale-arpeggio-rhythmic-displacement",
+          "narrative": "The same anti-predictability rule applies to Am7 scale arpeggio patterns: intervallic exercises must be animated by rhythmic displacement motifs and motif-overlap to transcend mechanical execution: \"we can make them sound better when we use them applying some rhythmic tricks...what we call 'rhythmic displacement'\" (Ch. 7, p. 270). Patterns are scaffolding only, not the final musical product.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 270",
+              "citation": "we can make them sound better when we use them applying some rhythmic tricks...what we call rhythmic displacement"
+            }
+          ],
+          "cross_ref": [
+            "maj7/scale-arpeggio-rhythmic-displacement"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "pentatonic-relative-visualization",
+          "narrative": "Although C6 (major pentatonic) and Am7 (minor pentatonic) share identical notes, they must be visualized separately for five-zone fretboard navigation: \"Although both pentatonic scales contain the same notes, it is extremely important to visualize them separately (major and minor), because we will use them to split the guitar fretboard into 5 zones\" (Ch. 3, p. 108).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 108",
+              "citation": "it is extremely important to visualize them separately (major and minor), because we will use them to split the guitar fretboard into 5 zones"
+            }
+          ],
+          "cross_ref": [
+            "maj6/pentatonic-identity",
+            "min7/zone-anchor"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "scale-pattern-first-step-only",
+          "narrative": "Scale pattern exercises over Cmaj7 context are explicitly first steps only and must not be mechanically relied upon: \"DO NOT rely on these. Remember these are only exercises and can sound very predictable. This is the first step on the long road that we have ahead of us\" (Ch. 6, p. 244). Horizontal melodic ideas are preferred over vertical ones.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "DO NOT rely on these. Remember these are only exercises and can sound very predictable"
+            },
+            {
+              "source": "Ch. 6, p. 246",
+              "citation": "Usually, the vertical ideas do not work as well as the horizontal ideas"
+            }
+          ],
+          "cross_ref": [
+            "min7/scale-pattern-first-step-only"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "scale-pattern-first-step-only",
+          "narrative": "Pattern exercises over Am7/Aeolian context are similarly treated as first-step scaffolding only: \"DO NOT rely on these\" (Ch. 6, p. 244). Both Ionian (Imaj7) and Aeolian (VIm7) patterns \"can sound very predictable\" and the pedagogy explicitly warns against mechanical reliance, requiring transition to horizontal melodic ideas.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "DO NOT rely on these. Remember these are only exercises and can sound very predictable"
+            }
+          ],
+          "cross_ref": [
+            "maj7/scale-pattern-first-step-only"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "extended-blues-lick-universal",
+          "narrative": "Extended blues licks in the key of C can theoretically be used over any major or minor chord because of the blues idiom's harmonic latitude: \"in theory, we could use all of them over any major or minor chord, because we are talking about the blues\" (Ch. 5, p. 210). Each lick's chord-context labels are suggestions rather than rules since blues lines float across harmonic situations.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 210",
+              "citation": "in theory, we could use all of them over any major or minor chord, because we are talking about the blues"
+            }
+          ],
+          "cross_ref": [
+            "maj7/major-blues-target",
+            "min7/minor-pentatonic-home"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "lick-internalization",
+          "narrative": "Every lick or melodic line intended for use over Cmaj7 must be sung and aurally internalized before physical application: \"learn to sing every melodic line (lick) that you know. Internalize the sound. If you do this, as time goes by things will become easier and you will know exactly when and where to use them\" (Ch. 5, p. 210). This ear-first rule precedes all theoretical understanding.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 210",
+              "citation": "learn to sing every melodic line (lick) that you know. Internalize the sound."
+            },
+            {
+              "source": "Ch. 7, p. 300",
+              "citation": "we must learn to sing melodies of songs and solos of our favorite artists"
+            }
+          ],
+          "cross_ref": [
+            "min7/lick-internalization"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "lick-internalization",
+          "narrative": "Licks and melodic lines over Am7 and the minor chord family must be internalized through singing before deployment, following the same ear-first discipline as all other chord contexts: \"learn to sing every melodic line (lick) that you know. Internalize the sound\" (Ch. 5, p. 210). Fingering and picking choices are inseparable from the lick and must be followed exactly as notated.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 210",
+              "citation": "learn to sing every melodic line (lick) that you know. Internalize the sound."
+            },
+            {
+              "source": "Ch. 5, p. 210",
+              "citation": "follow the given fingering and picking possibilities exactly as notated for each one of the examples"
+            }
+          ],
+          "cross_ref": [
+            "maj7/lick-internalization"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "lick-fingering-fixed",
+          "narrative": "Lick fingering and picking over dominant 7th blues contexts must be followed exactly as notated because hand coordination is inseparable from the lick itself: \"follow the given fingering and picking possibilities exactly as notated for each one of the examples\" (Ch. 5, p. 210). The option to choose among fingering variants depends on surrounding fretboard position: \"You can choose one of the examples depending on where you are coming from or going to\" (Ch. 5, p. 184).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 210",
+              "citation": "follow the given fingering and picking possibilities exactly as notated for each one of the examples"
+            },
+            {
+              "source": "Ch. 5, p. 184",
+              "citation": "You can choose one of the examples depending on where you are coming from or going to on the guitar fretboard"
+            }
+          ],
+          "cross_ref": [
+            "maj7/lick-internalization",
+            "min7/lick-internalization"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "triads-required-over-scales",
+          "narrative": "Scales alone are insufficient for strong melodic lines over Cmaj7; triads and tetrads must be added to create melodic substance: \"it is not enough to only use the scales of the chords to create melodies, we must add stronger melodic structures to them such as triads and tetrads\" (Ch. 7, p. 269). This is the foundational justification for the entire Chapter 7 arpeggio system.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "it is not enough to only use the scales of the chords to create melodies, we must add stronger melodic structures to them such as triads and tetrads"
+            }
+          ],
+          "cross_ref": [
+            "min7/triads-required-over-scales",
+            "maj7/scale-arpeggio-descending"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "triads-required-over-scales",
+          "narrative": "Over Am7 as well as Cmaj7, scale-only approaches are insufficient; triads and tetrad arpeggios must supplement scale lines to build melodic weight: \"it is not enough to only use the scales of the chords to create melodies, we must add stronger melodic structures to them such as triads and tetrads\" (Ch. 7, p. 269).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 269",
+              "citation": "it is not enough to only use the scales of the chords to create melodies, we must add stronger melodic structures to them such as triads and tetrads"
+            }
+          ],
+          "cross_ref": [
+            "maj7/triads-required-over-scales",
+            "min7/scale-arpeggio-descending"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "single-scale-proscription",
+          "narrative": "Relying on a single blues scale throughout an entire dominant-7th-based improvisation is explicitly named a failure mode: \"Be careful not to rely on this technique. It will make you sound like a 'lazy' improviser. Your lines will lack variation and will sound stagnant\" (Ch. 4, p. 140). The remedy is combining multiple melodic ideas: \"the secret of a great improviser is to combine all the melodic ideas at once\" (Ch. 4, p. 131).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 140",
+              "citation": "Be careful not to rely on this technique. It will make you sound like a lazy improviser. Your lines will lack variation and will sound stagnant"
+            },
+            {
+              "source": "Ch. 4, p. 131",
+              "citation": "the secret of a great improviser is to combine all the melodic ideas at once"
+            }
+          ],
+          "cross_ref": [
+            "dom7/blues-primary",
+            "maj7/scale-pattern-first-step-only"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "aeolian-mother-scale",
+          "narrative": "The Aeolian mode (Am7 context) serves as the relative scale summarizing all seven modes of the natural minor harmonic field, making it the dual anchor of the key improvisation system: \"We will summarize the seven scales of the harmonic fields into these two scales\" [Ionian and Aeolian] (Ch. 6, p. 244). This means Am7 context supports any chord from the A natural minor harmonic field.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "We will summarize the seven scales of the harmonic fields into these two scales"
+            },
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "We can improvise over any chord or any sequence of chords belonging to any harmonic field simply by using the Ionian or Aeolian Mode of the key we are in"
+            }
+          ],
+          "cross_ref": [
+            "maj7/ionian-mother-scale"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "ionian-mother-scale",
+          "narrative": "The Ionian mode (Cmaj7 context) is the mother scale generating six other modes and summarizing the entire natural major harmonic field: \"the natural harmonic scale, also known as the Ionian Mode, is the mother of six other scales and together they form the seven harmonic field modes\" (Ch. 6, p. 244). Key improvisation over any chord in the C major harmonic field requires only the Ionian scale—subject to the avoid-note constraint at the I chord.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "the natural harmonic scale, also known as the Ionian Mode, is the mother of six other scales and together they form the seven harmonic field modes"
+            }
+          ],
+          "cross_ref": [
+            "min7/aeolian-mother-scale",
+            "maj7/tonic-i"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "minor-blues-major-tonality-only",
+          "narrative": "The same-key minor-plus-major blues combination rule applies exclusively to major tonality dominant 7th chords; in a minor blues form the pairing shifts: \"Blues scales played in the same key work only for major tonalities and not for minor, where we use a 'C' minor blues scale working together with 'Eb' major blues scale\" (Ch. 4, p. 140). Applying the major-tonality combination rule to minor blues form is an error.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 140",
+              "citation": "Blues scales played in the same key work only for major tonalities and not for minor, where we use a C minor blues scale working together with Eb major blues scale"
+            },
+            {
+              "source": "Ch. 4, p. 151",
+              "citation": "This will not work for minor blues form"
+            }
+          ],
+          "cross_ref": [
+            "dom7/blues-scale-chord-by-chord",
+            "dom7/blues-primary"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "open-string-transposition",
+          "narrative": "When transposing Cmaj7 arpeggio shapes away from open position, all open strings must be replaced by the first finger to preserve interval relationships: \"all the open strings...finger number [1 can replace them when transposing]\" (Ch. 2, p. 47). This rule applies uniformly across all arpeggio groups and shapes.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 47",
+              "citation": "It is important to remember that, all the open strings (finger number [1 can replace them when transposing])"
+            }
+          ],
+          "cross_ref": [
+            "min7/open-string-transposition",
+            "dom7/arpeggio-root-position"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "open-string-transposition",
+          "narrative": "Transposing Am7 arpeggio shapes out of open position likewise requires replacing each open string with the first finger: \"all the open strings...finger number [1 can replace them when transposing]\" (Ch. 2, p. 47). This is the universal transposition rule across all chord quality arpeggio shapes in the system.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 47",
+              "citation": "It is important to remember that, all the open strings (finger number [1 can replace them when transposing])"
+            }
+          ],
+          "cross_ref": [
+            "maj7/open-string-transposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "playing-early-notes",
+          "narrative": "Over dominant 7th blues contexts the 'playing early notes' positioning anticipates the melody before the chord arrives: \"Improvise by playing early notes means to anticipate the melodies in anticipation of the chord, before the chord arrives. This is the most difficult positioning to master\" (Ch. 4, p. 155). This is one of three improvisation positionings applicable across chord types.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 155",
+              "citation": "Improvise by playing early notes means to anticipate the melodies in anticipation of the chord, before the chord arrives. This is the most difficult positioning to master"
+            }
+          ],
+          "cross_ref": [
+            "dom7/blues-primary",
+            "dom7/blues-scale-chord-by-chord"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "concept-extraction-transcription",
+          "narrative": "The ultimate use of Cmaj7 melodic vocabulary is not lick reproduction but harmonic concept extraction: \"a simple 'lick' can teach us a complete harmonic concept, allowing us to create countless new lines from it\" (Ch. 7, p. 300). The method's goal is to \"understand, organize and 'transcend' what we transcribe finding out the musical concepts behind them\" (Ch. 7, p. 300).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 300",
+              "citation": "a simple lick can teach us a complete harmonic concept, allowing us to create countless new lines from it"
+            },
+            {
+              "source": "Ch. 7, p. 300",
+              "citation": "understand, organize and transcend what we transcribe finding out the musical concepts behind them"
+            }
+          ],
+          "cross_ref": [
+            "min7/concept-extraction-transcription"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "concept-extraction-transcription",
+          "narrative": "Over Am7 as over all chord contexts, the improvisation method requires extracting the harmonic concept from transcribed lines rather than simply memorizing licks: \"The purpose of this book is not just proving the importance of memorizing many licks. It is to show how to understand, organize and 'transcend' what we transcribe\" (Ch. 7, p. 300). Concept extraction generates new lines from any transcribed idea.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 7, p. 300",
+              "citation": "The purpose of this book is not just proving the importance of memorizing many licks. It is to show how to understand, organize and transcend what we transcribe"
+            }
+          ],
+          "cross_ref": [
+            "maj7/concept-extraction-transcription"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "rest-stroke-clarity",
+          "narrative": "Over dominant 7th blues patterns, rest stroke picking technique is prescribed for equality and clarity of melodic articulation: \"This picking technique is one of the most important because it gives equality and clarity\" (Ch. 2, p. 14). The 6-note blues pattern exercise specifically requires rest stroke: \"It is a great exercise to practice the rest stroke picking technique...everytime you use a down stroke it should rest on the next string\" (Ch. 4, p. 131).",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 14",
+              "citation": "This picking technique is one of the most important because it gives equality and clarity"
+            },
+            {
+              "source": "Ch. 4, p. 131",
+              "citation": "everytime you use a down stroke it should rest on the next string"
+            }
+          ],
+          "cross_ref": [
+            "dom7/lick-fingering-fixed"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "four-finger-avoidance",
+          "narrative": "Cmaj7 arpeggio and scale fingerings preferentially use three fingers, avoiding the fourth finger as a foundational characteristic of Benson's technique: \"he does not use the pinky or 4th finger very often, playing mostly with three fingers\" (Ch. 1, p. 2). Though initially appearing difficult, the three-finger approach yields greater speed and articulation over time.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 2",
+              "citation": "he does not use the pinky or 4th finger very often, playing mostly with three fingers"
+            }
+          ],
+          "cross_ref": [
+            "min7/four-finger-avoidance"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "four-finger-avoidance",
+          "narrative": "Am7 arpeggio fingerings follow the same three-finger preference, avoiding the fourth finger: \"he does not use the pinky or 4th finger very often, playing mostly with three fingers. But as time goes by, it will become easier and we will be able to play much faster and more articulate\" (Ch. 1, p. 2). All fingering charts are built around this constraint.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 2",
+              "citation": "he does not use the pinky or 4th finger very often, playing mostly with three fingers. But as time goes by, it will become easier"
+            }
+          ],
+          "cross_ref": [
+            "maj7/four-finger-avoidance"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "hammer-on-pulloff-restraint",
+          "narrative": "Over dominant 7th blues lines, hammer-ons and pull-offs must be used with care; the default is to pick every note before introducing legato: \"'Pull off' and 'Hammer on' should be used with care, otherwise the articulation of our melodic lines can sound wrong or odd. Therefore, in the beginning we should give priority to pick every note we play\" (Ch. 1, p. 5). Legato becomes important especially at medium tempos.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 5",
+              "citation": "Pull off and Hammer on should be used with care, otherwise the articulation of our melodic lines can sound wrong or odd. Therefore, in the beginning we should give priority to pick every note we play"
+            }
+          ],
+          "cross_ref": [
+            "maj7/four-finger-avoidance",
+            "dom7/rest-stroke-clarity"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "digital-memory-consistency",
+          "narrative": "Consistent fingering must be established before speed is pursued over any chord including Cmaj7, because inconsistency destroys the digital memory (muscle-pattern learning) required for hand synchronization: \"If our fingerings are inconsistent, our fingers will not learn anything and they will always be lost\" (Ch. 1, p. 2). The method prescribes establishing fixed fingerings first.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 2",
+              "citation": "If our fingerings are inconsistent, our fingers will not learn anything and they will always be lost"
+            }
+          ],
+          "cross_ref": [
+            "min7/digital-memory-consistency"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "digital-memory-consistency",
+          "narrative": "Consistent, exact fingering must be established before speed is pursued over Am7 and all chord contexts: \"Play the exact suggested fingering for each melodic line or example. They were chosen specifically to better help you master this technique\" (Ch. 1, p. 2). The method requires studying the left-hand fingering first before adding right-hand picking.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 2",
+              "citation": "Play the exact suggested fingering for each melodic line or example. They were chosen specifically to better help you master this technique"
+            }
+          ],
+          "cross_ref": [
+            "maj7/digital-memory-consistency"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "inverted-hammer-on-upstroke-replace",
+          "narrative": "In dominant 7th arpeggio passages, the inverted hammer-on replaces upstrokes as a functional substitution technique: \"Inverted hammer on is a technique very similar to the pull off. However, instead of pulling [off]...it replaces upstrokes\" (Ch. 2, p. 24). This enables sweep-based arpeggio execution that maintains hand coordination.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 24",
+              "citation": "Inverted hammer on is a technique very similar to the pull off. However, instead of pulling...it replaces upstrokes"
+            }
+          ],
+          "cross_ref": [
+            "dom7/hammer-on-pulloff-restraint",
+            "maj7/arpeggio-root-position"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "harmonic-field-key-improvisation",
+          "narrative": "Key improvisation using Ionian mode extends over any chord sequence belonging to the C natural major harmonic field, not just the I chord: \"As the following pattern exercises were built using 'C' Ionian and 'A' Aeolian, they can also be played over any chord or sequence belonging to 'C' Natural Major Harmonic Field or 'A' Natural Minor Harmonic Field\" (Ch. 6, p. 244). The avoid-note constraint applies when landing on the Imaj7 chord specifically.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "they can also be played over any chord or sequence belonging to C Natural Major Harmonic Field or A Natural Minor Harmonic Field"
+            }
+          ],
+          "cross_ref": [
+            "maj7/ionian-mother-scale",
+            "maj7/tonic-i"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "harmonic-field-key-improvisation",
+          "narrative": "Key improvisation using Aeolian mode extends over any chord or sequence in the A natural minor harmonic field: \"We can improvise over any chord or any sequence of chords belonging to any harmonic field simply by using the Ionian or Aeolian Mode of the key we are in\" (Ch. 6, p. 244). The flat 6th avoid note applies when specifically targeting Am7.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 6, p. 244",
+              "citation": "We can improvise over any chord or any sequence of chords belonging to any harmonic field simply by using the Ionian or Aeolian Mode of the key we are in"
+            }
+          ],
+          "cross_ref": [
+            "min7/aeolian-mother-scale",
+            "min7/relative-vim"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "sweep-picking-medium-fast-tempo",
+          "narrative": "Sweep picking technique for maj7 arpeggio passages is suited to medium or fast tempos where the melody calls for sweeping direction across strings: \"Normally this type of technique is used for medium or fast tempos, when the melody is [suited to sweeping]\" (Ch. 2, p. 6). Practice must follow exact notated fingering and picking to develop hand coordination.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 6",
+              "citation": "Normally this type of technique is used for medium or fast tempos, when the melody is"
+            }
+          ],
+          "cross_ref": [
+            "dom7/rest-stroke-clarity",
+            "dom7/inverted-hammer-on-upstroke-replace"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "melodic-chord-arpeggio-definition",
+          "narrative": "The chord arpeggio over a dominant 7th is defined as playing the chord's notes individually in sequence, producing a melodic rather than harmonic result: \"Chord Arpeggio is a musical technique where we play notes from a determined chord one [at a time]\" (Ch. 2, p. 25). This melodic/harmonic distinction is the foundational definition of the arpeggio system.",
+          "source_work_id": "method-vol-3-technique-arpeggios",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 25",
+              "citation": "Chord Arpeggio is a musical technique where we play notes from a determined chord one"
+            }
+          ],
+          "cross_ref": [
+            "maj7/arpeggio-root-position",
+            "min7/arpeggio-root-position"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-dorian-superimposition",
+          "narrative": "Dorian single lines may be applied over any IIm7 chord using all tetrads and triads from the parent major scale as superimposed arpeggios. 'dorian scale is a static scale, which means that it does not have any avoid note. Therefore, we can play all the tetrads and triads from the harmonic field over a dorian chord' (Ch. 2, p. 144).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-avoid-note-avoidance"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "dorian-major7-leading-tone",
+          "narrative": "The major 7th should be added to the Dorian scale as a leading tone to increase melodic interest over IIm7. 'we can add the major 7th to the dorian scale, in order to make it more melodic. The reason we can do this, is because the major 7th works as a leading tone to the root of the scale, thus creating the illusion of a dominant 7th chord leading to a minor chord' (Ch. 2, p. 144).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/i-chord-dorian-recycling",
+            "maj7/iv-chord-dorian-recycling"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "non-diatonic-dorian-mandatory",
+          "narrative": "Dorian vocabulary is mandatory (not merely optional) over minor chords that fall outside the harmonic field. 'when we have minor chords that do not belong to the harmonic field, there is no other option than using dorian ideas, otherwise the melody will sound wrong' (Ch. 2, p. 144).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "parent-key-arpeggio-superimposition",
+          "narrative": "Major-7th arpeggio lines from the I and IV chords of the parent key should be recycled directly as Dorian vocabulary. 'by combining Cmaj7 lines with Fmaj7 lines, we can build a beautiful D dorian line. So, it means that we already have thousands of dorian lines just adapting the major 7th lines to minor chords' (Ch. 2, p. 145).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/i-chord-dorian-recycling"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-harmonic-minor-forbidden",
+          "narrative": "Harmonic minor lines are forbidden over the IIm7 chord when a full major cadence (IIm7-V7-Imaj7) is present. 'when we have a complete C major cadence such as Dm7 / G7 / Cmaj7, we cannot use C harmonic minor ideas over the Dm7, it would not work' (Ch. 3, p. 236).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/v-chord-harmonic-minor-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-avoid-note-avoidance",
+          "narrative": "The 4th scale degree (C over G7) is an avoid note and must not be used as a target tone over a standalone dominant 7th chord. 'when we have a single dominant 7th chord (G7 for example) we must be careful with the avoid note C, because it can make your melody sound weird or even incorrect... emphasize the B note instead the C note' (Ch. 2, p. 144).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "min7/ii-chord-dorian-superimposition",
+            "sus4/v-chord-4th-permitted"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-dorian-line-modification",
+          "narrative": "All Dorian lines that end on the 4th (C) must be actively modified before use over G7. 'it is very important to remember that all the lines ending on the C note have to be modified when played over G7 because the C note is an avoid note for that chord' (Ch. 2, p. 146).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/v-chord-avoid-note-avoidance"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-harmonic-minor-superimposition",
+          "narrative": "Harmonic minor lines should be applied over V7 chords in tension-and-resolution cadences. 'The most important characteristic from the harmonic minor scale is that it produces its own dominant chord creating tension and resolution at the same time... we will use its melodies over harmonic situations where we have tension & resolution' (Ch. 3, p. 235).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/ii-chord-harmonic-minor-forbidden",
+            "min-maj7/i-minor-resolution-note"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-tonic-root-omission",
+          "narrative": "When superimposing the harmonic minor chord family over the V7 chord, the tonic root (C) must be avoided as a landing note. 'be careful when using the root of the Cm(maj7), because it can sound weird, making the whole line sound incorrect. So the best thing to do it is to forget the root for now' (Ch. 3, p. 308).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/v-chord-passing-chord-tonic-note"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-passing-chord-tonic-note",
+          "narrative": "Chord arpeggios that contain the tonic note (Dø, Fm7, Abmaj7 over G7-Cm7) are permitted only as passing material in a melody moving toward resolution. 'We can use the triads and tetrads that contain the C note (Dø, Fm7, Abmaj7) only as passing chords in a melody going from G7 leading to Cm7' (Ch. 3, p. 308).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-tonic-root-omission"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-natural6-forbidden",
+          "narrative": "The natural 6th (A natural in C minor context) is forbidden over any V7-Im cadence because it derives from the Dorian (static) scale. 'If we have the cadence G7, Cm7, we cannot use the A note (major 6th) to build single lines, because this note is derived from the dorian scale and cannot be played over any cadence' (Ch. 3, p. 261).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "min7/ii-chord-dorian-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-chromatic-pre-arpeggio",
+          "narrative": "A chromatic approach note should be inserted before each arpeggiated chord shape to add color and disguise mechanical regularity. 'pay attention, because there is a chromatic note before each chord arpeggio, making them sound more colorful' (Ch. 2, p. 198).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-degree-substitution-options",
+          "narrative": "When harmonic minor chord-family arpeggios risk landing on the tonic C, specific scale degrees may be swapped for diminished or half-diminished variants. 'Second degree = Dø: can be replaced by D°; Fourth degree = Fm7: can be replaced by F°, or Fø; Fifth degree = G7: can be replaced by G+7; Sixth degree = Abmaj7: can be replaced by Abm(maj7) or Ab°(maj7)' (Ch. 3, p. 335).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-tonic-root-omission"
+          ]
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "v7b9-diminished-rootless-substitution",
+          "narrative": "The diminished chord on the 7th degree of harmonic minor functions as a rootless V7(b9) and all four enharmonic spellings are interchangeable over the dominant. 'B° will provide us three more equal chords: D°, F° and Ab°. However, all of them are what we call fake diminished chords, because they are G7(b9) [V7] without the root note' (Ch. 3, p. 246).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dim7/v7b9-melodic-cell-ascending-chromatic"
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "v7b9-melodic-cell-ascending-chromatic",
+          "narrative": "Diminished arpeggios used as melodic cells over V7(b9) should receive ascending chromatic approach notes between arpeggiated tones to create the chromatic illusion. 'Most often we will only use simple ascending chromatic approaches over the diminished arpeggios. Descending chromatic approaches work differently and we will cover them next' (Ch. 3, p. 260).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/v7b9-diminished-rootless-substitution"
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "v7b9-shape-selection-context-dependent",
+          "narrative": "No single diminished fingering shape is universally preferred; selection depends entirely on what comes next melodically. 'there is no rule about what shape is the best, because it will depend on what comes next in terms of melody. Therefore, the best thing to do is to memorize many single line ideas using the diminished chord' (Ch. 3, p. 248).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "aug7",
+          "function_role": "v-chord-augmented-melodic-cell",
+          "narrative": "Augmented chord shapes derived from harmonic minor must be used only as embedded melodic cells, never as consecutive harmonic material. 'these augmented chords are not to be played consecutively, they are just small melodic cells to help us build melodies using the harmonic minor scale' (Ch. 3, p. 284).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/v-chord-harmonic-minor-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "aug7",
+          "function_role": "descending-horizontal-picking-technique",
+          "narrative": "Descending augmented arpeggio shapes must be executed horizontally — one shape per string — to maintain the alternate-picking technique. 'the descending augmented chord shapes will be played horizontally, and for this reason we will have only one shape possibility per string... the George Benson picking technique works much better when we play horizontal ideas (mainly when we have a melodic line going from the high to low)' (Ch. 3, p. 284).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "i-chord-dorian-recycling",
+          "narrative": "Major-7th arpeggio lines originally learned for the I chord (Cmaj7) should be recycled as Dorian vocabulary over IIm7. 'by combining Cmaj7 lines with Fmaj7 lines, we can build a beautiful D dorian line. So, it means that we already have thousands of dorian lines just adapting the major 7th lines to minor chords' (Ch. 2, p. 145).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/ii-chord-dorian-superimposition",
+            "maj7/iv-chord-dorian-recycling"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "iv-chord-dorian-recycling",
+          "narrative": "Major-7th arpeggio lines from the IV chord (Fmaj7) are equally valid as Dorian vocabulary over IIm7, complementing those borrowed from the I chord. 'by combining Cmaj7 lines with Fmaj7 lines, we can build a beautiful D dorian line' (Ch. 2, p. 145).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/i-chord-dorian-recycling",
+            "min7/ii-chord-dorian-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "i-chord-scale-as-fretboard-map",
+          "narrative": "Scales over any chord, including Imaj7, must be treated as fretboard navigation aids rather than melodic content. 'we use scales only to guide us through the guitar fretboard. When building melodic ideas, we should always mix scales, superimposed arpeggios and chromatic tones, otherwise the improvisation will sound predictable' (Ch. 2, p. 147).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive"
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "i-minor-resolution-note",
+          "narrative": "The final note of any harmonic minor line resolving to a minor tonic chord must fit that chord, even though harmonic minor does not itself contain the destination chord. 'always pay attention to the resolution note because we must always respect the ending chord, which in this case is Cm7, a non C harmonic minor scale chord. Actually, most of the time, the ending chord of a cadence V7/I will not be derived from the harmonic minor scale' (Ch. 3, p. 235).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-harmonic-minor-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "i-minor-fretboard-zone-anchor",
+          "narrative": "The Cm(maj7) guide chord shape anchors the harmonic minor fretboard zone system for minor tonic contexts. 'Guide Chords: Harmonic Minor & Ionian (#5) = Cm(maj7) & Ebmaj7(#5)' and identifies the 1st zone as Cm(maj7) and 3rd zone as Cm(maj7) (Ch. 3, p. 238).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7#11/i-ionian-sharp5-zone-anchor"
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "i-minor-minor7-color-tone",
+          "narrative": "The minor 7th (b7) may be added to harmonic minor lines even though it does not belong to the scale, because it is borrowed from the Aeolian scale which shares the same harmonic function. 'we can also use the minor 7th, which is a note that is not derived from this scale but sounds great. The reason we can use both 7ths is because the harmonic minor came from the aeolian scale and both have the same harmonic function' (Ch. 3, p. 235).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "maj7#11",
+          "function_role": "i-ionian-sharp5-zone-anchor",
+          "narrative": "The Ionian (#5) scale serves as the relative major of harmonic minor and its guide chord (Eb+(maj7)) anchors the second zone of the fretboard navigation system. 'every minor chord/scale has a relative major chord/scale or vice-versa. So the relative from the Harmonic Minor chord/scale is what we call Ionian (#5)' (Ch. 3, p. 238).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min-maj7/i-minor-fretboard-zone-anchor"
+          ]
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "v-chord-4th-permitted",
+          "narrative": "The 4th scale degree (C over G) is explicitly permitted as a target tone — including as a starting or ending note — when the chord is G7sus rather than a plain G7. 'The only exception is when the chord is a Gsus, so the C note will work with this chord as a starting note or even an ending note' (Ch. 2, p. 144).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-avoid-note-avoidance"
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "vii-chord-passing-only-over-dominant",
+          "narrative": "The half-diminished chord built on the II degree (Dø) contains the tonic note C and therefore may only be used as a passing chord, not a melodic target, during a G7-Cm7 cadence. 'We can use the triads and tetrads that contain the C note (Dø, Fm7, Abmaj7) only as passing chords in a melody going from G7 leading to Cm7' (Ch. 3, p. 308).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-passing-chord-tonic-note"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "iv-chord-passing-only-over-dominant",
+          "narrative": "The Fm7 chord (IV of harmonic minor) contains the tonic C and may only function as passing material in a line moving from G7 to Cm7. 'We can use the triads and tetrads that contain the C note (Dø, Fm7, Abmaj7) only as passing chords in a melody going from G7 leading to Cm7' (Ch. 3, p. 308).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-passing-chord-tonic-note",
+            "dom7/v-chord-degree-substitution-options"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "vi-chord-passing-only-over-dominant",
+          "narrative": "The Abmaj7 chord (VI of harmonic minor) contains the tonic note C and is restricted to passing-chord status in a G7-Cm7 melodic line. 'We can use the triads and tetrads that contain the C note (Dø, Fm7, Abmaj7) only as passing chords in a melody going from G7 leading to Cm7' (Ch. 3, p. 308).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-degree-substitution-options"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-harmonic-minor-major-resolution",
+          "narrative": "Harmonic minor lines can resolve to a major I chord provided the resolution note is adapted to fit the destination. 'harmonic minor single lines can also fit perfectly over cadences ending on major chords depending on the resolution note' (Ch. 3, p. 236).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/i-major-harmonic-minor-resolution-note"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "i-major-harmonic-minor-resolution-note",
+          "narrative": "When harmonic minor lines resolve to a major I chord, the resolution note must be adapted to match that chord's tones. 'harmonic minor single lines can also fit perfectly over cadences ending on major chords depending on the resolution note' (Ch. 3, p. 236).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-harmonic-minor-major-resolution"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-scale-tone-approach",
+          "narrative": "Scale Tone Approach is available over minor 7th chords in all four sub-types (simple, double, triple, quadruple), applied in ascending or descending direction toward any chord tone or scale tension note target. 'There are four types of ST: simple, double, triple and quadruple Scale Tone Approach' and 'Notes used immediately before the target tone are called Ascending Scale Tone Approach, and notes used immediately after are called Descending Scale Tone Approach' (Ch. 1, pp. 3-4).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-scale-tone-approach"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-scale-tone-approach",
+          "narrative": "Scale Tone Approach is valid over dominant 7th chords, but the avoid note (4th) must not serve as a target tone. 'we can only use chord tones or chord tension notes as target tones, but not avoid notes' (Ch. 1, p. 1).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-avoid-note-avoidance"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "i-chord-scale-tone-approach",
+          "narrative": "Scale Tone Approach over major 7th chords targets chord tones or scale tension notes; avoid notes are structurally excluded as targets. 'we can only use chord tones or chord tension notes as target tones, but not avoid notes. The only exception would be when the avoid note becomes part of the chord' (Ch. 1, p. 1).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-chromatic-approach-caution",
+          "narrative": "Chromatic approach tones over all chord qualities including dominant 7th must be applied with care because overuse produces non-musical results. 'Although it is one of the most used approaches in every style of improvisation, chromatics must be studied very carefully because the borderline between building a beautiful melody or a non-musical melody is very thin' (Ch. 1, p. 5).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "min7/ii-chord-chromatic-approach-caution",
+            "maj7/i-chord-chromatic-approach-caution"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-chromatic-approach-caution",
+          "narrative": "Chromatic approach tones over IIm7 must be applied tastefully; the line between musical and non-musical is described as very thin. 'chromatics must be studied very carefully because the borderline between building a beautiful melody or a non-musical melody is very thin' (Ch. 1, p. 5).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/v-chord-chromatic-approach-caution"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "i-chord-chromatic-approach-caution",
+          "narrative": "Chromatic approach tones over major 7th chords are historically pervasive but require restraint to remain on the musical side of the quality threshold. 'chromatics must be studied very carefully because the borderline between building a beautiful melody or a non-musical melody is very thin' (Ch. 1, p. 5).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/v-chord-chromatic-approach-caution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-chromatic-chord-dependent",
+          "narrative": "The available sub-types of chromatic approach (simple, double, triple, mixed) vary over dominant 7th chords because the interval distances between chord tones differ from those in other chord types. 'depending on the chord, the possibilities of chromatic approaches can be different, because the distance from one note to another in each type of chord is different' (Ch. 1, p. 5).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-chromatic-chord-dependent",
+          "narrative": "Chromatic approach sub-type availability over IIm7 depends on the interval distances specific to the minor 7th chord structure. 'depending on the chord, the possibilities of chromatic approaches can be different, because the distance from one note to another in each type of chord is different' (Ch. 1, p. 5).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-simple-chromatic-universally-available",
+          "narrative": "Simple Chromatic Approach (one half-step ascending or descending) is the only chromatic sub-type available over every chord type including dominant 7th. 'Simple Chromatic Approach is when you approach a target tone by an ascending half step or by a descending half step. It is very important to mention that the simple chromatic approach is the only type of chromatic approach that' [is universally applicable regardless of chord type] (Ch. 1, p. 5).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/ii-chord-chromatic-chord-dependent",
+            "maj7/i-chord-chromatic-approach-caution"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-five-zone-horizontal-thinking",
+          "narrative": "IIm7 lines must be built by connecting neighboring fretboard zones horizontally rather than staying within a single vertical position. 'the idea to connect scale/arpeggios in different keys will help us start playing and thinking horizontally and not only vertically. The first step to understand this is to study the connections between neighboring zones' (Ch. 2, p. 151).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-avoid-note-avoidance"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-five-zone-horizontal-thinking",
+          "narrative": "Dominant 7th chord lines should be executed horizontally across fretboard zones using the eight-option arpeggio-connection system, not confined to a single vertical scale position. 'The scale/arpeggios should be understood as guiding melodies to help us, and not pre-set melodies that cannot be changed. The most important thing is to know what we can play melodically in each one of the five vertical guitar fretboard zones' (Ch. 2, p. 150).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-odd-even-rhythmic-displacement",
+          "narrative": "Arpeggio patterns over IIm7 should have their metric regularity disrupted through odd/even rhythmic displacement to sound like genuine improvisation rather than exercises. 'a fantastic device is to use odd rhythmic cells when we have even notes, and use even rhythmic cells when we have odd notes. By doing this we take out the exercise feel, making these arpeggio patterns sound more musical' (Ch. 2, p. 198).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-odd-even-rhythmic-displacement"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-odd-even-rhythmic-displacement",
+          "narrative": "The odd/even rhythmic displacement technique applies equally to dominant 7th arpeggio patterns, removing the exercise quality from mechanically generated lines. 'use odd rhythmic cells when we have even notes, and use even rhythmic cells when we have odd notes. By doing this we take out the exercise feel, making these arpeggio patterns sound more musical' (Ch. 2, p. 198).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/ii-chord-odd-even-rhythmic-displacement"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-modal-universalization",
+          "narrative": "All Dorian/IIm7 exercises in the method simultaneously constitute valid vocabulary for every mode derived from the parent major key, not only Dorian. 'all the melodic lines in this chapter can be used over any chord derived from C major scale: Dm7 (Dorian), Em7 or Esus(b9) (Phrygian), Fmaj7 (Lydian), G7 (Mixolydian), Am7 (Aeolian), Bø (Locrian)' (Ch. 2, p. 180).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-modal-universalization",
+          "narrative": "Lines built for G7 (Mixolydian function) in the Dorian chapter also serve every other modal function in the parent key, including IIm7 contexts. 'all the melodic lines in this chapter can be used over any chord derived from C major scale: Dm7 (Dorian), Em7 or Esus(b9) (Phrygian), Fmaj7 (Lydian), G7 (Mixolydian), Am7 (Aeolian), Bø (Locrian)' (Ch. 2, p. 180).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-avoid-note-avoidance"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "i-chord-modal-universalization",
+          "narrative": "Lines that work over Fmaj7 (Lydian function within C major) are simultaneously valid over all other chords derived from the same parent major scale, as the method's modal universalization rule applies to every degree. 'all the melodic lines in this chapter can be used over any chord derived from C major scale' (Ch. 2, p. 180).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "vii-chord-modal-universalization",
+          "narrative": "Lines built over the Bø (Locrian) chord from the parent key share the same melodic content as all other modal contexts in that key, per the method's universalization rule. 'all the melodic lines in this chapter can be used over any chord derived from C major scale: Dm7 (Dorian), Em7 or Esus(b9) (Phrygian), Fmaj7 (Lydian), G7 (Mixolydian), Am7 (Aeolian), Bø (Locrian)' (Ch. 2, p. 180).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-harmonic-minor-arpeggio-sharp5",
+          "narrative": "When constructing harmonic minor arpeggios for use over the dominant, major-type arpeggios require the perfect 5th to be replaced by #5. 'in the major scale arpeggio we will replace the perfect 5th with the #5th, and in the minor scale arpeggio we will replace the minor 7th with the major 7th' (Ch. 3, p. 243).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min-maj7/i-minor-harmonic-minor-arpeggio-maj7"
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "i-minor-harmonic-minor-arpeggio-maj7",
+          "narrative": "Minor-type arpeggios in the harmonic minor system require the minor 7th to be replaced by the major 7th, producing the characteristic min(maj7) arpeggio shape. 'in the minor scale arpeggio we will replace the minor 7th with the major 7th' (Ch. 3, p. 243).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-harmonic-minor-arpeggio-sharp5"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-active-scale-distinction",
+          "narrative": "The harmonic minor scale is classified as active by its flat 6th degree, distinguishing it from static scales (like Dorian) and making it exclusively appropriate for cadential, tension-and-resolution contexts over the V7. 'when we have a single line that uses a flat 6th, we can conclude the line was built from an active scale, and should be played when we have harmonic motion (cadences)' (Ch. 3, p. 261).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/ii-chord-dorian-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-two-mode-practice",
+          "narrative": "Practice of all arpeggio-connection patterns over dominant 7th chords must proceed in two distinct modes: first slow visualization for fretboard mapping, then musical integration combining the pattern with previously learned ideas. '1) Play the exercises very slowly in order to better visualize them on the fretboard... 2) Use the arpeggio sequence musically and not as an exercise. Therefore, we must combine them with other melodic ideas we have learned before, creating new single lines' (Ch. 2, p. 198).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/ii-chord-dorian-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-two-mode-practice",
+          "narrative": "Arpeggio-connection patterns over IIm7 must be studied first through slow fretboard visualization and then integrated musically with other ideas rather than drilled as exercises. '1) Play the exercises very slowly in order to better visualize them on the fretboard. Keep playing the same exercise in the same key until you feel comfortable with it. 2) Use the arpeggio sequence musically and not as an exercise' (Ch. 2, p. 198).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-zone-key-dependent-ordering",
+          "narrative": "The five fretboard zone shapes appear in a different order for each key, so zone numbering for IIm7 contexts must be recalculated per tonal center. 'the five chord shapes related with the five zones will appear in a different order depending on the key. For example, the chord shape representing the 1st zone in the key of C, represents the 4th zone in the key of F. The first zone of a tonality will always be related to the closest chord shape from the first fret' (Ch. 2, p. 150).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-zone-key-dependent-ordering",
+          "narrative": "Zone numbering for dominant 7th chord contexts is key-relative and must be recalibrated to the tonal center in use. 'the five chord shapes related with the five zones will appear in a different order depending on the key... The first zone of a tonality will always be related to the closest chord shape from the first fret' (Ch. 2, p. 150).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted"
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "v7b9-note-function-mapping",
+          "narrative": "Each note of the four enharmonic diminished spellings maps precisely to a function within G7, making the substitution logic transparent for melodic construction. 'B°: B, D, F, Ab (major 3rd, perf 5th, minor 7th and flat 9th of G) / D°: D, F, Ab, B (perf 5th, minor 7th, flat 9th and major 3rd of G) / F°: F, Ab, B, D (minor 7th, flat 9th, major 3rd and perf 5th of G) / Ab°: Ab, B, D, F (flat 9th, major 3rd, perf 5th and minor 7th of G)' (Ch. 3, p. 246).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/v7b9-diminished-rootless-substitution"
+          ]
+        },
+        {
+          "chord_quality": "aug7",
+          "function_role": "v-chord-augmented-note-function-mapping",
+          "narrative": "The three augmented rotations from C harmonic minor map directly to G7 chord functions and are interchangeable as melodic cells. 'G+: G, B, D# (Root, major 3rd, augmented 5th of G) / B+: B, D#, G (major 3rd, augmented 5th, Root of G) / D#+: Eb, G, B (minor 6th, Root, major 3rd of G)' (Ch. 3, p. 281).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "cross_ref": [
+            "aug7/v-chord-augmented-melodic-cell"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "ii-chord-avoid-note-target-exclusion",
+          "narrative": "Avoid notes are absolutely excluded as target tones over IIm7 chords unless the avoid note has been absorbed into the chord voicing itself. 'we can only use chord tones or chord tension notes as target tones, but not avoid notes. The only exception would be when the avoid note becomes part of the chord' (Ch. 1, p. 1).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/v-chord-avoid-note-avoidance",
+            "maj7/i-chord-scale-tone-approach"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v-chord-avoid-note-target-exclusion",
+          "narrative": "Avoid notes are excluded as target tones over dominant 7th chords, with the 4th (C over G7) as the canonical example. 'we can only use chord tones or chord tension notes as target tones, but not avoid notes' (Ch. 1, p. 1), and later operationalizes this for G7: 'we must be careful with the avoid note C... emphasize the B note instead the C note' (Ch. 2, p. 144).",
+          "source_work_id": "method-vol-4-approach-tones",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/v-chord-avoid-note-avoidance",
+            "sus4/v-chord-4th-permitted"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "static-vamp-target",
+          "polarity": "prescriptive",
+          "narrative": "The dominant 7th chord with ninth (D7(9)) is the primary laboratory for melodic minor Giant Lines throughout the volume. Chapter 5 establishes the core procedure: \"Over a Gsus(b9) we would visualize the single lines as being derived from 'F' melodic minor because the Gsus(b9) chord is the IInd degree of the F melodic minor scale,\" demonstrating that the parent melodic minor scale is selected by locating the target chord as a specific degree within the scale family.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Scale application examples by chord'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/melodic-minor-iv-target",
+            "dom7/flux-reflux-target"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "flux-reflux-target",
+          "polarity": "prescriptive",
+          "narrative": "D7(9) serves as the static dominant chord over which the book's signature 'flux and reflux' melodic tension-and-release motion is generated using extended melodic minor lines. Chapter 7 deepens this application by establishing that \"extended scale options require at least 2 guide chords in order to properly visualize what we are doing\" when working over D7(9) with richer melodic minor material.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/static-vamp-target",
+            "dom7#9/flux-reflux-target"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "melodic-minor-scale-source",
+          "polarity": "prescriptive",
+          "narrative": "For any dominant 7th chord, the player must identify that chord's degree position within a melodic minor scale family to select the correct parent scale. Chapter 5 demonstrates: \"Over a C#7alt we would visualize the single lines as being derived from 'D' melodic minor because the C# altered is the VIIth degree of the D melodic minor scale,\" establishing that degree-mapping governs scale selection universally across dominant chord types.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Scale application examples by chord'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/vii-degree-scale-source",
+            "dom7#11/iv-degree-scale-source"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "ear-application-rule",
+          "polarity": "prescriptive",
+          "narrative": "When applying Giant Line patterns over dominant 7th chords, the player must not be constrained by notated time signatures. Chapter 5 states: \"Don't let the time signatures confuse you. Learn the ideas that you like the most and apply them where you feel they sound the best. Give more attention to the single lines shown,\" prioritizing aural deployment of pitch content over rhythmic notation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Time signatures in patterns: usage rule'"
+            }
+          ],
+          "cross_ref": [
+            "min7/ear-application-rule",
+            "maj7/ear-application-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "no-avoid-note-advantage",
+          "polarity": "prescriptive",
+          "narrative": "Over dominant 7th chords within the melodic minor system, all scale tones are available without clash. Chapter 5 establishes: \"this scale has no 'avoid' notes, the possibilities are in<initely larger than other scales that contain 'avoid' notes,\" justifying the melodic minor as the preferred improvisation source over all chords in its family including dominant members.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Melodic Minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/no-avoid-note-advantage",
+            "dom7alt/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "tension-knowledge-requirement",
+          "polarity": "prescriptive",
+          "narrative": "For dominant 7th chords within the melodic minor family such as D7(9,#11,13) and E7(9,b13), the player must possess complete theoretical knowledge of all available tensions even when not voicing all of them. Chapter 7 rules: \"we have to know all of them in order to do not make a mistake when harmonizing or improvising,\" drawing a firm line between selective voicing practice and required harmonic knowledge.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor tensions: not all required'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/tension-knowledge-requirement",
+            "dom13/tension-knowledge-requirement"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7#9",
+          "function_role": "giant-lines-target",
+          "polarity": "prescriptive",
+          "narrative": "D7(#9) is a primary chord context for Giant Lines in Chapter 9, functioning as a variant dominant color requiring dedicated notated exercises. Although Chapter 9 contains no prose, the book's overall framework from Chapter 5 applies: the player locates D7(#9) as a degree within its parent melodic minor scale to determine the correct scale source for improvisation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 9",
+              "citation": "pp. 42-52, 'D7(#9) Giant Lines'"
+            },
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, degree-mapping procedure"
+            }
+          ],
+          "cross_ref": [
+            "dom7/flux-reflux-target",
+            "dom7#11/iv-degree-scale-source"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7#9",
+          "function_role": "melodic-minor-degree-mapping",
+          "polarity": "prescriptive",
+          "narrative": "The D7(#9) chord, like all dominant variants in the volume, is approached via the degree-mapping procedure established in Chapter 5: identify the chord's position as a specific degree in the melodic minor scale family and derive lines from the corresponding parent scale. The book's movement from D7(9) exercises (Chapters 2–5, 7–8) to D7(#9) (Chapter 9) demonstrates progressive application of the same parent-scale selection algorithm to altered dominant colors.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Scale application examples by chord'"
+            },
+            {
+              "source": "Chapter 9",
+              "citation": "pp. 42-52"
+            }
+          ],
+          "cross_ref": [
+            "dom7/melodic-minor-scale-source",
+            "dom7alt/vii-degree-scale-source"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7alt",
+          "function_role": "vii-degree-scale-source",
+          "polarity": "prescriptive",
+          "narrative": "The altered dominant chord is explicitly identified as the seventh degree of its parent melodic minor scale, making the melodic minor the prescribed improvisation source. Chapter 5 states: \"Over a C#7alt we would visualize the single lines as being derived from 'D' melodic minor because the C# altered is the VIIth degree of the D melodic minor scale,\" providing the canonical worked example for altered dominant scale selection.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Scale application examples by chord'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/melodic-minor-scale-source",
+            "dom7#11/iv-degree-scale-source"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7alt",
+          "function_role": "no-avoid-note-advantage",
+          "polarity": "prescriptive",
+          "narrative": "The altered dominant (e.g. G#7alt as the VII of A melodic minor) benefits from the melodic minor's defining property: no avoid notes. Chapter 7 confirms that \"the melodic minor scale has no avoid notes, and for that reason we can have a bigger variety of scale arpeggios and guide chords,\" enabling unrestricted use of all seven melodic minor tones over this chord quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/no-avoid-note-advantage",
+            "dom7#11/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7alt",
+          "function_role": "chord-shape-anchor",
+          "polarity": "prescriptive",
+          "narrative": "When improvising over altered dominant chords, the player must relate melodic ideas directly to the associated chord shape on the fretboard. Chapter 7 states: \"the secret is to relate the melodic idea with the chord shape given,\" using the Cm reference key to anchor melodic patterns spatially and to visualize the critical Eb/E substitution that characterizes melodic minor voicings.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 30, 'Cm key: visualizing Eb substitution'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/chord-shape-anchor",
+            "dom7/chord-shape-anchor"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7#11",
+          "function_role": "iv-degree-scale-source",
+          "polarity": "prescriptive",
+          "narrative": "D7(#11) is the IV degree of the A melodic minor scale family and the prescribed melodic minor lines from that parent scale are applicable over it. Chapter 7 identifies this membership: \"D7(#11) is the IV degre from the 'A' melodic minor scale chord family,\" listing D7(9, #11, 13) among the full melodic minor chord family as a valid target for scale arpeggio application.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'D7(#11) dual function warning'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/dual-identity-scale-constraint",
+            "dom7/melodic-minor-scale-source"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7#11",
+          "function_role": "dual-identity-scale-constraint",
+          "polarity": "proscriptive",
+          "narrative": "D7(#11) carries dual identity as both a melodic minor IV chord and a dominant diminished voicing, and this duality prohibits the use of certain scales and chords that would otherwise be available. Chapter 7 warns explicitly: \"this chord also can be considered as a dominant diminished chord voicing possibility... we must know that in some cases we cannot use certain types of scales and chords, otherwise we might have a terrible result.\"",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'D7(#11) dual function warning'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/iv-degree-scale-source",
+            "dom7/tension-knowledge-requirement"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7#11",
+          "function_role": "tension-knowledge-requirement",
+          "polarity": "prescriptive",
+          "narrative": "The full tension set of D7(#11) — tensions 9, #11, and 13 — must be known by the player even when not all are voiced in performance. Chapter 7 rules: \"The chords { D7(9,#11, 13), E7(9, b13) } do not have to contain all the tensions presented. However, we have to know all of them in order to do not make a mistake when harmonizing or improvising.\"",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor tensions: not all required'"
+            }
+          ],
+          "cross_ref": [
+            "dom13/tension-knowledge-requirement",
+            "dom7/tension-knowledge-requirement"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7#11",
+          "function_role": "no-avoid-note-advantage",
+          "polarity": "prescriptive",
+          "narrative": "As the IV degree of A melodic minor, D7(#11) is governed by the scale's defining property. Chapter 5 establishes: \"As this scale has no 'avoid' notes, the possibilities are in<initely larger than other scales that contain 'avoid' notes,\" meaning all melodic minor tones are available over D7(#11) within the standard degree-mapping framework, subject to the dual-identity constraint.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Melodic Minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/dual-identity-scale-constraint",
+            "dom7/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom13",
+          "function_role": "tension-knowledge-requirement",
+          "polarity": "prescriptive",
+          "narrative": "D7(9,#11,13) as the IV chord of A melodic minor requires the player to know all tensions — including the 13th — even when voicing selectively in practice. Chapter 7 states: \"do not have to contain all the tensions presented. However, we have to know all of them in order to do not make a mistake when harmonizing or improvising,\" establishing comprehensive tension knowledge as a prerequisite for this chord quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor tensions: not all required'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/tension-knowledge-requirement",
+            "dom7/tension-knowledge-requirement"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom13",
+          "function_role": "melodic-minor-chord-family-member",
+          "polarity": "prescriptive",
+          "narrative": "D7(9, #11, 13) is listed as a member of the A melodic minor chord family in Chapter 7: \"The next scale arpeggios can be applyed over any chord derived from 'A' melodic minor scale: Am(maj7) or Am6, Bsus(b9), Cmaj7(#5), *D7(9, #11, 13), *E7(9, b13), F#ø, G#7alt,\" making it a valid target for all melodic minor scale arpeggios defined in that family.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/iv-degree-scale-source",
+            "dom7/melodic-minor-chord-family-member"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min-maj7",
+          "function_role": "tonic-guide-chord",
+          "polarity": "prescriptive",
+          "narrative": "Am(maj7) is the first degree and tonic chord of the A melodic minor scale family and serves as one of two master guide chord shapes for fretboard visualization. Chapter 7 specifies: \"All the tetrads from the melodic minor family should be related to these two chords\" — Cmaj7(#5) and Am(maj7) — establishing Am(maj7) as a universal fretboard anchor for all melodic minor tetrad patterns.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 33, 'Visualizing melodic minor tetrads per zone'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-guide-chord",
+            "min-maj7/zone-anchor"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min-maj7",
+          "function_role": "zone-anchor",
+          "polarity": "prescriptive",
+          "narrative": "Am(maj7) anchors the even-numbered vertical zones (2nd, 4th) of the five-zone melodic minor fretboard system. Chapter 5 states: \"we can use the same 5 vertical zones exactly as we did before with Ionian and Aeolian but this time having Cmaj7(#5) and Am(maj7) as guiding chords,\" with guide chord assignment explicitly labeled: \"1st Zone: Cmaj7(#5), 2nd Zone: Am(maj7), 3rd Zone: Cmaj7(#5).\"",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Guide chords for vertical zones'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/zone-anchor",
+            "min-maj7/tonic-guide-chord"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min-maj7",
+          "function_role": "melodic-minor-chord-family-member",
+          "polarity": "prescriptive",
+          "narrative": "Am(maj7) (and its alternate voicing Am6) is explicitly named as the first member of the A melodic minor chord family. Chapter 7 lists: \"Am(maj7) or Am6, Bsus(b9), Cmaj7(#5), *D7(9, #11, 13), *E7(9, b13), F#ø, G#7alt,\" establishing that all scale arpeggios from this family apply over Am(maj7).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/tonic-guide-chord",
+            "min6/melodic-minor-chord-family-member"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min-maj7",
+          "function_role": "aeolian-derivation-source",
+          "polarity": "prescriptive",
+          "narrative": "The minor-major seventh chord's scale is derived from Aeolian by a specific modification. Chapter 5 instructs: \"The process to visualize the melodic minor scale is quite easy, because we only have to @lat the 3rd of the Ionian scale or change the perfect 5th of the Aeolian scale into the @lated 5th,\" providing two construction shortcuts that yield the same scale supporting Am(maj7).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Melodic minor construction rule'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/ionian-derivation-source",
+            "min-maj7/zone-anchor"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min-maj7",
+          "function_role": "chord-shape-anchor",
+          "polarity": "prescriptive",
+          "narrative": "When working with melodic minor tetrad patterns, the player must relate every melodic idea to the Am(maj7) chord shape as one of the two master reference shapes. Chapter 7 instructs: \"the secret is to relate the melodic idea with the chord shape given,\" and the Cm key example uses the Am(maj7)-type shape to anchor the Eb/E substitution visualization.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 30, 'Cm key: visualizing Eb substitution'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/chord-shape-anchor",
+            "dom7alt/chord-shape-anchor"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min6",
+          "function_role": "melodic-minor-chord-family-member",
+          "polarity": "prescriptive",
+          "narrative": "Am6 is listed as an alternate voicing of the tonic chord in the A melodic minor chord family. Chapter 7 states: \"The next scale arpeggios can be applyed over any chord derived from 'A' melodic minor scale: Am(maj7) or Am6,\" establishing Am6 as interchangeable with Am(maj7) for the purpose of applying melodic minor scale arpeggios.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/melodic-minor-chord-family-member",
+            "min7/melodic-minor-scale-target"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min6",
+          "function_role": "tonic-alternate-voicing",
+          "polarity": "prescriptive",
+          "narrative": "The minor 6th chord functions as a tonic alternative to min-maj7 within the melodic minor system, sharing the same scale-arpeggio pool. Chapter 7's listing of \"Am(maj7) or Am6\" as the first family member makes explicit that both chord qualities draw from the same melodic minor parent scale and the same guide-chord visualization framework anchored on the Am(maj7)/Am6 shape.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/tonic-guide-chord",
+            "min6/melodic-minor-chord-family-member"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "maj7",
+          "function_role": "tonic-guide-chord",
+          "polarity": "prescriptive",
+          "narrative": "Cmaj7(#5) is the III degree of A melodic minor (its Lydian(#5) relative) and serves as one of the two master guide chord shapes anchoring the five-zone fretboard system. Chapter 7 requires: \"All the tetrads from the melodic minor family should be related to these two chords\" — Cmaj7(#5) and Am(maj7) — making Cmaj7(#5) a universal visualization reference across all fretboard zones.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 33, 'Visualizing melodic minor tetrads per zone'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/tonic-guide-chord",
+            "maj7/zone-anchor"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "maj7",
+          "function_role": "zone-anchor",
+          "polarity": "prescriptive",
+          "narrative": "Cmaj7(#5) anchors the odd-numbered vertical zones (1st, 3rd, 5th) of the melodic minor fretboard system. Chapter 5 names the assignment explicitly: \"Guide Chords → Lydian (#5) & Melodic Minor = Cmaj7(#5) & Am(maj7)\" with \"1st Zone: Cmaj7(#5), 2nd Zone: Am(maj7), 3rd Zone: Cmaj7(#5),\" establishing the alternating anchor pattern.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Guide chords for vertical zones'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/zone-anchor",
+            "maj7/tonic-guide-chord"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "maj7",
+          "function_role": "melodic-minor-chord-family-member",
+          "polarity": "prescriptive",
+          "narrative": "Cmaj7(#5) is the III degree member of the A melodic minor chord family and a valid target for the full set of melodic minor scale arpeggios. Chapter 7 lists it as a family member: \"Am(maj7) or Am6, Bsus(b9), Cmaj7(#5), *D7(9, #11, 13), *E7(9, b13), F#ø, G#7alt,\" positioning it as the Lydian(#5) relative within the family.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-guide-chord",
+            "min-maj7/melodic-minor-chord-family-member"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "maj7",
+          "function_role": "ionian-derivation-source",
+          "polarity": "prescriptive",
+          "narrative": "The Cmaj7(#5) guide chord shape is derived from Ionian by raising the fifth. Chapter 5 explains: \"we only have to @lat the 3rd of the Ionian scale\" to obtain melodic minor, with the Ionian modification yielding the Cmaj7(#5) shape. Chapter 5 also notes: \"this scale is also derived from the Aeolian scale, we can assume that it has a relative chord as well, which will be the Lydian(#5), bIII of its chord family.\"",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Melodic minor construction rule'"
+            },
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Visualizing melodic minor: 5 vertical zones'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/aeolian-derivation-source",
+            "maj7/zone-anchor"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "maj7",
+          "function_role": "lydian-sharp5-pairing",
+          "polarity": "prescriptive",
+          "narrative": "The Cmaj7(#5) chord is explicitly characterized as the Lydian(#5) relative of the melodic minor, forming the book's characteristic harmonic pairing. Chapter 5 states: \"Just like we did with the harmonic minor scale visualization... this scale is also derived from the Aeolian scale... it has a relative chord as well, which will be the Lydian(#5), bIII of its chord family,\" with the guide chord equation \"Guide Chords → Lydian (#5) & Melodic Minor = Cmaj7(#5) & Am(maj7).\"",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Visualizing melodic minor: 5 vertical zones'"
+            },
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Guide chords for vertical zones'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/zone-anchor",
+            "min-maj7/tonic-guide-chord"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "maj7",
+          "function_role": "ear-application-rule",
+          "polarity": "prescriptive",
+          "narrative": "When Giant Lines are applied over major 7th chord contexts (covered in Chapter 10), the overarching meta-rule from Chapter 5 governs: \"Don't let the time signatures confuse you. Learn the ideas that you like the most and apply them where you feel they sound the best,\" instructing the player to internalize pitch content aurally and re-deploy it freely rather than replicating notated time-signature groupings.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Time signatures in patterns: usage rule'"
+            },
+            {
+              "source": "Chapter 10",
+              "citation": "pp. 53-59, 'The World of Minor 7th & Major 7th Giant Lines'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/ear-application-rule",
+            "min7/ear-application-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min7",
+          "function_role": "giant-lines-target",
+          "polarity": "prescriptive",
+          "narrative": "Minor 7th chords are primary Giant Lines targets in Chapters 10, 11, and 13, with Dm7 serving as the dedicated static and active chord context. Although those chapters contain no prose, the volume's foundational framework from Chapter 5 applies: the player identifies Dm7's degree within its parent melodic minor scale and derives lines from that scale, using the five-zone guide-chord system for fretboard visualization.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 10",
+              "citation": "pp. 53-59, 'The World of Minor 7th & Major 7th Giant Lines'"
+            },
+            {
+              "source": "Chapter 11",
+              "citation": "pp. 60-90, 'Dm7 Static Giant Lines'"
+            },
+            {
+              "source": "Chapter 13",
+              "citation": "pp. 96-145, 'Dm7 Active Giant Lines'"
+            }
+          ],
+          "cross_ref": [
+            "min7/ear-application-rule",
+            "min7/melodic-minor-scale-target"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min7",
+          "function_role": "melodic-minor-scale-target",
+          "polarity": "prescriptive",
+          "narrative": "Minor 7th chords receive dedicated volume attention as improvisation targets using melodic minor lines, with the degree-mapping procedure from Chapter 5 as the governing algorithm: locate the min7 chord as a specific degree within the melodic minor scale family, then use the parent scale associated with that position. The entire structural arc of Chapters 10–13 demonstrates this system applied progressively to static and active minor 7th contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, degree-mapping procedure"
+            },
+            {
+              "source": "Chapter 11",
+              "citation": "pp. 60-90"
+            }
+          ],
+          "cross_ref": [
+            "min7/giant-lines-target",
+            "min-maj7/melodic-minor-chord-family-member"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min7",
+          "function_role": "ear-application-rule",
+          "polarity": "prescriptive",
+          "narrative": "Giant Lines over minor 7th chords, like all patterns in the volume, must be applied by ear rather than by time-signature groupings. Chapter 5's meta-rule governs all contexts: \"Learn the ideas that you like the most and apply them where you feel they sound the best. Give more attention to the single lines shown,\" instructing the student to extract melodic content from the notated exercises and deploy it according to musical judgment.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Time signatures in patterns: usage rule'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/ear-application-rule",
+            "maj7/ear-application-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min7b5",
+          "function_role": "melodic-minor-chord-family-member",
+          "polarity": "prescriptive",
+          "narrative": "F#ø (F# half-diminished / min7b5) is the VI degree of A melodic minor and a named member of the melodic minor chord family. Chapter 7 lists it explicitly: \"Am(maj7) or Am6, Bsus(b9), Cmaj7(#5), *D7(9, #11, 13), *E7(9, b13), F#ø, G#7alt,\" establishing that all melodic minor scale arpeggios derived from A melodic minor apply over F#ø.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/vii-degree-scale-source",
+            "min7b5/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min7b5",
+          "function_role": "no-avoid-note-advantage",
+          "polarity": "prescriptive",
+          "narrative": "As the VI degree of A melodic minor, F#ø benefits from the scale's defining property: no avoid notes, yielding unrestricted tone availability. Chapter 7 confirms: \"the melodic minor scale has no avoid notes, and for that reason we can have a bigger variety of scale arpeggios and guide chords,\" making all seven melodic minor tones available over this chord quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "min7b5/melodic-minor-chord-family-member",
+            "dom7alt/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "sus4",
+          "function_role": "ii-degree-scale-source",
+          "polarity": "prescriptive",
+          "narrative": "The suspended chord with flat nine — Gsus(b9) / Bsus(b9) — is identified as the II degree of its parent melodic minor scale, making that parent the prescribed scale source. Chapter 5 demonstrates: \"Over a Gsus(b9) we would visualize the single lines as being derived from 'F' melodic minor because the Gsus(b9) chord is the IInd degree of the F melodic minor scale,\" giving the canonical worked example for the sus(b9) degree-mapping rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Scale application examples by chord'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/melodic-minor-scale-source",
+            "sus4/melodic-minor-chord-family-member"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "sus4",
+          "function_role": "melodic-minor-chord-family-member",
+          "polarity": "prescriptive",
+          "narrative": "Bsus(b9) is the II degree member of the A melodic minor chord family and a valid target for the full range of melodic minor scale arpeggios. Chapter 7 lists it explicitly: \"Am(maj7) or Am6, Bsus(b9), Cmaj7(#5), *D7(9, #11, 13), *E7(9, b13), F#ø, G#7alt,\" naming it as the second diatonic chord of the A melodic minor family.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            }
+          ],
+          "cross_ref": [
+            "sus4/ii-degree-scale-source",
+            "min-maj7/melodic-minor-chord-family-member"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "sus4",
+          "function_role": "no-avoid-note-advantage",
+          "polarity": "prescriptive",
+          "narrative": "The sus(b9) chord, as the II degree of its melodic minor parent, benefits from the scale's core advantage: all tones are available without harmonic clash. Chapter 5 establishes: \"this scale has no 'avoid' notes, the possibilities are in<initely larger than other scales that contain 'avoid' notes,\" meaning the player may freely use all seven tones of the parent melodic minor scale over Gsus(b9) or Bsus(b9).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Melodic Minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "sus4/ii-degree-scale-source",
+            "dom7/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "aug7",
+          "function_role": "iii-degree-scale-source",
+          "polarity": "prescriptive",
+          "narrative": "C+maj7 (augmented major seventh / Lydian #5 chord) is the III degree of A melodic minor and maps to either the A melodic minor or C Ionian(#5) scale as its improvisation source. Chapter 5 demonstrates: \"Over a C+maj7 we would visualize the single lines as being derived from 'A' melodic minor or 'C' Ionian (#5) because it is the IIIrd degree (relative) of A melodic minor,\" providing the degree-mapping worked example for augmented chord types.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Scale application examples by chord'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/lydian-sharp5-pairing",
+            "aug7/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "aug7",
+          "function_role": "no-avoid-note-advantage",
+          "polarity": "prescriptive",
+          "narrative": "The C+maj7 augmented chord sits at the III degree of A melodic minor and inherits the scale's defining property of having no avoid notes. Chapter 5 establishes this foundational rule: \"As this scale has no 'avoid' notes, the possibilities are in<initely larger than other scales that contain 'avoid' notes,\" permitting all tones of the A melodic minor / C Ionian(#5) scale over the augmented chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Melodic Minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "aug7/iii-degree-scale-source",
+            "maj7/lydian-sharp5-pairing"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "aug7",
+          "function_role": "lydian-sharp5-equivalence",
+          "polarity": "prescriptive",
+          "narrative": "The augmented chord (C+maj7) has a dual scale identity: it is simultaneously the III degree of A melodic minor and the root of C Ionian(#5) / Lydian(#5). Chapter 5 states this equivalence: \"Over a C+maj7 we would visualize the single lines as being derived from 'A' melodic minor or 'C' Ionian (#5) because it is the IIIrd degree (relative) of A melodic minor,\" and Chapter 5 further notes: \"this scale is also derived from the Aeolian scale... it has a relative chord as well, which will be the Lydian(#5).\"",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Scale application examples by chord'"
+            },
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Visualizing melodic minor: 5 vertical zones'"
+            }
+          ],
+          "cross_ref": [
+            "aug7/iii-degree-scale-source",
+            "maj7/lydian-sharp5-pairing"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "static-giant-lines-vamp",
+          "polarity": "prescriptive",
+          "narrative": "Dominant 7th chord vamping in a static context is the core application tested across Chapters 2, 4, and 8 ('Static Giant Lines 1st, 2nd, and 3rd Situations'). The book's overall pedagogical arc moves from static dominant applications through transitional ideas, treating the static dom7 vamp as the foundational context in which all melodic minor line vocabulary is first internalized before being applied over moving changes.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 2",
+              "citation": "pp. 1-2, 'Static Giant Lines 1st Situation'"
+            },
+            {
+              "source": "Chapter 4",
+              "citation": "p. 14, 'Static Giant Lines 2nd Situation'"
+            },
+            {
+              "source": "Chapter 8",
+              "citation": "pp. 38-41, 'Static Giant Lines 3rd Situation: Dominant 7th chord Vamp'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/flux-reflux-target",
+            "dom7/giant-lines-two-guide-chord-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "giant-lines-two-guide-chord-rule",
+          "polarity": "prescriptive",
+          "narrative": "Extended Giant Line options over dominant 7th chords require at minimum two guide chords for correct fretboard visualization. Chapter 7 establishes this as a binding constraint: \"In the following examples we have some extended scale options that can also work very well. Notice that in these cases we must use at least 2 guide chords in order to properly visualize what we are doing,\" making the two-guide-chord minimum a non-negotiable rule for extended dominant applications.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/flux-reflux-target",
+            "dom7/static-giant-lines-vamp"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "chord-transition-target",
+          "polarity": "prescriptive",
+          "narrative": "Dominant 7th chords also function as chord transition targets in Chapter 6 ('First & Second GB Chord Transition Idea'), which introduces Giant Lines in a moving harmonic context rather than a static vamp. Although Chapter 6 contains no prose, the system from Chapter 5 — degree-mapping to identify the parent melodic minor scale — governs scale selection across all dominant chord transition contexts in the book.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 6",
+              "citation": "p. 26, 'First & Second GB Chord Transition Idea'"
+            },
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, degree-mapping procedure"
+            }
+          ],
+          "cross_ref": [
+            "dom7/static-giant-lines-vamp",
+            "dom7/flux-reflux-target"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min7",
+          "function_role": "inside-outside-application",
+          "polarity": "prescriptive",
+          "narrative": "Minor 7th chords support both 'inside' and 'outside' Giant Line ideas, as Chapter 11 is explicitly subtitled 'inside & outside ideas.' The melodic minor's no-avoid-note property creates the foundation for outside playing: because the scale contains no avoid notes within its own family, excursions beyond the diatonic frame become the player's deliberate choice rather than avoidance of specific tones, per the overarching system described in Chapter 5.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 11",
+              "citation": "pp. 60-90, 'Dm7 Static Giant Lines (inside & outside ideas)'"
+            },
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Melodic Minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "min7/giant-lines-target",
+            "min7/ear-application-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min7",
+          "function_role": "active-giant-lines-target",
+          "polarity": "prescriptive",
+          "narrative": "Minor 7th chords in an 'active' (moving harmonic) context receive dedicated treatment in Chapter 13 ('Dm7 Active Giant Lines'), representing the final and most complex application of the melodic minor system. The active context demands the two-guide-chord minimum from Chapter 7 — \"we must use at least 2 guide chords in order to properly visualize what we are doing\" — even more critically than static applications, as the player must navigate chord motion while sustaining Giant Line vocabulary.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 13",
+              "citation": "pp. 96-145, 'Dm7 Active Giant Lines'"
+            },
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            }
+          ],
+          "cross_ref": [
+            "min7/giant-lines-target",
+            "min7/inside-outside-application"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7alt",
+          "function_role": "melodic-minor-chord-family-member",
+          "polarity": "prescriptive",
+          "narrative": "G#7alt is the VII degree member of the A melodic minor chord family and a valid target for the full set of melodic minor scale arpeggios. Chapter 7 lists it explicitly: \"Am(maj7) or Am6, Bsus(b9), Cmaj7(#5), *D7(9, #11, 13), *E7(9, b13), F#ø, G#7alt,\" placing the altered dominant at the seventh diatonic position of the family.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/vii-degree-scale-source",
+            "dom7alt/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7alt",
+          "function_role": "tension-knowledge-requirement",
+          "polarity": "prescriptive",
+          "narrative": "The altered dominant chord's tension set — whether the tensions of G#7alt specifically or those of any altered dominant within the melodic minor family — must be fully known even when not all tensions are voiced in practice. Chapter 7's epistemological rule governs all family members: \"we have to know all of them in order to do not make a mistake when harmonizing or improvising,\" requiring comprehensive tension knowledge as the prerequisite for competent improvisation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor tensions: not all required'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/melodic-minor-chord-family-member",
+            "dom7#11/tension-knowledge-requirement"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7",
+          "function_role": "e7-b13-v-degree-mapping",
+          "polarity": "prescriptive",
+          "narrative": "E7(9,b13) is the V degree of A melodic minor and receives the same degree-mapping treatment as all family members: the parent melodic minor scale is the prescribed improvisation source. Chapter 7 lists it in the chord family: \"*E7(9, b13)\" with the asterisk notation matching D7(#11), and applies the same tension-knowledge rule: all tensions (9 and b13) must be known even when not all are voiced.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor chord family'"
+            },
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor tensions: not all required'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/tension-knowledge-requirement",
+            "dom7#11/tension-knowledge-requirement"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "maj7",
+          "function_role": "giant-lines-target",
+          "polarity": "prescriptive",
+          "narrative": "Major 7th chord contexts receive dedicated Giant Lines treatment in Chapter 10 ('The World of Minor 7th & Major 7th Giant Lines'). Although that chapter contains no prose, the degree-mapping procedure from Chapter 5 governs: the player locates the major 7th chord as a specific degree within the melodic minor scale family — notably Cmaj7(#5) as the III degree — and derives lines from the corresponding parent scale.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 10",
+              "citation": "pp. 53-59, 'The World of Minor 7th & Major 7th Giant Lines'"
+            },
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, degree-mapping procedure"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-guide-chord",
+            "min7/giant-lines-target"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min-maj7",
+          "function_role": "no-avoid-note-advantage",
+          "polarity": "prescriptive",
+          "narrative": "As the tonic chord of the melodic minor scale, Am(maj7) is the clearest beneficiary of the scale's defining property: no avoid notes. Chapter 5 establishes: \"As this scale has no 'avoid' notes, the possibilities are in<initely larger than other scales that contain 'avoid' notes,\" meaning every degree of the A melodic minor scale is available without harmonic restriction when improvising over Am(maj7).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Melodic Minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/tonic-guide-chord",
+            "min-maj7/melodic-minor-chord-family-member"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min-maj7",
+          "function_role": "two-guide-chord-visualization-rule",
+          "polarity": "prescriptive",
+          "narrative": "Extended scale lines over Am(maj7) and all melodic minor family chords require at least two guide chords for proper fretboard visualization. Chapter 7 states: \"In the following examples we have some extended scale options that can also work very well. Notice that in these cases we must use at least 2 guide chords in order to properly visualize what we are doing,\" making the two-guide-chord minimum universally applicable including over the tonic min-maj7 chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            }
+          ],
+          "cross_ref": [
+            "min-maj7/zone-anchor",
+            "dom7/giant-lines-two-guide-chord-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "maj7",
+          "function_role": "two-guide-chord-visualization-rule",
+          "polarity": "prescriptive",
+          "narrative": "Extended melodic minor scale options over Cmaj7(#5) and all family members require at minimum two guide chords. Chapter 7 requires: \"we must use at least 2 guide chords in order to properly visualize what we are doing,\" and Chapter 7 further specifies: \"All the tetrads from the melodic minor family should be related to these two chords\" — both Cmaj7(#5) and Am(maj7) — making Cmaj7(#5) simultaneously a guide chord and a chord requiring both guides for extended line visualization.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            },
+            {
+              "source": "Chapter 7",
+              "citation": "p. 33, 'Visualizing melodic minor tetrads per zone'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/zone-anchor",
+            "min-maj7/two-guide-chord-visualization-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "sus4",
+          "function_role": "ear-application-rule",
+          "polarity": "prescriptive",
+          "narrative": "Sus(b9) chord patterns, like all Giant Lines in the volume, must be applied by ear rather than by their notated time-signature groupings. Chapter 5's meta-rule governs all chord types including the sus(b9): \"The patterns and scale visualizations in this book may have different time signatures in order to help with the organization and visualization... Don't let the time signatures confuse you. Learn the ideas that you like the most and apply them where you feel they sound the best.\"",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15, 'Time signatures in patterns: usage rule'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/ear-application-rule",
+            "sus4/ii-degree-scale-source"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "aug7",
+          "function_role": "chord-shape-anchor",
+          "polarity": "prescriptive",
+          "narrative": "When generating Giant Lines over C+maj7, the player must relate the melodic idea directly to the associated chord shape, per the governing method stated in Chapter 7: \"the secret is to relate the melodic idea with the chord shape given.\" The Cmaj7(#5) guide chord shape serves as the fretboard anchor for the augmented-major-seventh context, with the scale visualization derived from the III-degree position within A melodic minor.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 30, 'Cm key: visualizing Eb substitution'"
+            },
+            {
+              "source": "Chapter 5",
+              "citation": "p. 15 (p. 4 of chapter), 'Guide chords for vertical zones'"
+            }
+          ],
+          "cross_ref": [
+            "aug7/iii-degree-scale-source",
+            "maj7/chord-shape-anchor"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min7b5",
+          "function_role": "chord-shape-anchor",
+          "polarity": "prescriptive",
+          "narrative": "F#ø (min7b5 as VI of A melodic minor) requires the player to visualize its associated melodic ideas through the chord shape reference system. Chapter 7 states: \"the secret is to relate the melodic idea with the chord shape given,\" and Chapter 7 further requires: \"All the tetrads from the melodic minor family should be related to these two chords\" — Cmaj7(#5) and Am(maj7) — establishing those two shapes as the fretboard anchors for all family members including F#ø.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 30, 'Cm key: visualizing Eb substitution'"
+            },
+            {
+              "source": "Chapter 7",
+              "citation": "p. 33, 'Visualizing melodic minor tetrads per zone'"
+            }
+          ],
+          "cross_ref": [
+            "min7b5/melodic-minor-chord-family-member",
+            "min-maj7/tonic-guide-chord"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7#11",
+          "function_role": "two-guide-chord-visualization-rule",
+          "polarity": "prescriptive",
+          "narrative": "Extended scale options over D7(#11) — particularly those arising from its dual melodic minor IV and dominant diminished identity — require at minimum two guide chords for proper fretboard visualization. Chapter 7 establishes: \"we must use at least 2 guide chords in order to properly visualize what we are doing,\" making the two-guide-chord minimum especially critical for a chord whose dual identity generates a broader and more complex set of usable and unusable scale options.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#11/dual-identity-scale-constraint",
+            "dom7/giant-lines-two-guide-chord-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "dom7alt",
+          "function_role": "two-guide-chord-visualization-rule",
+          "polarity": "prescriptive",
+          "narrative": "Extended melodic minor lines over altered dominant chords (G#7alt as VII of A melodic minor) require at least two guide chords for correct visualization. Chapter 7 states: \"we must use at least 2 guide chords in order to properly visualize what we are doing,\" and Chapter 7 reinforces: \"All the tetrads from the melodic minor family should be related to these two chords\" — Cmaj7(#5) and Am(maj7).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            },
+            {
+              "source": "Chapter 7",
+              "citation": "p. 33, 'Visualizing melodic minor tetrads per zone'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/melodic-minor-chord-family-member",
+            "dom7/giant-lines-two-guide-chord-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "sus4",
+          "function_role": "two-guide-chord-visualization-rule",
+          "polarity": "prescriptive",
+          "narrative": "Extended scale lines over Bsus(b9) as the II degree of A melodic minor require at minimum two guide chords for proper fretboard visualization. Chapter 7 establishes universally: \"we must use at least 2 guide chords in order to properly visualize what we are doing,\" and Chapter 7 further specifies: \"All the tetrads from the melodic minor family should be related to these two chords\" — Cmaj7(#5) and Am(maj7) — covering all seven family members including the sus(b9).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            },
+            {
+              "source": "Chapter 7",
+              "citation": "p. 33, 'Visualizing melodic minor tetrads per zone'"
+            }
+          ],
+          "cross_ref": [
+            "sus4/melodic-minor-chord-family-member",
+            "min-maj7/two-guide-chord-visualization-rule"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min6",
+          "function_role": "no-avoid-note-advantage",
+          "polarity": "prescriptive",
+          "narrative": "Am6 as the alternate tonic chord of A melodic minor inherits the scale's foundational advantage: no avoid notes. Chapter 7 confirms: \"the melodic minor scale has no avoid notes, and for that reason we can have a bigger variety of scale arpeggios and guide chords,\" meaning the full seven-tone palette is available without restriction over this chord quality when deriving Giant Lines from the A melodic minor parent.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 28, 'Melodic minor: no avoid notes'"
+            }
+          ],
+          "cross_ref": [
+            "min6/melodic-minor-chord-family-member",
+            "min-maj7/no-avoid-note-advantage"
+          ]
+        },
+        {
+          "source_work_id": "method-vol-5-melodic-minor",
+          "chord_quality": "min6",
+          "function_role": "two-guide-chord-visualization-rule",
+          "polarity": "prescriptive",
+          "narrative": "Extended scale options over Am6 (the alternate tonic voicing) require at least two guide chords, as established universally for all melodic minor family members. Chapter 7 states: \"we must use at least 2 guide chords in order to properly visualize what we are doing,\" and the two master guide chords — Cmaj7(#5) and Am(maj7) — anchor the Am6 context through the Am(maj7) shape.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Chapter 7",
+              "citation": "p. 27, 'Extended scale options: guide chords required'"
+            },
+            {
+              "source": "Chapter 7",
+              "citation": "p. 33, 'Visualizing melodic minor tetrads per zone'"
+            }
+          ],
+          "cross_ref": [
+            "min6/melodic-minor-chord-family-member",
+            "min-maj7/two-guide-chord-visualization-rule"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "static-giant-line-foundation",
+          "narrative": "'The chords led me to the harmony, that helped me to become a better single line player.' (Ch. 1, p. 2) Chord knowledge of the dominant 7th is the prerequisite gateway before constructing any Giant Line over that chord; melodic fluency follows from harmonic understanding, not the reverse.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/outside-superimposition-entry",
+            "dom7/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "static-situation-vamp",
+          "narrative": "Static Giant Lines over a dominant 7th chord vamp are organized across three progressively more complex Situations (Chs. 2, 4, 8). The student must master each situation in order before combining ideas.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/flux-reflux-tension",
+            "dom7#9/outside-substitution-framework"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "flux-reflux-tension",
+          "narrative": "Giant Lines over a sustained D7(9) chord must create and release harmonic tension — the Flux & Reflux motion (Chs. 5, 7). Building melodic tension and resolving it within a static dominant vamp is a required skill before moving to active harmonic situations.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/static-situation-vamp",
+            "dom7#9/flux-reflux-outside-effect"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "outside-superimposition-entry",
+          "narrative": "'We can create a very interesting outside effect over a D7 chord by playing small A7 ideas using the following scales in the middle of the line.' (Ch. 9, p. 26) A7 ideas — arpeggios and scale fragments — are the prescribed first GB Chord Transition device for generating outside color over a D7 chord.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/outside-duration-ceiling",
+            "dom7/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "outside-duration-ceiling",
+          "narrative": "'Attention: Do not stay on the A7 too long because you will destroy the effect.' (Ch. 9, p. 26) Remaining on the outside substitution chord idea beyond the effective threshold collapses the outside color into mere dissonance; duration control is non-negotiable.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/outside-superimposition-entry",
+            "dom7#9/outside-duration-ceiling"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "ending-note-resolution",
+          "narrative": "'Attention: In case you want to create your own D7 ideas based on the possibilities given in this chapter, make sure that the ending note from your single line idea is a chord tone for D7.' (Ch. 9, p. 26) Every line — inside or outside — must conclude on a chord tone of D7; the ending note rule is absolute.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/outside-superimposition-entry",
+            "dom7#9/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "v7-i-cadence-superimposition",
+          "narrative": "'The second trick is also to create a cadence V7/I just like we did before by using D7 leading to G major.' (Ch. 9, p. 26) The Second GB Chord Transition prescribes embedding a mini V7-I cadence (D7→G major) within the line over the target dominant chord as a second outside device.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/outside-superimposition-entry",
+            "dom7/modal-family-outside-entry"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "modal-family-outside-entry",
+          "narrative": "'As D Mixolydian derives from Emi Chord Family, we can use also B7 ideas leading to Emi. This creates a very beautiful Outside idea over a single D7.' (Ch. 9, p. 31) Using B7→Em ideas over D7 is prescribed as a third outside device, justified by Mixolydian modal parentage from the Em chord family.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v7-i-cadence-superimposition",
+            "dom7/outside-duration-ceiling"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "chord-transition-reuse",
+          "narrative": "The First and Second GB Chord Transition techniques introduced in Ch. 6 are reactivated in Ch. 9 for D7(#9) outside playing, establishing that these transitions are a recurring toolkit applicable across all dominant situations.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7#9/chord-transition-toolkit",
+            "dom7/outside-superimposition-entry"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "guide-chord-visualization",
+          "narrative": "'In order to better understand the concept behind the Active Giant Lines, let's use the Dm key as an example.' (Ch. 13, p. 77) All melodic Giant Line concepts over dominant chords must be translated to the fretboard by mapping single-note fingerings onto guide chord shapes already known to the player.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/static-situation-vamp",
+            "min7/active-giant-line-application"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "static-before-active-sequencing",
+          "narrative": "The method prescribes mastering Static Giant Lines (one sustained dominant chord) across all three Situations before advancing to Active Giant Lines (changing harmony). This sequencing — static first, then active — is the structural pedagogical rule governing all dominant chord study in the book.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/flux-reflux-tension",
+            "min7/active-giant-line-application"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "outside-substitution-framework",
+          "narrative": "D7(#9) is the primary harmonic laboratory for outside playing: Chs. 3, 5, 7, 8, and 9 all center on D7 variants, with D7(#9) specifically as the chord over which the GB Chord Transitions and their outside substitution devices (A7, B7) are systematically demonstrated.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7#9/outside-duration-ceiling",
+            "dom7#9/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "outside-duration-ceiling",
+          "narrative": "'Do not stay on the A7 too long because you will destroy the effect.' (Ch. 9, p. 26) The same proscription governing D7 applies explicitly to D7(#9) outside ideas: exceeding the effective duration threshold tips outside color into dissonance.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/outside-duration-ceiling",
+            "dom7#9/outside-substitution-framework"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "ending-note-resolution",
+          "narrative": "'Make sure that the ending note from your single line idea is a chord tone for D7.' (Ch. 9, p. 26) The Ending Note Rule applies fully to D7(#9): regardless of how far outside the line travels, its final note must be a chord tone of the target D7(#9).",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/ending-note-resolution",
+            "dom7#9/outside-substitution-framework"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "chord-transition-toolkit",
+          "narrative": "Both GB Chord Transition techniques (Ch. 6, reactivated Ch. 9) are prescribed for use over D7(#9): first via A7 superimposition, second via D7→G cadence embedding. The techniques are not situational — they transfer to D7(#9) without modification.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/chord-transition-reuse",
+            "dom7#9/outside-substitution-framework"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "flux-reflux-outside-effect",
+          "narrative": "Chapters 5 and 7 develop Flux & Reflux — creating and releasing melodic tension — over D7(9), and Chapter 7 goes deeper into this technique before Ch. 9 extends outside devices to D7(#9). Flux & Reflux is a prerequisite skill before introducing the sharper dissonance of the #9 outside vocabulary.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/flux-reflux-tension",
+            "dom7#9/outside-duration-ceiling"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "b7-modal-outside-device",
+          "narrative": "'As D Mixolydian derives from Emi Chord Family, we can use also B7 ideas leading to Emi. This creates a very beautiful Outside idea over a single D7.' (Ch. 9, p. 31) The B7→Em modal family substitution is a prescribed outside device for D7(#9) lines, grounded in Mixolydian derivation theory.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/modal-family-outside-entry",
+            "dom7#9/outside-substitution-framework"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "static-giant-line-inside-outside",
+          "narrative": "Chapter 11 explicitly provides both inside and outside ideas for Dm7 Static Giant Lines (Ch. 11, pp. 60-90). The inside/outside distinction is a structural organizing principle: the student must learn both categories for Dm7 and understand which is which before applying them.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/active-giant-line-application",
+            "min7/major7-superimposition-for-minor-dominant"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "active-giant-line-application",
+          "narrative": "'Although we can combine melodies derived from Dm7 (key) with melodies derived from its relative major (Fmaj7), the melodic options for their dominant 7th chords must be treated differently because some options might not work.' (Ch. 13, p. 77) Active Giant Lines over Dm7 require distinguishing melodic options by cadential direction.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/static-giant-line-inside-outside",
+            "maj7/relative-major-melodic-options"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "relative-major-combination",
+          "narrative": "'Although we can combine melodies derived from Dm7 (key) with melodies derived from its relative major (Fmaj7)...' (Ch. 13, p. 77) Combining Dm7 melodic vocabulary with Fmaj7 (relative major) melodic vocabulary is a prescribed strategy for expanding the Active Giant Line palette in the minor key context.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/active-giant-line-application",
+            "maj7/relative-major-melodic-options"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "guide-chord-visualization",
+          "narrative": "'In order to better understand the concept behind the Active Giant Lines, let's use the Dm key as an example.' (Ch. 13, p. 77) Guide chord visualization — mapping single-note melodic fingerings onto known chord shapes — is the prescribed fretboard method for internalizing all Active Giant Lines over Dm7.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/guide-chord-visualization",
+            "min7/active-giant-line-application"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "dominant-option-discrimination",
+          "narrative": "'The secret is to know the options that will work almost always: In a cadence || Gm7 | A7 | Dm7 ||' (Ch. 13, p. 77) For Dm7 in an active cadential context, certain dominant 7th options over A7 will work almost always; learning to identify the reliable options is the key decision-making skill.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/active-giant-line-application",
+            "dom7/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "major7-superimposition-for-minor-dominant",
+          "narrative": "'The major 7th superimposed ideas will work better for A7 leading to Dm7.' (Ch. 13, p. 77) When the dominant (A7) resolves to a minor tonic (Dm7), major 7th superimposed arpeggio ideas over A7 are the prescribed device to strengthen the cadential pull.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/superimposition-over-minor-dominant",
+            "min7/dominant-option-discrimination"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "chord-knowledge-gateway",
+          "narrative": "'The chords led me to the harmony, that helped me to become a better single line player.' (Ch. 1, p. 2) Chord knowledge of Dm7 — its voicings, fingerings, and harmonic function — is the necessary foundation before any Giant Line vocabulary over that chord can be meaningfully constructed.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/static-giant-line-foundation",
+            "maj7/chord-knowledge-gateway"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "relative-major-melodic-options",
+          "narrative": "'Although we can combine melodies derived from Dm7 (key) with melodies derived from its relative major (Fmaj7)...' (Ch. 13, p. 77) Fmaj7 melodic vocabulary is combinable with Dm7 vocabulary in Active Giant Lines, but the dominant chord options for Fmaj7 (C7→Fmaj7) must be evaluated separately from those for Dm7 (A7→Dm7).",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/relative-major-combination",
+            "maj7/dominant-approach-tension-warning"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "superimposition-over-minor-dominant",
+          "narrative": "'The major 7th superimposed ideas will work better for A7 leading to Dm7.' (Ch. 13, p. 77) Major 7th superimposition ideas are prescribed specifically in the context of a dominant resolving to a minor tonic.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/major7-superimposition-for-minor-dominant",
+            "dom7/v7-i-cadence-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "dominant-approach-tension-warning",
+          "narrative": "'These options over C7 leading to Fmaj7 might sound too tense or even sometimes incorrect.' (Ch. 13, p. 77) Major 7th superimposed ideas that work over A7→Dm7 are proscribed over C7→Fmaj7: the same ideas may create unacceptable tension or outright harmonic incorrectness in the major resolution context.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "maj7/relative-major-melodic-options",
+            "min7/dominant-option-discrimination"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "chord-knowledge-gateway",
+          "narrative": "Chapter 10 introduces Major 7th Giant Lines alongside Minor 7th lines under the heading 'The World of Minor 7th & Major 7th Giant Lines,' establishing that chord knowledge of the major 7th quality is the gateway to constructing any Giant Line vocabulary over it (Ch. 1, p. 2).",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/chord-knowledge-gateway",
+            "maj7/relative-major-melodic-options"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "mixolydian-mode-theoretical-anchor",
+          "narrative": "'As D Mixolydian derives from Emi Chord Family, we can use also B7 ideas leading to Emi.' (Ch. 9, p. 31) The Mixolydian mode over a dominant chord must be understood through its parent chord family (Em), not in isolation.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/modal-family-outside-entry",
+            "dom7/outside-superimposition-entry"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "line-harmony-bridge",
+          "narrative": "'The chords led me to the harmony, that helped me to become a better single line player.' (Ch. 1, p. 2) Chord study over dominant chords is explicitly not an end in itself but the mechanism by which harmonic understanding is gained.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/static-giant-line-foundation",
+            "min7/chord-knowledge-gateway"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "a7-substitution-scale-selection",
+          "narrative": "'We can create a very interesting outside effect over a D7 chord by playing small A7 ideas using the following scales in the middle of the line.' (Ch. 9, p. 26) The A7 substitution over D7 requires using specific prescribed scales — not arbitrary ones — to maintain the outside effect.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/outside-superimposition-entry",
+            "dom7/outside-duration-ceiling"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "small-idea-superimposition",
+          "narrative": "'We can create a very interesting outside effect over a D7 chord by playing small A7 ideas.' (Ch. 9, p. 26) The prescribed unit of outside material is small ideas — brief melodic fragments from the substitution chord — not extended passages.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/outside-duration-ceiling",
+            "dom7/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "in-line-placement-of-outside-idea",
+          "narrative": "'We can create a very interesting outside effect over a D7 chord by playing small A7 ideas using the following scales in the middle of the line.' (Ch. 9, p. 26) The outside idea must be placed in the middle of the line, not at its start or end; the ending note must still resolve to a D7 chord tone.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/ending-note-resolution",
+            "dom7/small-idea-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "in-line-placement-of-outside-idea",
+          "narrative": "The same in-line placement rule governing D7 outside ideas (Ch. 9, p. 26) applies to D7(#9): outside substitution ideas belong in the middle of the Giant Line, bracketed by inside material and closed by a chord-tone resolution.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/in-line-placement-of-outside-idea",
+            "dom7#9/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "em-chord-family-derivation",
+          "narrative": "'As D Mixolydian derives from Emi Chord Family, we can use also B7 ideas leading to Emi. This creates a very beautiful Outside idea over a single D7.' (Ch. 9, p. 31) The Em chord family (not the D major scale) is the theoretical parent that authorizes B7 as an outside device over D7.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/mixolydian-mode-theoretical-anchor",
+            "dom7/modal-family-outside-entry"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "b7-leading-to-em-outside-color",
+          "narrative": "'This creates a very beautiful Outside idea over a single D7.' (Ch. 9, p. 31) The B7→Em substitution is characterized as producing a very beautiful outside color — a qualitative prescription indicating aesthetic preference.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/em-chord-family-derivation",
+            "dom7#9/b7-modal-outside-device"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "iv-v7-i-cadence-context",
+          "narrative": "'The secret is to know the options that will work almost always: In a cadence || Gm7 | A7 | Dm7 ||' (Ch. 13, p. 77) The prescribed harmonic context for applying Active Giant Lines to Dm7 is the ii-V7-i cadence (Gm7-A7-Dm7).",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dominant-option-discrimination",
+            "min7/active-giant-line-application"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "c7-to-fmaj7-option-restriction",
+          "narrative": "'These options over C7 leading to Fmaj7 might sound too tense or even sometimes incorrect.' (Ch. 13, p. 77) Options that work over A7→Dm7 must not be automatically transferred to C7→Fmaj7.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "maj7/dominant-approach-tension-warning",
+            "maj7/relative-major-melodic-options"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "three-situation-progression",
+          "narrative": "Static Giant Lines over a dominant 7th chord are organized across three Situations (Chs. 2, 4, 8), each progressively more complex. The player must work through all three in sequence.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/static-situation-vamp",
+            "dom7/flux-reflux-tension"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "gb-transition-first-technique",
+          "narrative": "'First GB Chord Transition Idea: We can create a very interesting outside effect over a D7 chord by playing small A7 ideas using the following scales in the middle of the line.' (Ch. 9, p. 26) The First GB Chord Transition is explicitly named and prescribed as a discrete technique.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/gb-transition-second-technique",
+            "dom7/outside-duration-ceiling"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "gb-transition-second-technique",
+          "narrative": "'The second trick is also to create a cadence V7/I just like we did before by using D7 leading to G major. However, this time let...' (Ch. 9, p. 26) The Second GB Chord Transition is a named discrete technique that embeds a V7-I cadence (D7→G) within the dominant line.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/gb-transition-first-technique",
+            "dom7/v7-i-cadence-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "outside-effect-coherence-discipline",
+          "narrative": "'Do not stay on the A7 too long because you will destroy the effect.' (Ch. 9, p. 26) Outside playing over a dominant is explicitly framed as disciplined artistic choice, not harmonic freedom.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/outside-duration-ceiling",
+            "dom7#9/outside-duration-ceiling"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "a7-substitution-over-sharp9",
+          "narrative": "The A7 superimposition technique (First GB Chord Transition) is explicitly carried over to D7(#9) in Ch. 9; the same prescribed mechanism — small A7 ideas in the middle of the line using specific scales — applies to the D7(#9) context.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/gb-transition-first-technique",
+            "dom7#9/chord-transition-toolkit"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "deep-flux-reflux-prerequisite",
+          "narrative": "Chapter 7 'Going Deeper into the Flux & Reflux over D7(9)' is a prerequisite chapter that must be mastered before D7(#9) outside playing in Ch. 9.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/flux-reflux-tension",
+            "dom7#9/flux-reflux-outside-effect"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "outside-ideas-distinct-from-inside",
+          "narrative": "Chapter 11 explicitly titles Dm7 Static Giant Lines as 'inside & outside ideas,' establishing that outside vocabulary for Dm7 is a formally distinct category from inside vocabulary.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/static-giant-line-inside-outside",
+            "dom7/outside-superimposition-entry"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "static-before-active-minor7",
+          "narrative": "Chapter 11 (Dm7 Static Giant Lines) precedes Chapter 13 (Dm7 Active Giant Lines), establishing the same static-before-active sequencing rule for minor 7th chords as for dominant chords.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/static-before-active-sequencing",
+            "min7/active-giant-line-application"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "static-before-active-major7",
+          "narrative": "Chapter 10 ('The World of Minor 7th & Major 7th Giant Lines') introduces major 7th Giant Lines in the static domain before any active application; consistent with the book's governing pedagogical rule.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/static-before-active-sequencing",
+            "maj7/chord-knowledge-gateway"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "outside-color-vs-dissonance-threshold",
+          "narrative": "'Do not stay on the A7 too long because you will destroy the effect.' (Ch. 9, p. 26) The book establishes an implicit aesthetic threshold: below the duration ceiling, the outside substitution creates desirable outside color; above it, the result is undesirable dissonance.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "dom7/outside-duration-ceiling",
+            "dom7/outside-effect-coherence-discipline"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "harmonic-coherence-at-line-end",
+          "narrative": "'Make sure that the ending note from your single line idea is a chord tone for D7.' (Ch. 9, p. 26) The Ending Note Rule functions as a harmonic coherence guarantee: no matter how adventurous the line's interior, coherence is restored at the line's final note.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/ending-note-resolution",
+            "dom7#9/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "own-line-composition-constraint",
+          "narrative": "'In case you want to create your own D7 ideas based on the possibilities given in this chapter, make sure that the ending note from your single line idea is a chord tone for D7.' (Ch. 9, p. 26) The Ending Note Rule is explicitly extended to student-composed lines, not just the book's worked examples.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/ending-note-resolution",
+            "dom7/harmonic-coherence-at-line-end"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "fmaj7-relative-major-boundary",
+          "narrative": "'Although we can combine melodies derived from Dm7 (key) with melodies derived from its relative major (Fmaj7), the melodic options for their dominant 7th chords must be treated differently because some options might not work.' (Ch. 13, p. 77) Relative-major/minor melodic combination is permitted at the tonic level but prohibited from being assumed at the dominant level.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/active-giant-line-application",
+            "maj7/c7-to-fmaj7-option-restriction"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "almost-always-works-filter",
+          "narrative": "'The secret is to know the options that will work almost always: In a cadence || Gm7 | A7 | Dm7 ||' (Ch. 13, p. 77) For Active Giant Lines over Dm7, the practitioner must identify and prioritize the subset of options that will work almost always over the ii-V7-i cadence.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dominant-option-discrimination",
+            "min7/iv-v7-i-cadence-context"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "second-gb-relative-minor-scales",
+          "narrative": "'The second trick is also to create a cadence V7/I just like we did before by using D7 leading to G major. However, this time let...' (Ch. 9, p. 26) The Second GB Chord Transition opens access to relative-minor substitute scales by treating D7 as V7 of G.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/gb-transition-second-technique",
+            "dom7/gb-transition-first-technique"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "outside-inside-balance",
+          "narrative": "Chapter 9's systematic treatment of D7(#9) outside playing balances theoretical justification (Mixolydian derivation, chord family theory) with practical constraint (duration ceiling, Ending Note Rule).",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7#9/outside-duration-ceiling",
+            "dom7#9/ending-note-resolution"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "fretboard-grounding-of-abstract-theory",
+          "narrative": "'In order to better understand the concept behind the Active Giant Lines, let's use the Dm key as an example.' (Ch. 13, p. 77) All abstract harmonic concepts — including those for dominant chords — must be grounded in the fretboard by mapping them onto guide chord shapes.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/guide-chord-visualization",
+            "min7/guide-chord-visualization"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "fretboard-grounding-of-abstract-theory",
+          "narrative": "Chapter 10 introduces Major 7th Giant Lines as a domain requiring the same fretboard grounding through guide chord visualization that governs all Giant Line work in the book (Ch. 13, p. 77).",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/fretboard-grounding-of-abstract-theory",
+            "min7/guide-chord-visualization"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "fretboard-grounding-of-abstract-theory",
+          "narrative": "'In order to better understand the concept behind the Active Giant Lines, let's use the Dm key as an example.' (Ch. 13, p. 77) Active Giant Lines over Dm7 must be internalized via guide chord visualization.",
+          "source_work_id": "method-vol-6-giant-lines",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/guide-chord-visualization",
+            "dom7/fretboard-grounding-of-abstract-theory"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "blues-scale-foundation",
+          "narrative": "Chapter 6 establishes Blues Scale Ideas as the foundational first layer over D7(9): '1) Blues Scale Ideas' precedes all other vocabulary. (Ch. 6, p. 27)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/mixolydian-lydian-dom-blend",
+            "dom7/maj7-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "mixolydian-lydian-dom-blend",
+          "narrative": "The second layer over D7(9) combines all three sources simultaneously: '2) Mixolydian, Lydian Dominant & Blues Ideas.' The method prescribes integrating these three vocabulary streams together rather than using each in isolation. (Ch. 6, p. 31)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/blues-scale-foundation",
+            "dom7/maj7-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "maj7-superimposition",
+          "narrative": "The most advanced layer combines dominant vocabulary with superimposed major-7th arpeggios: 'In the following examples we will combine dominant 7th ideas (Blues Scale, Mixolydian and Lydian Dominant Scales) with superimposition of major 7th arpeggios over dominant 7th chords.' (Ch. 6, p. 35)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/blues-scale-foundation",
+            "maj7/lydian-over-superimposed-iv"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "harmonic-region-interchangeability",
+          "narrative": "Within a dominant-chord vamp, chords from the same harmonic region are interchangeable. The Fmaj7 substitution over a dominant vamp is one such interchangeable chord trick: 'Note: This option might sound better with faster tempos.' (Ch. 7, p. 38)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/tritone-substitution-iv-degree",
+            "maj7/lydian-over-superimposed-iv"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "tritone-substitution-iv-degree",
+          "narrative": "The IV degree dominant chord can be replaced by its tritone substitute: 'replacing the IV degree by the V degree using Tritone Substitution (C7= F#7 or Gb7).' (Ch. 8, p. 44)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/harmonic-region-interchangeability",
+            "dom7/lydian-dominant-over-tritone-sub"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "scale-visualization-context-specific",
+          "narrative": "Even when scales share the same pitch content, they must be assigned distinct identities per context: 'depending on the situation you must visualize one of them or maybe both at the same time.' (Ch. 4, p. 17)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dorian-over-nondiatonic-minor",
+            "maj7/lydian-over-superimposed-iv"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "lydian-dominant-over-tritone-sub",
+          "narrative": "When the V degree of a superimposed cadence is itself a tritone substitute of a real dominant, the method expands available colors: 'exception which is when the V degree of the superimposed cadence is the Tritone Substitution from a real dominant chord in the harmony. Then we can choose' Lydian Dominant or Dominant Diminished. (Ch. 9, p. 53)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/tritone-substitution-iv-degree",
+            "min7/dorian-over-nondiatonic-minor"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "diminished-as-v7-substitute",
+          "narrative": "Diminished chords on the root can function as V7 substitutes: 'Diminished Chords on the Root can work as V7. It happens because the F° = E7 which contains all the notes half step above from F7 thus creating many leading tones at once to F7.' (Ch. 8, p. 49)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dim7/leading-tone-v7-proxy",
+            "dom7/tritone-substitution-iv-degree"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "subdominant-minor-region-substitution",
+          "narrative": "Over D7(#9), the Subdominant Minor region provides chords that can replace the dominant: Gbmaj7 and Emaj7 replace Bb7. 'replacing Bb7 (Subdominant Region chord) by Gbmaj7, which is a chord derived from the Subdominant Minor (Bm) of the tonality (F).' (Ch. 8, p. 46)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/lydian-over-subdominant-minor-sub",
+            "dom7#9/minor-subdominant-regional-extension"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "minor-subdominant-regional-extension",
+          "narrative": "The minor-tonality subdominant region rules extend to major tonalities for dominant-7th substitutions: 'the harmonic region rules we have learned as connected to minor tonalities can also work for major tonalities when we talk about dominant 7th chord substitutions.' (Ch. 8, p. 50)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7#9/subdominant-minor-region-substitution",
+            "maj7/lydian-over-subdominant-minor-sub"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "minor-subdominant-replacing-major-subdominant",
+          "narrative": "A Minor Subdominant Region chord can replace a Major Subdominant Region chord: 'Bm7 (Minor Subdominant Region chord) is replacing Bb7 (Major Subdominant Region chord).' (Ch. 8, p. 52)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dorian-over-nondiatonic-minor",
+            "dom7#9/subdominant-minor-region-substitution"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "dorian-over-nondiatonic-minor",
+          "narrative": "Any non-diatonic minor-7th substitution chord must be assigned Dorian identity: 'Bm7 should be considered Dorian because it is a minor chord not derived from the chord family of the tonality. Actually, Bm7 Dorian is a combination between F Dominant Diminished and F Altered Scale that can lead us to Bb7.' (Ch. 10, p. 62)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/hybrid-preferred-over-strict-dorian",
+            "min7/chain-consecutive-dorian-or-hybrid"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "hybrid-preferred-over-strict-dorian",
+          "narrative": "Over non-diatonic minor substitution chords, hybrid ideas are preferred over strict modal application: 'Usually hybrid ideas tend to sound better.' (Ch. 9, p. 53)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dorian-over-nondiatonic-minor",
+            "min7/chain-consecutive-dorian-or-hybrid"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "chain-consecutive-dorian-or-hybrid",
+          "narrative": "Over a chain of consecutive minor-7th chords substituting a single dominant target: 'We should play hybrid or Dorian ideas over each one of the chain of chords.' G#m7 Dorian over D7 'will sound like a combination between D Altered and D Dominant Diminished Scale.' (Ch. 10, p. 70)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dorian-over-nondiatonic-minor",
+            "min7/hybrid-preferred-over-strict-dorian"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "v-degree-stripped-under-superimposition",
+          "narrative": "When superimposing a IIm7-V7-I cadence, the V degree must be stripped: 'the V7 degree cannot have tensions anymore thus becoming part of the IIm7 degree dorian. In other words, in general the superimposed IIm7, V7, I cadences lose the V degree and stay only with the IIm7 and the Imaj7.' (Ch. 10, p. 69)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/imaj7-retained-under-superimposition",
+            "min7/dorian-over-nondiatonic-minor"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "relative-chord-as-additional-color",
+          "narrative": "Relative chords of superimposed minor-7th chords are always available as additional color sources: 'remember that we can always use the relative chords from minor and major chords.' For Ebm7, this means Gbmaj7 is accessible. (Ch. 10, p. 72)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/lydian-over-superimposed-iv",
+            "min7/dorian-over-nondiatonic-minor"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "dorian-color-note-major-seventh",
+          "narrative": "The color note of a non-diatonic minor-7th substitution is the pitch that functions as major 7th of the target chord: Ebm7 Dorian over D7 creates 'an interesting flavor, mainly because of the note Db (flat 7th from Eb or major 7th from D).' (Ch. 10, p. 72)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/chain-consecutive-dorian-or-hybrid",
+            "min7/dorian-over-nondiatonic-minor"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "iim7-dorian-in-superimposed-cadence",
+          "narrative": "Within a superimposed cadence framework, Dorian is the prescribed mode for the IIm7 chord: 'we can use Dorian ideas over the IIm7 of a cadence.' (Ch. 9, p. 53)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/v-degree-stripped-under-superimposition",
+            "maj7/lydian-over-superimposed-iv"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "consecutive-chain-color-note-dual-function",
+          "narrative": "In the consecutive minor-7th chain Gm7-Abm7-Am7, Abm7 Dorian yields two color notes with dual interval function: 'Cb (B) and F (minor 3rd & major 6th from Abm7, and major 7th of & perfect 4th from C).' (Ch. 12, p. 120)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/chain-consecutive-dorian-or-hybrid",
+            "min7/dorian-color-note-major-seventh"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "lydian-over-superimposed-iv",
+          "narrative": "Over the relative IV chord of a superimposed IIm7 cadence, Lydian is the prescribed scale: 'use Lydian ideas over its relative chord, which will be the IV degree (in this case, Fmaj7).' (Ch. 9, p. 53)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/iim7-dorian-in-superimposed-cadence",
+            "maj7/lydian-over-subdominant-minor-sub"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "lydian-over-subdominant-minor-sub",
+          "narrative": "Non-diatonic major-7th chords used as subdominant-minor-region substitutes must be treated with Lydian identity: 'Bmaj7 chord must be treated as a Lydian chord, however we can also use hybrid ideas over it. Notice that the Bmaj7 Lydian scale contains the altered tensions from F7 (#9, b9, #11, b13).' (Ch. 10, p. 60)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/lydian-over-superimposed-iv",
+            "dom7/maj7-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "lydian-hybrid-also-permitted",
+          "narrative": "Although Lydian is the primary prescription for non-diatonic major substitutes, hybrid ideas are also permitted: 'Bmaj7 chord must be treated as a Lydian chord, however we can also use hybrid ideas over it.' (Ch. 10, p. 60)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/lydian-over-subdominant-minor-sub",
+            "min7/hybrid-preferred-over-strict-dorian"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "imaj7-retained-under-superimposition",
+          "narrative": "When the V degree is stripped from a superimposed cadence, the Imaj7 is retained alongside the IIm7: 'superimposed IIm7, V7, I cadences lose the V degree and stay only with the IIm7 and the Imaj7.' (Ch. 9, p. 53)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/v-degree-stripped-under-superimposition",
+            "min7/iim7-dorian-in-superimposed-cadence"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "superimposed-four-color-options",
+          "narrative": "Four specific colors are prescribed for superimposition over a IIm7-I cadence in C: 'Dm7, Fmaj7 (relative of Dm7) Cmaj7 and Am7 (relative of Cmaj7).' (Ch. 9, p. 53)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/lydian-over-superimposed-iv",
+            "min7/relative-chord-as-additional-color"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "gbmaj7-replacing-bb7-subdominant-minor",
+          "narrative": "Gbmaj7 is prescribed as a substitution for Bb7 derived through the Minor Subdominant Region: 'we can replace a Major Subdominant Region chord (Bb) by one of the chords derived from the Minor Subdominant Region (Bbm) in this case we have chosen Gbmaj7 which has the Ebm7 as a relative chord.' (Ch. 11, p. 95)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7#9/subdominant-minor-region-substitution",
+            "min7/relative-chord-as-additional-color"
+          ]
+        },
+        {
+          "chord_quality": "maj7",
+          "function_role": "emaj7-replacing-bb7-relative-major-derivation",
+          "narrative": "Emaj7 can replace Bb7 by tracing through the relative major of the parallel minor: 'the tonality is Fm and its relative is Ab major. Now let's get the Minor Subdominant Region chords from Ab major: Dbm (7, maj7, 6), Gb7, Emaj7... ops, here is the chord we are talking about.' (Ch. 8, p. 50)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/gbmaj7-replacing-bb7-subdominant-minor",
+            "dom7#9/minor-subdominant-regional-extension"
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "cm7-dorian-replaces-half-diminished",
+          "narrative": "A Cm7/F7 cadence can replace A half-diminished, and the treatment is a single Cm7 Dorian: 'Above we have the cadence Cm7, F7 replacing Aø. In this case we should consider it as being a single Cm7 Dorian or Cm7 hybrid chord.' (Ch. 12, p. 100)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dorian-over-nondiatonic-minor",
+            "dom7/diminished-as-v7-substitute"
+          ]
+        },
+        {
+          "chord_quality": "min7b5",
+          "function_role": "locrian-dorian-shared-pitch-content",
+          "narrative": "The scale equivalence between Cm7 Dorian and Aø Locrian justifies the substitution: 'Cm7 Dorian contains the same notes as Aø Locrian because both are derived from Bb key.' (Ch. 12, p. 100)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7b5/cm7-dorian-replaces-half-diminished",
+            "dom7/scale-visualization-context-specific"
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "leading-tone-v7-proxy",
+          "narrative": "Diminished chords function as dominant-7th substitutes through their leading-tone content: 'F° = E7 which contains all the notes half step above from F7 thus creating many leading tones at once to F7.' (Ch. 8, p. 49)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/diminished-as-v7-substitute",
+            "dim7/whole-step-leading-note-exception"
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "whole-step-leading-note-exception",
+          "narrative": "The leading-tone principle allows a whole step as well as a half step: 'a leading note sometimes can be a whole step, not exactly a half step as usual. Actually it is a process of understanding where a note wants to go. So, the D note (b7th of E) can work as a leading note to E (major 7th of F).' (Ch. 10, p. 63)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dim7/leading-tone-v7-proxy",
+            "dom7/diminished-as-v7-substitute"
+          ]
+        },
+        {
+          "chord_quality": "dim7",
+          "function_role": "subdominant-replacement-via-dominant-function",
+          "narrative": "A diminished chord can replace the Subdominant Region chord by functioning as the Dominant Region: 'we are replacing the Subdominant Region chord Bb7 by a diminished chord working as C7 (Dominant Region chord) leading to Fmaj7 (key). B° is the same chord as F° which is actually the same chord as E7 with a different bass note.' (Ch. 10, p. 63)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dim7/leading-tone-v7-proxy",
+            "dom7/diminished-as-v7-substitute"
+          ]
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "bm7-dorian-hybrid-as-f-altered",
+          "narrative": "Bm7 Dorian substitution over F7 produces an altered sound: 'Bm7 Dorian is a combination between F Dominant Diminished and F Altered Scale that can lead us to Bb7 (next chord of the blues form).' (Ch. 10, p. 62)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dorian-over-nondiatonic-minor",
+            "dom7alt/f-sharp-m7-dorian-dom-dim-alt-hybrid"
+          ]
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "f-sharp-m7-dorian-dom-dim-alt-hybrid",
+          "narrative": "F#m7 Dorian or hybrid ideas over C7 produce a specific prescribed sound: 'the melodic ideas from F#m7 Dorian or F#m7 hybrid when played over C7, will sound a combination between C7 Dominant Diminished with C7alt.' (Ch. 12, p. 115)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/bm7-dorian-hybrid-as-f-altered",
+            "min7/dorian-over-nondiatonic-minor"
+          ]
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "c-sharp-m7-altered-tensions-source",
+          "narrative": "C#m7/F#7 can replace C7 because it contains the altered tensions: 'In this case we have the cadence C#m7, F#7 replacing C7. We can do that because it contains the altered tensions from F7 (#9, b9, #11, b13).' (Ch. 12, p. 110)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/f-sharp-m7-dorian-dom-dim-alt-hybrid",
+            "min7/dorian-color-note-major-seventh"
+          ]
+        },
+        {
+          "chord_quality": "dom7alt",
+          "function_role": "abm7-db7-dorian-replaces-dominant",
+          "narrative": "Abm7/Db7 replaces C7 and is treated as a single Abm7 Dorian: 'we should consider this cadence as a single Abm7 Dorian, which can give a special flavor to C7 because of two specific notes: Cb (B) and F (minor 3rd & major 6th from Abm7, and major 7th of & perfect 4th from C).' (Ch. 12, p. 120)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/consecutive-chain-color-note-dual-function",
+            "dom7alt/c-sharp-m7-altered-tensions-source"
+          ]
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "bmaj7-lydian-altered-tensions-over-f7",
+          "narrative": "Bmaj7 Lydian is prescribed over F7 as a substitution chord because its scale contains all altered tensions: 'the Bmaj7 Lydian scale contains the altered tensions from F7 (#9, b9, #11, b13). Also it can give a special flavor to F7 because of the note Bb (A#), which is the major 7th from B and the perfect 4th from F.' (Ch. 10, p. 60)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/lydian-over-subdominant-minor-sub",
+            "dom7alt/c-sharp-m7-altered-tensions-source"
+          ]
+        },
+        {
+          "chord_quality": "dom7b9",
+          "function_role": "ebm7-ab7-tritone-lydian-dom-or-dom-dim",
+          "narrative": "When Ab7 is the tritone substitution of D7, either Lydian Dominant or Dominant Diminished ideas are available: 'we can simply use Ab7 Lydian Dominant or Ab7 Dominant Diminished ideas because Ab7 is the Tritone Substitution from D7.' (Ch. 10, p. 72)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/lydian-dominant-over-tritone-sub",
+            "min7/dorian-over-nondiatonic-minor"
+          ]
+        },
+        {
+          "chord_quality": "dom13",
+          "function_role": "section-isolation-before-full-form",
+          "narrative": "The method prescribes studying each blues section separately before assembling the full form: 'It is extremely important to understand that we should not study the whole form at once. If we really want to master it, we must study each part and each possibility separately to make them part of ourselves.' (Ch. 4, p. 21)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/blues-scale-foundation",
+            "dom7/scale-visualization-context-specific"
+          ]
+        },
+        {
+          "chord_quality": "maj7#11",
+          "function_role": "lydian-as-default-non-diatonic-major-identity",
+          "narrative": "Lydian is the default scale identity assigned to any non-diatonic major chord functioning as a regional substitution: 'Bmaj7 chord must be treated as a Lydian chord.' (Ch. 10, p. 60)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/lydian-over-subdominant-minor-sub",
+            "maj7/lydian-hybrid-also-permitted"
+          ]
+        },
+        {
+          "chord_quality": "maj7#11",
+          "function_role": "fmaj7-substitution-tempo-conditioned",
+          "narrative": "The Fmaj7 substitution over a dominant vamp is tempo-conditioned: 'Note: This option might sound better with faster tempos.' (Ch. 7, p. 38)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/harmonic-region-interchangeability",
+            "maj7/lydian-over-superimposed-iv"
+          ]
+        },
+        {
+          "chord_quality": "min9",
+          "function_role": "ebm7-dorian-single-scale-reading",
+          "narrative": "The Ebm7/Ab7 cadence replacing Bb7 is prescribed as a single Ebm7 Dorian reading: 'we should consider it as being a single Ebm7 Dorian or Ebm7 hybrid chord.' (Ch. 11, p. 95)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dorian-over-nondiatonic-minor",
+            "min7/relative-chord-as-additional-color"
+          ]
+        },
+        {
+          "chord_quality": "min9",
+          "function_role": "g-sharp-m7-chain-peculiar-flavor",
+          "narrative": "G#m7 Dorian lines over D7 carry a specific flavor source: 'G#m7 lines can give a peculiar flavor to D7 because the 4th from G#m7 (C#) is the major 7th of D.' (Ch. 10, p. 70)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/chain-consecutive-dorian-or-hybrid",
+            "min7/dorian-color-note-major-seventh"
+          ]
+        },
+        {
+          "chord_quality": "sus4",
+          "function_role": "turnaround-rest-as-structural-punctuation",
+          "narrative": "Silence during the turnaround is a structural prescription, not passive inaction: 'we must remember that usually we should breathe in this part in order to give space' between choruses. (Ch. 12, p. 98)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/section-isolation-before-full-form",
+            "dom7/blues-scale-foundation"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "new-concept-start-at-110bpm",
+          "narrative": "Any new concept practice must begin at 110 bpm: 'we should do it over a slow medium tempo backing track (110 bpm works fine). After getting used to some new possibilities, we should do the same process using faster tempos and slower tempos.' (Ch. 4, p. 21)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/fast-tempo-technique-fluency",
+            "dom7/blues-scale-foundation"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "fast-tempo-technique-fluency",
+          "narrative": "Fast tempos are prescribed for building technical fluency rather than for performance display: 'With Fast Tempos we will improve our reasoning speed and of course the right & left-hand technique thus giving us more fluency with the connections between scales and all the ideas we have been learning.' (Ch. 4, p. 15)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/new-concept-start-at-110bpm",
+            "dom7/fast-as-consequence-not-goal"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "fast-as-consequence-not-goal",
+          "narrative": "Speed must not be pursued as an end in itself: 'it is important to mention that we do not have to play fast tempos if we do not like it. But we must understand that playing fast is a consequence, not a goal.' (Ch. 4, p. 21)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/new-concept-start-at-110bpm",
+            "dom7/fast-tempo-technique-fluency"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "medium-tempo-inverted-hammer-breathing",
+          "narrative": "Medium tempos call for the inverted/reverse hammer technique and phrase breathing: 'With the Medium Tempos we will be using all the time a very special and unique technique that we have learned previously called inverted hammer or also called reverse hammer. Also, in this type of tempo, we will learn how to breathe between the melodies thus giving the solo a different vibe and context.' (Ch. 4, p. 15)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/new-concept-start-at-110bpm",
+            "dom7/fast-tempo-technique-fluency"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "rhythmic-positioning-slow-tempo",
+          "narrative": "Slow tempos require Rhythmic Positioning: 'This is the most difficult tempo to master and improvise because we will be using what we call Rhythmic Positioning, which combines all types of time feel and rhythmic cells we have been working on.' (Ch. 4, p. 15)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/medium-tempo-inverted-hammer-breathing",
+            "dom7/new-concept-start-at-110bpm"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "jazz-pulse-beats-1-and-3",
+          "narrative": "The jazz pulse anchor is prescribed on beats 1 and 3, not 2 and 4: 'Although some people think that the secret of jazz is the pulse 2 and 4, actually it is the opposite. The real Jazz feeling has its pillar in 1 and 3. But what about the 2 and the 4? Guess what, the stronger we feel the 1 and 3, the easier we can feel the pulse in 2 and 4.' (Ch. 4, p. 18)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/rhythmic-positioning-slow-tempo",
+            "dom7/medium-tempo-inverted-hammer-breathing"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "lines-as-concept-vehicles-not-ends",
+          "narrative": "Memorized lines are vehicles for internalizing harmonic concepts: 'the idea is not to become a parrot but a wise improviser that creates new combinations derived from a single line.' (Ch. 4, p. 21)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/section-isolation-before-full-form",
+            "dom7/new-concept-start-at-110bpm"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "preset-chorus-combination-fingering-picking",
+          "narrative": "Pre-set chorus combinations must be studied beyond melody to include fingering and picking: 'we also must study, memorize and combine some pre-set choruses, not only melodically speaking but in terms of fingering, picking and line combinations.' (Ch. 4, p. 21)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/lines-as-concept-vehicles-not-ends",
+            "dom7/section-isolation-before-full-form"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "time-signatures-as-visualization-not-meter",
+          "narrative": "Time signatures in the book's notation are visualization aids, not metric prescriptions: 'The patterns and scale visualizations in this book may have different time signatures in order to help with the organization and visualization. Don't let the time signatures confuse you.' (Ch. 4, p. 18)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/scale-visualization-context-specific",
+            "dom7/rhythmic-positioning-slow-tempo"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "non-diatonic-minor-not-chord-family-derived",
+          "narrative": "The key criterion for assigning Dorian to a minor chord is whether it derives from the chord family of the tonality: 'Bm7 should be considered Dorian because it is a minor chord not derived from the chord family of the tonality.' (Ch. 10, p. 62)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/dorian-over-nondiatonic-minor",
+            "dom7/scale-visualization-context-specific"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "cm7-f7-single-scale-simplification",
+          "narrative": "Two-chord cadential substitutions over a half-diminished chord are simplified to a single Dorian scale reading: 'In this case we should consider it as being a single Cm7 Dorian or Cm7 hybrid chord.' (Ch. 12, p. 100)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7b5/cm7-dorian-replaces-half-diminished",
+            "min7/v-degree-stripped-under-superimposition"
+          ]
+        },
+        {
+          "chord_quality": "dom7#9",
+          "function_role": "gbmaj7-emaj7-regional-substitute-for-bb7",
+          "narrative": "Both Gbmaj7 and Emaj7 are prescribed regional substitutes for Bb7 over D7(#9) contexts, derived from different steps of the same minor-subdominant derivation chain. 'leading dominant 7th chord substitution rules can work to lead us to major or minor chords.' (Ch. 8, p. 50)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/gbmaj7-replacing-bb7-subdominant-minor",
+            "maj7/emaj7-replacing-bb7-relative-major-derivation"
+          ]
+        },
+        {
+          "chord_quality": "min7",
+          "function_role": "g-sharp-m7-hybrid-altered-dominant-diminished",
+          "narrative": "G#m7 hybrid ideas produce a specific prescribed sound over D7: 'we can also play G#m7 hybrid ideas over D7 because it will sound like a combination between D Altered and D Dominant Diminished Scale.' (Ch. 10, p. 70)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7/chain-consecutive-dorian-or-hybrid",
+            "dom7alt/bm7-dorian-hybrid-as-f-altered"
+          ]
+        },
+        {
+          "chord_quality": "dom11",
+          "function_role": "ebm7-ab7-eb-cadence-dorian-hybrid",
+          "narrative": "The Ebm7/Ab7 cadence replacing D7 can be treated in three ways: Ab7 Lydian Dominant, Ab7 Dominant Diminished (as tritone sub of D7), or as 'a single Ebm7 Dorian or Ebm7 hybrid, which brings to D7 an interesting flavor, mainly because of the note Db (flat 7th from Eb or major 7th from D).' (Ch. 10, p. 72)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/ebm7-ab7-tritone-lydian-dom-or-dom-dim",
+            "min7/dorian-over-nondiatonic-minor"
+          ]
+        },
+        {
+          "chord_quality": "maj6",
+          "function_role": "cm6-equals-f7-9-aø-inversion",
+          "narrative": "Cm6 is prescribed as harmonically equivalent to both F7(9) and Aø: 'Aø is an inversion chord from Cm6, which is the same chord as F7(9) chord. Apart from that, Cm7 Dorian contains the same notes as Aø Locrian because both are derived from Bb key.' (Ch. 12, p. 100)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "min7b5/cm7-dorian-replaces-half-diminished",
+            "min7b5/locrian-dorian-shared-pitch-content"
+          ]
+        },
+        {
+          "chord_quality": "min-maj7",
+          "function_role": "minor-subdominant-regional-parent-for-ebm7",
+          "narrative": "The derivation of Ebm7 as a substitution for Bb7 proceeds through the minor subdominant region: 'we can replace a Major Subdominant Region chord (Bb) by one of the chords derived from the Minor Subdominant Region (Bbm) in this case we have chosen Gbmaj7 which has the Ebm7 as a relative chord.' (Ch. 11, p. 95)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/gbmaj7-replacing-bb7-subdominant-minor",
+            "min7/relative-chord-as-additional-color"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "dance-of-elephant-pulse-internalization",
+          "narrative": "Physical body movement is prescribed for internalizing the jazz pulse: 'the dance of the elephant which is to move your body from one side to the other just like an elephant walks.' (Ch. 4, p. 18)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/jazz-pulse-beats-1-and-3",
+            "dom7/rhythmic-positioning-slow-tempo"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "slow-blues-vibe-wes-montgomery-reference",
+          "narrative": "The Slow Blues Vibe tempo feel is anchored to a canonical recorded reference: '1) SLOW BLUES VIBE (as an example listen to the song Bumpin from Wes Montgomery.' (Ch. 4, p. 19)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/rhythmic-positioning-slow-tempo",
+            "dom7/medium-tempo-inverted-hammer-breathing"
+          ]
+        },
+        {
+          "chord_quality": "dom7",
+          "function_role": "free-slow-blues-rhythmic-liberation",
+          "narrative": "Free Slow Blues Vibe is distinguished from Slow Blues Vibe by rhythmic liberation: 'Although we use the same groove feeling as in the slow blues vibe, in the free slow blues vibe you can release yourself from the common rhythmic cell and play more flying in the air.' (Ch. 4, p. 19)",
+          "source_work_id": "method-vol-7-blues-ideas",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/slow-blues-vibe-wes-montgomery-reference",
+            "dom7/rhythmic-positioning-slow-tempo"
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary

Bulk Stage B injection for Benson Method Vols 2-7 (361 usage_notes). With PR #487 (V1, 66 notes), Benson total becomes 427 usage_notes across the 7-volume corpus.

| Vol | Title | Notes |
|---|---|---|
| 2 | Advanced Harmony | 66 |
| 3 | Technique & Arpeggios | 56 |
| 4 | Approach Tones | 59 |
| 5 | Melodic Minor | 61 |
| 6 | Giant Lines | 57 |
| 7 | Blues Ideas | 62 |

## Polarity

57 proscriptive marks total (Benson cumulative across all 7 vols), with cross_ref pairs throughout. Notable structural pairs:

- `dom7/v-chord-avoid-note-avoidance` ↔ `sus4/v-chord-4th-permitted`
- `dom7/outside-duration-ceiling` ↔ `dom7/outside-superimposition-entry`
- `dom7/v-chord-tonic-root-omission` ↔ `dom7/v-chord-passing-chord-tonic-note`
- `dom11/dominant-natural-11-avoid` ↔ `dom7#11/dominant-v`

## Coverage highlights

- **V2** Advanced Harmony — harmonic-fields rule system, modal interchange, Lydian superimposition
- **V3** Technique & Arpeggios — avoid-note discipline, arpeggio-as-melody
- **V4** Approach Tones — Dorian/static-vs-active, harmonic-minor-over-V7 superimposition, four scale-tone approach subtypes, rootless V7(b9) diminished spellings
- **V5** Melodic Minor — Lydian Dominant, Altered Scale, flux-and-reflux
- **V6** Giant Lines — GB Chord Transitions, Ending Note Rule, static-before-active
- **V7** Blues Ideas — harmonic-region interchangeability, Dorian-over-non-diatonic-minor, tempo-feel taxonomy

## Pipeline state

Extraction model: sonnet (cyberpower run-ids `2026-05-28T15-05-20-benson-vol-{2..7}-*`). s5 orchestrator state for V2-V7 still awaiting-review; resume + advance to be done in housekeeping pass (same status as Pass/Baker/Greene/Laukens drafts). `prescriptive-lessons-draft.json` + `PRESCRIPTIVE.md` artifacts not yet committed — separate housekeeping ticket will cover that.

## Validation

Schema: 24/24 pass.

## Next

Switching focus to the remaining ~25 books in #457 backlog after this lands.

Refs #457, #459, #471.