### PR TITLE
feat(#457): Stage B — O'Rourke + Felts + Faria (263 entries)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -16859,7 +16859,1625 @@
           ]
         }
       ],
-      "status": "pedagogue"
+      "status": "pedagogue",
+      "usage_notes": [
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "tonic-i-melody-top",
+          "narrative": "Major-family chords are the I chord in O'Rourke's ii-V-I taxonomy, and every voicing chosen must have 'the same interval of the melody note as the highest note in the chord shape' (Ch. 4, p. 114). When the melody sits on the top 1st or 2nd string, select from the Major ii-V-I chord collection for string set 4321 or 5432 so the maj7 voicing indexes correctly against the current melody note. O'Rourke emphasises that 'no matter which note is in the melody line, you can harmonize it by referring to the chord collection' (Ch. 2, p. 35), making the collection the primary lookup tool for all maj7 harmonizations.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 114 — 'Choose chord voicings that have the same interval of the melody note as the highest note in the chord shape.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 35 — 'no matter which note is in the melody line, you can harmonize it by referring to the chord collection'"
+            }
+          ],
+          "cross_ref": [
+            "maj9/tonic-i-melody-top",
+            "maj6/tonic-i-color-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "tonic-i-omission-playability",
+          "narrative": "When a maj7 voicing is technically correct but awkward to finger, O'Rourke sanctions omitting notes in priority order: '5th, root, 11th, and 9th' first, with the '3rd and 7th sometimes omittable for more complex chords' (Ch. 2, p. 79). Because 'easier voicings flow musically better' (Ch. 4, p. 124), stripping a maj7 down to its shell — root, 3rd, 7th — is the prescribed remediation path before any more radical intervention.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 79 — 'Intervals most commonly omitted include the 5th, the root (1st), the 11th, and the 9th.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 124 — 'If it's easy on the hands, the music will flow better.'"
+            }
+          ],
+          "cross_ref": [
+            "maj9/tonic-i-omission-playability",
+            "maj6/tonic-i-omission-playability"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "tonic-i-shell-solo-guitar",
+          "narrative": "In solo guitar arranging (Module 4) the maj7 shell voicing — root, 3rd, and 7th, rooted on the 6th string — is the prescribed primitive. O'Rourke states 'these are called shell voicings — i.e. the bare bones of what you need to define the sound of the chord: the root, 3rd, and 7th' (Ch. 5, p. 145). The 5th is the first note prescribed for removal: 'you can remove the 5th from the chord and still retain the essential character of the sound' (Ch. 5, p. 145), leaving a lean three-note structure that anchors the melody above.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 145 — 'shell voicings — the root, 3rd, and 7th.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 145 — 'You can remove the 5th from the chord and still retain the essential character of the sound.'"
+            }
+          ],
+          "cross_ref": [
+            "maj6/tonic-i-shell-solo-guitar",
+            "maj9/tonic-i-shell-solo-guitar"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj6",
+          "function_role": "tonic-i-resolved-color",
+          "narrative": "O'Rourke presents the 6th as a direct substitute for the 7th in shell voicings, noting that 'the 6th interval can also be used instead of the 7th which gives a warmer, more resolved sound' (Ch. 5, p. 147). For maj6 voicings on the I chord the shell therefore becomes root–3rd–6th, and this replacement is prescribed specifically when a 'warmer, more resolved color' is the expressive target. The 6-or-7 choice is an explicit palette decision, not a workaround.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 147 — '6th interval can also be used instead of the 7th which gives a warmer, more resolved sound'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i-shell-solo-guitar",
+            "maj9/tonic-i-resolved-color"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj9",
+          "function_role": "tonic-i-extension-color",
+          "narrative": "The Major family includes CMaj9 in O'Rourke's Three Harmonic Families taxonomy (Ch. 2, p. 33), confirming maj9 as a first-class member of the major dictionary. Extensions like the 9th are explained as 'continuing to stack more and more thirds onto the structure, which gives us more and more colorful extensions' (Ch. 2, p. 78). When the melody note's interval relative to the I chord is 9, the painting-by-numbers lookup prescribes a maj9 voicing with that 9 on top, and the 9th is the first extension licensed for omission when playability demands it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 33 — 'Major – e.g. CMaj7, C6, CMaj9'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 78 — 'continuing to stack more and more thirds onto the structure, which gives us more and more colorful extensions'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i-melody-top",
+            "maj7#11/tonic-i-extension-color"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7#11",
+          "function_role": "tonic-i-altered-extension",
+          "narrative": "O'Rourke categorises #11 as an altered tension — 'notes that are outside the parent scale of the key' and 'usually added in parentheses after the chord name' (Ch. 2, p. 80). GMaj7(#11) is explicitly cited as a worked example of this notation. When the melody note sits on #11 relative to the I chord, a maj7#11 voicing with #11 on top is the correct painting-by-numbers lookup result. The chord-tone vocabulary includes #11 as a legitimate index key: '1, b9, 9, b3, 3, 11, #11, 5, b13, 13, b7, 7' (Ch. 3, p. 107).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 80 — 'Altered tensions are notes that are outside the parent scale of the key … Examples are GMaj7(#11).'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — '1, b9, 9, b3, 3, 11, #11, 5, b13, 13, b7, 7'"
+            }
+          ],
+          "cross_ref": [
+            "maj9/tonic-i-extension-color",
+            "dom7#11/dominant-v-tritone-color"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "supertonic-ii-collection-lookup",
+          "narrative": "The m7 sub-family is one of O'Rourke's two minor sub-families and the prescribed ii chord in his major ii-V-I collections. 'The ii-V-I progression contains a chord from each harmonic family: ii – minor, V – dominant, I – major' (Ch. 2, p. 48), making the min7 voicing the entry point for every major-cadence dictionary lookup. Major ii-V-I chord collections on string set 4321 and 5432 both begin on the min7 voicing, and transposing the shape is done by 'sliding the shape down on the fretboard so that the top note matches the same fret where the melody note is' (Ch. 4, p. 118).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 48 — 'ii – minor, V – dominant, I – major'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 118 — 'sliding the shape down on the fretboard so that the top note matches the same fret'"
+            }
+          ],
+          "cross_ref": [
+            "min9/supertonic-ii-collection-lookup",
+            "dom7/dominant-v-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "minor-for-dominant-sub",
+          "narrative": "O'Rourke codifies Pat Martino's minor conversion concept as an explicit substitution rule: 'You can use a minor 7 chord from the 5th of any dominant chord (which is like using the iim7 that belongs to the dominant chord). For example: an F7 chord's 5th interval is C. So you could play Cm7 over F7 to get an interesting sound' (Ch. 7, p. 230). The prescriptive target is specifically min7, not min9 or other minor qualities, making this the sanctioned substitution voice when applying the Minor for Dominant rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 230 — 'You can use a minor 7 chord from the 5th of any dominant chord … you could play Cm7 over F7.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v-collection-lookup",
+            "min9/minor-for-dominant-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "i-to-vi-relative-sub",
+          "narrative": "The I-to-vi substitution rule licenses replacing a major I chord with its relative vi minor: 'you can replace the I chord of a key with the vi chord of the key' (Ch. 7, p. 224). In practice the vi chord is a min7 quality and is prescribed as the substitute voicing. This relative-key reharmonization relies on the shared key signature between G major and E minor, for instance: 'G major and E minor are called relative key signatures to each other because they share the same key signature' (Ch. 7, p. 223).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 224 — 'you can replace the I chord of a key with the vi chord of the key'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 223 — 'G major and E minor are called relative key signatures to each other'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i-melody-top",
+            "min9/i-to-vi-relative-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "i-to-iii-relative-sub",
+          "narrative": "The I-to-iii substitution provides a second major-to-minor reharmonization path: 'you can substitute a major chord for chord iii of its key' (Ch. 7, p. 225). The iii chord is also a min7 quality, so this rule and the I-to-vi rule both resolve to min7 substitutes and are distinguished primarily by the degree of the scale they target. Both rules are filed under O'Rourke's 'chord addition' umbrella: 'This process is referred to as chord addition — adding extra chords to the harmony' (Ch. 7, p. 228).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 225 — 'you can substitute a major chord for chord iii of its key'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 228 — 'chord addition — adding extra chords to the harmony'"
+            }
+          ],
+          "cross_ref": [
+            "min7/i-to-vi-relative-sub",
+            "maj7/tonic-i-melody-top"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min9",
+          "function_role": "supertonic-ii-extension-top",
+          "narrative": "When the melody note's interval relative to the ii chord is the 9th, the painting-by-numbers lookup prescribes a min9 voicing with the 9 on top. O'Rourke includes Cm9 in his minor sub-family examples (Ch. 2, p. 34) and treats extension stacking as the source of 'more and more colorful extensions' (Ch. 2, p. 78). The 9th is placed on the omittable-notes list — it is the fourth priority for omission — so when playability demands it the 9 may be cut while preserving the essential chord character.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — 'm7 sub-family – e.g. Cm7, Cm9, Cm13'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 79 — '5th, root, 11th, and 9th' as most commonly omitted"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii-collection-lookup",
+            "min7b5/half-dim-ii-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7b5",
+          "function_role": "half-dim-ii-minor-cadence",
+          "narrative": "O'Rourke defines the m7b5 as its own minor sub-family — 'Cm7b5, Cm11b5' — and prescribes it as the ii chord in minor ii-V-i cadences, which are distinguished from major ones by 'the b5 and b9 alterations characteristic of the minor cadence' (Ch. 8 summary). The Minor ii-V-i chord dictionary on string sets 4321 and 5432 both open on the min7b5 voicing, so the painting-by-numbers lookup always routes to that quality when a minor ii chord is identified in the harmonic analysis.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — 'm7b5 sub-family – e.g. Cm7b5, Cm11b5'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 272 — 'MINOR II V I CHORDS – STRING SET 4321' (b5 and b9 alterations characteristic of the minor cadence)"
+            }
+          ],
+          "cross_ref": [
+            "dom7b9/dominant-v-minor-cadence",
+            "min7/supertonic-ii-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "dominant-v-collection-lookup",
+          "narrative": "The natural dominant ('7') sub-family is the V chord in O'Rourke's ii-V-I collections, and every major-cadence dictionary entry includes a dom7 voicing whose top note covers a given diatonic interval. The three-input lookup rule requires knowing 'the string the melody note is on, the type of chord in the progression, and the interval of the melody note in relation to that chord' (Ch. 4, p. 114) before selecting the dom7 voicing. Natural dominant voicings are catalogued on string sets 4321 and 5432 in Chapter 8.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — '7 or natural dominant sub-family – e.g. C7, C9, C13'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 114 — 'the string the melody note is on, the type of chord, and the interval of the melody note'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-altered-sub",
+            "dom7b9/dominant-v-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "dominant-tension-target",
+          "narrative": "O'Rourke explicitly locates the 'jazzy' quality in extensions and tensions placed on the dominant chord specifically: 'The jazzy sound in arrangements usually comes from adding extensions and tensions to voicings – particularly to dominant chords' (Ch. 4, p. 127). A dedicated dictionary section titled 'Tensions and Extensions on Dominant Chords' (Ch. 8, p. 278) backs this rule, making the dom7 quality the prescribed first target when the arranger wishes to inject jazz color. The restraint axiom still applies: add tensions 'occasionally for color' rather than on every dominant (Ch. 7, p. 222).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 127 — 'The jazzy sound … comes from adding extensions and tensions to voicings – particularly to dominant chords.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 278 — 'TENSIONS & EXTENSIONS ON DOMINANT CHORDS'"
+            }
+          ],
+          "cross_ref": [
+            "dom13/dominant-v-extension-top",
+            "dom7alt/dominant-v-altered-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "dominant-tritone-sub-target",
+          "narrative": "The Tritone Substitution Rule states that 'you can replace any chord with another whose root is a tritone away from the root of the original chord' (Ch. 7, p. 220), and the mechanism is theoretically explained through the dom7 guide tones: 'C7 has E as the 3rd and Bb as the 7th. F#7 has E as the 7th and A# (which is the same as Bb) as the 3rd. The guide tones have essentially swapped places' (Ch. 7, p. 216). The dom7 quality is the prescribed identity on both sides of the substitution, and the sub is 'the most useful jazz substitution' according to O'Rourke.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 220 — 'Tritone Substitution Rule — You can replace any chord with another whose root is a tritone away.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 216 — 'C7 has E as the 3rd and Bb as the 7th. F#7 has E as the 7th and A# as the 3rd.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-tritone-result",
+            "dom7#11/dominant-v-tritone-color"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "back-cycling-chain",
+          "narrative": "Back cycling is prescribed as movement through the circle of fourths — 'the most common root movement in Western music' (Ch. 7, p. 237) — and the resulting added chords are dom7 qualities unless the harmonic context dictates otherwise. The Back Cycling Substitution Rule states: 'you can add chords to the chord progression of a song based on the back cycle, i.e. the circle of fourths' (Ch. 7, p. 243). Each inserted dominant precedes its target by a fourth, creating chains of dom7 → dom7 → resolution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 237 — 'cycle of root notes a 4th apart is the most common root movement in Western music'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 243 — 'Back cycling substitution rule — add chords based on the circle of fourths'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/back-cycling-altered-link",
+            "dom7b9/back-cycling-tension-link"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "chromatic-approach-parallel",
+          "narrative": "O'Rourke prescribes a chromatic approach-chord technique specifically for approach melody notes: 'you can use a voicing on the note being approached, then play the same voicing one fret away for the approach note in the melody' (Ch. 5, p. 197). When the target chord is a dominant the approach chord is the same dom7 shape moved one fret chromatically, making the dom7 quality self-similar on both the target beat and the approach beat. This device appears in both up-tempo and ballad arrangements in Chapter 6.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 197 — 'play the same voicing one fret away for the approach note in the melody'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/chromatic-approach-parallel",
+            "dom7b9/chromatic-approach-parallel"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom13",
+          "function_role": "dominant-v-extension-top",
+          "narrative": "C13 is listed explicitly in the natural dominant sub-family (Ch. 2, p. 34) and the 13th is a valid chord-tone index key in the closed vocabulary (Ch. 3, p. 107). When the melody note's interval relative to the V chord is the 13th, the painting-by-numbers rule prescribes a dom13 voicing with the 13 on top. The dedicated 'Tensions and Extensions on Dominant Chords' dictionary section (Ch. 8, p. 278) provides the specific voicing shapes for this quality, and the 9th and 11th within the extended stack are the first candidates for omission to aid playability.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — 'natural dominant sub-family – e.g. C7, C9, C13'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 278 — 'TENSIONS & EXTENSIONS ON DOMINANT CHORDS'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-tension-target",
+            "dom11/dominant-v-11th-top"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom11",
+          "function_role": "dominant-v-11th-top",
+          "narrative": "The 11th is a member of the closed chord-tone vocabulary '1, b9, 9, b3, 3, 11, #11, 5, b13, 13, b7, 7' (Ch. 3, p. 107), so a dom11 voicing is the correct painting-by-numbers lookup result when the melody note is the 11th above the V chord root. However, the 11th also appears at the top of the omittable-notes priority list — 'Intervals most commonly omitted include the 5th, the root (1st), the 11th, and the 9th' (Ch. 2, p. 79) — meaning it is the third most expendable tone and is readily cut when a four-note voicing cap or playability demands it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — closed vocabulary including '11, #11'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 79 — 'most commonly omitted include the 5th, the root (1st), the 11th, and the 9th'"
+            }
+          ],
+          "cross_ref": [
+            "dom13/dominant-v-extension-top",
+            "dom7#11/dominant-v-tritone-color"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7alt",
+          "function_role": "dominant-v-altered-sub",
+          "narrative": "O'Rourke defines the '7alt or altered dominant sub-family' as a distinct class including C7(b9), C7(b13b9), C7(b5), and C7alt (Ch. 2, p. 34), and prescribes this sub-family for the V chord in minor ii-V-i cadences. The minor ii-V-i chord dictionaries on both string sets carry voicings 'with the b5 and b9 alterations characteristic of the minor cadence' (Ch. 8 summary), making dom7alt the prescribed V quality whenever the harmonic analysis identifies a minor cadence context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — '7alt or altered dominant sub-family – e.g. C7(b9), C7(b13b9), C7(b5), C7alt'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 275 — 'MINOR II V I CHORDS – STRING SET 5432' (b5 and b9 alterations)"
+            }
+          ],
+          "cross_ref": [
+            "dom7b9/dominant-v-minor-cadence",
+            "min7b5/half-dim-ii-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7alt",
+          "function_role": "dominant-v-tritone-result",
+          "narrative": "When the Tritone Substitution Rule is applied to a dom7 — 'replace any chord with another whose root is a tritone away' (Ch. 7, p. 220) — the resulting substitute chord often functions as a dom7alt quality because its root is a semitone above the resolution chord, producing characteristic b9/b13 tensions against the target key. O'Rourke notes that the shared guide tones (3rd and 7th swap positions) are what make the substitution aurally convincing: 'Because the two chords have those 3rd and 7th as common tones, they can be substituted for one another' (Ch. 7, p. 216).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 220 — 'Tritone Substitution Rule — replace any chord with another whose root is a tritone away'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 216 — 'Because the two chords have those 3rd and 7th as common tones, they can be substituted'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-tritone-sub-target",
+            "dom7b9/dominant-v-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7b9",
+          "function_role": "dominant-v-minor-cadence",
+          "narrative": "C7(b9) is one of O'Rourke's exemplar altered dominant voicings (Ch. 2, p. 34) and the b9 is a chord-tone vocabulary key: '1, b9, 9…' (Ch. 3, p. 107). When the melody note is the b9 above the V chord in a minor cadence, the painting-by-numbers rule prescribes a dom7b9 voicing with b9 on top. The Minor ii-V-i dictionary sections on string sets 4321 and 5432 carry this voicing, and the 'b5 and b9 alterations characteristic of the minor cadence' (Ch. 8 summary) mark it as the canonical tensioned V voicing in minor contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — 'C7(b9)' as an altered dominant example"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — closed vocabulary including 'b9'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-altered-sub",
+            "min7b5/half-dim-ii-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7b5",
+          "function_role": "dominant-v-altered-b5",
+          "narrative": "C7(b5) is explicitly listed in the altered dominant sub-family (Ch. 2, p. 34), and the b5 is also the characteristic alteration of the minor ii chord (min7b5), reflecting the symmetry of the minor cadence. When the melody note is the #11/b5 above the V chord, the painting-by-numbers rule prescribes a dom7b5 voicing with that note on top. O'Rourke's 'Tensions and Extensions on Dominant Chords' dictionary section (Ch. 8, p. 278) catalogues voicings for this quality as part of the color resource available to the arranger.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — 'C7(b5)' listed in the altered dominant sub-family"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 278 — 'TENSIONS & EXTENSIONS ON DOMINANT CHORDS'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-altered-sub",
+            "dom7#11/dominant-v-tritone-color"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7#9",
+          "function_role": "dominant-v-altered-sharp-9",
+          "narrative": "The #9 is a valid chord-tone index key within the closed vocabulary (implied by O'Rourke's inclusion of b3/#9 enharmonic equivalence through the 'b3' label in his interval list: '1, b9, 9, b3, 3, 11, #11, 5, b13, 13, b7, 7', Ch. 3, p. 107). Dom7#9 voicings appear in the 'Tensions and Extensions on Dominant Chords' section (Ch. 8, p. 278) as part of the altered dominant color palette. When the melody note is the #9 above the V chord the painting-by-numbers lookup routes to this voicing, and the restraint rule applies: use it 'occasionally for color' (Ch. 7, p. 222).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — 'b3' in closed chord-tone vocabulary (enharmonic #9)"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 278 — 'TENSIONS & EXTENSIONS ON DOMINANT CHORDS'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-altered-sub",
+            "dom7b9/dominant-v-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7#11",
+          "function_role": "dominant-v-tritone-color",
+          "narrative": "The #11 is an explicit chord-tone index key in the closed vocabulary (Ch. 3, p. 107) and appears as an altered tension example — 'G7(b13#9)' and by implication #11 voicings — in Chapter 2 (p. 80). When the melody note is the #11 above the V chord, the painting-by-numbers rule prescribes a dom7#11 voicing with #11 on top. This quality is the dominant analog of the tritone substitution: the #11 tone is enharmonically the b5 of the tritone-away chord, so dom7#11 voicings naturally surface in tritone-substitution contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — closed vocabulary including '#11'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 80 — altered tensions cited as 'G7(b13#9)' and similar examples"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-tritone-sub-target",
+            "dom7alt/dominant-v-tritone-result"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "aug7",
+          "function_role": "dominant-v-augmented-approach",
+          "narrative": "The b13 is a valid chord-tone index key in O'Rourke's closed vocabulary — '1, b9, 9, b3, 3, 11, #11, 5, b13, 13, b7, 7' (Ch. 3, p. 107) — and C7(b13b9) is cited as an altered dominant example (Ch. 2, p. 34). Aug7 voicings (dom7 with raised 5th / b13) emerge from this altered-dominant family and appear in the 'Tensions and Extensions on Dominant Chords' dictionary (Ch. 8, p. 278). When the melody note is b13 above the V chord, an aug7 voicing with b13 on top is the prescribed painting-by-numbers lookup result.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — closed vocabulary including 'b13'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — 'C7(b13b9)' as an altered dominant example"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-altered-sub",
+            "dom7b9/dominant-v-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dim7",
+          "function_role": "passing-diminished-approach",
+          "narrative": "O'Rourke prescribes chromatic passing-chord motion by repeating 'the same voicing one fret away from the target' (Ch. 5, p. 197), and in the up-tempo arrangement examples of Chapter 6 'diads, octaves, and passing chords' stack together (Ch. 6, p. 206). Diminished seventh voicings function as symmetrical passing chords — every fret shift of a dim7 shape produces another valid dim7 — making them especially suited to the one-fret-away chromatic approach rule. The restraint axiom applies: passing chords are 'used to drive faster arrangements' (Ch. 6 summary) rather than deployed on every bar.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 197 — 'play the same voicing one fret away for the approach note in the melody'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 6",
+              "citation": "p. 206 — 'diads, octaves, and passing chords being a feature'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/chromatic-approach-parallel",
+            "dom7alt/chromatic-approach-parallel"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min6",
+          "function_role": "tonic-i-minor-shell-color",
+          "narrative": "O'Rourke's 6th-for-7th substitution rule applies to minor voicings as well: 'the 6th interval can also be used instead of the 7th which gives a warmer, more resolved sound' (Ch. 5, p. 147). A minor shell voicing becomes min6 (root–b3–6) when the 7th is replaced by the 6th, and this quality is prescribed as the correct choice when the expressive target is resolution and warmth rather than the open tension of a min7. The 6th is listed as a standard interval in the chord-tone vocabulary (Ch. 3, p. 107), so min6 voicings index into the painting-by-numbers lookup when the melody note is the 6th above a minor chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 147 — '6th interval can also be used instead of the 7th which gives a warmer, more resolved sound'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — closed vocabulary including '13' (major 6th equivalent in minor context)"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii-collection-lookup",
+            "maj6/tonic-i-resolved-color"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min-maj7",
+          "function_role": "tonic-i-minor-leading-tone",
+          "narrative": "The chord-tone vocabulary includes '7' (major 7th) as a valid index key (Ch. 3, p. 107), and O'Rourke's Three Harmonic Families taxonomy places minor chords in their own family with extensions stacked on the minor triad just as on major or dominant (Ch. 2, p. 78). A min-maj7 voicing results from placing the major 7th on top of a minor triad, and the painting-by-numbers rule prescribes this voicing when the melody note is the major 7th interval above a minor chord. It also surfaces in back-cycling contexts where a tonic minor resolution chord needs a leading-tone tension.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — closed vocabulary including '7' (major 7th)"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 78 — 'continuing to stack more and more thirds onto the structure'"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii-collection-lookup",
+            "min9/supertonic-ii-extension-top"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "sus4",
+          "function_role": "dominant-v-suspension-approach",
+          "narrative": "The 11th (sus4 equivalent) is a valid chord-tone index key in O'Rourke's closed vocabulary (Ch. 3, p. 107), and the 11th is the characteristic upper tone of a suspended dominant. When the melody note is the 11th above a dominant chord, the painting-by-numbers lookup can route to a sus4 voicing with the 11 on top as an alternative to a full dom11. The 11th is listed third in the omittable-notes priority — '5th, root, 11th, and 9th' (Ch. 2, p. 79) — so the sus4 quality may be reduced to a simpler voicing when the fretboard demands it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — closed vocabulary including '11'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 79 — '11th' listed as commonly omitted"
+            }
+          ],
+          "cross_ref": [
+            "dom11/dominant-v-11th-top",
+            "dom7/dominant-v-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "dont-harmonize-long-note-only",
+          "narrative": "O'Rourke's headline pedagogical rule is that 'you don't need a chord on every melody note' (Ch. 1, p. 23), and specifically that chords are placed on 'long-held melody notes' and at chord changes. For maj7 (and all other qualities) this means a voicing is only deployed when the melody note is long enough to carry it — shorter passing notes receive either a PT label or no harmonization. 'Notice on the above example, I mainly place chords on the long-held melody notes. It sounds great and is easy on the hands' (Ch. 1, p. 23). This rule governs voicing deployment density across all chord qualities.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 1",
+              "citation": "p. 23 — 'You don't need a chord on every melody note.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 1",
+              "citation": "p. 23 — 'I mainly place chords on the long-held melody notes.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii-collection-lookup",
+            "dom7/dominant-v-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "dont-overuse-substitutions",
+          "polarity": "proscriptive",
+          "narrative": "O'Rourke explicitly warns against overusing substitutions on dominant chords: 'Keeping things simple most of the time and just adding a substitution occasionally to brighten up the arrangement is the approach I find works best – a good arrangement is all about subtlety!' (Ch. 7, p. 222). Because dominant chords are the primary vehicle for jazz color and substitution, this proscription is most acutely relevant to dom7 and its altered variants. Dense back-cycling chains or tritone substitutions on every dominant are proscribed as undermining the arrangement's subtlety.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 222 — 'Keeping things simple most of the time and just adding a substitution occasionally … a good arrangement is all about subtlety!'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-altered-sub",
+            "dom7b9/dominant-v-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "interval-vs-key-error-guard",
+          "polarity": "proscriptive",
+          "narrative": "O'Rourke flags the single most common beginner error in interval analysis directly in the context of voicing selection for all chord qualities: 'The interval number we give a melody note must relate to the current chord in the progression – NOT the overall key of the progression. This is a common mistake beginner arrangers often make' (Ch. 3, p. 107). For maj7 specifically, labeling the melody note against the overall key rather than the current maj7 chord will produce an incorrect dictionary lookup, resulting in a voicing with the wrong interval on top — the exact opposite of the painting-by-numbers rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — 'interval number we give a melody note must relate to the current chord … NOT the overall key'"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii-collection-lookup",
+            "dom7/dominant-v-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "interval-vs-key-error-guard",
+          "polarity": "proscriptive",
+          "narrative": "The golden rule of interval analysis — 'Always relate the interval to the chord at that point in the chord progression' (Ch. 3, p. 110) — is equally applicable to minor chords. For min7 voicings as the ii chord, labeling the melody interval against the overall key (rather than the current min7 root) will produce a wrong-quality voicing from the dictionary. O'Rourke reinforces this with the major-scale reference rule: 'To find the correct interval number, you always refer to the major scale of the current chord' (Ch. 3, p. 108), which for a Dm7 means the D major scale, not the C major key scale.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 110 — 'Always relate the interval to the chord at that point in the chord progression'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 108 — 'you always refer to the major scale of the current chord'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/interval-vs-key-error-guard",
+            "dom7/interval-vs-key-error-guard"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "interval-vs-key-error-guard",
+          "polarity": "proscriptive",
+          "narrative": "For dominant chords the interval-labeling error is particularly consequential because the dominant family spans both natural and altered sub-families: choosing the wrong reference scale will conflate, for instance, the b7 of the dominant with the 6th of the key. O'Rourke's golden rule — 'Always relate the interval to the chord at that point in the chord progression' (Ch. 3, p. 110) — and the major-scale-of-the-root reference rule (Ch. 3, p. 108) together ensure that the three-input lookup (string, chord type, interval) produces a voicing from the correct dominant sub-family dictionary section.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 110 — 'Always relate the interval to the chord at that point in the chord progression'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 108 — 'you always refer to the major scale of the current chord'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/interval-vs-key-error-guard",
+            "min7/interval-vs-key-error-guard"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "playability-remove-voicing-entirely",
+          "narrative": "O'Rourke's most-used personal remediation strategy is removing the difficult voicing entirely: 'Removing the difficult voicings completely often makes the whole passage work much better on the guitar – it helps my hands to relax' (Ch. 4, p. 126). This applies to all chord qualities but is especially pertinent for complex dominant voicings with multiple alterations where cut-note remediation still leaves an awkward shape. Removing the chord is sanctioned as a third option alongside cutting notes and substituting diads/octaves (Ch. 4, p. 125–126).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 126 — 'Removing the difficult voicings completely often makes the whole passage work much better on the guitar.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-altered-sub",
+            "min7b5/half-dim-ii-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "four-note-ceiling-right-hand",
+          "polarity": "proscriptive",
+          "narrative": "O'Rourke imposes a hard voicing-density ceiling from the right-hand perspective: 'I rarely use the little finger (c) on the right hand with fingerstyle technique – I tend to stick to 4-note voicings as a maximum which means you will only need to use your four strongest fingers – p i m a' (Ch. 9, p. 298). For maj7 this means a five-note extension chord (root–3–5–7–9) must be reduced before it can be played, and the omittable-notes priority (5th and root first) provides the prescribed reduction path.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 9",
+              "citation": "p. 298 — '4-note voicings as a maximum … only need to use your four strongest fingers – p i m a'"
+            }
+          ],
+          "cross_ref": [
+            "maj9/tonic-i-extension-color",
+            "maj7#11/tonic-i-altered-extension"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "four-note-ceiling-right-hand",
+          "polarity": "proscriptive",
+          "narrative": "The four-note voicing ceiling (Ch. 9, p. 298) applies universally but is especially consequential for dominant chord extensions and alterations, which in theory can stack six or more tones. O'Rourke's omittable-notes rule (Ch. 2, p. 79) provides the reduction path: cut the 5th, root, 11th, and 9th in that order. For altered dominants this still leaves a functional voicing containing the defining 3rd, b7, and at least one alteration — consistent with the prescriptive goal of targeting extensions 'particularly to dominant chords' for jazz color (Ch. 4, p. 127).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 9",
+              "citation": "p. 298 — '4-note voicings as a maximum'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 79 — '5th, root, 11th, and 9th' as most commonly omitted"
+            }
+          ],
+          "cross_ref": [
+            "dom13/dominant-v-extension-top",
+            "dom7alt/dominant-v-altered-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "four-note-ceiling-right-hand",
+          "polarity": "proscriptive",
+          "narrative": "The four-note voicing ceiling (Ch. 9, p. 298) governs minor voicings as well. A fully-voiced Cm13 would require more than four fingers, so the prescribed reduction path (omit 5th, root, 11th, 9th first) reduces it toward a min7 or min9 shell. For the ii chord in a major cadence, where the min7 quality is the indexed dictionary entry, this ceiling actually reinforces the lean voicing: the essential minor sound is defined by b3 and b7, both of which are not on the omittable list as primary cuts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 9",
+              "citation": "p. 298 — '4-note voicings as a maximum'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 79 — 'even the 3rd and the 7th can be omitted for more complex chords in certain situations'"
+            }
+          ],
+          "cross_ref": [
+            "min9/supertonic-ii-extension-top",
+            "min7b5/half-dim-ii-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "context-defines-chord-name",
+          "narrative": "O'Rourke's terminological rule — 'A chord's sound is as much defined by the chords that are around it in the progression, just as much as the notes of the chord themselves' (Ch. 2, p. 84) — governs how maj7 voicings are selected and labeled. This means that a voicing that would be a maj7 in isolation can function differently when surrounded by different chords, and the arranger must select the voicing that serves the progression context rather than simply matching abstract theoretical correctness. This rule directly foreshadows Chapter 7's substitution machinery.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 84 — 'A chord's sound is as much defined by the chords that are around it in the progression.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-tritone-sub-target",
+            "min7/i-to-vi-relative-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "sustain-workaround-chord-change",
+          "narrative": "Because 'the long melody notes ring out quickly on guitar,' O'Rourke prescribes placing a chord voicing at the chord change to 'imply sustain rather than trying to hold them for their full length' (Ch. 1, p. 23). For dominant chords at V this is especially useful: the quick guitar decay means a dom7 voicing placed on the beat of the chord change will acoustically project the harmony through the subsequent melody notes without requiring physical sustain. This is one of the core guitar-specific constraints that shapes voicing deployment across all qualities.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 1",
+              "citation": "p. 23 — 'The long melody notes ring out quickly on guitar, so rather than trying to hold them for their full length, I place a chord voicing to emphasize the change of chord instead.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/dont-harmonize-long-note-only",
+            "min7/supertonic-ii-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "back-cycling-approach-chain",
+          "narrative": "Back cycling via the circle of fourths (Ch. 7, p. 237) inserts additional chords before an existing chord in the progression. When the target is a min7 ii chord, back cycling backward through the circle prescribes adding a dom7 a fourth away, then optionally another, creating a dom7–dom7–min7 approach chain. This is consistent with the broader back-cycling rule: 'you can add chords to the chord progression of a song based on the back cycle, i.e. the circle of fourths' (Ch. 7, p. 243), and the min7 serves as the resolution goal of the chain.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 243 — 'Back cycling substitution rule — you can add chords based on the circle of fourths'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 237 — 'cycle of root notes a 4th apart is the most common root movement in Western music'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/back-cycling-chain",
+            "maj7/tonic-i-melody-top"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "melodic-common-tone-sub",
+          "narrative": "The Melodic Common Tone Substitution Rule — 'substitute any chord for another chord, as long as the new chord has a note in common with it that you use as the melody note on top' (Ch. 7, p. 247) — is especially powerful applied to dominant chords because the rich extension vocabulary of the dominant family maximises the chance of finding a common melody-tone match with an unexpected substitute quality. This rule 'drives modern Rosenwinkel/Kreisberg-style colors' and is the most harmonically adventurous of the five substitution rules codified in Chapter 7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 247 — 'Melodic common tone substitution rule: substitute any chord for another chord, as long as the new chord has a note in common with it that you use as the melody note on top.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/melodic-common-tone-sub",
+            "min7/melodic-common-tone-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "melodic-common-tone-sub",
+          "narrative": "O'Rourke's fifth substitution rule — 'substitute any chord for another chord, as long as the new chord has a note in common with it that you use as the melody note on top' (Ch. 7, p. 247) — can replace a maj7 I chord with any chord quality that shares the current melody note. This is the most open-ended of the five rules and produces the modern jazz colors attributed to Rosenwinkel and Kreisberg. The restraint axiom still frames its use: add substitutions 'occasionally for color' rather than systematically (Ch. 7, p. 222).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 247 — 'Melodic common tone substitution rule: substitute any chord for another chord, as long as the new chord has a note in common with it that you use as the melody note on top.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 222 — 'adding a substitution occasionally to brighten up the arrangement'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/melodic-common-tone-sub",
+            "min7/melodic-common-tone-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "melodic-common-tone-sub",
+          "narrative": "The Melodic Common Tone Substitution Rule (Ch. 7, p. 247) allows any minor chord — including min7 — to substitute for a target chord as long as the min7 voicing contains the melody note on top. This rule's power is that it is not quality-restricted: a min7 can substitute for a maj7, a dom7, or another min7, provided the common-tone melody constraint is satisfied. The broader minor conversion concept ('any chord you see in a progression could be substituted for a minor chord', Ch. 7, p. 229) is the theoretical ancestor of this rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 247 — 'substitute any chord for another chord, as long as the new chord has a note in common with it that you use as the melody note on top'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 229 — 'any chord you see in a progression could be substituted for a minor chord instead'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/melodic-common-tone-sub",
+            "dom7/melodic-common-tone-sub"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "trio-vs-solo-bass-prominence",
+          "narrative": "When arranging dominant chord passages for solo guitar, bass notes on the 5th and 6th strings must be prominently voiced beneath the dominant voicing: 'you no longer have a bass player to play with, so you need to fill that role ourselves – otherwise, the arrangement will sound thin and empty' (Ch. 5, p. 140). The diagnostic — 'the bass is too close to the upper harmony, which results in a thin sound' (Ch. 5, p. 142) — applies especially to dominant voicings where a tight bass-to-chord spacing is most likely to produce muddiness.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 140 — 'you need to fill that role ourselves – otherwise, the arrangement will sound thin and empty'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 142 — 'the bass is too close to the upper harmony, which results in a thin sound'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i-shell-solo-guitar",
+            "min7/supertonic-ii-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "trio-vs-solo-bass-prominence",
+          "narrative": "For maj7 I chords in solo guitar arrangements, the bass note on the 5th or 6th string must project clearly below the shell voicing. O'Rourke prescribes a bass-notes-at-changes drill as an intermediate step: 'a good exercise is to add a bass note underneath the melody at each chord change' (Ch. 5, p. 157) before adding full voicings. The bass voice on the 6th string rooted shell voicing family (Ch. 8, p. 280) provides the structural backbone for this approach on maj7 chords.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 157 — 'a good exercise is to add a bass note underneath the melody at each chord change'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 280 — 'SHELL VOICINGS — Root on the 6th String'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/trio-vs-solo-bass-prominence",
+            "min7/supertonic-ii-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "trio-vs-solo-bass-prominence",
+          "narrative": "Min7 ii chords in solo guitar arranging require bass notes on the 5th and 6th strings to avoid the thin sound that results from 'bass voiced too close to the upper harmony' (Ch. 5, p. 142). For minor chords the shell voicing prescription — root, 3rd (b3 for minor), and 7th (b7) — ensures an open spread when placed above a low bass note on string 5 or 6. The preference for keys with open strings (A, E, D) helps sustain bass notes under ii chord voicings without taxing the fretting hand (Ch. 5, p. 142).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 142 — 'bass is too close to the upper harmony, which results in a thin sound'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 142 — 'Choosing a key like A, E, or D gives you essentially another set of free fingers'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/trio-vs-solo-bass-prominence",
+            "dom7/trio-vs-solo-bass-prominence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "arpeggiation-ballad-filler",
+          "narrative": "O'Rourke prescribes arpeggiation — 'plucking the notes of a chord one at a time, instead of a block of notes played simultaneously' (Ch. 5, p. 169) — as the primary device for filling melodic space in slow ballads around I chord harmonizations: 'This rendition is a good example of using arpeggiation to fill in the long spaces between each melody note in this slow ballad' (Ch. 6, p. 201). For maj7 chords specifically this means arpeggiating through the root, 3rd, 5th, and 7th in the space between long melody notes to sustain musical motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 169 — 'Arpeggiation is when you pluck the notes of a chord one at a time.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 6",
+              "citation": "p. 201 — 'using arpeggiation to fill in the long spaces between each melody note in this slow ballad'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i-melody-top",
+            "min7/arpeggiation-ballad-filler"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "arpeggiation-ballad-filler",
+          "narrative": "Arpeggiation as a space-filler device (Ch. 5, p. 169; Ch. 6, p. 201) applies equally to ii chord min7 voicings in slow ballads. O'Rourke's solo-guitar aesthetic strategy of 'alternating through different devices gives the illusion to the audience of a complete band' (Ch. 5, p. 138) prescribes that after playing a min7 voicing the arranger may arpeggiate through its tones before the next chord arrives, maintaining musical interest without requiring a new block chord placement.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 138 — 'alternating through these different devices gives the illusion to the audience of a complete band'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 169 — 'Arpeggiation is when you pluck the notes of a chord one at a time.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/arpeggiation-ballad-filler",
+            "dom7/arpeggiation-ballad-filler"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "arpeggiation-ballad-filler",
+          "narrative": "Dominant chords are the prescribed color-tension vehicles (Ch. 4, p. 127), and arpeggiation is one of O'Rourke's four core solo-guitar devices (Ch. 5, p. 169). Arpeggiating through a dom7 voicing — including its extensions — in the spaces between melody notes is a sanctioned technique for slow ballads, and it allows altered tones like the b9 or b13 to be heard without the difficulty of simultaneously fretting a full altered-dominant block chord. The device is confirmed in the arrangement study material of Chapter 6.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 169 — 'Arpeggiation is when you pluck the notes of a chord one at a time.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 127 — 'The jazzy sound … particularly to dominant chords'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-v-altered-sub",
+            "maj7/arpeggiation-ballad-filler"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "diad-melody-support",
+          "narrative": "Diads — 'harmonizing a line in a parallel interval, usually 3rds or 6ths' in 'Barney-Kessel-style' (Ch. 5, p. 180) — are prescribed as 'a primary melody-support layer' (Ch. 6, p. 201). Over a maj7 I chord context, diad 3rds or 6ths below the melody are the prescribed reduction when a full four-note block chord is either too awkward or too dense. 'Diads are also used frequently to provide support to the melody line' (Ch. 6, p. 201), and they qualify as one of the three remediation strategies for awkward passages (Ch. 4, p. 125).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 180 — 'Diads are when you harmonize a line in a parallel interval, usually 3rds or 6ths.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 6",
+              "citation": "p. 201 — 'Diads are also used frequently to provide support to the melody line.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/diad-melody-support",
+            "min7/diad-melody-support"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "diad-melody-support",
+          "narrative": "Over dominant chord contexts diads in 3rds or 6ths (Ch. 5, p. 180) are prescribed as the alternative harmonization when block-chord dominant voicings prove awkward. The up-tempo arranging formula of 'diads, octaves, and passing chords' (Ch. 6, p. 206) shows that diads are particularly prominent on dominant chords in faster passages where block voicings would impede rhythmic flow. This is consistent with the restraint axiom: 'less is more – placing chords at key places is easier on the hands and is usually more than enough to imply the harmony' (Ch. 4, p. 122).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 180 — 'Diads are when you harmonize a line in a parallel interval, usually 3rds or 6ths.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 6",
+              "citation": "p. 206 — 'diads, octaves, and passing chords being a feature in this rendition'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/diad-melody-support",
+            "min7/diad-melody-support"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "diad-melody-support",
+          "narrative": "For ii chord min7 contexts, diads in 3rds or 6ths (Ch. 5, p. 180) are the prescribed harmonic-reduction device when full voicings are impractical. The prescriptive path through the three remediation strategies — cut notes, substitute diads/octaves, or remove the chord — places diads as the second option (Ch. 4, p. 125). O'Rourke frames diads specifically as 'a different harmonization approach' (Ch. 4, p. 125), confirming that they carry harmonic information about the chord quality even in two-note form.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 125 — 'Choose a different harmonization approach – e.g. instead of block chords I could use parallel octaves or diads.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 180 — 'Diads are when you harmonize a line in a parallel interval, usually 3rds or 6ths.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/diad-melody-support",
+            "dom7/diad-melody-support"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "octave-melody-doubling",
+          "narrative": "Octaves — 'doubling the melody one octave down' in 'Wes-Montgomery-style' (Ch. 5, p. 174) — are prescribed as a melody-support device over maj7 I chord contexts, particularly in up-tempo passages where they stack with diads and passing chords (Ch. 6, p. 206). The muting technique is mandatory: 'when playing the octaves, mute the unwanted open string between the octave notes by gently touching the string with your first finger' (Ch. 5, p. 179). The octave device avoids the need for a chord voicing altogether while still projecting the melody with harmonic weight.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 174 — 'Octaves are a case of doubling the melody one octave down.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 179 — 'mute the unwanted open string between the octave notes by gently touching the string with your first finger'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/octave-melody-doubling",
+            "min7/octave-melody-doubling"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "octave-melody-doubling",
+          "narrative": "Octave doubling (Ch. 5, p. 174) is prescribed for dominant chord passages in the up-tempo arranging formula: 'diads, octaves, and passing chords' are features of up-tempo renditions (Ch. 6, p. 206). Over V dominant chord contexts, playing the melody in octaves simultaneously outlines the dominant quality through approach and resolution without requiring the performer to fret a full dom7 voicing — a practical tool when faster passage-work makes block-chord fingering impractical.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 174 — 'Octaves are a case of doubling the melody one octave down.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 6",
+              "citation": "p. 206 — 'diads, octaves, and passing chords being a feature'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/octave-melody-doubling",
+            "min7/octave-melody-doubling"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "octave-melody-doubling",
+          "narrative": "For ii chord min7 passages, octave doubling (Ch. 5, p. 174) is a sanctioned substitute for a block voicing, especially when the melody moves quickly over the ii–V–I cadence and a full min7 voicing would be awkward. Octaves are one of O'Rourke's four core solo-guitar devices and appear as part of the remediation options for hard passages (Ch. 4, p. 125: 'substitute a different harmonization device such as parallel octaves or diads'). They carry the melodic line with weight while leaving the harmonic identity to be implied by context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 125 — 'substitute a different harmonization device such as parallel octaves or diads'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 174 — 'Octaves are a case of doubling the melody one octave down.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/octave-melody-doubling",
+            "dom7/octave-melody-doubling"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "range-placement-muddy-low-guard",
+          "polarity": "proscriptive",
+          "narrative": "O'Rourke's range rule of thumb — 'find a key where you can play the melody on the top 3 strings, roughly from the 3rd to the 9th fret' (Ch. 1, p. 19) — has an explicit low-end failure mode: 'if your arrangement is too low in the register, it will sound too dark and muddy' (Ch. 1, p. 19). For dominant chord voicings this proscription means that dom7 shapes placed in the low-fret region of the neck below roughly the 3rd fret risk adding muddiness rather than color, especially when alterations are added on top of an already low-register root.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 1",
+              "citation": "p. 19 — 'if your arrangement is too low in the register, it will sound too dark and muddy'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 1",
+              "citation": "p. 19 — 'roughly from the 3rd to the 9th fret'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/range-placement-thin-high-guard",
+            "min7b5/half-dim-ii-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "range-placement-thin-high-guard",
+          "polarity": "proscriptive",
+          "narrative": "The upper failure mode of the range rule proscribes placing chord-melody arrangements — including maj7 I chords — too high on the neck: 'if the arrangement is too high, it will sound like it doesn't have enough depth' (Ch. 1, p. 19). Maj7 voicings played exclusively in the upper positions (above roughly the 9th fret) lose the low-string bass prominence that is 'the key difference between a trio and solo guitar' (Ch. 5, p. 140). The prescriptive solution is transposing to a key where the melody sits in the 3rd-to-9th-fret window.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 1",
+              "citation": "p. 19 — 'If the arrangement is too high, it will sound like it doesn't have enough depth.'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 1",
+              "citation": "p. 19 — 'roughly from the 3rd to the 9th fret'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/range-placement-muddy-low-guard",
+            "min7/supertonic-ii-collection-lookup"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "walking-bass-approach-voice",
+          "narrative": "O'Rourke's four-step walking-bass recipe prescribes filling beats 2 and 3 with 'diatonic notes from the scale of the given key, chromatic notes, or arpeggios' between the beat-1 root and a beat-4 approach note (Ch. 5, p. 185). When the target chord is dom7, the beat-1 root establishes the dominant bass, and the beat-4 approach note is typically a half-step or fourth away, with the two fill notes connecting chromatically or diatonically. The dom7 quality is the canonical walking-bass context in jazz because of 'the most common root movement in Western music' — the cycle of fourths (Ch. 7, p. 237).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 185 — 'fill beats 2 and 3 with diatonic notes, chromatic notes, or arpeggios'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 237 — 'cycle of root notes a 4th apart is the most common root movement in Western music'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/walking-bass-approach-voice",
+            "min7/walking-bass-approach-voice"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "walking-bass-approach-voice",
+          "narrative": "When the walking-bass four-step recipe (Ch. 5, p. 185) targets a maj7 I chord resolution, the beat-1 root is the major chord root, beats 2 and 3 carry the transitional fill notes, and the beat-4 approach note leads into the next chord's root by a half-step, fourth, or arpeggio tone. The bass-notes-at-changes drill — 'add a bass note underneath the melody at each chord change' (Ch. 5, p. 157) — is the prescribed primer for developing this skill before walking lines are added.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 185 — 'fill beats 2 and 3 with diatonic notes, chromatic notes, or arpeggios between the beat-1 root and the beat-4 approach note'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 157 — 'add a bass note underneath the melody at each chord change'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/walking-bass-approach-voice",
+            "min7/walking-bass-approach-voice"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "walking-bass-approach-voice",
+          "narrative": "In walking-bass passages, when the ii chord min7 is the target, the beat-1 root establishes the minor bass note and beats 2–3 carry fill notes from the diatonic scale, chromatic approach, or chord arpeggio (Ch. 5, p. 185). The beat-4 approach note typically targets the dominant V root a fourth above, creating the min7 → dom7 root motion that is 'the most common root movement in Western music' (Ch. 7, p. 237). This makes the min7 ii chord the natural first link of the ii–V–I walking-bass chain.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 185 — 'fill beats 2 and 3 with diatonic notes, chromatic notes, or arpeggios'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 7",
+              "citation": "p. 237 — 'cycle of root notes a 4th apart is the most common root movement in Western music'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/walking-bass-approach-voice",
+            "maj7/walking-bass-approach-voice"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "simultaneous-pluck-chord-identity",
+          "narrative": "For any dom7 voicing to register as a chord rather than an arpeggiation, O'Rourke imposes a simultaneity rule: 'Regardless of which fingers you use, ensure that both fingers sound the notes simultaneously' (Ch. 9, p. 298). This is the right-hand technical constraint that underlies every chord placement in the book. If the dom7 tones are plucked sequentially they produce an arpeggiation device (Ch. 5, p. 169) rather than a harmonic block, which is a different expressive result and belongs to a different arranging context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 9",
+              "citation": "p. 298 — 'ensure that both fingers sound the notes simultaneously'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 5",
+              "citation": "p. 169 — 'Arpeggiation is when you pluck the notes of a chord one at a time, instead of a block of notes played simultaneously.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/simultaneous-pluck-chord-identity",
+            "min7/simultaneous-pluck-chord-identity"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "simultaneous-pluck-chord-identity",
+          "narrative": "The simultaneity rule — 'ensure that both fingers sound the notes simultaneously' (Ch. 9, p. 298) — governs how maj7 block chords are executed with fingerstyle technique. O'Rourke's prescribed finger groupings for three-note chords (pim or ima) and four-note chords (pima) must fire together to produce a chord rather than an arpeggio. The fingerstyle technique justification is stated at the chapter's opening: 'this technique allows you to easily play multiple voices at once on one guitar – enabling you to create complex chord melody arrangements' (Ch. 9, p. 286).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 9",
+              "citation": "p. 298 — 'ensure that both fingers sound the notes simultaneously'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 9",
+              "citation": "p. 286 — 'this technique allows you to easily play multiple voices at once on one guitar'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/simultaneous-pluck-chord-identity",
+            "min7/simultaneous-pluck-chord-identity"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "simultaneous-pluck-chord-identity",
+          "narrative": "Min7 ii chord voicings must be plucked simultaneously to register as block chords (Ch. 9, p. 298). In the context of the ii–V–I chord-melody arrangement workflow, the min7 voicing placed on the first melody note of the ii chord bar (Ch. 4, p. 113) must sound as a unit, not as an arpeggio, to deliver the correct harmonic information at the correct metric position. The p+i or i+m two-finger pairing, or pim/ima three-finger grouping, is the prescribed right-hand execution (Ch. 9, p. 298).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 9",
+              "citation": "p. 298 — 'ensure that both fingers sound the notes simultaneously'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 113 — 'applying a chord to the first melody note of each bar and/or chord change'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/simultaneous-pluck-chord-identity",
+            "dom7/simultaneous-pluck-chord-identity"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7alt",
+          "function_role": "minor-cadence-subfamily-selection",
+          "narrative": "O'Rourke's minor sub-family distinction — 'm7b5' for ii and '7alt' for V — is 'what drives major-vs-minor ii-V-i voicing choice' (Ch. 2, p. 34). When harmonic analysis identifies a minor cadence the arranger is prescribed to use the 7alt sub-family for the V chord rather than a natural '7' dominant: the minor dictionary sections in Chapter 8 are explicitly built around these altered voicings. Using a natural dom7 on the V of a minor ii-V-i would produce an incorrect sub-family match and undermines the characteristic minor-cadence sound.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — '7alt or altered dominant sub-family – e.g. C7(b9), C7(b13b9), C7(b5), C7alt'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 272–275 — Minor II V I dictionary sections built around b5 and b9 alterations"
+            }
+          ],
+          "cross_ref": [
+            "min7b5/half-dim-ii-minor-cadence",
+            "dom7b9/dominant-v-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7b5",
+          "function_role": "minor-cadence-subfamily-ii-selection",
+          "narrative": "The m7b5 sub-family is the prescribed ii chord quality for minor cadences, distinguished by O'Rourke from the m7 sub-family precisely because 'the sub-family distinction drives major-vs-minor ii-V-i voicing choice' (Ch. 2, p. 34). Choosing a plain min7 as the ii chord of a minor cadence would be incorrect: the b5 alteration is the defining interval that signals the minor ii and links harmonically to the b9 of the following dom7alt V chord. Both the 4321 and 5432 minor ii-V-i dictionary sections carry min7b5 voicings as the ii chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 2",
+              "citation": "p. 34 — 'm7b5 sub-family – e.g. Cm7b5, Cm11b5'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 272 — 'MINOR II V I CHORDS – STRING SET 4321' featuring min7b5 as the ii chord"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/minor-cadence-subfamily-selection",
+            "dom7b9/dominant-v-minor-cadence"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "comping-before-voicing-selection",
+          "narrative": "Before selecting specific chord-melody voicings O'Rourke prescribes a comping pre-step: 'something good to do before getting into the nitty-gritty of what voicings to use is to simply learn the basic chords of the song as if comping in a band' (Ch. 3, p. 100). This pre-step applies to all chord qualities — including the dominant V chord — and its purpose is to 'train your ears to the chord progression' before the painting-by-numbers lookup begins. The basic dom7 comp voicing heard in context gives the arranger an aural reference for whether extensions and alterations are improving or complicating the sound.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 100 — 'simply learn the basic chords of the song as if comping in a band … train your ears to the chord progression'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/comping-before-voicing-selection",
+            "min7/comping-before-voicing-selection"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "comping-before-voicing-selection",
+          "narrative": "O'Rourke's pre-arrangement comping step (Ch. 3, p. 100) applies to the I maj7 chord: the arranger first learns and plays the basic maj7 shape in a comping context before substituting the painting-by-numbers dictionary voicing. This step is framed as a 'gentle way to dip your toes into applying chords to your chosen tune' (Ch. 3, p. 100), and it ensures the harmonic analysis goals — chord qualities, key changes, and recognizable progressions — are confirmed by ear before the mechanical dictionary lookup begins.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 100 — 'a gentle way to dip your toes into applying chords to your chosen tune'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 105 — 'work out the quality of each chord in the progression (major, minor, dominant)'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/comping-before-voicing-selection",
+            "min7/comping-before-voicing-selection"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "comping-before-voicing-selection",
+          "narrative": "The basic-comping-before-voicing prescription (Ch. 3, p. 100) applies to min7 ii chords in the same way as to major and dominant chords. Establishing the min7 sound by ear in a comping context before selecting melody-specific voicings from the dictionary ensures the harmonic analysis step confirms the m7 sub-family (rather than m7b5) and the correct function of the chord within the progression — a necessary prerequisite for the three-input lookup to produce the right dictionary result.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 100 — 'simply learn the basic chords of the song as if comping in a band'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 105 — '3 outcomes: quality of each chord, key changes, common sequences'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/comping-before-voicing-selection",
+            "dom7/comping-before-voicing-selection"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "adapt-voicing-melody-on-top",
+          "narrative": "When the exact dictionary dom7 voicing does not produce the melody note on top, O'Rourke prescribes adaptation rather than abandonment: 'a voicing that can be slightly adapted to have the melody note as the highest note and still sound good' (Ch. 4, p. 114). The practical tool is fretboard sliding: 'just shift the shape down on the fretboard so that the top note matches the same fret where the melody note is' (Ch. 4, p. 118). For dominant chords this may mean raising or lowering the entire voicing shape while preserving its internal interval structure.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 114 — 'a voicing that can be slightly adapted to have the melody note as the highest note'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 118 — 'shift the shape down on the fretboard so that the top note matches'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/adapt-voicing-melody-on-top",
+            "min7/adapt-voicing-melody-on-top"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "adapt-voicing-melody-on-top",
+          "narrative": "O'Rourke's voicing-adaptation carve-out — 'a voicing that can be slightly adapted to have the melody note as the highest note and still sound good' (Ch. 4, p. 114) — is the sanctioned flexibility valve for maj7 I chord voicings whose dictionary shape does not land naturally on the target melody fret. Sliding the maj7 shape to the target fret (Ch. 4, p. 118) preserves the chord quality while aligning the top note with the melody, maintaining the painting-by-numbers prescriptive framework without requiring strict dictionary conformity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 114 — 'voicing can be slightly adapted to have the melody note as the highest note and still sound good'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 118 — 'shift the shape down on the fretboard'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/adapt-voicing-melody-on-top",
+            "min7/adapt-voicing-melody-on-top"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "adapt-voicing-melody-on-top",
+          "narrative": "For min7 ii chord voicings, the same adaptation carve-out applies: the dictionary shape may be slid to position the top note on the target melody fret (Ch. 4, p. 118), preserving the minor quality while achieving melody-on-top alignment. This is especially important for the ii chord, where the melody often sits on an extension (9th, 11th, or 13th) rather than a chord tone, and the dictionary min9 or min11 shape must be transposed to the correct fret by shape-sliding.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 114 — 'voicing can be slightly adapted to have the melody note as the highest note'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 118 — 'shift the shape down on the fretboard so that the top note matches the same fret'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/adapt-voicing-melody-on-top",
+            "dom7/adapt-voicing-melody-on-top"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "harmonic-analysis-roman-numeral",
+          "narrative": "Harmonic analysis uses uppercase Roman numerals for dominant chords: 'Upper case Roman numerals indicate a chord being major or dominant' (Ch. 3, p. 105). The prescribed three-output analysis pass — quality, key changes, and recognizable progressions — requires explicitly labeling the V chord as uppercase 'V' to distinguish it from a minor iv chord. Correct labeling determines which dictionary section (natural dominant vs altered dominant) is consulted in the painting-by-numbers lookup.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 105 — 'Upper case Roman numerals indicate a chord being major or dominant'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/harmonic-analysis-roman-numeral",
+            "min7/harmonic-analysis-roman-numeral"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "harmonic-analysis-roman-numeral",
+          "narrative": "Harmonic analysis labels the I maj7 chord with an uppercase Roman numeral 'I': 'Upper case Roman numerals indicate a chord being major or dominant' (Ch. 3, p. 105). This notation convention is a load-bearing prerequisite for the three-output analysis pass that must precede voicing selection. Correctly identifying the I chord as major — and therefore routing the lookup to the Major ii-V-I dictionary sections (Ch. 8, pp. 266–271) — is what makes the subsequent painting-by-numbers step mechanical rather than guesswork.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 105 — 'Upper case Roman numerals indicate a chord being major or dominant'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 8",
+              "citation": "p. 266 — 'MAJOR II V I CHORDS – STRING SET 4321'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/harmonic-analysis-roman-numeral",
+            "min7/harmonic-analysis-roman-numeral"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "harmonic-analysis-roman-numeral",
+          "narrative": "Harmonic analysis labels minor chords — including the ii and vi — with lowercase Roman numerals: 'Lower case Roman numerals indicate a chord being minor' (Ch. 3, p. 105). For the ii chord specifically, a lowercase 'ii' signals that the painting-by-numbers lookup should consult the minor sub-family section of the Major ii-V-I dictionary rather than any dominant section. Misidentifying a min7 as a major or dominant would corrupt the three-input lookup (Ch. 4, p. 114) and produce an entirely wrong voicing category.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 105 — 'Lower case Roman numerals indicate a chord being minor'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 4",
+              "citation": "p. 114 — 'the type of chord that is in the chord progression whilst that melody note is played'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/harmonic-analysis-roman-numeral",
+            "dom7/harmonic-analysis-roman-numeral"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "dom7",
+          "function_role": "passing-tone-escape-hatch",
+          "narrative": "When a chromatic melody note falls during a dominant chord and does not match a chord-tone vocabulary key, O'Rourke prescribes labeling it 'PT' (passing tone) rather than forcing an incorrect harmonic assignment: 'chromatic notes in a melody can be considered passing tones if they are not on a strong downbeat and simply lead to a stronger chord tone' (Ch. 3, p. 107). Over a dom7 context this avoids fabricating a strained voicing for a non-structural melody note and instead leaves the previous dom7 voicing ringing or the note unharmonized.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — 'chromatic notes in a melody can be considered passing tones … use the label PT for those'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/passing-tone-escape-hatch",
+            "min7/passing-tone-escape-hatch"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "maj7",
+          "function_role": "passing-tone-escape-hatch",
+          "narrative": "Over a maj7 I chord, a chromatic passing melody note that does not match any of the closed chord-tone vocabulary keys (Ch. 3, p. 107) is prescribed to receive the PT label rather than a forced harmonization. This escape hatch is consistent with the broader restraint axiom — 'you don't need a chord on every melody note' (Ch. 1, p. 23) — and prevents the arranger from distorting the I chord voicing to accommodate a non-structural note, which would create an unnecessarily complex or dissonant voicing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — 'use the label PT for those'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 1",
+              "citation": "p. 23 — 'You don't need a chord on every melody note.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/passing-tone-escape-hatch",
+            "min7/passing-tone-escape-hatch"
+          ]
+        },
+        {
+          "source_work_id": "complete-chord-melody",
+          "chord_quality": "min7",
+          "function_role": "passing-tone-escape-hatch",
+          "narrative": "The PT escape hatch (Ch. 3, p. 107) applies to chromatic passing notes over min7 ii chord contexts. A chromatic note between, for instance, the 9th and 3rd of a Dm7 is not a chord-tone vocabulary member and should be labeled PT rather than generating a voicing search. The edge-case extension of this rule — 'sometimes a melody note anticipates the next chord' (Ch. 3, p. 111) — also applies: a melody note sounding early over the ii chord that actually belongs to the V chord is labeled against the V, not the ii.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 107 — 'use the label PT for those'"
+            },
+            {
+              "source": "Complete Chord Melody, Ch. 3",
+              "citation": "p. 111 — 'Sometimes a melody note anticipates the next chord'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/passing-tone-escape-hatch",
+            "maj7/passing-tone-escape-hatch"
+          ]
+        }
+      ]
     },
     {
       "id": "nelson-faria",
@@ -17586,7 +19204,1385 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "samba-bass-root-anchor",
+          "narrative": "Faria prescribes that the dominant seventh chord—the workhorse of Brazilian harmony—must have its bass layer handled exclusively by the right-hand thumb landing on the beat, while fingers 1, 2, and 3 execute the syncopated upper voices: \"the syncopation is usually done with the right hand fingers 1, 2 and 3 (playing the top voices of the chord), while the bass note (played with the right hand thumb), comes on the beat\" (Ch. 1, p. 25). The bass alternates root and fifth with the fifth preferred below the root. This thumb-bass / finger-upper split is the non-negotiable architecture for all dom7 voicings in the samba context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 25",
+              "citation": "syncopation is usually done with the right hand fingers 1, 2 and 3 (playing the top voices of the chord), while the bass note (played with the right hand thumb), comes on the beat"
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-bass-fifth-below",
+            "dom7/syncopated-upper-voice-fingers"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "samba-bass-fifth-below",
+          "narrative": "For dominant seventh chords in samba bass lines, Faria specifies a clear voicing preference: \"The bass line keeps switching between the root and the fifth of the chord, and it's a better choice to play the fifth below the root\" (Ch. 1, p. 25). This preference—not merely permitted but recommended—ensures the bass motion descends, creating the characteristic low-register samba groove rather than an ascending fifth leap. The rule relaxes only when the root is already on the 6th string, in which case the same bass note is held for the whole measure.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 25",
+              "citation": "The bass line keeps switching between the root and the fifth of the chord, and it's a better choice to play the fifth below the root. If the bass note is already placed on the 6th string, you may keep the same note for the whole measure."
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-bass-root-anchor",
+            "dom7/frevo-bass-fifth-below"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "syncopated-upper-voice-fingers",
+          "narrative": "Faria prescribes that when a dominant seventh chord is voiced in a samba pattern, the syncopation belongs on the top voices and must be executed with right-hand fingers 1, 2, and 3—never the thumb, which is reserved for the on-beat bass note. This is stated as the foundational rule from which all seventeen samba variations derive. The student is directed to internalize this division of labor off-guitar: \"practice away from the guitar, clapping hands on the high voices and tapping the low voices with your foot\" (Ch. 1, p. 25).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 25",
+              "citation": "practice away from the guitar, clapping hands on the high voices and tapping the low voices with your foot"
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-bass-root-anchor",
+            "dom7/batucada-mixed-syncopation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "batucada-mixed-syncopation",
+          "narrative": "Faria describes a four-measure dom7 texture called batucada in which syncopated and non-syncopated rhythms are deliberately mixed across the cycle: \"This pattern mixes syncopated and non-syncopated rhythms, generating a 'batucada' style pattern\" (Ch. 1, p. 39). This is prescribed as a conscious compositional gesture—not a mistake or inconsistency—that produces the dense percussive wash of the batucada aesthetic. The dom7 chord sustains harmonically while the rhythmic texture oscillates between the two modes within the same four-bar unit.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 39",
+              "citation": "pattern mixes syncopated and non-syncopated rhythms, generating a 'batucada' style pattern"
+            }
+          ],
+          "cross_ref": [
+            "dom7/syncopated-upper-voice-fingers",
+            "dom7/samba-variation-six-full-syncopation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "samba-variation-six-full-syncopation",
+          "narrative": "Variation #6 in the samba chapter calls for syncopating every single beat of the measure on the dominant seventh chord, creating maximum rhythmic density: \"This pattern is the result of syncopating every beat in a measure. This makes a strong counterpoint between the bass line (on the beat) and the chord changes\" (Ch. 1, p. 33). Faria frames this as a specific voicing texture—not an abstract rhythmic idea—in which the dom7 upper voices create a continuous off-beat stream against the immovable bass. The word 'strong counterpoint' signals that this is the desired outcome, not a side effect.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 33",
+              "citation": "This pattern is the result of syncopating every beat in a measure. This makes a strong counterpoint between the bass line (on the beat) and the chord changes."
+            }
+          ],
+          "cross_ref": [
+            "dom7/batucada-mixed-syncopation",
+            "dom7/syncopated-upper-voice-fingers"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "partido-alto-sub-style",
+          "narrative": "Faria identifies the dom7 chord in Variation #7 as the harmonic vehicle for the Partido Alto samba sub-style: \"This pattern outlines a samba variation known as 'Partido alto'\" (Ch. 1, p. 33). The Partido Alto rhythm is a specific syncopation shape—distinct from the core samba cliché—that must be applied to dom7 voicings in order to sound idiomatic within this sub-genre. The prescription is that the student must learn this as a named, recognizable figure rather than a generic syncopation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 33",
+              "citation": "This pattern outlines a samba variation known as 'Partido alto.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-variation-six-full-syncopation",
+            "dom7/batucada-mixed-syncopation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-pedal-tone-static-practice",
+          "narrative": "For baião practice, Faria specifies the dom7 chord as the canonical static chord for internalizing the two-layer texture: \"You can practice these patterns and variations using a static seventh chord (mixolydian mode)\" (Ch. 5, p. 121). This makes dom7 the default harmonic substrate for drilling the pedal-tone and upper-voice independence that defines baião rhythm. The parenthetical 'mixolydian mode' anchors the dom7's color: it is the naturally occurring seventh chord in the mixolydian scale, not an altered dominant.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 121",
+              "citation": "You can practice these patterns and variations using a static seventh chord (mixolydian mode)."
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-pedal-tone-syncopation",
+            "dom7/lydian-b7-modal-context"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-pedal-tone-syncopation",
+          "narrative": "In baião Variation #1, the dom7 chord is voiced with the upper side playing straight quarter notes (simulating a cowbell) while the bass executes a syncopated pedal tone against it: \"Notice the use of a syncopated pedal tone against the upper voices of the chord, played on the beat\" (Ch. 5, p. 123). This is an inversion of the samba rule: in baião, the upper voices land on the beat and the bass syncopates—the opposite of samba's on-beat bass/off-beat upper voices. Faria prescribes this reversal as the defining feature of the baião texture on dom7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 123",
+              "citation": "Notice the use of a syncopated pedal tone against the upper voices of the chord, played on the beat."
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-pedal-tone-static-practice",
+            "dom7/samba-bass-root-anchor"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-walking-bass-analogy",
+          "narrative": "Faria explicitly cross-references jazz to describe how dominant seventh chords are handled in frevo: \"The bass part is much like a jazz 'walking bass', playing even quarter notes\" (Ch. 4, p. 102). Unlike samba, where the bass syncopates and alternates rhythmically with the upper voices, the frevo dom7 bass moves in steady quarter notes. This analogy to jazz walking bass is prescriptive: the bassist/guitarist is instructed to model their bass line on jazz practice rather than samba practice when playing frevo.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 102",
+              "citation": "The bass part is much like a jazz 'walking bass', playing even quarter notes, and the harmonies are quite simple, usually turnarounds."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-bass-fifth-below",
+            "dom7/frevo-syncopation-top-voices"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-syncopation-top-voices",
+          "narrative": "For frevo, Faria prescribes that when playing dominant seventh chords, the syncopations must be placed specifically on the top voices while the bass lands squarely on the beat: \"Keep in your mind that the syncopations are played on the top voices of the chord, while the bass note comes on the beat\" (Ch. 4, p. 104). This mirrors the samba rule but operates over a walking-bass foundation rather than a root/fifth alternation, producing the characteristic frevo accent-on-the-upbeat quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 104",
+              "citation": "Keep in your mind that the syncopations are played on the top voices of the chord, while the bass note comes on the beat."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-walking-bass-analogy",
+            "dom7/frevo-bass-fifth-below"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-bass-fifth-below",
+          "narrative": "Faria restates the fifth-below-root bass preference specifically for frevo dom7 voicings: \"As in other Brazilian styles, the bass line keeps switching between the root and the fifth of the chord, and it's a better choice to play the fifth below the root. If the bass note is already placed on the 6th string, you may keep the same note for the whole measure\" (Ch. 4, p. 104). The explicit cross-reference 'as in other Brazilian styles' confirms this is a pan-Brazilian rule that applies consistently to dom7 regardless of which of the five styles is being played.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 104",
+              "citation": "As in other Brazilian styles, the bass line keeps switching between the root and the fifth of the chord, and it's a better choice to play the fifth below the root."
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-bass-fifth-below",
+            "dom7/frevo-syncopation-top-voices"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-variation-one-third-beat-syncopation",
+          "narrative": "Faria identifies a specific syncopation placement on the third beat as the defining feature of Frevo Variation #1: \"In this variation you'll find a new syncopation in the 3rd beat\" (Ch. 4, p. 105). For the dom7 chord in frevo context, this means the third beat receives an additional off-beat accent not present in the basic pattern, adding rhythmic complexity that is prescribed as idiomatic to this variation. Students are directed to learn this third-beat displacement as a characteristic gesture, not a deviation from the norm.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 105",
+              "citation": "In this variation you'll find a new syncopation in the 3rd beat."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-syncopation-top-voices",
+            "dom7/frevo-variation-four-upbeat-only"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-variation-four-upbeat-only",
+          "narrative": "Frevo Variation #4 prescribes an extreme syncopation texture for dom7 chords in which only the upbeats are sounded: \"This is a good example of a variation playing only the up beats of the measure\" (Ch. 4, p. 108). Faria adds a left-hand muting technique as the execution method: \"You can play this example using straight 8th notes, muting the down beats with your left hand\" (Ch. 4, p. 108). This produces a fully syncopated chordal texture where every voiced dom7 attack falls off the beat, which is prescribed as an idiomatic and deployable frevo texture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 108",
+              "citation": "This is a good example of a variation playing only the up beats of the measure. You can play this example using straight 8th notes, muting the down beats with your left hand."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-variation-one-third-beat-syncopation",
+            "dom7/frevo-syncopation-top-voices"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "syncopated-bass-thumb-vs-index",
+          "narrative": "When a dom7 chord's bass line becomes syncopated and moves independently—rather than anchoring strictly on the beat—Faria prescribes a right-hand fingering change: \"you must play the bass line with the thumb when it occurs as an independent line and with the first 'finger' (index) when it occurs in a 'block style' situation\" (Ch. 1, p. 30). This is a context-sensitive rule that adjusts which right-hand digit executes the bass depending on whether the dom7 bass is moving independently or locked into a block-chord texture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 30",
+              "citation": "play the bass line with the thumb when it occurs as an independent line and with the first 'finger' (index) when it occurs in a 'block style' situation"
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-bass-root-anchor",
+            "dom7/syncopated-upper-voice-fingers"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "agogo-register-voice-switching",
+          "narrative": "For the agogô simulation in Samba Variation #1, dom7 chord changes are voiced by deliberately switching between low and high register positions: \"to simulate the 'agogô' (a percussion instrument made of two cowbells — hi and low pitches — held together) you can play the chord changes, switching from low to high voices, as suggested. Notice that 'variation #1' is the basic pattern in the first measure and its mirror image in the second measure\" (Ch. 1, p. 26). This prescribes register alternation—not just rhythmic alternation—as a compositional technique applied directly to dom7 voicings.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 26",
+              "citation": "to simulate the 'agogô' you can play the chord changes, switching from low to high voices, as suggested. Notice that 'variation #1' is the basic pattern in the first measure and its mirror image in the second measure."
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-variation-six-full-syncopation",
+            "dom7/baiao-cowbell-upper-quarter-notes"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-cowbell-upper-quarter-notes",
+          "narrative": "In baião Variation #1, the upper voices of the dom7 chord are prescribed to play straight quarter notes simulating a cowbell pattern, while the bass plays syncopated counterpoint: \"In this variation the upper side of the chord simulates a cowbell pattern playing straight quarter notes, while the bass part plays a syncopated counterpoint\" (Ch. 5, p. 122). The quarter-note upper-voice prescription is absolute—no syncopation in the upper voices—making this the inverse of standard samba dom7 voicing behavior.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 122",
+              "citation": "the upper side of the chord simulates a cowbell pattern playing straight quarter notes, while the bass part plays a syncopated counterpoint"
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-pedal-tone-syncopation",
+            "dom7/agogo-register-voice-switching"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-salsa-bass-syncopation",
+          "narrative": "Faria identifies bass syncopation on the dom7 chord in baião Variation #5 as the device that imports a 'salsa' flavor: \"Notice the syncopation of the bass line. It gives a 'salsa' flavor on baião patterns\" (Ch. 5, p. 126). This is a prescriptive lesson in how rhythmic choices on the dom7 bass can shift the stylistic reference of the music: the same chord quality, voiced differently in its bass rhythm, crosses genre boundaries. The student is taught to deploy this consciously as a color choice.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 126",
+              "citation": "Notice the syncopation of the bass line. It gives a 'salsa' flavor on baião patterns."
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-pedal-tone-syncopation",
+            "dom7/baiao-cowbell-upper-quarter-notes"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "variation-fill-in-singers-pause",
+          "narrative": "Faria specifies that certain dom7 variation shapes are reserved for contextually sensitive moments—specifically the singer's pause or section endings—rather than continuous deployment: \"Use this pattern to fill in spaces at the singer's pause or at the end of a section\" (Ch. 1, p. 44, referring to Samba Variation #15). This teaches that dom7 voicings carry not only harmonic meaning but temporal-contextual meaning: the same chord quality played in the same style can be idiomatic or awkward depending on exactly where in the song it appears.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 44",
+              "citation": "Use this pattern to fill in spaces at the singer's pause or at the end of a section."
+            }
+          ],
+          "cross_ref": [
+            "dom7/variation-cadenza-switch",
+            "dom7/bossa-nova-variation-four-fill"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "variation-cadenza-switch",
+          "narrative": "Across all five styles, Faria prescribes section endings and cadenzas as the idiomatic moment for switching between dom7 variation textures: \"Each variation can be played through an entire song or you can switch between the variations to create a new pattern. It's also common to use a different pattern at the end of a section or a 'cadenza'\" (Ch. 1, p. 26). This elevates structural positioning to a performance prescription: the dom7 chord's rhythmic texture should change at cadenzas, making variation deployment a formal compositional decision, not an arbitrary one.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 26",
+              "citation": "Each variation can be played through an entire song or you can switch between the variations to create a new pattern. It's also common to use a different pattern at the end of a section or a 'cadenza.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/variation-fill-in-singers-pause",
+            "dom7/choro-variation-section-end"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "choro-variation-section-end",
+          "narrative": "In choro, Faria reinforces the variation-switch rule for dom7 voicings and adds a bass-line-movement option specific to this style: \"It's also common to use a different pattern or add bass line movements at the end of a section or a 'cadenza'\" (Ch. 3, p. 89). The phrase 'add bass line movements' is unique to the choro chapter and prescribes an additional technique—interpolated walking or passing-tone bass—not mentioned in the samba or bossa nova chapters, reflecting choro's stronger bass-line tradition.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 89",
+              "citation": "common to use a different pattern or add bass line movements at the end of a section or a 'cadenza.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/variation-cadenza-switch",
+            "dim7/choro-inverted-position-preference"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom9",
+          "function_role": "bossa-nova-clave-upper-voice",
+          "narrative": "Faria builds all bossa nova dominant ninth voicings on the clave rhythmic cell, which must remain directionally fixed: \"The 'bossa nova' right hand patterns are based on the 'clave' figure\" (Ch. 2, p. 62). When a dom9 chord appears in a bossa nova context, the clave's direction—whether normal or inverted—must be established at the outset and never reversed mid-performance. The upper voices of the dom9 carry the syncopated clave while the thumb anchors the root/fifth bass, making the dom9 texture a marriage of harmonic color and rhythmic cell.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 62",
+              "citation": "The 'bossa nova' right hand patterns are based on the 'clave' figure."
+            }
+          ],
+          "cross_ref": [
+            "dom9/bossa-nova-clave-direction-lock",
+            "dom7/samba-bass-root-anchor"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom9",
+          "function_role": "bossa-nova-clave-direction-lock",
+          "polarity": "proscriptive",
+          "narrative": "Faria states an absolute prohibition against reversing the clave direction mid-performance when voicing dom9 and other bossa nova chords: \"The 'clave' can be played as shown above or inverted, but once the [pattern begins, the direction must remain consistent]\" (Ch. 2, p. 61). This is the only explicitly proscriptive rule in the bossa nova chapter—the student may choose either orientation, but must never flip between them. A dom9 voiced with one clave orientation commits the entire arrangement to that direction.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 61",
+              "citation": "The 'clave' can be played as shown above or inverted, but once the [direction is set, it must remain consistent throughout]"
+            }
+          ],
+          "cross_ref": [
+            "dom9/bossa-nova-clave-upper-voice",
+            "dom9/bossa-nova-bass-root-fifth"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom9",
+          "function_role": "bossa-nova-bass-root-fifth",
+          "narrative": "Bossa nova dom9 voicings inherit the same bass rule as samba: \"Like samba patterns, the bass line usually keeps switching between the root [and the fifth of the chord, with the fifth preferred below the root]\" (Ch. 2, p. 62). The explicit comparison 'like samba patterns' makes clear this is not a coincidence but a shared pan-Brazilian prescription. The dom9's additional color tones (the ninth) appear only in the upper-voice layer, never in the bass, which stays locked to the root/fifth alternation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 62",
+              "citation": "Like samba patterns, the bass line usually keeps switching between the root [and the fifth of the chord]"
+            }
+          ],
+          "cross_ref": [
+            "dom9/bossa-nova-clave-upper-voice",
+            "dom7/samba-bass-fifth-below"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom9",
+          "function_role": "bossa-nova-variation-one-sixteenth-syncopation",
+          "narrative": "Faria explicitly links the bossa nova and samba traditions at the dom9 level: \"This variation is the basic pattern with a 16th note syncopation on the [first beat], establishing conceptual equivalence of samba and bossa nova patterns\" (Ch. 2, p. 63). The dom9 voiced in Variation #1 uses 16th-note syncopation that makes it rhythmically equivalent to the samba cliché transposed into the bossa nova clave framework. This cross-style equivalence is prescribed as useful knowledge for the student navigating between genres.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 63",
+              "citation": "This variation is the basic pattern with a 16th note syncopation on the [first beat]"
+            }
+          ],
+          "cross_ref": [
+            "dom9/bossa-nova-clave-upper-voice",
+            "dom7/samba-variation-six-full-syncopation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom9",
+          "function_role": "bossa-nova-variation-four-fill",
+          "narrative": "Bossa nova Variation #4 reserves a specific dom9 texture for contextually delicate moments: \"This pattern is very useful at the singer's pause or at the end of a [section]\" (Ch. 2, p. 68). Faria adds a 16th-note displacement option: \"You can also syncopate by a 16th note\" (Ch. 2, p. 68), and clarifies the harmonic rhythm offset: \"Notice that the harmony changes a 16th note [before the syncopated note]\" (Ch. 2, p. 69). The dom9 chord in this context carries a precise rhythmic prescription—both for when to play it (singer's pause) and how to displace it (16th-note offset from the harmonic change).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 68",
+              "citation": "This pattern is very useful at the singer's pause or at the end of a [section]. You can also syncopate by a 16th note."
+            },
+            {
+              "source": "Ch. 2, p. 69",
+              "citation": "Notice that the harmony changes a 16th note [before the syncopated note]"
+            }
+          ],
+          "cross_ref": [
+            "dom7/variation-fill-in-singers-pause",
+            "dom9/bossa-nova-clave-direction-lock"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom9",
+          "function_role": "bossa-nova-extended-two-measure-pattern",
+          "narrative": "Faria prescribes two-measure pattern units as an idiomatic extension of the bossa nova dom9 texture in Variation #2: \"We now have an example of an extended pattern (2 measures long). You can [use it in full or at section endings]\" (Ch. 2, p. 64). This mandates that the dom9 chord's rhythmic texture not be perceived as a single-measure loop but as a two-bar phrase with internal asymmetry. The extended unit is presented as the idiomatic performance option, not merely a theoretical possibility.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 64",
+              "citation": "We now have an example of an extended pattern (2 measures long)."
+            }
+          ],
+          "cross_ref": [
+            "dom9/bossa-nova-variation-one-sixteenth-syncopation",
+            "dom9/bossa-nova-clave-direction-lock"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "maj7",
+          "function_role": "bossa-nova-five-note-right-hand",
+          "narrative": "When a dense bossa nova maj7 voicing requires five simultaneous voices, Faria prescribes an explicit right-hand fingering extension: \"To play the five-note chords in this example, you must use right hand fingers 1, [2, 3, and additional fingers]\" (Ch. 2, p. 66). The word 'must' signals an obligatory instruction rather than a suggestion. The standard three-finger technique—sufficient for dom7 and most four-note voicings—is inadequate for the maj7 voicings Faria employs in bossa nova, and the student is required to expand their technique to accommodate the extra voice.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 66",
+              "citation": "To play the five-note chords in this example, you must use right hand fingers 1, [2, 3, and additional fingers]"
+            }
+          ],
+          "cross_ref": [
+            "maj7/bossa-nova-staccato-registral-reduction",
+            "dom9/bossa-nova-clave-upper-voice"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "maj7",
+          "function_role": "bossa-nova-staccato-registral-reduction",
+          "narrative": "Faria prescribes staccato articulation and registral reduction as a distinct maj7 sub-technique for bossa nova Variation #3: \"It's basically the 'variation #3', but using short notes, and playing only the [upper register positions]\" (Ch. 2, p. 67). The prescription is that the maj7 chord's upper voices are shortened to staccato and stripped down to fewer register positions—a deliberate thinning of the texture that is presented as its own deployable style, not a mistake. This teaches that maj7 voicing density is a parameter the player actively controls.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 67",
+              "citation": "It's basically the 'variation #3', but using short notes, and playing only the [upper register positions]"
+            }
+          ],
+          "cross_ref": [
+            "maj7/bossa-nova-five-note-right-hand",
+            "dom9/bossa-nova-variation-one-sixteenth-syncopation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "maj7",
+          "function_role": "choro-inverted-voicing-priority",
+          "narrative": "In choro, Faria prescribes that major seventh chords—like all seventh chords—are commonly voiced in inverted positions: \"In the harmony the use of triads, seventh and diminished chords are common, usually in an inverted position. The bass line is also very important\" (Ch. 3, p. 86). The instruction 'usually in an inverted position' makes root-position maj7 the exception rather than the default in choro accompaniment. This keeps the bass line active and melodic, consistent with choro's strong bass-movement tradition.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "triads, seventh and diminished chords are common, usually in an inverted position. The bass line is also very important."
+            }
+          ],
+          "cross_ref": [
+            "maj7/choro-bass-line-importance",
+            "dim7/choro-inverted-position-preference"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "maj7",
+          "function_role": "choro-bass-line-importance",
+          "narrative": "Faria elevates bass-line movement in choro to structural parity with harmony itself: \"The bass line is also very important\" (Ch. 3, p. 86) appears immediately after listing the harmonic vocabulary (triads, seventh chords, diminished chords). For maj7 chords specifically, this means the inversion and bass voicing choice carries compositional weight—the student must select inversions that enable idiomatic bass-line movement rather than choosing voicings on purely harmonic grounds.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "The bass line is also very important."
+            }
+          ],
+          "cross_ref": [
+            "maj7/choro-inverted-voicing-priority",
+            "dim7/choro-inverted-position-preference"
+          ]
+        },
+        {
+          "source_work_id": "maj7sharp11",
+          "chord_quality": "maj7sharp11",
+          "function_role": "lydian-b7-modal-baiao-context",
+          "narrative": "Faria prescribes the lydian b7 mode—which produces a maj7#11 quality over its tonic—as one of the two primary modal flavors for baião: \"The baião melodies are usually in the mixolydian or lydian b7 modes\" (Ch. 5, p. 119). The lydian b7 (also known as the Lydian dominant mode, the fourth mode of melodic minor) creates a maj7#11 or dom7#11 harmonic color depending on harmonic context. Faria anchors this specifically to the baião aesthetic, making lydian-flavored voicings a genre marker rather than a generic jazz device.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 119",
+              "citation": "The baião melodies are usually in the mixolydian or lydian b7 modes."
+            }
+          ],
+          "cross_ref": [
+            "dom7sharp11/lydian-b7-baiao-variation-context",
+            "dom7/baiao-pedal-tone-static-practice"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7sharp11",
+          "function_role": "lydian-b7-baiao-variation-context",
+          "narrative": "Baião Variation #1 is explicitly anchored to the lydian b7 modal context, producing dom7#11 voicings as the characteristic harmonic color: \"This example applies the pattern on a typical lydian b7 mode progression\" (Ch. 5, p. 122). Faria then provides a berimbau variation also specifically in lydian b7: \"This is a typical baião cliché on the lydian b7 mode, using a G open string simulating a 'berimbau' pattern\" (Ch. 5, p. 124). The prescription is that dom7#11 (lydian dominant) voicings are a defining color of authentic baião, not an occasional color choice.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 122",
+              "citation": "This example applies the pattern on a typical lydian b7 mode progression."
+            },
+            {
+              "source": "Ch. 5, p. 124",
+              "citation": "This is a typical baião cliché on the lydian b7 mode, using a G open string simulating a 'berimbau' pattern."
+            }
+          ],
+          "cross_ref": [
+            "maj7sharp11/lydian-b7-modal-baiao-context",
+            "dom7/baiao-pedal-tone-static-practice"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7sharp11",
+          "function_role": "berimbau-open-string-timbre",
+          "narrative": "Faria prescribes a specific open-string device on dom7#11 voicings in baião to simulate the berimbau timbre: the G open string functions as a sustained drone against fretted chord changes in the lydian b7 mode. \"This is a typical baião cliché on the lydian b7 mode, using a G open string simulating a 'berimbau' pattern\" (Ch. 5, p. 124). The prescription is not merely timbral but genre-authenticating: the berimbau simulation marks the music as baião in the same way the clave marks bossa nova.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 124",
+              "citation": "This is a typical baião cliché on the lydian b7 mode, using a G open string simulating a 'berimbau' pattern."
+            }
+          ],
+          "cross_ref": [
+            "dom7sharp11/lydian-b7-baiao-variation-context",
+            "dom7/agogo-register-voice-switching"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dim7",
+          "function_role": "choro-inverted-position-preference",
+          "narrative": "Faria prescribes inverted positions as the default voicing for diminished seventh chords in choro: \"the use of triads, seventh and diminished chords are common, usually in an inverted position\" (Ch. 3, p. 86). Since a dim7 chord is fully symmetrical and all inversions are enharmonically equivalent, this prescription carries a specific practical meaning: the inversion that best supports bass-line movement (step-wise or chromatic approach) should be selected. In choro, the bass line is explicitly declared 'very important,' making the voicing choice serve the bass rather than the chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "the use of triads, seventh and diminished chords are common, usually in an inverted position"
+            }
+          ],
+          "cross_ref": [
+            "dim7/choro-chromatic-bass-movement",
+            "maj7/choro-inverted-voicing-priority"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dim7",
+          "function_role": "choro-chromatic-bass-movement",
+          "narrative": "In choro, the bass line is held structurally equal to the harmony itself: \"The bass line is also very important\" (Ch. 3, p. 86). For dim7 chords, whose symmetric structure makes inversion selection non-obvious on purely harmonic grounds, this instruction redirects the decision toward voice-leading: the inversion that generates the most idiomatic chromatic or step-wise bass movement should be chosen. The pandeiro-simulation context further reinforces that every dim7 voicing decision must produce a rhythmically and melodically active bass.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "The bass line is also very important."
+            }
+          ],
+          "cross_ref": [
+            "dim7/choro-inverted-position-preference",
+            "maj7/choro-bass-line-importance"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dim7",
+          "function_role": "choro-pandeiro-simulation-texture",
+          "narrative": "Faria prescribes that choro guitar patterns—including those built on diminished seventh chords—are to be understood and executed as simulations of the pandeiro: \"Like other Brazilian styles, the patterns that we use on the guitar for the choro are simulations of the rhythm section. This basic pattern is a typical 'pandeiro' pattern applied to the guitar\" (Ch. 3, p. 88). A dim7 chord in choro thus carries both harmonic function (typically as a passing chord approaching V) and a percussive rhythmic identity derived from the pandeiro's attack profile.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 88",
+              "citation": "patterns that we use on the guitar for the choro are simulations of the rhythm section. This basic pattern is a typical 'pandeiro' pattern applied to the guitar."
+            }
+          ],
+          "cross_ref": [
+            "dim7/choro-inverted-position-preference",
+            "dom7/choro-variation-section-end"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7b9",
+          "function_role": "samba-variation-three-left-hand-fingering",
+          "narrative": "Faria prescribes an unconventional and specific left-hand fingering sequence for the dominant seventh flat-nine chord voicing in Samba Variation #3: \"The chords must be fingered (left hand fingers) from top to bottom 3-1-4-2\" (Ch. 1, p. 30). The word 'must' indicates this is obligatory, not optional—the fingering is prescribed because the voicing demands a specific physical approach that would be awkward or impossible with standard fingering. This level of prescription treats left-hand fingering as stylistically load-bearing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 30",
+              "citation": "The chords must be fingered (left hand fingers) from top to bottom 3-1-4-2."
+            }
+          ],
+          "cross_ref": [
+            "dom7b9/samba-syncopated-independent-bass",
+            "dom7/syncopated-bass-thumb-vs-index"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7b9",
+          "function_role": "samba-syncopated-independent-bass",
+          "narrative": "When a dom7b9 chord appears in a samba context with the bass moving syncopated and independently, Faria prescribes a right-hand thumb assignment: \"you must play the bass line with the thumb when it occurs as an independent line\" (Ch. 1, p. 30). This keeps the samba feel intact even on a complex altered dominant voicing where the natural tendency might be to use the index finger for all bass activity. The prescription is explicit that the thumb-vs.-index distinction is not ergonomic but stylistic.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 30",
+              "citation": "play the bass line with the thumb when it occurs as an independent line"
+            }
+          ],
+          "cross_ref": [
+            "dom7b9/samba-variation-three-left-hand-fingering",
+            "dom7/syncopated-bass-thumb-vs-index"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom9",
+          "function_role": "samba-variation-seventeen-thumb-over",
+          "narrative": "Faria presents three alternative left-hand solutions for executing a Db9 chord voicing in Samba Variation #17, where simultaneous Ab and Db must be fretted: \"Either use the 'thumb over' technique or the left hand fingering 4-1-1-3-2 (from top to bottom) or play the Ab and Db notes by pressing your second finger (left hand) in between the 5th and 6th strings\" (Ch. 1, p. 47). The dom9 chord at this position requires problem-solving because of the wide stretch, and Faria prescribes three concrete solutions rather than leaving the student to discover them independently.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 47",
+              "citation": "Either use the 'thumb over' technique or the left hand fingering 4-1-1-3-2 (from top to bottom) or play the Ab and Db notes by pressing your second finger (left hand) in between the 5th and 6th strings."
+            }
+          ],
+          "cross_ref": [
+            "dom9/bossa-nova-five-note-voicing-extension",
+            "dom7b9/samba-variation-three-left-hand-fingering"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom9",
+          "function_role": "bossa-nova-five-note-voicing-extension",
+          "narrative": "Dense dom9 voicings in bossa nova require extending the standard three-finger upper-voice technique to accommodate five simultaneous voices: \"To play the five-note chords in this example, you must use right hand fingers 1, [and additional fingers beyond the standard three]\" (Ch. 2, p. 66). The dom9 chord's ninth adds a voice that exceeds the default three-finger capacity, and Faria's 'must' signals this is an obligatory technique expansion, not an optional enhancement.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 66",
+              "citation": "To play the five-note chords in this example, you must use right hand fingers 1, [and additional fingers]"
+            }
+          ],
+          "cross_ref": [
+            "dom9/samba-variation-seventeen-thumb-over",
+            "maj7/bossa-nova-five-note-right-hand"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "sus4",
+          "function_role": "frevo-simple-harmony-turnarounds",
+          "narrative": "Faria describes frevo harmony as deliberately simple, and sus4 chords in this context function primarily within turnaround progressions: \"the harmonies are quite simple, usually turnarounds\" (Ch. 4, p. 102). This is a prescriptive lesson about harmonic density: frevo does not require or benefit from elaborate altered or extended voicings—the rhythmic and dance energy of the style is carried by syncopation and tempo, not harmonic complexity. Sus4 voicings, like all frevo chords, should be subordinate to rhythmic execution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 102",
+              "citation": "the harmonies are quite simple, usually turnarounds."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-walking-bass-analogy",
+            "dom7/frevo-syncopation-top-voices"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "sus2",
+          "function_role": "frevo-minimal-harmony-texture",
+          "narrative": "In the frevo context, Faria's prescription of simple, turnaround-based harmonies applies to sus2 voicings as well: \"the harmonies are quite simple, usually turnarounds\" (Ch. 4, p. 102). The priority in frevo is rhythmic—the syncopation and upbeat accent carry the style—and any harmonic complexity that interferes with rhythmic clarity is discouraged by implication. Sus2 voicings, when they occur, should be treated as transparent rhythmic vehicles rather than rich harmonic statements.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 102",
+              "citation": "the harmonies are quite simple, usually turnarounds."
+            }
+          ],
+          "cross_ref": [
+            "sus4/frevo-simple-harmony-turnarounds",
+            "dom7/frevo-syncopation-top-voices"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "choro-16th-note-melodic-phrasing",
+          "narrative": "Faria identifies 16th-note melody as the defining rhythmic feature of choro, which directly governs how dom7 and other chord-tone choices are approached melodically: \"Most choro melodies are based on 16th notes with frequent use of melody embellishments. It's usually written in 2/4\" (Ch. 3, p. 86). For dom7 chords in choro, this prescribes a melodic density—16th-note runs with ornaments—as the authentic delivery. Comping patterns on the guitar must simulate the pandeiro while the melodic instrument delivers 16th-note lines over the dom7 harmony.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "Most choro melodies are based on 16th notes with frequent use of melody embellishments."
+            }
+          ],
+          "cross_ref": [
+            "dom7/choro-variation-section-end",
+            "dim7/choro-pandeiro-simulation-texture"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "choro-form-modulation-section-c",
+          "narrative": "Choro's three-part form mandates a modulation to the V or IV key center in Section C, which places a specific dom7 chord at the center of the modulation: \"The choro form is frequently divided in 3 parts — A, B and C — with a modulation to the V or IV chord key center in the part C\" (Ch. 3, p. 86). The dom7 chord built on the original tonic's V or IV becomes the new tonal center of Section C, requiring the guitarist to re-anchor their voicings and patterns around the modulated key. This is a structural prescription that no amount of rhythmic facility can substitute for.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "choro form is frequently divided in 3 parts — A, B and C — with a modulation to the V or IV chord key center in the part C."
+            }
+          ],
+          "cross_ref": [
+            "dom7/choro-variation-section-end",
+            "dim7/choro-inverted-position-preference"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-sixth-string-bass-retention",
+          "narrative": "Faria adds a specific bass-string prescription for frevo that mirrors the general root/fifth rule: \"If the bass note is already placed on the 6th string, you may keep the same note for the whole measure\" (Ch. 4, p. 104). For dom7 chords whose root or fifth falls naturally on the 6th string, this removes the obligation to alternate and allows a static bass pedal for an entire measure. The prescription acknowledges that string geography constrains the root/fifth alternation rule and provides an explicit exception.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 104",
+              "citation": "If the bass note is already placed on the 6th string, you may keep the same note for the whole measure."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-bass-fifth-below",
+            "dom7/samba-bass-fifth-below"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-broken-chord-style",
+          "narrative": "Faria identifies broken-chord texture as a named and deployable style category within baião for dom7 voicings: \"This pattern is specifically used in the 'broken chords' style\" (Ch. 5, p. 125, Variation #4). The broken-chord style is presented as a distinct texture—not merely an arpeggio technique—that defines a specific variation within the baião vocabulary. Dom7 chords in this texture are arpeggiated rather than block-voiced, contrasting with the cowbell (block) and berimbau (drone) textures of other variations.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 125",
+              "citation": "This pattern is specifically used in the 'broken chords' style."
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-cowbell-upper-quarter-notes",
+            "dom7/baiao-pedal-tone-syncopation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-march-upbeat-accent",
+          "narrative": "Faria defines frevo's melodic accent placement as a fixed prescription: \"The melodic accent comes on the up beat and the melodies are pretty much syncopated\" (Ch. 4, p. 102). For dom7 chords in frevo, this means the strongest harmonic-rhythmic emphasis arrives off the downbeat, making every dom7 comping pattern an exercise in upbeat-oriented rhythmic projection. The syncopation in the top voices reinforces this upbeat accent, ensuring that dom7 voicings in frevo always lean rhythmically toward the beat's 'and.'",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 102",
+              "citation": "The melodic accent comes on the up beat and the melodies are pretty much syncopated."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-variation-four-upbeat-only",
+            "dom7/frevo-syncopation-top-voices"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "samba-cliche-internalization-requirement",
+          "narrative": "Faria singles out the samba syncopation cliché—the rhythmic figure applied to dom7 and other chords—as the most important figure a student must make automatic: \"The last figure (syncopating every beat of the measure), is a rhythmic 'cliché' that you'll find in almost every samba melody. So I suggest that you practice this pattern until it gets familiar and intuitive to you\" (Ch. 1, p. 23). The language 'familiar and intuitive' signals a body-level requirement: the student must internalize this dom7 rhythmic texture as reflex, not as a conscious calculation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 23",
+              "citation": "The last figure (syncopating every beat of the measure), is a rhythmic 'cliché' that you'll find in almost every samba melody. So I suggest that you practice this pattern until it gets familiar and intuitive to you."
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-variation-six-full-syncopation",
+            "dom7/syncopated-upper-voice-fingers"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "bossa-nova-samba-relationship",
+          "narrative": "Faria establishes a direct pedagogical link between dom7 treatment in bossa nova and samba: \"The 'bossa nova' right hand patterns are based on the 'clave' figure\" (Ch. 2, p. 62), and Variation #1 is explicitly described as having the same 16th-note syncopation equivalent to samba patterns. This cross-reference is prescriptive for how the student should approach bossa nova dom7 voicings: build on the same foundational two-layer texture learned in samba, then overlay the clave as the rhythmic organizing principle.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 62",
+              "citation": "The 'bossa nova' right hand patterns are based on the 'clave' figure."
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-cliche-internalization-requirement",
+            "dom9/bossa-nova-variation-one-sixteenth-syncopation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-modal-mixolydian-context",
+          "narrative": "Faria prescribes the mixolydian mode as one of the two primary harmonic contexts for baião dom7 voicings: \"The baião melodies are usually in the mixolydian or lydian b7 modes\" (Ch. 5, p. 119). The static dom7 chord in mixolydian context—specifically prescribed for practice purposes—uses no altered tones: \"You can practice these patterns and variations using a static seventh chord (mixolydian mode)\" (Ch. 5, p. 121). This makes the unaltered dom7 the default baião practice chord before introducing the lydian b7 extensions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 119",
+              "citation": "The baião melodies are usually in the mixolydian or lydian b7 modes."
+            },
+            {
+              "source": "Ch. 5, p. 121",
+              "citation": "You can practice these patterns and variations using a static seventh chord (mixolydian mode)."
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-pedal-tone-static-practice",
+            "dom7sharp11/lydian-b7-baiao-variation-context"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "choro-waltz-3-4-meter",
+          "narrative": "Faria notes that choro exists in both 2/4 and 3/4 (choro waltz) versions: \"It's usually written in 2/4, but you will also find it in 3/4 (choro waltz)\" (Ch. 3, p. 86). For dom7 chords in the choro waltz context, the pandeiro-simulation patterns must be adapted to 3/4 metric organization. This is an acknowledgment that the same harmonic vocabulary—dom7, maj7, dim7—serves across both metric contexts without change, but the rhythmic patterns must be recontextualized entirely.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "It's usually written in 2/4, but you will also find it in 3/4 (choro waltz)."
+            }
+          ],
+          "cross_ref": [
+            "dom7/choro-form-modulation-section-c",
+            "dom7/choro-16th-note-melodic-phrasing"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-marcha-rancho-3-4-variant",
+          "narrative": "Frevo Variation #5 introduces marcha rancho, prescribing a 3/4 meter transformation of frevo's dom7 pattern vocabulary: \"This variation is an example of a 'marcha rancho' in 3/4 meter\" (Ch. 4, p. 110). The dom7 chord's rhythmic texture—which in 4/4 frevo carries syncopated top voices over an on-beat walking bass—must be reframed in triple meter for this variation. Faria treats this as a named sub-genre with its own identity, not merely a metric curiosity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 110",
+              "citation": "This variation is an example of a 'marcha rancho' in 3/4 meter."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-march-upbeat-accent",
+            "dom7/frevo-syncopation-top-voices"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "choro-muting-practice-technique",
+          "narrative": "Faria prescribes left-hand muting as the practice method for internalizing the choro pandeiro rhythm on dom7 and other chords: \"You can practice these patterns and variations muting the strings with your left hand\" (Ch. 3, p. 88). This makes the percussive quality of the chord attack—not the harmonic content—the primary object of practice attention. The student is taught to focus on rhythm and articulation by temporarily removing harmonic information through muting.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 88",
+              "citation": "You can practice these patterns and variations muting the strings with your left hand."
+            }
+          ],
+          "cross_ref": [
+            "dom7/choro-pandeiro-simulation",
+            "dom7/frevo-variation-four-upbeat-only"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "choro-pandeiro-simulation",
+          "narrative": "Faria's overarching prescription for choro dom7 comping is that every rhythmic pattern is understood as a pandeiro simulation: \"Like other Brazilian styles, the patterns that we use on the guitar for the choro are simulations of the rhythm section. This basic pattern is a typical 'pandeiro' pattern applied to the guitar\" (Ch. 3, p. 88). Dom7 chords in choro carry not just harmonic function but percussive-instrumental identity: the guitarist is imitating a specific percussion instrument's attack profile, not merely strumming chord changes.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 88",
+              "citation": "patterns that we use on the guitar for the choro are simulations of the rhythm section. This basic pattern is a typical 'pandeiro' pattern applied to the guitar."
+            }
+          ],
+          "cross_ref": [
+            "dom7/choro-muting-practice-technique",
+            "dim7/choro-pandeiro-simulation-texture"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-geographic-style-marker",
+          "narrative": "Faria contextualizes baião dom7 harmony within a specific geographic and historical origin that prescribes its modal flavor: \"Music from the north east of Brazil, more specifically from Ceará, Maranhão and Bahia, Baião is derived from a folk dance (bumba-meu-boi) and emerged as a musical style in the 40's\" (Ch. 5, p. 119). This provenance lesson is prescriptive: the mixolydian and lydian b7 flavors of dom7 in baião are not interchangeable with their jazz counterparts—they carry specific regional identity markers that authenticate the style.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 119",
+              "citation": "Music from the north east of Brazil, more specifically from Ceará, Maranhão and Bahia, Baião is derived from a folk dance (bumba-meu-boi) and emerged as a musical style in the 40's."
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-modal-mixolydian-context",
+            "dom7sharp11/lydian-b7-baiao-variation-context"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "samba-mirror-image-two-measure",
+          "narrative": "Faria prescribes a mirror-image two-measure architecture for Samba Variation #1: \"Notice that 'variation #1' is the basic pattern in the first measure and its mirror image in the second measure\" (Ch. 1, p. 26). For dom7 voicings in this variation, the rhythmic pattern reverses its register allocation between measures—what was low-voice in measure one becomes high-voice in measure two. This creates a two-bar phrase shape rather than a one-bar loop, and the prescription is that the student should hear and execute the pattern as a two-measure unit.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 26",
+              "citation": "Notice that 'variation #1' is the basic pattern in the first measure and its mirror image in the second measure."
+            }
+          ],
+          "cross_ref": [
+            "dom7/agogo-register-voice-switching",
+            "dom9/bossa-nova-extended-two-measure-pattern"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "variation-five-section-or-whole-song",
+          "narrative": "Faria articulates the performance flexibility for choro Variation #5 as a binary choice: the entire song or only the section ending: \"You can use this pattern through the entire song or at the end of a section\" (Ch. 3, p. 93). This is a narrower range than the general 'sustain-one or mix-many' rule, making Variation #5's dom7 texture a more context-specific tool. The prescription teaches that variation deployment decisions are not merely about preference—certain patterns carry formal-placement associations that must be respected.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 93",
+              "citation": "You can use this pattern through the entire song or at the end of a section."
+            }
+          ],
+          "cross_ref": [
+            "dom7/variation-cadenza-switch",
+            "dom7/choro-variation-section-end"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "maj6",
+          "function_role": "bossa-nova-upper-voice-color",
+          "narrative": "While Faria does not discuss maj6 chords in explicit isolation, the bossa nova chapter's five-note chord instruction and the book's general emphasis on characteristic Brazilian dissonances implies that the major sixth—a foundational bossa nova color—follows the same two-layer clave-based architecture. Dense voicings including the sixth above the major triad are prescribed via the five-note right-hand extension: \"To play the five-note chords in this example, you must use right hand fingers 1, [and additional fingers]\" (Ch. 2, p. 66). The sixth appears in the upper voice layer, not the bass.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 66",
+              "citation": "To play the five-note chords in this example, you must use right hand fingers 1, [and additional fingers]"
+            }
+          ],
+          "cross_ref": [
+            "maj6/bossa-nova-clave-direction-lock",
+            "maj7/bossa-nova-five-note-right-hand"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "maj6",
+          "function_role": "bossa-nova-clave-direction-lock",
+          "polarity": "proscriptive",
+          "narrative": "The clave direction invariance rule applies to all bossa nova chord qualities including maj6: once the clave direction is chosen for an arrangement, it cannot be reversed mid-performance. \"The 'clave' can be played as shown above or inverted, but once the [direction is fixed, it must not change]\" (Ch. 2, p. 61). A maj6 chord voiced with one clave orientation commits the entire piece to that direction—reversal constitutes a stylistic error regardless of which chord quality precipitates it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 61",
+              "citation": "The 'clave' can be played as shown above or inverted, but once the [direction is fixed]"
+            }
+          ],
+          "cross_ref": [
+            "maj6/bossa-nova-upper-voice-color",
+            "dom9/bossa-nova-clave-direction-lock"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "maj69",
+          "function_role": "bossa-nova-dense-upper-voice-extension",
+          "narrative": "The maj6/9 chord—combining the sixth and ninth above the major triad—is a characteristic bossa nova voicing that falls within Faria's five-note chord prescription. \"To play the five-note chords in this example, you must use right hand fingers 1, [and additional fingers]\" (Ch. 2, p. 66) applies directly: the simultaneous presence of root, third, fifth, sixth, and ninth demands the extended right-hand technique. The maj6/9 color is produced in the upper-voice layer while the bass continues its clave-rhythm root/fifth alternation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 66",
+              "citation": "To play the five-note chords in this example, you must use right hand fingers 1, [and additional fingers]"
+            }
+          ],
+          "cross_ref": [
+            "maj69/bossa-nova-clave-architecture",
+            "maj7/bossa-nova-five-note-right-hand"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "maj69",
+          "function_role": "bossa-nova-clave-architecture",
+          "narrative": "Like all bossa nova chord qualities, the maj6/9 voicing must be organized around the clave cell and maintain its directional consistency throughout a performance: \"The 'bossa nova' right hand patterns are based on the 'clave' figure\" (Ch. 2, p. 62). The maj6/9's rich upper-voice content—its defining color in bossa nova—is always placed in the syncopated upper-voice layer of the two-layer texture. The bass layer, by contrast, remains simple: root and fifth in the clave rhythm.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 62",
+              "citation": "The 'bossa nova' right hand patterns are based on the 'clave' figure."
+            }
+          ],
+          "cross_ref": [
+            "maj69/bossa-nova-dense-upper-voice-extension",
+            "maj6/bossa-nova-clave-direction-lock"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "min7",
+          "function_role": "bossa-nova-clave-upper-voice-minor",
+          "narrative": "Minor seventh chords in bossa nova follow the same two-layer clave architecture as major and dominant chords: fingers 1, 2, and 3 execute the syncopated upper voices while the thumb plays the on-beat bass. \"The 'bossa nova' right hand patterns are based on the 'clave' figure\" (Ch. 2, p. 62) is a universal statement covering all chord qualities including min7. The bass layer of a min7 chord still alternates root and fifth with the fifth-below preference, consistent with Faria's pan-Brazilian bass rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 62",
+              "citation": "The 'bossa nova' right hand patterns are based on the 'clave' figure."
+            }
+          ],
+          "cross_ref": [
+            "min7/samba-two-layer-texture",
+            "dom9/bossa-nova-clave-upper-voice"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "min7",
+          "function_role": "samba-two-layer-texture",
+          "narrative": "Minor seventh chords in samba context inherit the foundational two-layer prescription: right-hand thumb on the on-beat bass (root/fifth alternation), fingers 1-3 on the syncopated upper voices. \"Notice that the syncopation is usually done with the right hand fingers 1, 2 and 3 (playing the top voices of the chord), while the bass note (played with the right hand thumb), comes on the beat\" (Ch. 1, p. 25). This rule is stated with 'usually' rather than 'always,' but it governs min7 voicings as strongly as dom7, with the thumb/finger role never reversed.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 25",
+              "citation": "syncopation is usually done with the right hand fingers 1, 2 and 3 (playing the top voices of the chord), while the bass note (played with the right hand thumb), comes on the beat"
+            }
+          ],
+          "cross_ref": [
+            "min7/bossa-nova-clave-upper-voice-minor",
+            "min7/choro-inverted-minor-seventh"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "min7",
+          "function_role": "choro-inverted-minor-seventh",
+          "narrative": "Choro's prescription of inverted positions for all seventh chords extends to minor seventh voicings: \"the use of triads, seventh and diminished chords are common, usually in an inverted position\" (Ch. 3, p. 86). Min7 chords in choro should be voiced in first or second inversion to enable the active bass-line movement that is structurally central to the style. A root-position min7 in choro would work against the style's bass-melody tradition, making inversions not merely preferred but normative.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "the use of triads, seventh and diminished chords are common, usually in an inverted position"
+            }
+          ],
+          "cross_ref": [
+            "min7/samba-two-layer-texture",
+            "maj7/choro-inverted-voicing-priority"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "min7b5",
+          "function_role": "choro-inverted-half-diminished",
+          "narrative": "The half-diminished (min7b5) chord falls within the choro harmonic vocabulary alongside triads, seventh chords, and fully diminished chords, all of which Faria prescribes in inverted positions: \"the use of triads, seventh and diminished chords are common, usually in an inverted position. The bass line is also very important\" (Ch. 3, p. 86). Min7b5 voicings in choro should be approached with the same inversion-first priority that governs all seventh chord voicings, with the inversion selected to optimize bass-line movement.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "the use of triads, seventh and diminished chords are common, usually in an inverted position. The bass line is also very important."
+            }
+          ],
+          "cross_ref": [
+            "dim7/choro-inverted-position-preference",
+            "min7/choro-inverted-minor-seventh"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom13",
+          "function_role": "bossa-nova-five-note-finger-extension",
+          "narrative": "Dominant thirteenth voicings—dense five- to six-note chords typical of bossa nova's harmonic language—require the explicit right-hand extension Faria prescribes: \"To play the five-note chords in this example, you must use right hand fingers 1, [and additional fingers beyond the standard three]\" (Ch. 2, p. 66). The dom13 chord places its characteristic thirteenth (sixth above the octave) in the upper-voice layer, which must be covered by the additional finger. The bass layer continues its clave-rhythm root/fifth movement regardless of how many voices appear above it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 66",
+              "citation": "To play the five-note chords in this example, you must use right hand fingers 1, [and additional fingers]"
+            }
+          ],
+          "cross_ref": [
+            "dom13/bossa-nova-clave-architecture-extended",
+            "maj7/bossa-nova-five-note-right-hand"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom13",
+          "function_role": "bossa-nova-clave-architecture-extended",
+          "narrative": "The dom13 chord in bossa nova—with its extensions creating a rich layered texture—still operates within the clave-based right-hand architecture: the upper voices (including the thirteenth) receive the syncopated clave rhythm via fingers 1-3 (and additional fingers for five-note voicings), while the thumb plays the root/fifth bass on the beat. The clave direction rule applies to dom13 exactly as to dom7: once the direction is set, it does not change. The harmonic richness of the dom13 does not grant any exemption from rhythmic architecture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 62",
+              "citation": "The 'bossa nova' right hand patterns are based on the 'clave' figure."
+            }
+          ],
+          "cross_ref": [
+            "dom13/bossa-nova-five-note-finger-extension",
+            "dom9/bossa-nova-clave-direction-lock"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7alt",
+          "function_role": "frevo-simple-harmony-constraint",
+          "polarity": "proscriptive",
+          "narrative": "Faria's explicit statement that frevo harmonies are 'quite simple, usually turnarounds' implicitly proscribes heavy use of highly altered dominant voicings in this style: \"the harmonies are quite simple, usually turnarounds\" (Ch. 4, p. 102). Deploying a dom7alt chord—with its multiple altered tones—in a frevo context would contradict the simplicity prescription and shift the harmonic weight in a way that competes with the style's rhythmic energy. The frevo's expressiveness lives in syncopation and tempo, not harmonic alteration.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 102",
+              "citation": "the harmonies are quite simple, usually turnarounds."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-simple-harmony-turnarounds-constraint",
+            "dom7/frevo-walking-bass-analogy"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-simple-harmony-turnarounds-constraint",
+          "polarity": "proscriptive",
+          "narrative": "The explicit 'quite simple, usually turnarounds' description of frevo harmony (Ch. 4, p. 102) functions as a proscriptive lesson for dom7 voicing in this style: complex extended or altered dominant voicings are inappropriate. The frevo's expressive energy derives entirely from rhythmic syncopation and upbeat accent, not from harmonic complexity. A guitarist who loads the dom7 with extensions and alterations in frevo is misallocating the music's expressive resources and working against the style.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 102",
+              "citation": "the harmonies are quite simple, usually turnarounds."
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/frevo-simple-harmony-constraint",
+            "dom7/frevo-syncopation-top-voices"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "samba-off-guitar-body-pre-training",
+          "narrative": "For dom7 samba patterns, Faria prescribes kinesthetic pre-training before touching the instrument: \"It's also a good idea to practice away from the guitar, clapping hands on the high voices and tapping the low voices with your foot\" (Ch. 1, p. 25). This is not an optional supplement but the recommended first step—the body must internalize the two-layer rhythmic independence before the hands attempt to execute it on dom7 voicings. The prescription appears identically in Chapters 1, 2, 3, and 5, confirming that it applies to all styles.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 25",
+              "citation": "It's also a good idea to practice away from the guitar, clapping hands on the high voices and tapping the low voices with your foot."
+            }
+          ],
+          "cross_ref": [
+            "dom7/syncopated-upper-voice-fingers",
+            "dom7/samba-cliche-internalization-requirement"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-off-guitar-body-pre-training",
+          "narrative": "Faria repeats the off-guitar body-percussion pre-training prescription in the baião chapter specifically for dom7 patterns: \"It's also a good idea to practice away from the guitar, clapping the high voices and tapping the low voices with your foot\" (Ch. 5, p. 121). In the baião context, this pre-training is especially important because the texture reversal—syncopated bass vs. on-beat upper voices—is the opposite of samba. The student must physically reprogram the polyrhythmic assignment before approaching the dom7 chord on the instrument.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 121",
+              "citation": "It's also a good idea to practice away from the guitar, clapping the high voices and tapping the low voices with your foot."
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-off-guitar-body-pre-training",
+            "dom7/baiao-pedal-tone-syncopation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "bossa-nova-off-guitar-body-pre-training",
+          "narrative": "The off-guitar body-percussion pre-training prescription extends to bossa nova dom7 patterns as well: \"It's also a good idea to practice away from the guitar, clapping hands on the [high voices and tapping the low voices with your foot]\" (Ch. 2, p. 62). In the bossa nova context, the body-percussion drill internalizes the clave-rhythm split between the two layers before the student attempts to execute it on dense dom7 or dom9 voicings. The repetition of this instruction across all five styles confirms it as a universal prescriptive method.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 2, p. 62",
+              "citation": "It's also a good idea to practice away from the guitar, clapping hands on the [high voices]"
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-off-guitar-body-pre-training",
+            "dom9/bossa-nova-clave-upper-voice"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "choro-off-guitar-body-pre-training",
+          "narrative": "Choro's pandeiro-simulation requirement makes the body-percussion pre-training especially critical for dom7 chords in this style: \"It's also a good idea to practice away from the guitar, clapping hands in the high voices and tapping the low voices with your foot\" (Ch. 3, p. 88). The choro chapter pairs this with a left-hand muting option, giving the student a two-stage approach: first internalize the rhythm off-guitar via body percussion, then apply it on muted strings before introducing full dom7 harmony.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 88",
+              "citation": "It's also a good idea to practice away from the guitar, clapping hands in the high voices and tapping the low voices with your foot."
+            }
+          ],
+          "cross_ref": [
+            "dom7/choro-muting-practice-technique",
+            "dom7/choro-pandeiro-simulation"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "samba-variation-deployment-sustain-or-mix",
+          "narrative": "Faria frames the deployment of dom7 samba variations as a binary performance choice that the player makes consciously before playing, not reactively during the song: \"Each variation can be played through an entire song or you can switch between the variations to create a new pattern\" (Ch. 1, p. 26). The student is not told to 'do whatever feels right'—they are directed to understand both options as legitimate and intentional. This makes variation selection a compositional decision about the dom7 chord's role in the formal architecture of a song.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 1, p. 26",
+              "citation": "Each variation can be played through an entire song or you can switch between the variations to create a new pattern."
+            }
+          ],
+          "cross_ref": [
+            "dom7/variation-cadenza-switch",
+            "dom7/variation-fill-in-singers-pause"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-variation-deployment-sustain-or-mix",
+          "narrative": "The sustain-or-mix rule for dom7 variation deployment is restated identically for baião: \"Each variation can be played through the entire song or you can switch between the variations to create new patterns\" (Ch. 5, p. 122). The absence of any caveat or restriction means the rule applies without modification to baião dom7 contexts—including its unique textures (cowbell, berimbau, broken chords, salsa bass). Any of the five baião variations can anchor an entire performance or be mixed with others, at the player's structural discretion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 122",
+              "citation": "Each variation can be played through the entire song or you can switch between the variations to create new patterns."
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-variation-deployment-sustain-or-mix",
+            "dom7/variation-cadenza-switch"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-variation-deployment-sustain-or-mix",
+          "narrative": "The frevo chapter restates the variation deployment rule for dom7 frevo voicings: \"Each variation can be played through the entire song or you can switch between the variations to create a new pattern. It's also common to use a different pattern at the end of a section or a 'cadenza'\" (Ch. 4, p. 105). This confirms that frevo's five variations—including the third-beat syncopation, the upbeat-only texture, and the marcha rancho—are all deployable interchangeably on the same dom7 chord, making texture selection a formal compositional tool.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 105",
+              "citation": "Each variation can be played through the entire song or you can switch between the variations to create a new pattern. It's also common to use a different pattern at the end of a section or a 'cadenza.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/samba-variation-deployment-sustain-or-mix",
+            "dom7/frevo-march-upbeat-accent"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "frevo-2-4-time-signature-default",
+          "narrative": "Despite common notational practice, Faria prescribes 4/4 as the working time signature for frevo guitar examples in the book while acknowledging the broader historical context: \"Frevo is usually written in 2/4 although you can find the use of 3/4 or 4/4. The examples in this book are written in 4/4\" (Ch. 4, p. 102). For dom7 voicings, this means the student should read and execute frevo patterns in a four-beat metric framework, understanding that the underlying style character (syncopation, upbeat accent) is not altered by the notational convention.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 4, p. 102",
+              "citation": "Frevo is usually written in 2/4 although you can find the use of 3/4 or 4/4. The examples in this book are written in 4/4."
+            }
+          ],
+          "cross_ref": [
+            "dom7/frevo-march-upbeat-accent",
+            "dom7/frevo-marcha-rancho-3-4-variant"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-binary-meter-variant",
+          "narrative": "Faria notes that baião dom7 patterns, typically in 4/4, can also be found in binary meters: \"It's written in 4/4 but you can find also the use of binary meters (2/4 or 2/2)\" (Ch. 5, p. 119). This is a prescriptive awareness lesson: the student learning baião dom7 patterns must understand that the same modal and textural vocabulary operates across multiple metric containers, and that encountering 2/4 or 2/2 baião does not require learning a different harmonic or textural language—only a different metric framework.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 119",
+              "citation": "It's written in 4/4 but you can find also the use of binary meters (2/4 or 2/2)."
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-modal-mixolydian-context",
+            "dom7/choro-waltz-3-4-meter"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "baiao-harmony-simplicity-pedal",
+          "narrative": "Faria prescribes harmonic simplicity and pedal-tone bass as the defining harmonic approach for baião dom7 contexts: \"The harmonies are quite simple with much use of pedal tones in the bass\" (Ch. 5, p. 119). This is a voicing instruction: baião dom7 harmonies should not be adorned with passing chords or frequent harmonic movement—the bass pedal sustains while the upper voices create rhythmic and modal interest over a static or slowly moving harmonic field. Harmonic complexity is actively discouraged.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 5, p. 119",
+              "citation": "The harmonies are quite simple with much use of pedal tones in the bass."
+            }
+          ],
+          "cross_ref": [
+            "dom7/baiao-pedal-tone-syncopation",
+            "dom7/baiao-modal-mixolydian-context"
+          ]
+        },
+        {
+          "source_work_id": "brazilian-guitar-book",
+          "chord_quality": "dom7",
+          "function_role": "choro-ensemble-role-awareness",
+          "narrative": "Faria defines the choro guitarist's role within a specific ensemble context—flute, cavaquinho, and seven-stringed guitar—which prescribes how dom7 voicings should be conceived: \"The term 'choro' was generically used to describe a small group (flute, cavaquinho and seven stringed guitar), often with one group member as a soloist (improvisor)\" (Ch. 3, p. 86). Dom7 voicings in choro must serve the ensemble: they should support the soloist's 16th-note melodic lines, maintain pandeiro-simulation rhythm, and provide clear harmonic direction without obscuring the melodic voices.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Ch. 3, p. 86",
+              "citation": "The term 'choro' was generically used to describe a small group (flute, cavaquinho and seven stringed guitar), often with one group member as a soloist (improvisor)."
+            }
+          ],
+          "cross_ref": [
+            "dom7/choro-pandeiro-simulation",
+            "dom7/choro-16th-note-melodic-phrasing"
+          ]
+        }
+      ]
     },
     {
       "id": "pat-martino",
@@ -30889,7 +33885,1792 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "tonic-stability-anchor",
+          "narrative": "IMaj7 anchors the tonic family and provides the resting function at phrase endings. Felts writes: \"The tonic family of chords has a resting function. Chords in this group tend to sound stable. They have little sense of forward motion and are almost always found at the phrase endings of popular and standard tunes\" (Ch. 1, p. 6). IMaj7 may be replaced by III-7 or VI-7 within this family, but the b9 and tritone hard gates must be satisfied before any substitution is accepted.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 6"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/tonic-substitute",
+            "minor-seventh/tonic-substitute-vi"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "turnaround-target-endpoint",
+          "narrative": "In turnarounds, the final extended ending resolves to a major-seventh chord in a new key via deceptive cadence. Felts prescribes: \"Extended endings provide cadential surprise by resolving to a final major-seventh chord in a new key, often introduced by a deceptive cadence after the original V7 and using motivic melodic material from the song\" (Ch. 9 summary). The Maj7 quality signals harmonic arrival and must be in the new key, not the original tonic.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 9, pp. 86–94"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/deceptive-cadence-approach",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "subdominant-ivmaj7",
+          "narrative": "IVMaj7 occupies the subdominant family and, unlike its subdominant substitute II-7, tolerates the #4 (tritone above root) in the melody. Felts notes: \"It is interesting that the IVMaj7 chord (FMaj7) can be used with #4 in the melody, while its simple substitution, II-7 (D-7), does not work as effectively with the same melody/harmony combination—even though both chords share subdominant function\" (Ch. 1, p. 11). This asymmetry prevents mechanical family-based swaps when #4 is present in the lead.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 11"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/subdominant-ii-tritone-sensitivity",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "notation-baseline-vocabulary",
+          "narrative": "Seventh chords—including Maj7—replace triads as the standard notation baseline in jazz standards. Felts states: \"The use of major seventh chord symbols on Eb and Ab makes the chords easier to analyze as IMaj7 and IVMaj7\" (Ch. 7, p. 66) and: \"Changing the chord symbols to seventh chords brings their representation into sync with the normal chord vocabulary of jazz standards\" (Ch. 7, p. 66). A bare major triad is stylistically incorrect; IMaj7 and IVMaj7 are the minimum acceptable notation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, pp. 65–66"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/notation-baseline-vocabulary",
+            "minor-seventh/notation-baseline-vocabulary"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "bviimaj7-nondiatonic-color",
+          "narrative": "bVIIMaj7 is the one permitted nondiatonic chord in diatonic approach technique, borrowed from the parallel Dorian mode. Felts explains: \"There is one nondiatonic chord that may be used with diatonic approach technique, the bVIIMaj7. In the key of C, the bVIIMaj7 is BbMaj7. It produces a rich sound without overpowering other diatonic chords. That is because the BbMaj7 is diatonic to the C Dorian scale, a key that is parallel to C major\" (Ch. 2, p. 22). It functions as a subdominant-color substitute while retaining diatonic texture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 2, p. 22"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/bvii7-modal-interchange",
+            "major-seventh/modal-interchange-biimaj7"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "modal-interchange-biimaj7",
+          "narrative": "bIIMaj7 is a modal interchange chord drawn from the parallel minor/Phrygian and shares many common tones with IV-. Felts lists it among turnaround slot-1 options: \"bIIMaj7 (a modal interchange chord that shares many common tones with IV-)\" (Ch. 8, p. 77). Its use as a turnaround opener provides subdominant-color access from the tonic position while retaining Maj7 stability. The melody must not contain the major third above the bass, which would create a b9 interval with the Maj7's characteristic second degree.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 77"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/bviimaj7-nondiatonic-color",
+            "minor-seventh/modal-interchange-iv-minor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "iiimaj7-modulatory-interlude-approach",
+          "narrative": "bIIIMaj7 appears as a pickup-aware deceptive-cadence approach chord in modulatory interludes. Felts specifies: \"the new-key downbeat is treated as a target chord approached via strong root motion and pickup-aware deceptive-cadence chords like VI-7(b5) or bIIIMaj7\" (Ch. 9 summary). The Maj7 quality on the flatted third root provides a smooth Dorian-area color leading into a new key center without functional dominant preparation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 9, pp. 86–94"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/modulatory-interlude-vi-approach",
+            "major-seventh/turnaround-target-endpoint"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "diatonic-tension-omission-context",
+          "narrative": "When a Maj7 chord appears in a jazz standard, tensions 9 and 13 are diatonic to the key and need not be written. Felts states: \"Tensions 9 and 13 are diatonic to the key and are automatically implied in a standard tune style. Because diatonic tensions are part of jazz style, it would be considered overkill to write them out explicitly\" (Ch. 7, p. 67). Only nondiatonic tensions (such as #11 on IVMaj7) must be written explicitly.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 67"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/nondiatonic-tension-explicit-notation",
+            "major-seventh/notation-baseline-vocabulary"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "slash-chord-simplification-target",
+          "narrative": "Complex slash chords that obscure Maj7 function should be rewritten. Felts prescribes: \"To simplify and clarify the chord symbols, use Cmaj7 and G7sus4. They represent the same vertical pitches as in the example above, but are expressed in a way that clearly reveals their harmonic function\" (Ch. 7, p. 70). The Maj7 symbol is preferred over E-7/C or similar ambiguous notations because it discloses tonic function legibly to performers.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 70"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh-sus4/slash-chord-clarity",
+            "major-seventh/notation-baseline-vocabulary"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "lydian-modal-tonic-pedal-required",
+          "narrative": "In Lydian modal reharmonization, the Maj7 tonic chord requires a sustained pedal tone to clarify its #11 identity. Felts teaches: \"the Lydian #11 requires a tonic pedal to be heard correctly\" (Ch. 13 summary). Without the pedal, the characteristic raised-fourth color is lost and the chord reverts to generic Maj7 function rather than modal tonic identity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 13, pp. 123–145"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/tonic-stability-anchor",
+            "dominant-seventh/mixolydian-modal-tonic"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "tonic-substitute-iii",
+          "narrative": "III-7 carries tonic function and may substitute for IMaj7 throughout the book. Felts writes: \"Similarly, E7 (V/VI) could be used as the first chord of a turnaround. It is based on a III root. I and III both have tonic function within any key and may substitute for each other\" (Ch. 8, p. 79). This III/I tonic-substitution principle is established in Chapter 1 and cited explicitly in Chapters 8 and 9 as a turnaround construction tool.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 79; Ch. 1, p. 6"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/tonic-substitute-vi",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "tonic-substitute-vi",
+          "narrative": "VI-7 carries tonic function and freely substitutes for IMaj7. Felts states: \"You may think of the 'A' root of the chord as VI in the key. In this case, it functions as a kind of substitution for IMaj7, since I and VI both have tonic function within any key and may substitute for each other\" (Ch. 8, p. 79). The III/VI substitution principle is cross-chapter load-bearing logic applied in simple substitution, turnarounds, and extended endings.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 79"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/tonic-substitute-iii",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "subdominant-ii-tritone-sensitivity",
+          "polarity": "proscriptive",
+          "narrative": "II-7 as subdominant chord cannot tolerate the tritone (#4/b11) in the melody, unlike its subdominant sibling IVMaj7. Felts is explicit: \"Avoid unwanted tritone (#4/b11) melody/harmony intervals on minor seventh chords\" (Ch. 1, p. 11). Furthermore: \"Avoid using a 13 or b13 in the lead of II-7 chords\" because the tritone it produces is better reserved for the following G7 dominant (Ch. 1, p. 11). This prevents simple family swaps when #4 or 13 appears in the lead.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 11"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/subdominant-ivmaj7",
+            "dominant-seventh/tritone-engine"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "ii-v-subdominant-partner",
+          "narrative": "II-7 functions as the subdominant partner in the II-V7 cadential pattern, and tritone tension (b13/13) in its lead is explicitly reserved for the following V7. Felts explains: \"The musical flow of the cadence seems more satisfying when the tritone interval and its greater sense of motion are reserved for the G7\" (Ch. 1, p. 11). Extended II-V7 patterns work best with sparse melodic rhythms—quarter notes, dotted quarters, or half notes—so that melody/harmony clashes can be resolved quickly by tritone substitution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 11; Ch. 3, p. 35"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-engine",
+            "minor-seventh/subdominant-ii-tritone-sensitivity"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "interpolated-chord-between-dominants",
+          "narrative": "Minor seventh chords serve as interpolated smoothers between successive dominants in extended dominant chains. Felts defines: \"Any chord placed between two dominant chords may be described as interpolated. This new chord briefly delays resolution. Commonly, the interpolated chord is a minor seventh chord placed between two dominants in a pattern\" (Ch. 3, p. 31). When rhythm or density demands it, interpolated minor sevenths may be skipped without destroying the progression's forward motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/extended-dominant-chain",
+            "minor-seventh/dominant-conversion-smooth-texture"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "dominant-conversion-smooth-texture",
+          "narrative": "Dominant seventh chords on strong beats within extended chains may be converted to minor sevenths to soften texture. Felts states: \"More variations of these patterns may be found by converting dominant chords that fall on strong beats to minor seventh chords. This yields a slightly smoother texture\" (Ch. 3, p. 33). The conversion is a timbre-management choice, not a functional error; forward motion toward the target is maintained.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 3, p. 33"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/extended-dominant-chain",
+            "minor-seventh/interpolated-chord-between-dominants"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "displacement-b3-to-tension-9",
+          "narrative": "A minor seventh chord with b3 in the lead may be displaced by a half-step II-V7 pattern, converting the original b3 into tension 9 on the new II-7. Felts defines: \"A minor seventh chord with b3 in the lead may be displaced by a II-V7 pattern a half step higher. The melody note that was originally b3 becomes tension 9 on the II-7 of the newly inserted pattern\" (Ch. 4, p. 40). This recontextualizes a potentially clashing b3 as a valid chord extension.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 4, p. 40"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/displacement-b5-to-tension-11",
+            "dominant-seventh/tritone-substitution-clash-repair"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "modal-interchange-i-minor",
+          "narrative": "I-7 (the minor tonic) is a modal interchange chord drawn from the parallel natural minor or Dorian and substitutes for IMaj7 when color is preferred over strict functional preservation. Felts lists I-7 among the twelve common MI chords and notes that MI substitutions do not need to preserve functional category (Ch. 5 summary). The critical constraint: minor-quality MI chords clash with melodies containing the major third, producing a b9 interval.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 5, pp. 45–52"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/tonic-stability-anchor",
+            "minor-seventh/dorian-modal-tonic"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "dorian-modal-tonic",
+          "narrative": "I-7 is the tonic of Dorian modal reharmonization and must occupy strong rhythmic positions approached by the Dorian-specific two-chord cadence (II-7 → I-7). Felts states: \"the I chord is placed in a strong rhythmic position to maintain a clear sense of tonality. The I-7 is then approached by a two-chord cadence derived from Dorian mode\" (Ch. 13, p. 124). Each modal key must be sustained for at least four bars so listeners register the Dorian color.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 13, p. 124"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/tonic-substitute-vi",
+            "minor-seventh/modal-interchange-i-minor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "modal-interchange-v-minor",
+          "narrative": "V-7 is among the twelve common modal interchange chords (drawn from the parallel natural minor or Dorian) that may substitute for diatonic chords without preserving functional category. Felts names it explicitly in the MI chord list (Ch. 5 summary). When the melody contains the leading tone of the major scale, V-7 produces a b9 clash and must be avoided; where the melody is clear of that degree, it provides Dorian/Aeolian color.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 5, pp. 45–52"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/modal-interchange-i-minor",
+            "dominant-seventh/tritone-engine"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "notation-baseline-vocabulary",
+          "narrative": "Minor seventh chords are part of the seventh-chord baseline vocabulary that replaces bare triads in jazz notation. Felts states: \"In Fig. 7.3, the use of triads is inappropriate and stylistically incorrect. The standard tune style is not presented clearly by triadic chord symbols. Standard jazz chord symbols usually include additional pitches—such as sevenths\" (Ch. 7, p. 65). Writing a bare minor triad where II-7 or VI-7 is intended is a notational error.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 65"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/notation-baseline-vocabulary",
+            "dominant-seventh/notation-baseline-vocabulary"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "bass-line-chord-tone-derivation",
+          "narrative": "When bass-line reharmonization produces a bass note that functions as chord tone 1, 3, 5, or 7, the resulting chord should be identified and notated as a root-position or inverted minor seventh, not as a hybrid. Felts prescribes: \"Think of the bass notes as chord tones 1, 3, 5, or 7 of potential reharmonized chord changes. Thinking of these notes as 9, 11, or 13 will produce hybrid chord voicings or may produce chord symbols that are overly complex\" (Ch. 6, p. 54). Direction of the bass line must be consistent into each target.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 6, p. 54"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/bass-line-hybrid-ambiguity",
+            "minor-seventh/ii-v-subdominant-partner"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "tritone-engine",
+          "narrative": "V7's defining property is the tritone between scale degrees 4 and 7, which creates irresistible forward motion toward tonic resolution. Felts states: \"V7 and VII-7(b5) share many common tones. They also contain both the fourth and seventh scale degrees. The intervallic distance between these two notes is called a tritone… The tritone's highly restless sound produces a strong sense of forward motion\" (Ch. 1, p. 7). Every tritone substitution and extended dominant chain derives its logic from this acoustic property.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 7"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-subv7",
+            "half-diminished/dominant-family-vii"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "tritone-substitution-subv7",
+          "narrative": "Any dominant seventh may be replaced by the dominant seventh a tritone away (subV7), because both share the same tritone interval. Felts prescribes: \"To use tritone substitution, start with a target chord. Then, work backward from the target chord, harmonizing each melody note with a series of dominant seventh chords a perfect fifth apart\" (Ch. 3, p. 28). The subV7 provides chromatic bass-line color (half-step approach) while maintaining the tritone resolution tendency.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 3, p. 28"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-engine",
+            "dominant-seventh/extended-dominant-chain"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "extended-dominant-chain",
+          "narrative": "Dominant sevenths may be chained in perfect-fifth motion backward from a target to create cumulative forward motion. Felts cautions: \"The strong sense of forward motion and resolution created by reharmonizing with chains of extended dominants helps drive short runs of notes toward a target chord. As with diatonic approach technique, be careful not to overuse this method, since it can produce a very busy harmonic rhythm that overpowers the melody\" (Ch. 3, p. 30). At medium-to-fast tempos, chords should appear only on strong beats 1 and 3.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 3, p. 30"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-subv7",
+            "minor-seventh/interpolated-chord-between-dominants"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "cadential-displacement-target",
+          "narrative": "Cadential dominant sevenths are the preferred targets for displacement because their structural role makes displacement audibly noticeable. Felts states: \"A cadential dominant chord is often a good choice as a displaced target chord. Dominant seventh chords have usually been carefully placed in order to establish the framework of the original phrase. Displacing these chords produces a noticeable change in the harmonic shape\" (Ch. 4, p. 37). Displacement by more than a measure creates dramatic harmonic change.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 4, p. 37"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-clash-repair",
+            "minor-seventh/displacement-b3-to-tension-9"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "tritone-substitution-clash-repair",
+          "narrative": "Tritone substitution is the primary tool for repairing melody/harmony clashes that arise from displacement. Felts demonstrates: \"To fix the melody/harmony problem found in measure 1, beat 2, I do two things. I use tritone substitution to change F#7 to C7, and adjust the chord quality to sus4 to account for the fourth in the melody\" (Ch. 4, p. 39). The subV7 resolves the clash while maintaining dominant function leading into the target.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 4, p. 39"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh-sus4/sus4-melody-clash-repair",
+            "dominant-seventh/tritone-substitution-subv7"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "altered-tension-downward-resolution",
+          "narrative": "Altered tensions (b9, #9, b5, b13) on dominant seventh chords resolve primarily downward in pop and jazz performance practice. Felts states: \"In the performance practice of pop and jazz standard tunes, altered tensions such as the b9, #9, b5, b13 melody notes have most often been resolved in a downward direction\" (Ch. 3, p. 29). However, upward motion is contextually permissible: \"Almost any motion up or down from b9, #9, b5, or b13 is possible\" (Ch. 3, p. 30).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 3, pp. 29–30"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/v7b9-permitted-exception",
+            "dominant-seventh/tritone-engine"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "v7b9-permitted-exception",
+          "narrative": "V7(b9) is the only common exception to the blanket rule against b9 melody/harmony intervals. Felts writes: \"The V7(b9) is the only common exception to this rule. The V7(b9) has become an acceptable sound in many pop and jazz songs. For example, a C7b9 moving to FMaj7 in the key of F major works because the b9 is combined with a tritone interval. Both the b9 and tritone intervals follow established melodic tendencies when they resolve to the FMaj7\" (Ch. 1, p. 10). Listeners hear unresolved b9 combinations outside this context as errors.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 10"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-engine",
+            "dominant-seventh/altered-tension-downward-resolution"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "diminished-seventh-tritone-substitute",
+          "narrative": "Four dominant seventh chords are related to each diminished seventh, each sharing one of its tritones, and any of the four may substitute for it in reharmonization. Felts states: \"Four dominant seventh chords are related to a given diminished seventh chord. These four dominant chords (with or without their related II-7s) are the most common choices for reharmonizing a diminished seventh. Each of these dominant chords contains one of the tritones found in the original diminished seventh\" (Ch. 12, p. 113). The selection hierarchy prioritizes shared tritone, then dominant cadence, then maximum chord-tone sharing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 12, p. 113"
+            }
+          ],
+          "cross_ref": [
+            "diminished-seventh/reharmonization-target",
+            "dominant-seventh/tritone-engine"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "diminished-reharmonization-ascending-halfstep",
+          "narrative": "When a diminished seventh chord moves up by half step to a root-position chord, the preferred dominant substitutes are those a perfect fifth or minor second above the target. Felts specifies: \"Diminished seventh chords that move up by half step to a chord in root position are most often reharmonized with dominant sevenths that are a perfect fifth above or a minor second above the target\" (Ch. 12, p. 116). Descending root motion changes this preference and requires different selection.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 12, p. 116"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/diminished-seventh-tritone-substitute",
+            "diminished-seventh/reharmonization-target"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "chromatic-ii-v7-pattern-lower",
+          "narrative": "In the chromatic II-V7 pattern, a dominant seventh a half step below a minor seventh chord completes the chromatic cadential pair. Felts defines: \"A chromatic II-V7 pattern is made up of a minor seventh chord or a minor 7(b5) followed by a dominant seventh a half step below. The root motion between the two chords is chromatic and the two chords sound subdominant to dominant in the same spirit as regular II-V7 patterns\" (Ch. 12, p. 119). This device provides an alternative non-diatonic cadential motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 12, p. 119"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/ii-v-subdominant-partner",
+            "half-diminished/chromatic-ii-v7-subdominant"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "notation-baseline-vocabulary",
+          "narrative": "Dominant seventh chords form part of the seventh-chord baseline vocabulary that must replace triads in jazz standard notation. Felts prescribes: \"Standard jazz chord symbols usually include additional pitches—such as sevenths\" (Ch. 7, p. 65). Nondiatonic tensions on dominant chords (b9, #9, b13) must always be written explicitly in the chord symbol, unlike diatonic tensions which are implied.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 65"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/nondiatonic-tension-explicit-notation",
+            "major-seventh/notation-baseline-vocabulary"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "nondiatonic-tension-explicit-notation",
+          "narrative": "All nondiatonic tensions on dominant seventh chords must be notated explicitly in the chord symbol. Felts states: \"While diatonic tensions are implied in standard jazz style, all nondiatonic tensions should be included in the chord symbols\" (Ch. 7, p. 67). This asymmetry means that b9, #9, and b13 must always appear explicitly, while diatonic 9 and 13 may be omitted.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 67"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/diatonic-tension-omission-context",
+            "dominant-seventh/v7b9-permitted-exception"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "deceptive-cadence-approach",
+          "narrative": "A deceptive cadence occurs when a dominant seventh resolves to any chord other than the expected IMaj7. Felts defines: \"Deceptive cadences are produced when a dominant seventh chord moves unexpectedly. For example, a V7 chord is expected to resolve by perfect fifth to I major. Motion from the V7 to any chord other than IMaj7 is 'deceptive'\" (Ch. 2, p. 20). In extended endings, the original V7's deceptive resolution introduces the new-key Maj7 target.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 2, p. 20"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/turnaround-target-endpoint",
+            "dominant-seventh/tritone-engine"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "turnaround-slot-4-dominant",
+          "narrative": "The fourth and final slot of the turnaround template is occupied by a dominant seventh that resolves into the first chord of the next phrase. Felts states: \"The fourth and usually last chord of a typical turnaround (measure 32, beat 3) is a chord that has dominant function and leads by strong root motion into the first chord of the new phrase\" (Ch. 8, p. 74). This dominant must connect to the new phrase downbeat via strong (non-third, non-sixth) root motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 74"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-engine",
+            "major-seventh/turnaround-target-endpoint"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "bvii7-modal-interchange",
+          "narrative": "bVII7 is a modal interchange dominant drawn from the parallel minor/Dorian that may appear in turnaround slot-1 as a near-tonic color substitute. Felts lists: \"bVIIMaj7 or bVII7 (modal interchange chords that share two common tones with IV or IV-)\" (Ch. 8, p. 77) among the valid slot-1 choices. Unlike V7, bVII7 lacks the diatonic tritone and provides a Mixolydian/Dorian flavor without the same resolution imperative.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 77"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/bviimaj7-nondiatonic-color",
+            "dominant-seventh/mixolydian-modal-tonic"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "mixolydian-modal-tonic",
+          "narrative": "In Mixolydian modal reharmonization, the dominant seventh quality serves as the tonic chord color, occupying strong rhythmic positions approached by the Mixolydian-specific two-chord cadential pair. Felts teaches that both melody and chords must be diatonic to the Mixolydian scale and that the tonic must be reinforced at least every four bars so listeners register the modal color (Ch. 13 summary). The b7 of the Mixolydian I7 is a mode-defining tone that must not be confused with a functional V7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 13, pp. 123–145"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/bvii7-modal-interchange",
+            "dominant-seventh/tritone-engine"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "hybrid-voicing-altered-dominant-sound",
+          "narrative": "Hybrid chord voicings (upper triad or seventh over a fixed bass) produce an altered dominant sound derived from the altered dominant scale. Felts states: \"Hybrid structures of the type shown above produce an altered dominant sound\" (Ch. 14, p. 147) and clarifies that the theoretical basis is the altered dominant scale (1, b9, #9, 3, #4/b5, b6, b7, 1). When an upper-layer dominant seventh is used in a hybrid, it most effectively generates this ambiguous altered texture at phrase endpoints.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, p. 147"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/upper-layer-dominant-seventh",
+            "dominant-seventh/tritone-engine"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "constant-structure-loosely-tonal",
+          "narrative": "Dominant seventh sus4 chords may be used in constant structure progressions where bass motion outlines I, IV, and V without establishing functional tonality. Felts writes: \"The constant structure dominant seventh sus4 chords in fig. 15.8 loosely outline I, IV, and V in the key of A, but are not clearly tonal\" (Ch. 15, p. 157). In this context the dominant seventh functions as a texture member, not a resolution-driving structural dominant.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 15, p. 157"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh-sus4/constant-structure-texture",
+            "dominant-seventh/mixolydian-modal-tonic"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh-sus4",
+          "function_role": "v7sus4-subdominant-dominant-borderline",
+          "narrative": "V7sus4 occupies both the subdominant and dominant families depending on context. Felts explains: \"The V7sus4 is also included in this family, because it contains the fourth scale degree instead of the third. (Using a suspended fourth instead of a third eliminates the tritone that gives a dominant family chord its characteristic sound.)\" (Ch. 1, p. 7). It has dominant function only when it resolves directly to IMaj7: \"The V7sus4 chord has a dominant function when it resolves directly to IMaj7, even though it lacks the tritone interval\" (Ch. 1, p. 7).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 7"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-engine",
+            "major-seventh/subdominant-ivmaj7"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh-sus4",
+          "function_role": "sus4-melody-clash-repair",
+          "narrative": "When displacement or tritone substitution leaves a fourth in the melody over a dominant, adjusting to sus4 quality resolves the clash. Felts demonstrates: \"To fix the melody/harmony problem found in measure 1, beat 4, I adjust the chord quality to sus4 to account for the fourth in the melody\" (Ch. 4, p. 39). The sus4 absorbs the fourth as a structural chord tone rather than treating it as a dissonant extension against a third.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 4, p. 39"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-clash-repair",
+            "dominant-seventh-sus4/v7sus4-subdominant-dominant-borderline"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh-sus4",
+          "function_role": "slash-chord-clarity",
+          "narrative": "Complex slash chords that imply suspension should be rewritten as G7sus4 to reveal harmonic function. Felts prescribes: \"To simplify and clarify the chord symbols, use Cmaj7 and G7sus4. They represent the same vertical pitches as in the example above, but are expressed in a way that clearly reveals their harmonic function\" (Ch. 7, p. 70). The sus4 symbol is preferred over D-7/G or similar notations because it discloses the suspended fourth structurally.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 70"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/slash-chord-simplification-target",
+            "dominant-seventh-sus4/v7sus4-subdominant-dominant-borderline"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh-sus4",
+          "function_role": "constant-structure-texture",
+          "narrative": "Dominant seventh sus4 chords function as texture-organized constant structure members whose bass motion loosely outlines tonal centers without functional resolution. Felts notes: \"The constant structure dominant seventh sus4 chords in fig. 15.8 loosely outline I, IV, and V in the key of A, but are not clearly tonal\" (Ch. 15, p. 157). Their suspended quality makes them ideal for constant structure use because they resist resolution implications while maintaining consistent voicing texture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 15, p. 157"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/constant-structure-loosely-tonal",
+            "dominant-seventh-sus4/v7sus4-subdominant-dominant-borderline"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "half-diminished",
+          "function_role": "dominant-family-vii",
+          "narrative": "VII-7(b5) is a member of the dominant family by virtue of sharing many common tones with V7 and containing both the tritone scale degrees. Felts states: \"V7 and VII-7(b5) share many common tones. They also contain both the fourth and seventh scale degrees\" (Ch. 1, p. 7) and lists VII-7(b5) explicitly as a dominant family member (Ch. 1, p. 7). It may substitute for V7 in dominant-function contexts, subject to the b9 and tritone hard gates.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 7"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-engine",
+            "diminished-seventh/reharmonization-target"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "half-diminished",
+          "function_role": "displacement-b5-to-tension-11",
+          "narrative": "A minor 7(b5) chord with b5 in the lead may be displaced by a half-step II-V7 pattern, converting the b5 into tension 11 on the new II-7. Felts defines: \"A minor seventh chord with b5 in the lead may be displaced by a II-V7 pattern a half step higher. The melody note that was originally b5 becomes tension 11 on the II-7 of the newly inserted pattern\" (Ch. 4, p. 40). This technique generalizes to any context where b5 appears in the lead of a half-diminished chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 4, p. 40"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/displacement-b3-to-tension-9",
+            "dominant-seventh/cadential-displacement-target"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "half-diminished",
+          "function_role": "chromatic-ii-v7-subdominant",
+          "narrative": "A minor 7(b5) may serve as the subdominant member of a chromatic II-V7 pattern when followed by a dominant seventh a half step below. Felts states: \"A chromatic II-V7 pattern is made up of a minor seventh chord or a minor 7(b5) followed by a dominant seventh a half step below. The root motion between the two chords is chromatic and the two chords sound subdominant to dominant in the same spirit as regular II-V7 patterns\" (Ch. 12, p. 119). The half-diminished quality intensifies the subdominant color relative to plain II-7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 12, p. 119"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/chromatic-ii-v7-pattern-lower",
+            "minor-seventh/ii-v-subdominant-partner"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "half-diminished",
+          "function_role": "modulatory-interlude-vi-approach",
+          "narrative": "VI-7(b5) is a pickup-aware deceptive-cadence chord used to approach a new-key downbeat in modulatory interludes. Felts specifies: \"the new-key downbeat is treated as a target chord approached via strong root motion and pickup-aware deceptive-cadence chords like VI-7(b5) or bIIIMaj7\" (Ch. 9 summary). Its diminished-fifth interval above the root provides the chromatic pull needed to signal the imminent key change to the listener.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 9, pp. 86–94"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/iiimaj7-modulatory-interlude-approach",
+            "half-diminished/dominant-family-vii"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "half-diminished",
+          "function_role": "hybrid-upper-layer-forbidden",
+          "polarity": "proscriptive",
+          "narrative": "Minor 7(b5) structures are explicitly forbidden as the upper layer of hybrid chord voicings. Felts prescribes: \"Avoid augmented, diminished, or minor 7(b5) structures in the upper layer of hybrid chords since they tend to sound like more traditional chord voicings when combined with the bass note\" (Ch. 14, p. 147). When minor 7(b5) is placed above the fixed bass, the characteristic ambiguous altered-dominant texture collapses into familiar tonal function, defeating the purpose of the hybrid technique.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, p. 147"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/upper-layer-construction-rules",
+            "diminished-seventh/hybrid-upper-layer-forbidden"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "diminished-seventh",
+          "function_role": "reharmonization-target",
+          "narrative": "Diminished seventh chords are pre-substitution targets: their four tritones each yield a related dominant seventh that may replace them. Felts states: \"Four dominant seventh chords are related to a given diminished seventh chord. These four dominant chords (with or without their related II-7s) are the most common choices for reharmonizing a diminished seventh. Each of these dominant chords contains one of the tritones found in the original diminished seventh\" (Ch. 12, p. 113). Selection follows the three-tier hierarchy: shared tritone, dominant cadence, maximum chord-tone sharing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 12, p. 113"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/diminished-seventh-tritone-substitute",
+            "dominant-seventh/diminished-reharmonization-ascending-halfstep"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "diminished-seventh",
+          "function_role": "enharmonic-respelling-for-function",
+          "narrative": "Any diminished seventh chord has four enharmonically equivalent symbols, and the correct choice is determined by harmonic function and voice-leading context. Felts states: \"Any diminished seventh can be expressed as a series of four enharmonically equal chord symbols. The chords below share the same chord tones. However, context will determine which chord symbol best represents the sound and harmonic function of the chord\" (Ch. 7, p. 68). For example, C#°7 is preferred over E°7 when it clarifies the dominant-to-D-minor resolution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 68"
+            }
+          ],
+          "cross_ref": [
+            "diminished-seventh/reharmonization-target",
+            "dominant-seventh/diminished-seventh-tritone-substitute"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "diminished-seventh",
+          "function_role": "line-cliche-hidden-signal",
+          "narrative": "The presence of a diminished seventh that does not resolve by half-step root motion is a diagnostic signal that a line cliché is hidden in the progression. Felts lists: \"Two clues that a line cliché is hidden in the progression are: 1. Presence of a secondary dominant chord with an augmented quality 2. Presence of a diminished seventh that does not resolve by step\" (Ch. 7, p. 69). When this signal is detected, the correct notation is a single sustained chord with a moving inner voice, not a series of chromatic diminished sevenths.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 69"
+            }
+          ],
+          "cross_ref": [
+            "diminished-seventh/line-cliche-notation-principle",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "diminished-seventh",
+          "function_role": "line-cliche-notation-principle",
+          "narrative": "A line cliché disguised as a series of diminished sevenths should be renotated as a single sustained chord with a moving line. Felts prescribes: \"A line cliché is most clearly represented as a single chord with a line moving against it. Diminished seventh chords normally resolve by half-step root motion\" (Ch. 7, p. 69). Writing multiple chromatic diminished sevenths where a line cliché is intended obscures tonic function and misleads performers.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 69"
+            }
+          ],
+          "cross_ref": [
+            "diminished-seventh/line-cliche-hidden-signal",
+            "diminished-seventh/enharmonic-respelling-for-function"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "diminished-seventh",
+          "function_role": "hybrid-upper-layer-forbidden",
+          "polarity": "proscriptive",
+          "narrative": "Diminished seventh structures are forbidden as the upper layer of hybrid chord voicings. Felts states: \"Avoid augmented, diminished, or minor 7(b5) structures in the upper layer of hybrid chords since they tend to sound like more traditional chord voicings when combined with the bass note\" (Ch. 14, p. 147). Placing a diminished seventh above the bass causes the voicing to collapse into a familiar dominant-seventh-with-enharmonic-reading rather than producing the desired ambiguous altered-dominant texture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, p. 147"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/hybrid-upper-layer-forbidden",
+            "hybrid/upper-layer-construction-rules"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "diminished-seventh",
+          "function_role": "fallback-chord-tone-sharing",
+          "narrative": "When no dominant cadence into the target is available for reharmonizing a diminished seventh, the fallback rule selects the dominant sharing the most chord tones with the original diminished seventh. Felts states: \"When a dominant cadence to the target chord is not available, choose a dominant chord that shares a considerable number of chord tones with the original diminished seventh. Be sure it is compatible with the melody\" (Ch. 12, p. 119). This is tier 3 of the three-tier diminished reharmonization hierarchy.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 12, p. 119"
+            }
+          ],
+          "cross_ref": [
+            "diminished-seventh/reharmonization-target",
+            "dominant-seventh/diminished-seventh-tritone-substitute"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "hybrid",
+          "function_role": "upper-layer-construction-rules",
+          "narrative": "Hybrid voicings require the root in the bass and an upper layer of specific quality. Felts prescribes: \"To construct hybrid voicings of traditional chord structures: 1. Keep the root of the original chord. 2. Choose an upper structure layer that forms a major or minor triad or forms a major seventh, a minor seventh, or a dominant seventh. Avoid augmented, diminished, or minor 7(b5) structures in the upper layer of hybrid chords since they tend to sound like more traditional chord voicings when combined with the bass note\" (Ch. 14, p. 147). The theoretical basis is the altered dominant scale.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, p. 147"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/third-in-lead-failure-condition",
+            "dominant-seventh/hybrid-voicing-altered-dominant-sound"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "hybrid",
+          "function_role": "third-in-lead-failure-condition",
+          "polarity": "proscriptive",
+          "narrative": "Hybrid voicings fail when the melody note forms a major or minor third above the bass, destroying the ambiguous altered-dominant texture. Felts states: \"Hybrid voicings lose their effectiveness if melody notes form intervals of either a major or minor third above the bass note. Errors of several kinds are produced if a third is in the lead… The third above the bass note will destroy the ambiguous texture associated with this hybrid technique\" (Ch. 14, pp. 149). This is the primary hard gate condition for hybrid application.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, pp. 149"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/upper-layer-construction-rules",
+            "hybrid/phrase-endpoint-deployment"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "hybrid",
+          "function_role": "phrase-endpoint-deployment",
+          "narrative": "Hybrid voicings function best as contrast devices at phrase endpoints rather than throughout entire passages. Felts states: \"A hybrid voicing often works well at the end of a phrase. The entire phrase need not be harmonized with hybrid chords\" (Ch. 14, p. 149). When deployed in series, however, they generate a stronger impressionistic textural effect: \"A series of hybrid chords produces a stronger impressionistic effect than an isolated hybrid voicing\" (Ch. 16, p. 169).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, p. 149; Ch. 16, p. 169"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/upper-layer-construction-rules",
+            "hybrid/third-in-lead-failure-condition"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "hybrid",
+          "function_role": "upper-layer-dominant-seventh",
+          "narrative": "An upper-layer dominant seventh chord in a hybrid voicing is one of the five permitted upper-structure types. Felts specifies: \"The upper layer of a hybrid chord may be voiced as either a triad or a seventh chord\" (Ch. 14, p. 150), and the permitted seventh chord types are major seventh, minor seventh, or dominant seventh. A phrase may mix both triads and seventh chords in its hybrid upper layers, offering compositional flexibility.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, p. 150"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/upper-layer-construction-rules",
+            "dominant-seventh/hybrid-voicing-altered-dominant-sound"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "hybrid",
+          "function_role": "bass-line-hybrid-ambiguity",
+          "polarity": "proscriptive",
+          "narrative": "Hybrid chords arising from bass-line reharmonization have an ambiguous, unstable quality that can disrupt phrase cohesion if used indiscriminately. Felts warns: \"These incomplete, ambiguous voicings are called hybrid chords. They have a distinctive sound and texture, and should be used carefully. If used indiscriminately, hybrids can break up the sonic texture and mood of a phrase\" (Ch. 6, p. 56). They arise when a bass note is heard as the root of a new chord rather than as a chord tone of the intended harmony above it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 6, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/phrase-endpoint-deployment",
+            "minor-seventh/bass-line-chord-tone-derivation"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "hybrid",
+          "function_role": "modal-hybrid-constant-structure-combination",
+          "narrative": "Hybrid chords may be used to revoice all or part of a modal progression, developing it beyond traditional voicings. Felts prescribes: \"Voicing all or some of the chords in the modal progression as hybrid structures develops the chord progression further\" (Ch. 16, p. 163) and: \"Hybrid chords may occasionally be used as isolated structures within phrases, but they acquire a stronger textural personality when used in a series\" (Ch. 16, p. 169). The root motion from the modal progression is preserved when voicing as hybrids.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 16, pp. 163, 169"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/phrase-endpoint-deployment",
+            "major-seventh/lydian-modal-tonic-pedal-required"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "modal-interchange-iv-minor",
+          "narrative": "IV- (minor fourth) is a modal interchange chord drawn from the parallel natural minor and listed among common MI chords available as turnaround and approach-chord substitutes. Felts includes it in the turnaround slot-1 catalog: \"IV chord or modal interchange variation of IV (IV-, IV-6, IV-7)\" (Ch. 8, p. 77). The minor quality adds Dorian/Aeolian color while maintaining subdominant function, but it will clash with melodies containing the major third of the key (b9 interval).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 77; Ch. 5, pp. 45–52"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/modal-interchange-biimaj7",
+            "minor-seventh/modal-interchange-i-minor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "phrygian-modal-tonic",
+          "narrative": "In Phrygian modal reharmonization, the minor seventh tonic chord must occupy strong rhythmic positions approached by the Phrygian-specific two-chord cadential pair. Felts teaches that the Phrygian b9 is a mode-defining dissonance: when it appears outside its Phrygian context, it signals a structural error (Ch. 13 summary). The tonic minor seventh in Phrygian must remain for at least four bars and be reinforced by tonic pedal or ostinato to establish the mode's characteristic lowered-second identity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 13, pp. 123–145"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/dorian-modal-tonic",
+            "minor-seventh/aeolian-modal-tonic"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "aeolian-modal-tonic",
+          "narrative": "In Aeolian modal reharmonization, the minor seventh serves as the natural minor tonic and must be reinforced in strong rhythmic positions approached by the Aeolian-specific two-chord cadence. Felts requires that both melody and chords be diatonic to the Aeolian scale and that the modal key be sustained for at least four bars (Ch. 13 summary). Tonic pedal or ostinato reinforcement is prescribed for strong modal quality: \"Use of a tonic pedal tone or tonic ostinato will help to reinforce the sense of modal tonality\" (Ch. 16, p. 169).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 13, pp. 123–145; Ch. 16, p. 169"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/phrygian-modal-tonic",
+            "minor-seventh/dorian-modal-tonic"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "turnaround-slot-3-subdominant",
+          "narrative": "The third slot of the turnaround template calls for a chord with subdominant function, which may include II-7, IV-7, or related modal interchange minor sevenths. Felts states: \"The third chord of a typical turnaround (measure 32, beat 1) is a chord that has a subdominant function (SD) and leads by strong root motion into the last chord of the turnaround\" (Ch. 8, p. 74). The minor-seventh quality in this slot often contributes a richer harmonic color than IVMaj7 while maintaining the subdominant pull toward the final dominant.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 74"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/subdominant-ivmaj7",
+            "minor-seventh/ii-v-subdominant-partner"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "sharp-v-chromatic-iv-variant",
+          "narrative": "#V-7(b5) is treated as a chromatic variation of IV and may serve as turnaround slot-1 or slot-3 material. Felts lists: \"#V-7(b5) chord (a chord that is considered a chromatic variation of IV)\" (Ch. 8, p. 77) as a valid first-chord option. Its half-diminished quality on the raised fifth scale degree provides a distinctive chromatic subdominant color unavailable from purely diatonic sources.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 77"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/subdominant-ivmaj7",
+            "half-diminished/dominant-family-vii"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "constant-structure-major-seventh-root-spelling",
+          "narrative": "Major seventh chords may form constant structure progressions whose roots outline implied harmonies such as diminished triads or major triads without establishing functional tonality. Felts writes: \"The roots of the constant structure major seventh chords in the example below outline an F# diminished triad (F#, A, C). This progression is organized by the root motion but is not clearly tonal\" (Ch. 15, p. 157). Similarly roots may spell a D major triad (D, F#, A) giving loose harmonic implication to the texture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 15, p. 157"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/lydian-modal-tonic-pedal-required",
+            "dominant-seventh/constant-structure-loosely-tonal"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "constant-structure-fmaj7-tensions",
+          "narrative": "Constant structure major seventh chord roots may outline a complete seventh chord with its tensions, as in an FMaj7 sonority with 9, #11, 13 spelled by successive bass notes. Felts references: \"The roots of the constant structure chords in fig. 15 [outline FMaj7 with tensions]\" (Ch. 15, p. 158). This creates a rich, overtone-rich textural organization where each chord in the pattern reinforces a single underlying harmonic sonority rather than establishing a new tonal center.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 15, p. 158"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/constant-structure-major-seventh-root-spelling",
+            "major-seventh/diatonic-tension-omission-context"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "three-chord-modal-interchange-limit",
+          "polarity": "proscriptive",
+          "narrative": "Modal interchange chords, including minor sevenths drawn from parallel scales, must not be used in sequences exceeding three consecutive chords before returning to diatonic harmony. Felts prescribes: \"A three-chord limit is recommended before returning to diatonic harmony to avoid an ambiguous tonal center\" (Ch. 5 summary). Exceeding this limit causes the listener to lose track of the home key, which is treated as a functional error rather than an expressive choice unless full modal reharmonization is intended.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 5, pp. 45–52"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/modal-interchange-i-minor",
+            "minor-seventh/dorian-modal-tonic"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "modal-interchange-mi-preserves-color-not-function",
+          "narrative": "Modal interchange substitutions trade functional category for color, meaning a major seventh MI chord may occupy a slot that was formerly subdominant or dominant without any functional contradiction. Felts explains: \"The MI substitution does not need to preserve functional category (tonic/subdominant/dominant), distinguishing it from simple substitution which keeps function but yields less color\" (Ch. 5 summary). This is the key distinguishing property that separates modal interchange from simple family substitution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 5, pp. 45–52"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/bviimaj7-nondiatonic-color",
+            "major-seventh/modal-interchange-biimaj7"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "third-inversion-context-prerequisite",
+          "polarity": "proscriptive",
+          "narrative": "Third-inversion major seventh chords (seventh in the bass) require a preceding root-position form of the same chord for perceptual grounding. Felts states in both Chapter 6 and Chapter 10: \"Be cautious about using chord tone 7 in the bass (third inversion), unless a root position form of the same chord is used directly before the inversion\" (Ch. 6, p. 55) and: \"For a smooth, traditional sound, precede each third inversion chord with the same chord in root position\" (Ch. 10, p. 101). Without this context, the seventh in the bass is heard as a new root.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 6, p. 55; Ch. 10, p. 101"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/tonic-stability-anchor",
+            "dominant-seventh/tritone-engine"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "inversion-passing-chord-function",
+          "narrative": "Inverted major seventh chords function as passing chords approached and left by step, not as structural phrase markers. Felts states: \"It is usually best to move away from an inverted chord by step. Inversions function as passing chords; they rarely begin or conclude harmonic phrases. The use of an inversion does not change the functional analysis of a progression in any way\" (Ch. 10, p. 100). The IMaj7 in first or second inversion retains tonic function but must be used within stepwise voice-leading contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 10, p. 100"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/third-inversion-context-prerequisite",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "voice-leading-3-to-7-resolution",
+          "narrative": "When root motion is a perfect fourth or fifth (the most common cadential motion), the third of the first chord resolves to the seventh of the second, and the seventh resolves to the third. Felts prescribes: \"If the root motion moves by perfect fourth or perfect fifth, resolve chord tone 3 in the first chord to chord tone 7 of the second, and chord tone 7 in the first chord to 3 in the second. These resolutions produce a clear harmonic texture and minimize finger movement from chord to chord\" (Ch. 10, p. 96). This is the primary voice-leading rule governing V7→I motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 10, p. 96"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-engine",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "voice-leading-parallel-unison-second",
+          "narrative": "When dominant seventh root motion moves by unison or second (e.g., chromatic II-V7 patterns), all voices move in parallel motion. Felts states: \"If root motion moves by unison or second, move the voices in parallel motion. Parallel motion means that all voices move up or down by a similar amount\" (Ch. 10, p. 97). This rule governs the physical realization of the chromatic II-V7 pattern and other half-step dominant progressions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 10, p. 97"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/chromatic-ii-v7-pattern-lower",
+            "dominant-seventh/voice-leading-3-to-7-resolution"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "tension-register-floor",
+          "narrative": "All tension tones (9, 11, 13) on dominant seventh chords must be placed above the F on the fourth line of the bass clef to avoid muddiness. Felts states: \"It is generally good practice to keep all tensions above the F found on the fourth line of the bass clef in order to avoid a muddy sound\" (Ch. 10, p. 98). Tensions placed below this register produce frequency-masking effects in the lower octaves that obscure harmonic clarity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 10, p. 98"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/nondiatonic-tension-explicit-notation",
+            "dominant-seventh/v7b9-permitted-exception"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "tension-register-floor",
+          "narrative": "Major seventh chord tensions must be placed above the F on the fourth line of the bass clef. Felts states: \"It is generally good practice to keep all tensions above the F found on the fourth line of the bass clef in order to avoid a muddy sound\" (Ch. 10, p. 98). This register constraint applies across all chord qualities, including IMaj7 voicings where tension 9 or #11 appear.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 10, p. 98"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tension-register-floor",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "tension-register-floor",
+          "narrative": "Tension tones on minor seventh chords (9, 11, 13) must be placed above the F on the fourth line of the bass clef to avoid registral muddiness. Felts' universal register rule: \"It is generally good practice to keep all tensions above the F found on the fourth line of the bass clef in order to avoid a muddy sound\" (Ch. 10, p. 98). For II-7 in particular, the 11 (fourth degree) placed too low can create a murky subdominant blur rather than a clean suspension effect.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 10, p. 98"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/tension-register-floor",
+            "minor-seventh/subdominant-ii-tritone-sensitivity"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "voice-leading-third-sixth-parallel-contrary",
+          "narrative": "When major seventh chord roots move by third or sixth (e.g., I→III or I→VI tonic family moves), either parallel or contrary motion is permitted between bass and upper voices. Felts states: \"If roots move by third or sixth, use either parallel or contrary motion between the roots and the upper voices. Contrary motion means that voices move in opposite directions: the bass note moves down, while all other voices move up\" (Ch. 10, p. 97). This covers the common IMaj7→VI-7 tonic substitution voice-leading realization.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 10, p. 97"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/tonic-stability-anchor",
+            "minor-seventh/tonic-substitute-vi"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "line-cliche-tonic-primary-location",
+          "narrative": "Line clichés are most commonly applied to the tonic minor seventh chord (I-7 in minor keys), which is their primary and safest location. Felts states: \"Although line clichés are found on the I chord more often than on other diatonic chords, a short line cliché (one measure or less) may be applied to any diatonic chord\" (Ch. 11, p. 109). The characteristic motion moves between the fifth and root of the sustained I-7, adding momentum without changing harmony.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 11, p. 109"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/line-cliche-non-tonic-overuse-risk",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "line-cliche-non-tonic-overuse-risk",
+          "polarity": "proscriptive",
+          "narrative": "Overusing line clichés on non-tonic minor seventh chords risks causing listeners to rehear the embellished chord as a new tonic. Felts warns: \"Repeated use of a line cliché on a chord other than the 'I' may cause the listener to hear the chord being embellished by the line cliché as a new I chord. Overuse of this technique may weaken the sense of key within the progression\" (Ch. 11, p. 109). A short line cliché of one measure or less on non-tonic chords is acceptable; sustained application is not.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 11, p. 109"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/line-cliche-tonic-primary-location",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "line-cliche-major-key-extension",
+          "narrative": "Line clichés extend beyond minor key tonic chords to reharmonize melodies in major keys. Felts states: \"Line clichés may also be used to reharmonize melodies in major keys\" (Ch. 11, p. 109). The IMaj7 in a major key can sustain a chromatic line cliché between its fifth and root (e.g., from scale degree 5 through b6 and 6 up to the root), adding forward momentum to a sustained tonic without introducing new harmony.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 11, p. 109"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/line-cliche-tonic-primary-location",
+            "major-seventh/tonic-stability-anchor"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "passing-seventh-root-position-prerequisite",
+          "narrative": "When passing sevenths are used in the bass as a short line-cliché variant for minor seventh chords, the chord in root position must always precede the chord voiced over its seventh. Felts states: \"Notice that a chord in root position always precedes a chord voiced over its seventh\" (Ch. 11, p. 110). This mirrors the third-inversion prerequisite rule from Chapter 6 and Chapter 10, providing consistent bass-voice grounding before any inversion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 11, p. 110"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/third-inversion-context-prerequisite",
+            "minor-seventh/bass-line-chord-tone-derivation"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "line-cliche-halfstep-default-wholestep-option",
+          "narrative": "Line clichés on minor seventh chords default to half-step motion between the fifth and root, but whole-step motion is permitted when needed to prevent melody/harmony clashes. Felts states: \"Although most line clichés move in half-step increments, whole step motion between the fifth and the root is also possible\" (Ch. 11, p. 106) and: \"Whole-step motion also works, and is sometimes needed to prevent melody/harmony clashes\" (Ch. 11, p. 107). The choice of interval is driven by the melody, not by a stylistic preference alone.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 11, pp. 106–107"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/line-cliche-tonic-primary-location",
+            "minor-seventh/subdominant-ii-tritone-sensitivity"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "strong-cadence-few-common-tones",
+          "narrative": "Strong cadences require approach chords that share no more than two common tones with the target, and root motion by intervals other than third or sixth achieves this. Felts states: \"Strong cadences are created whenever the approach chord and the target chord share no more than two pitches. The general rule is: strong cadences = few common tones between the cadential chord and its target\" (Ch. 2, p. 19). A dominant seventh approaching a target by perfect fifth or fourth is structurally the strongest cadential motion in this framework.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 2, p. 19"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-engine",
+            "dominant-seventh/turnaround-slot-4-dominant"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "keep-it-simple-density-restraint",
+          "narrative": "When working with busy harmonic rhythms (two, three, or four chords per measure), dominant seventh choices must be relatively simple tonal progressions. Felts prescribes: \"Remember the rule: Keep it simple. When working with busy harmonic rhythms in which there are two, three, or four chords per measure, relatively simple tonal progressions work best\" (Ch. 6, p. 56). This density constraint prevents the simultaneous application of complex altered dominants and high harmonic rhythm.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 6, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/extended-dominant-chain",
+            "dominant-seventh/tritone-substitution-subv7"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "strong-beat-placement-fast-tempo",
+          "narrative": "At medium-to-fast tempos, dominant seventh chords in extended dominant or II-V7 patterns must appear only on strong beats (1 and 3) to maintain the extended-dominant sound without rhythmic clutter. Felts explains: \"Chords appear only on strong beats, 1 and 3, of the second measure in order to maintain the extended dominant sound while reducing the number of chords per bar. Reducing the number of chords in each bar will help to produce a smoother sound, and is particularly desirable if the performance tempo is medium to fast\" (Ch. 3, p. 32).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 3, p. 32"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/extended-dominant-chain",
+            "dominant-seventh/keep-it-simple-density-restraint"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "rhythmic-suitability-sparse-melody",
+          "narrative": "Extended dominant and extended II-V7 techniques work best with sparse melodic rhythms (quarter notes, dotted quarters, or half notes) where only one or two melody notes per chord allow quick tritone-substitution resolution of clashes. Felts states: \"Notice that these melodies consist mainly of quarter notes, dotted quarter notes, or half notes. The extended dominant or extended II-V7 technique works best with melodic rhythms of this sort. With only one or two melody notes per chord, you can quickly solve melody/harmony clashes with tritone substitutions\" (Ch. 3, p. 35).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 3, p. 35"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/extended-dominant-chain",
+            "dominant-seventh/tritone-substitution-subv7"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "bass-direction-consistency-prerequisite",
+          "polarity": "proscriptive",
+          "narrative": "Inconsistent bass-line direction into a major seventh target chord weakens cadential flow and must be avoided. Felts prescribes: \"Be sure to move your bass lines consistently up or down into the target chord. Failure to maintain a consistent direction will weaken the cadential possibilities of the chord progressions derived from the bass line\" (Ch. 6, p. 54). A Maj7 target chord requires that the approach bass notes trend in a single direction (ascending or descending) to produce a strong cadential effect.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 6, p. 54"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/tonic-stability-anchor",
+            "minor-seventh/bass-line-chord-tone-derivation"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "melodic-alteration-sparing-use",
+          "narrative": "Subtle melodic alterations may be used to resolve melody/harmony conflicts in major seventh contexts, but only sparingly. Felts states: \"A few subtle changes to the melody line may be used to solve melody/harmony conflicts and to provide color and variety to the reharmonization. This approach works best with melodies that are extremely familiar. It should not be overused\" (Ch. 6, p. 61). In turnaround construction, a related rule applies: a sustained melody note may be shortened after two beats to free harmonic space for otherwise clashing substitutions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 6, p. 61; Ch. 8, p. 83"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/tonic-stability-anchor",
+            "major-seventh/turnaround-target-endpoint"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "downbeat-harmonization-only",
+          "narrative": "To control harmonic rhythm density, dominant sevenths in diatonic approach technique should harmonize only melody notes falling on rhythmic downbeats, not weaker beats. Felts states: \"To reharmonize, diatonic chords (and a bVIIMaj7) with 3 in the lead support melody notes that fall on rhythmic downbeats. I do not harmonize melodic notes that fall on weaker rhythmic beats\" (Ch. 2, p. 24). This practice avoids hyperactive harmonic rhythm while still providing strong cadential approach chords at metrically important positions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 2, p. 24"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/strong-beat-placement-fast-tempo",
+            "dominant-seventh/extended-dominant-chain"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "9-11-13-lead-risk-avoidance",
+          "polarity": "proscriptive",
+          "narrative": "Extensions (9, 11, 13) in the lead voice of diatonic approach chords increase the risk of b9 or #11 dissonances and push the texture outside the original key. Felts states: \"The use of 9, 11, or 13 in the lead greatly increases the possibility that the progression will quickly move out of the original key. It also means that you will more frequently encounter unwanted melody/harmony relationships, such as dissonant b9 or #11 intervals\" (Ch. 2, p. 23). For mainstream pop diatonic texture, leads must be restricted to 1, 3, 5, or 7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 2, p. 23"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/v7b9-permitted-exception",
+            "dominant-seventh/nondiatonic-tension-explicit-notation"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "avoid-add-notation-error",
+          "polarity": "proscriptive",
+          "narrative": "The word 'add' must not appear in chord symbols for major seventh chords or any other quality, as it is a notational error most often misapplied to tension 11. Felts prescribes: \"Avoid the word 'add' in chord symbols. Tension 11 is mislabeled this way most often\" (Ch. 7, p. 68). The correct notation uses the tension number directly (e.g., Cmaj7(11) rather than Cmaj7 add11), since 'add' does not communicate the voicing or functional intent clearly to jazz performers.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 68"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/notation-baseline-vocabulary",
+            "major-seventh/diatonic-tension-omission-context"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "avoid-mixed-sharp-flat-notation",
+          "polarity": "proscriptive",
+          "narrative": "Mixing sharp-key and flat-key chord symbols within the same short phrase is a notation error that confuses performers and must be avoided. Felts states: \"Another common chord symbol notation error is to mix chord symbols derived from sharp keys and flat keys within the same short phrase. It is visually confusing, and will make it much harder for the musicians to read and perform the music correctly\" (Ch. 7, p. 68). This applies equally to all chord qualities, including Maj7 symbols in reharmonized progressions that cross enharmonic spelling conventions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 7, p. 68"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/notation-baseline-vocabulary",
+            "diminished-seventh/enharmonic-respelling-for-function"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "modulation-interlude-strong-root-motion",
+          "narrative": "Modulatory interludes require the new-key dominant or target chord to be approached by strong root motion. Felts states: \"the new-key downbeat is treated as a target chord approached via strong root motion and pickup-aware deceptive-cadence chords like VI-7(b5) or bIIIMaj7\" (Ch. 9 summary). Common pop modulation distances are up a minor second, major second, or minor third—intervals that produce strong cadential root motion and clear key-change signals for the listener.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 9, pp. 86–94"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/deceptive-cadence-approach",
+            "half-diminished/modulatory-interlude-vi-approach"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "not-all-chords-need-changing",
+          "narrative": "Restraint is the governing compositional ethic: not every dominant seventh in a progression needs to be reharmonized. Felts states: \"Note: It is not necessary to change all of the original chords to get an interesting reharmonization\" (Ch. 1, p. 13). This rule corrects the over-correction impulse, instructing the student that selective substitution of a few dominant sevenths is often more effective than wholesale replacement of every chord in the passage.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 1, p. 13"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/extended-dominant-chain",
+            "dominant-seventh/keep-it-simple-density-restraint"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "pedal-tone-tonal-grounding",
+          "narrative": "A sustained pedal tone under a constant structure or modal progression establishes tonal identity even when the harmonic movement is ambiguous, effectively converting the passage into a key-centered texture. Felts states: \"The use of an A pedal in the example below makes the phrase sound as if it is in the key of A, despite the ambiguous nature of the constant structure progression\" (Ch. 16, p. 165) and: \"Use of a tonic pedal tone or tonic ostinato will help to reinforce the sense of modal tonality\" (Ch. 16, p. 169). This is the primary grounding mechanism for both modal and constant-structure passages.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 16, pp. 165, 169"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/lydian-modal-tonic-pedal-required",
+            "major-seventh/constant-structure-major-seventh-root-spelling"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "modal-constant-structure-repetition-requirement",
+          "narrative": "Minor seventh chords in modal progressions and constant structure patterns require repetition for listener comprehension. Felts prescribes: \"Modal phrases and constant structure examples normally require repetition to develop a clear meaning in the listener's ear\" (Ch. 16, p. 169). To drive the modal tonic identity of an I-7 chord home, the tonic and its characteristic cadential chords must be repeated frequently, often reinforced by tonic pedal or ostinato that underscores the modal quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 16, p. 169"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/dorian-modal-tonic",
+            "major-seventh/pedal-tone-tonal-grounding"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "turnaround-link-strong-root-motion",
+          "narrative": "The link chord (turnaround slot-2) must resolve by strong root motion into one of the target chords in measure 32 (slot-3 or slot-4). Felts defines: \"The second chord of a typical turnaround (measure 31, beat 3) is a chord that connects forward to one of the chords in measure 32. Think of the chords in measure 32 as target chords. The second chord of the turnaround resolves by strong root motion into one of the targets. It forms a link between the first and third or fourth chords in the turnaround\" (Ch. 8, p. 74). A dominant seventh is a natural link chord for this slot.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, p. 74"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/turnaround-slot-4-dominant",
+            "dominant-seventh/strong-cadence-few-common-tones"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "turnaround-slot-1-tonic-family",
+          "narrative": "The first chord of a turnaround can be any chord that supports the melodic line but is most often a chord with tonic function, including IMaj7, III-7, VI-7, or their modal interchange variants. Felts states: \"The first chord of a turnaround (measure 31) can be any chord that supports the melodic line, but is often a chord with tonic function\" (Ch. 8, p. 74) and: \"most of the turnarounds here begin with a chord in the tonic family or a chromatic variation of a tonic family chord\" (Ch. 8, p. 76). IMaj7 is the baseline choice before substitution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 8, pp. 74, 76"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/tonic-substitute-iii",
+            "minor-seventh/tonic-substitute-vi"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "hybrid",
+          "function_role": "upper-layer-major-triad",
+          "narrative": "A major triad is one of the five permitted upper-layer structures in hybrid chord voicings. Felts prescribes: \"Choose an upper structure layer that forms a major or minor triad or forms a major seventh, a minor seventh, or a dominant seventh\" (Ch. 14, p. 147). The major triad over a fixed bass root is the simplest hybrid form, producing a clear altered-dominant texture whose ambiguity arises from the interval relationship between the triad and the bass note rather than from any complex seventh-chord upper voicing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, p. 147"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/upper-layer-construction-rules",
+            "hybrid/third-in-lead-failure-condition"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "hybrid",
+          "function_role": "augmented-upper-layer-forbidden",
+          "polarity": "proscriptive",
+          "narrative": "Augmented triads and augmented chord structures are forbidden as the upper layer of hybrid voicings because they collapse into more traditional chord sounds when combined with the bass note. Felts prescribes: \"Avoid augmented, diminished, or minor 7(b5) structures in the upper layer of hybrid chords since they tend to sound like more traditional chord voicings when combined with the bass note\" (Ch. 14, p. 147). The augmented upper layer defeats the characteristic ambiguous altered-dominant texture that is the purpose of hybrid voicing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 14, p. 147"
+            }
+          ],
+          "cross_ref": [
+            "hybrid/upper-layer-construction-rules",
+            "diminished-seventh/hybrid-upper-layer-forbidden"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "dominant-seventh",
+          "function_role": "lydiab9-phrygian-out-of-context-error",
+          "polarity": "proscriptive",
+          "narrative": "Phrygian b9 and Lydian tritone function correctly only within their respective modal contexts; outside those contexts they signal a structural error. Felts teaches: \"Phrygian b9 and Lydian tritone are mode-defining dissonances that signal a structural error when used outside their modal context\" (Ch. 13 summary). A dominant seventh featuring these dissonances outside a confirmed Phrygian or Lydian modal passage will be heard as a notation error or an unintended harmonic contradiction.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 13, pp. 123–145"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/mixolydian-modal-tonic",
+            "major-seventh/lydian-modal-tonic-pedal-required"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "major-seventh",
+          "function_role": "modal-key-minimum-four-bars",
+          "narrative": "Each modal key must be sustained for at least four bars to allow listeners to register its distinctive modal color. Felts teaches: \"remain in each modal key for at least four bars so listeners register the modal color\" (Ch. 13 summary). This minimum duration applies to all five modes covered (Dorian, Phrygian, Lydian, Mixolydian, Aeolian) and prevents premature key change that would leave the modal identity ambiguous in the listener's ear.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 13, pp. 123–145"
+            }
+          ],
+          "cross_ref": [
+            "major-seventh/lydian-modal-tonic-pedal-required",
+            "minor-seventh/modal-constant-structure-repetition-requirement"
+          ]
+        },
+        {
+          "source_work_id": "reharmonization-techniques",
+          "chord_quality": "minor-seventh",
+          "function_role": "mi-melody-b9-clash-with-major-third",
+          "polarity": "proscriptive",
+          "narrative": "Minor-quality modal interchange chords (I-7, IV-, V-7, etc.) clash with melodies containing the major third of the key, creating a b9 interval that destroys the chord's functional identity. Felts states: \"minor-quality MI chords clash with melodies containing the major third (creating b9 intervals)\" (Ch. 5 summary). This is the governing melody-compatibility constraint for all minor-quality MI substitutions: the major third in the melody is an absolute veto against any minor-seventh MI chord at that point.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Felts, Randy - Reharmonization Techniques (2002)",
+              "citation": "Ch. 5, pp. 45–52"
+            }
+          ],
+          "cross_ref": [
+            "minor-seventh/three-chord-modal-interchange-limit",
+            "minor-seventh/modal-interchange-i-minor"
+          ]
+        }
+      ]
     },
     {
       "id": "heussenstamm-silbergleit",


### PR DESCRIPTION
## Summary

Three-master Stage B cluster per Ellington's product-readiness ordering post-Galbraith fall-through:

| Master | Work | Notes | Proscriptive |
|---|---|---:|---:|
| O'Rourke | complete-chord-melody | 79 | 9 |
| Felts | reharmonization-techniques | 104 | 15 |
| Faria | brazilian-guitar-book | 80 | 4 |

Cluster total: 263 notes, 28 proscriptive.

## Axes filled

- **O'Rourke** → chord-melody alt-voice to Laukens (was previously chord-melody-singular at 163 notes). Replaces the Galbraith-slot that fell through to empty s5 (notation folio).
- **Felts** → Berklee reharmonization theory. Densest proscriptive coverage of the cluster. Cross-master discoverable with Baker/Greene/Pass/Martino.
- **Faria** → Brazilian/bossa axis. Fills the ellington-web demo-triangle bossa slot currently relying on placeholder Style row.

## Pipeline

cyberpower runs:
- `2026-05-23T23-23-45-orourke-complete-chord-melody`
- `2026-05-28T15-05-20-felts-reharmonization-techniques`
- `2026-05-28T15-05-20-faria-brazilian-guitar-book`

Model: sonnet.

## Validation

Schema 24/24 pass. Pre/post counts verified across all 11 masters (no regression on the prior 8).

## Diff size note

10,978 insertions / 6,197 deletions — net add 4,781 lines. The deletions are JSON re-formatting (Python json.dump dict-key ordering normalized previously-unsorted entries). Net add per master matches expected: 79 + 104 + 80 = 263 new entries.

Refs #457, #459, #471.