### PR TITLE
fix(#495): fold i-chord-harmonic-family → harmonic-family-membership

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -8441,7 +8441,7 @@
         },
         {
           "chord_quality": "maj7",
-          "function_role": "i-chord-harmonic-family",
+          "function_role": "harmonic-family-membership",
           "narrative": "Greene establishes maj7 as the I chord in modern major-key harmony, listing the full extension family in Chapter 4 (p.15): C, C△, C6, C/9, C6/9, C2, C4/5, with parenthetical extensions C△/6 and Csus. Use any of these on the I chord according to context, treating the bare triad as the minimal option.",
           "source_principle_ids": [],
           "source_work_id": "modern-chord-progressions",


### PR DESCRIPTION
## Summary

Single-entry rename per Ellington census decision (post-#486 prod sync). \`i-chord-harmonic-family\` singleton on ted-greene/maj7 folds to the cross-master \`harmonic-family-membership\` (33+ entries).

## Kept as-is per Ellington

- \`i-chord-extension-family\` (3 Greene) — roman-numeral specificity IS the principle
- \`iv-chord-extension-family\` (3 Greene) — same

## Validation

- Zero residual \`i-chord-harmonic-family\` in masters.json
- Schema 24/24 pass

Closes #495. Refs #474.