### PR TITLE
feat(#457): Stage B — 6-master tractable backlog drain (469 entries)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -15097,7 +15097,817 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj7",
+          "function_role": "tonic-upper-structure-arpeggio",
+          "narrative": "Over a major seventh chord, Larsen prescribes selecting arpeggios by shared tones rather than root relationship: 'You can also look for arpeggios that have notes in common with Fmaj7. The most common candidate is the one found on the 3rd (A) — Am7. Fmaj7 and Am7 have three notes in common' (Ch. 1, p. 14). The Am7 arpeggio contains every note of Fmaj7 except the root, producing richer melodic color without departing from the chord's harmonic identity. This shared-tone principle is the book's master rule for all upper-structure substitution and underpins every lick example that follows.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/tonic-upper-structure-arpeggio",
+            "m7/tonic-upper-structure-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj7",
+          "function_role": "tonic-pentatonic-reframe",
+          "narrative": "Larsen prescribes reframing the minor pentatonic built on the 3rd of a major chord as an extended arpeggio to make its harmonic rationale explicit: 'Playing the minor pentatonic scale from the 3rd is a great device to use over tonic major chords' (Ch. 4, p. 57). The same principle appears earlier where 'D Minor Pentatonic can be used very effectively. Imagine the notes of D Minor Pentatonic as though they are an arpeggio and they spell a Dm7add11 chord' (Ch. 1, p. 18). This reframing prevents treating pentatonic use as mere habit and instead grounds it in the chord's extension structure.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/tonic-upper-structure-arpeggio",
+            "m7/tonic-pentatonic-reframe"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj7",
+          "function_role": "tonic-shell-voicing-line",
+          "narrative": "Shell voicings — root, 3rd, and 7th only — are prescribed as a melodic skeleton over major seventh chords: 'A shell voicing is a chord voicing that use only the root, 3rd and 7th intervals. Playing lines like this with no exotic ingredients forces us to dig deeper to create a strong melody' (Ch. 1, p. 19). The pedagogical intent is to strip away coloristic options and compel the improviser to develop melodic strength from harmonic fundamentals alone. Shell voicings return explicitly in Chapter 4 as the underpinning of altered dominant comping.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-shell-voicing-anchor",
+            "m7/tonic-shell-voicing-line"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj7",
+          "function_role": "tonic-quartal-arpeggio",
+          "narrative": "Quartal arpeggios — stacked in fourths rather than thirds — are prescribed as an alternative melodic structure over major seventh tonic chords: 'Stacking notes in 4ths is known as quartal harmony and was popularised in jazz by Miles Davis during his modal period' (Ch. 1, p. 19). The chapter assignments consolidate this as a required practice item: 'Quartal shapes, chord voicings with added notes, or shell voicings' (Ch. 1, p. 24). Quintal arpeggios (stacks of fifths) are the closely related extension endorsed in Chapter 6, with Jonathan Kreisberg and Kurt Rosenwinkel named as exemplars.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/tonic-quartal-arpeggio",
+            "dom7/v-chord-quartal-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj7",
+          "function_role": "tonic-ascending-arpeggio-descending-scale",
+          "narrative": "Larsen's signature melodic formula — ascending arpeggio followed by descending scale run — is prescribed as a generative template applicable over major seventh tonics: 'This lick also illustrates a common concept where a melody is created with an ascending arpeggio and a descending scale run' (Ch. 1, p. 16). The formula appears across multiple lick examples in Chapters 1 through 4 and is identified in the book-level summary as the master's signature melodic shape. It structures large-scale phrase contour while keeping harmonic identity clear on the ascent.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-ascending-arpeggio-descending-scale",
+            "m7/tonic-ascending-arpeggio-descending-scale"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj7",
+          "function_role": "tonic-counterpoint-large-interval-resolution",
+          "narrative": "The classical counterpoint rule that large intervals resolve stepwise in the opposite direction is prescribed as a structural constraint on jazz melody construction over tonic major seventh chords: 'This lick also demonstrates a common rule in counterpoint melody writing: to resolve a series of large ascending intervals with a stepwise movement in the opposite direction' (Ch. 1, p. 21). The rule is restated in Chapter 6: 'An interval skip of a 6th is a beautiful way to add variation. The traditional counterpoint rule for a melody like this demands that the tension of the large ascending interval is resolved with step-wise motion in a descending direction' (Ch. 6, p. 76).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/tonic-counterpoint-large-interval-resolution",
+            "dom7/v-chord-counterpoint-large-interval-resolution"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj7",
+          "function_role": "tonic-triad-inversion-practice",
+          "narrative": "Practicing triad inversions over major seventh tonic chords is prescribed as a required component of II-V-I lick development: 'Triad inversions' appears explicitly in the chapter assignments list (Ch. 1, p. 24). The inversion-skip pattern is attributed to canonical guitarists in Chapter 6: 'the line over Cm7 has an Ebmaj7 arpeggio that begins on the root, but skips down to the G, then ascends the arpeggio. This type of phrase is very common with George Benson and Grant Green. In fact, Grant Green's solo on I'll Remember April is almost entirely built on this phrase right from the pick-up' (Ch. 6, p. 77).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/tonic-upper-structure-arpeggio",
+            "m7/tonic-ebmaj7-inversion-skip"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "ii-chord-arpeggio-on-5th",
+          "narrative": "Over a minor seventh II chord, arpeggiation from the chord's 5th degree is prescribed as a characteristic bebop sound with a critical caveat: 'Playing the arpeggio from the 5th degree of the minor seventh chord creates a nice sound over a II chord, but you could consider adding the 3rd of the Dm7 chord, since that note is not in the arpeggio. Adding the third helps to clearly define the sound of the underlying chord' (Ch. 2, p. 35). Chapter 6 confirms the remedy: 'The problem with using the arpeggio built from the 5th of a minor chord is that it does not contain the 3rd. A standard way of dealing with this is to use the arpeggio to encircle the 3rd' (Ch. 6, p. 75).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/ii-chord-upper-structure-substitution",
+            "dom7/v-chord-5th-of-ii-targeting"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "ii-chord-upper-structure-substitution",
+          "narrative": "Upper-structure arpeggio substitution is prescribed over minor seventh II chords using the 3rd-rooted option as the primary bebop choice: 'Playing an arpeggio from the 3rd of a chord is a useful device to produce characteristic bebop lines' (Ch. 2, p. 36). The shared-tone lattice governs which substitute is selected — the arpeggio whose notes overlap the chord's extensions is preferred. For a Dm7 II chord this yields the Am7 or Am7add11 as the idiomatic choice, as demonstrated by the D Minor Pentatonic reframing: 'Imagine the notes of D Minor Pentatonic as though they are an arpeggio and they spell a Dm7add11 chord' (Ch. 1, p. 18).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/ii-chord-arpeggio-on-5th",
+            "dom7/v-chord-m7b5-on-3rd"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "ii-chord-pentatonic-root",
+          "narrative": "Larsen prescribes deploying the pentatonic scale built on the root of a II or VI minor chord as a melodic resource: 'The pentatonic scale from the root of a II or VI minor chord, or the 3rd of the I chord (e.g., E Minor Pentatonic over Cmaj7)' (Ch. 1, p. 24). This is supported by the Dm7add11 reframing in which D Minor Pentatonic (D F G A C) is revealed as a fully harmonic arpeggio spelling the 1, b3, 11, 5, and b7 of the chord: 'Imagine the notes of D Minor Pentatonic as though they are an arpeggio and they spell a Dm7add11 chord' (Ch. 1, p. 18).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/ii-chord-upper-structure-substitution",
+            "maj7/tonic-pentatonic-reframe"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "ii-chord-coltrane-pattern-minor",
+          "narrative": "The Coltrane 1-b3-4-5 pattern is prescribed specifically for minor chords as the minor-chord variant of the four-note grouping technique: 'Coltrane patterns (1 2 35 on a major chord, 1 b3 4.5 on a minor chord)' (Ch. 1, p. 24). The parent pattern is defined as: 'Coltrane mastered the approach of using four-note groupings to spell out chords as a way of navigating bars that contain two chords, played at a fast tempo. Coltrane patterns are a useful way to break up scalic lines and create interest while playing diatonically' (Ch. 1, p. 17). The minor variant maps directly onto the Dm7add11 arpeggio structure.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "maj7/tonic-ascending-arpeggio-descending-scale",
+            "dom7/v-chord-coltrane-pattern-major"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "ii-chord-chord-tone-omission",
+          "narrative": "Deliberate chord-tone omission is prescribed as an advanced coloring device over minor seventh chords, provided the harmonic context makes the intent clear: 'I have omitted the 3rd (Bb) of Gm7 which immediately makes the line more open sounding. In isolation, it could sound like a G7sus4 chord, but is fine when we hear it in the context of our key of F Major. We can play challenging lines like this as long as we are conscious of their overall effect on the music' (Ch. 3, p. 52). The qualification conscious of their overall effect frames this as a deliberate expressive choice rather than an error.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/ii-chord-upper-structure-substitution",
+            "dom7sus4/v-chord-sus4-tension"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "ii-chord-triad-sequence-variation",
+          "narrative": "Using triads arranged in varied sequences — 1-3-5 patterns and quartal arpeggios — is prescribed to bring motivic variety to minor seventh chord lines: 'A useful concept to bring more variation to your melodic lines is to use triads arranged in different patterns. Example 3k begins with a G minor triad played in a 135 sequence. It continues into a quartal arpeggio leading from a G note, using the same pattern. The effect is to create a repeating motif' (Ch. 3, p. 49). The combination of diatonic triads and quartal arpeggios over the same minor seventh chord produces a modern, intervallic quality while maintaining harmonic fidelity.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/tonic-quartal-arpeggio",
+            "m7/ii-chord-upper-structure-substitution"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "tonic-quintal-arpeggio",
+          "narrative": "Quintal arpeggios (stacks of fifths) are prescribed as an open sounding structure over minor seventh tonic chords: 'The quintal arpeggio is also a great open sounding structure to apply to a Cm7 chord. Here it is used from the Eb and spells out a Cm11 sound. The quintal arpeggio is preceded by a diatonic enclosure of the Eb' (Ch. 6, p. 78). Larsen also names Jonathan Kreisberg and Kurt Rosenwinkel as practitioners who deploy quintal arpeggios frequently: 'Quintal Arpeggios (stacks of 5ths) are becoming very common melodic ideas in jazz' (Ch. 6, p. 78), situating this technique within a specific lineage of modern jazz guitar.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/tonic-quartal-arpeggio",
+            "maj7/tonic-quartal-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "tonic-arpeggio-scale-interpolation",
+          "narrative": "Scale-tone interpolation within an arpeggio line is prescribed over minor seventh tonic chords to avoid predictability while keeping chord tones on the beat: 'Embellishing an arpeggio by adding scale notes in between can be a good way to craft a melody that still has the chord tones on the beat but doesn't sound too predictable. The line on the Cm7 chord in this example is constructed in this manner using a Cm9 arpeggio. A D note is added in the lower octave between the C and Eb' (Ch. 6, p. 76). The constraint that chord tones remain on the beat preserves harmonic intelligibility while interpolated scale tones provide linear smoothness.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/tonic-quintal-arpeggio",
+            "m7/ii-chord-upper-structure-substitution"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "tonic-ebmaj7-inversion-skip",
+          "narrative": "Over a Cm7 tonic chord, an Ebmaj7 arpeggio with an inversion skip is prescribed as a signature bebop-derived pattern: 'The line over Cm7 has an Ebmaj7 arpeggio that begins on the root, but skips down to the G, then ascends the arpeggio. The remainder of the bar is a straight Cm7 arpeggio. This type of phrase is very common with George Benson and Grant Green. In fact, Grant Green's solo on I'll Remember April is almost entirely built on this phrase right from the pick-up' (Ch. 6, p. 77). The attribution to canonical guitarists signals this as a load-bearing idiomatic choice rather than a theoretical abstraction.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/tonic-arpeggio-scale-interpolation",
+            "maj7/tonic-upper-structure-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "ii-chord-bebop-3rd-arpeggio-device",
+          "narrative": "Playing an arpeggio from the 3rd degree of a minor seventh chord is prescribed as the defining bebop line-construction device: 'Playing an arpeggio from the 3rd of a chord is a useful device to produce characteristic bebop lines' (Ch. 2, p. 36). For a Dm7 II chord, the 3rd-rooted arpeggio is Fmaj7, which maps its 1, 3, 5, and 7 onto the b3, 5, b7, and 9 of Dm7, providing a complete minor-ninth sound without playing the root. This is the minor-chord instantiation of the universal arpeggio-on-the-3rd rule from Chapter 1.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/ii-chord-upper-structure-substitution",
+            "dom7/v-chord-m7b5-on-3rd"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "tonic-chromatic-encirclement",
+          "narrative": "Encirclement — using the last two notes of one melodic gesture to encircle the first note of the next — is prescribed as a voice-leading device applicable to minor seventh tonic chord lines: 'Example 5n uses a similar device — chaining triads together by using the last two notes of one triad to encircle the first note of the next' (Ch. 6, p. 74). The quintal arpeggio over Cm7 in Chapter 6 is itself preceded by a diatonic enclosure of the Eb (Ch. 6, p. 78), demonstrating that encirclement is woven into the approach to every target chord tone, not only to triad boundaries.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/tonic-quintal-arpeggio",
+            "dom7/v-chord-two-note-enclosure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7",
+          "function_role": "ii-chord-chromatic-legato-string-change",
+          "narrative": "The legato technique is prescribed for executing string-crossing triad pair lines over minor seventh chords: 'The line is executed with legato technique to make it easier for the right hand to play the many string changes' (Ch. 6, p. 75). This extends the Chapter 2 legato rule — originally prescribed to keep chromatic passing notes soft — to a technical efficiency rationale for positions involving many string changes. Both motivations (expressive softening of passing notes and right-hand efficiency on string crossings) are simultaneously served by the hammer-on, pull-off, and slide approach.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/tonic-quintal-arpeggio",
+            "dom7/v-chord-legato-chromatic-technique"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-m7b5-on-3rd",
+          "narrative": "The m7b5 arpeggio rooted on the 3rd of a dominant seventh chord is identified as the single most important substitution in the book: 'Playing a m7b5 chord on the 3rd of a dominant 7 chord causes us to avoid playing the root (G) and adds the rich-sounding 9th (A). It sounds so good that many musicians always use it instead of the original arpeggio' (Ch. 1, p. 15). This is designated one of the most common uses of arpeggios in jazz (Ch. 1, p. 15) and governs all subsequent dominant substitution choices. The avoidance of the root combined with the addition of the 9th produces a more modern, coloristic dominant sound.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-upper-structure-hierarchy",
+            "m7b5/v-chord-guide-tone-substitution"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-upper-structure-hierarchy",
+          "narrative": "A strict hierarchy governs upper-structure arpeggio choices over dominant seventh chords: 3rd-rooted is most versatile, 5th- and 7th-rooted require increasing caution: 'Jazz musicians will often play a new arpeggio from any note in the underlying chord. We will play arpeggios from the third (B) fifth (D) or even the seventh (F)' (Ch. 1, p. 14). The cautionary rider is explicit: 'As you move up the chord and play arpeggios from the higher notes (5th and 7th), you include fewer notes from the original chord, so you need to be a bit more careful' (Ch. 1, p. 15). This calibrates how boldly the practitioner should push away from the chord's harmonic center.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-m7b5-on-3rd",
+            "dom7/v-chord-guide-tone-preservation"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-sus4-avoidance",
+          "polarity": "proscriptive",
+          "narrative": "Larsen explicitly proscribes playing the 11th (C) over a G7 dominant chord unless the sus4 color is intentionally desired: 'The only thing to watch for here is to choose carefully when to use the C note. Playing a C over a G7 chord will suggest a G7sus4 sound. This might be desirable in some instances but not in others' (Ch. 1, p. 23). An unguarded deployment of the 11th unintentionally weakens the dominant's resolution drive by replacing the major 3rd guide tone with the suspended 4th. This aligns with the guide-tone preservation rule that governs all arpeggio selection in the book.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7sus4/v-chord-sus4-tension",
+            "m7/ii-chord-chord-tone-omission"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-chromatic-off-beat-placement",
+          "narrative": "Chromatic passing notes over dominant seventh chords must be placed on off-beats, with strong chord tones landing on the beat: 'We can play 1/8th note jazz lines that begin on a scale note and cause all the strong chord tones to fall on the beat, and the chromatic passing notes on the off-beat. This is useful, because in hardbop / bebop jazz, chromatic notes are generally placed on the off-beats' (Ch. 2, p. 29). This is stated as a foundational constraint in the book-level summary, meaning it is a hard rhythmic-placement law governing all chromatic line construction over any chord quality, including dominant sevenths.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-four-note-enclosure",
+            "dom7/v-chord-legato-chromatic-technique"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-legato-chromatic-technique",
+          "narrative": "The legato technique — hammer-ons, pull-offs, and slides — is prescribed as the execution method for all chromatic lines over dominant seventh chords: 'I tend to play these exercises using a legato technique with lots of hammer-ons, pull-offs and slides. Aim to pick a chromatic note and resolve it to the following note with a legato movement. This should result in nice phrasing, because the passing note is accented and the scale note is softer. To aid this approach, I try to keep passing notes and scale notes on the same string where possible' (Ch. 2, p. 29). The single-string guideline reinforces the rhythmic off-beat rule by ensuring the dynamic accent lands on the chromatic rather than the scale tone.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-chromatic-off-beat-placement",
+            "dom7/v-chord-four-note-enclosure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-two-note-enclosure",
+          "narrative": "Two-note enclosures — a chromatic note and a diatonic note surrounding a triad tone — are prescribed over dominant seventh chords with both orderings valid: 'The concept is, for each note of a C major triad, to play a chromatic note below and a diatonic note above. The first two bars place the chromatic note first, followed by the diatonic note, then the triad note. The second two bars flip this sequence around. Either way sounds good, so you can find your preference' (Ch. 2, p. 32). The practitioner retains creative latitude on ordering, but must anchor the enclosure to a triad tone in all cases.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-four-note-enclosure",
+            "dom7/v-chord-enclosure-target-chord-tone"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-four-note-enclosure",
+          "narrative": "Four-note enclosures are prescribed for dominant seventh contexts specifically because they align resolution with the strong beats 1 and 3: 'These are very common in modern jazz, since they provide an easy way to emphasise the basic jazz groove, in which the heavy beats fall on the 1 and the 3' (Ch. 2, p. 33). Two distinct deployment functions are prescribed: 'Four-note enclosures can work in two ways. They can precede a chord tone to create a suspended sound, or they can be used as a way of pulling towards the chord tone you intend to resolve to' (Ch. 2, p. 39). The suspended function delays arrival; the tension-pull function drives toward the chord tone.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-two-note-enclosure",
+            "dom7/v-chord-enclosure-beat-2-displacement"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-enclosure-beat-2-displacement",
+          "narrative": "Placing an enclosure on beat 2 rather than beat 1 so that resolution falls on beat 4 is prescribed as an advanced coloristic option producing a Metheny-esque unresolved quality: 'The chromatic enclosure in this bar is placed on beat 2, so that it will resolve on beat 4 of the bar. This leaves a chromatic note on beat 3, which is a strong beat in jazz. The effect is to give the line an unresolved quality, again reminiscent of Metheny. Using this idea throughout a solo can open things up, because the melodic lines will sound less connected to the underlying chords, achieving a more modern sound' (Ch. 2, p. 41). The book frames this as an advanced option rather than a default.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-four-note-enclosure",
+            "dom7/v-chord-enclosure-target-chord-tone"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-enclosure-target-chord-tone",
+          "polarity": "proscriptive",
+          "narrative": "All enclosures over dominant seventh chords must resolve to a chord or scale tone; enclosures floating free of harmonic targets are explicitly warned against: 'Chromatic enclosures and passing notes are a big part of the sound we associate with the bebop and hardbop melodic language. However, be careful to exercise some control over how you use them: remain aware that their main purpose is to target or gravitate towards scale / chord tones' (Ch. 2, p. 42). This closing rule of Chapter 2 functions as the governing constraint on all chromatic technique: expressiveness is permitted only within a framework of harmonic resolution.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-four-note-enclosure",
+            "dom7/v-chord-two-note-enclosure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-diatonic-gap-fill",
+          "narrative": "When a chromatic half-step gap does not exist between two adjacent enclosure notes over a dominant seventh chord, the prescribed solution is to substitute the diatonic note above: 'Since it's not possible to add a chromatic note in between, I added a G note (the diatonic note above F). Listen to how natural that approach sounds' (Ch. 2, p. 37). This modification rule keeps the enclosure's surrounding function intact even when pure chromatic voice-leading is unavailable, demonstrating Larsen's principle that scale and chord tones are always the anchor, not mere fallbacks.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-two-note-enclosure",
+            "dom7/v-chord-enclosure-target-chord-tone"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-5th-of-ii-targeting",
+          "narrative": "Arpeggiation from the 5th of the preceding II chord is prescribed as a powerful voice-leading device for targeting the 3rd of the following dominant: 'Playing an arpeggio from the 5th of the II chord is a fantastic way to target the third of the V chord that follows it. To the ears, it sounds like a suspended chord, but without moving very far from the key' (Ch. 3, p. 49). This rule encodes a voice-leading traversal between two chord qualities — the suspended quality arises because the II chord's 5th lies a half-step above the V chord's 3rd, making the resolution audible and directional.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/ii-chord-arpeggio-on-5th",
+            "dom7/v-chord-m7b5-on-3rd"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-triplet-seventh-arpeggio",
+          "narrative": "Deploying triplet rhythms on seventh arpeggios over dominant chords is prescribed as a fundamental bebop phrasing device: 'Using triplets to play 7th arpeggios is a great bebop trick that works well in a more modern jazz context as well' (Ch. 4, p. 56). The triplet subdivision disrupts the quarter/eighth-note grid, creating forward momentum and implying rhythmic displacement without departing from the arpeggio's harmonic content. This rule is paired throughout Chapter 4 with the altered dominant context but applies broadly to dominant seventh chords.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-rhythmic-subdivision",
+            "dom7alt/v-chord-guide-tone-preservation"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-rhythmic-subdivision",
+          "narrative": "Rhythmic variation through eighth-note triplets and sixteenth-note subdivisions is prescribed to embellish dominant seventh arpeggio lines and imply passing chords: 'Lines can be made more interesting by introducing rhythmic variation. In the next example, an 8th note triplet is used for the chromatic passing notes that introduce the melody' (Ch. 4, p. 59). The related rule states that sixteenth-note chromatic passing notes on an Fm9 arpeggio make the rhythm more interesting (Ch. 4, p. 58). These rhythmic modifications operate on top of the underlying harmonic substitution choices and should not alter the placement rule that chord tones land on the beat.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-triplet-seventh-arpeggio",
+            "dom7/v-chord-chromatic-off-beat-placement"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-passing-chord-implication",
+          "narrative": "Implying unwritten passing chords through arpeggio selection over dominant seventh chords is prescribed as a device for creating harmonic motion: 'Suggesting passing chords that aren't written is a great way to create motion towards a chord change. In Example 4j, the line in bar one begins with an Fm7 arpeggio line. In bar two there is an Abm7b5 arpeggio played over the Bb7alt chord. To connect these two ideas, in the latter half of bar one we have a Gm7 arpeggio. The effect is a strong motion from the Fm7 to Bb7alt chords' (Ch. 4, p. 58). The Gm7 in the transition slot is not written in the changes; its presence is a melodic-harmonic illusion generated by arpeggio choice.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-guide-tone-preservation",
+            "dom7/v-chord-triplet-seventh-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-harmonic-minor-pull",
+          "narrative": "Applying harmonic minor material over a dominant seventh chord to create a directional pull toward the next chord is prescribed as a functional coloring device: 'Bar 4 — Uses the harmonic minor on Bb7 to pull towards the Eb7 (in this case playing the pattern of a Ddim arpeggio)' (Ch. 6, p. 82). The mechanism is that the raised 7th degree of the harmonic minor scale (the leading tone) intensifies the resolution drive of the dominant. This principle is the central subject of Chapter 3, which systematically maps harmonic minor arpeggios available over a V chord.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-m7b5-on-3rd",
+            "dim7/v-chord-harmonic-minor-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-diminished-scale-upper-structure",
+          "narrative": "The half-whole diminished scale is prescribed over dominant seventh chords through its four embedded major triads as upper-structure melodic material: 'This chapter will focus on using major triads to create the diminished sound. The four major triads are F, Ab, B and D' (Ch. 5, p. 67). The most idiomatic application is the 13b9 voicing: 'The most common sound associated with this scale is probably the 13b9. Guitarists generally think of this as an upper-structure triad placed above a dominant 7th chord. E.g. F713b9 is a D major triad over an F7 chord' (Ch. 5, p. 66). The practitioner selects triad pairs to target specific extension colors.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-color-tone-triad-pair",
+            "dom7/v-chord-minor-third-symmetry-rotation"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-color-tone-triad-pair",
+          "narrative": "Specific triad pairs are prescribed to produce specific extension colors over dominant seventh chords: the Ab+D pair produces b9+#9+13 color, while the B+Ab pair produces sharp-11+b9+#9 color. 'The combination of the Ab and D major triads conveys the sound of an F7 with a #9 (Ab), b9 (Gb) and 13 (D)' (Ch. 5, p. 70). Chapter 6 confirms: 'On the F7 chord, the line combines B and Ab major triads. Both are in first inversion and together they add a lot of colour with the b9, #9 and #11' (Ch. 6, p. 77). These triad pair assignments are prescriptive mappings from desired harmonic color to melodic material.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-diminished-scale-upper-structure",
+            "dom7/v-chord-root-triad-omission"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-root-triad-omission",
+          "polarity": "proscriptive",
+          "narrative": "Larsen explicitly proscribes using the root-position major triad (F major over F7) because it adds no harmonic color: 'You may have noticed that I don't often use the F major triad because it doesn't add any colour and only so many 1/8th notes are available in a 4/4 bar!' (Ch. 6, p. 74). Of the four major triads embedded in the half-whole diminished scale, the root triad duplicates the chord's own notes and generates no upper-structure extension tension. The practitioner should prefer Ab, B, or D major triads, which all produce altered or extended colors.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-color-tone-triad-pair",
+            "dom7/v-chord-diminished-scale-upper-structure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-minor-third-symmetry-rotation",
+          "narrative": "The minor-third symmetry of the half-whole diminished scale is prescribed as the primary learning-load reducer for dominant seventh triad material: 'Due to the nature of its construction using diminished arpeggios, everything that exists inside the Half Whole Diminished scale can be moved in minor 3rds, so we only have to look at the chords we can build on the first two notes and we can find the rest by transposing them in minor 3rd intervals' (Ch. 5, p. 65). This symmetry means the practitioner learns one triad shape and derives three others by rotation — a structural economy the book frames explicitly as a pedagogical advantage.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-diminished-scale-upper-structure",
+            "dom7/v-chord-positional-cycling"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-positional-cycling",
+          "narrative": "Cycling through all four diminished-scale major triads in a single neck position before crossing to the next is prescribed as the primary practice method for dominant seventh diminished material: 'Another way to practise these triads is to mix and match the inversions, but play in the same position. Example 5h demonstrates cycling through the triads in a single position before moving to the next position to cycle through them again' (Ch. 5, p. 68). This positional discipline trains both harmonic knowledge and fretboard navigation simultaneously, which the chapter identifies as the dual pedagogical purpose of triad exercises.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-minor-third-symmetry-rotation",
+            "dom7/v-chord-triad-common-tone-chaining"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-triad-common-tone-chaining",
+          "narrative": "Connecting consecutive upper-structure triads over dominant seventh chords by linking shared top or bottom notes is prescribed as the primary voice-leading mechanism for triad pair lines: 'In this example the melody relies on connecting the D and Ab major triads by linking the top two notes of the D triad to the lowest two notes of the Ab triad' (Ch. 6, p. 74). An alternative method is also prescribed: 'Example 5n uses a similar device — chaining triads together by using the last two notes of one triad to encircle the first note of the next' (Ch. 6, p. 74). Both mechanisms ensure melodic continuity is preserved across the triad boundary.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-color-tone-triad-pair",
+            "dom7/v-chord-positional-cycling"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-triad-stacking",
+          "narrative": "Stacking triads — superimposing multiple triads to extend melodic range — is prescribed as a named technique over dominant seventh chords: 'The second example demonstrates how stacking triads can yield some colourful, yet logical-sounding melodies with a fairly big range' (Ch. 5, p. 71). The chapter assignments reinforce this: 'Stack triads to create a bigger structure, superimposing them over each other' (Ch. 6, p. 79). Stacking operates as a macro-level extension of the color-tone triad pair rule, producing extended melodic arcs rather than single-triad cells.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-color-tone-triad-pair",
+            "dom7/v-chord-triad-common-tone-chaining"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-motif-repeat-with-alteration",
+          "narrative": "Restating a melodic phrase over a new dominant chord while altering only one or two notes to fit the new harmony is prescribed as a very common melodic trick: 'Bars 5-6 — This is a very common melodic trick which makes a statement over the Eb7 chord and repeats it over the Edim chord, altering it slightly to fit. The F note in bar 5 is changed to an E in bar 6' (Ch. 6, p. 82). This modification rule applies the motif-based approach from Chapter 3 — where the descending Bbmaj7 arpeggio motif is repeated using the descending E diminished arpeggio (Ch. 3, p. 48) — to a dominant-chord context with minimal pitch adjustment.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-harmonic-minor-pull",
+            "m7/ii-chord-triad-sequence-variation"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-ascending-arpeggio-descending-scale",
+          "narrative": "The ascending arpeggio plus descending scale formula is prescribed over dominant seventh chords as the master's signature melodic shape, appearing in multiple lick examples across Chapters 1 and 4: 'This lick also illustrates a common concept where a melody is created with an ascending arpeggio and a descending scale run' (Ch. 1, p. 16). The formula is described in the book-level summary as the master's signature melodic shape. The ascent by arpeggio defines harmonic content; the descent by scale provides linear melodic continuity and implies forward momentum toward the next chord.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-m7b5-on-3rd",
+            "dom7alt/v-chord-guide-tone-preservation"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-diatonic-triad-sequence",
+          "narrative": "Diatonic triads arranged in sequences — rather than scalar runs — are prescribed as the primary alternative to chord-tone soloing over dominant seventh chords: 'Playing through this will be of immense help in creating interesting melodic ideas, so it doesn't sound as though you're simply running up and down scales. Solos that only contain 1/8th scalic ideas get boring pretty quickly!' (Ch. 3, p. 43). The chapter assignments reinforce this: 'Diatonic triads or arpeggios in sequences' (Ch. 1, p. 24). Triad sequencing is the mechanism by which the book converts scale knowledge into actionable melodic vocabulary.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-diminished-scale-upper-structure",
+            "dom7b9/v-chord-harmonic-minor-arpeggio-set"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-scalic-line-avoidance",
+          "polarity": "proscriptive",
+          "narrative": "Pure scalic lines — eighth-note runs up and down the scale without triadic or motivic shaping — are explicitly proscribed as insufficient melodic vocabulary over dominant seventh chords: 'Playing through this will be of immense help in creating interesting melodic ideas, so it doesn't sound as though you're simply running up and down scales. Solos that only contain 1/8th scalic ideas get boring pretty quickly!' (Ch. 3, p. 43). The entire system of triad substitution, enclosure, and Coltrane patterning exists to break up and replace pure scale-running as the default improvisational response.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-diatonic-triad-sequence",
+            "dom7/v-chord-coltrane-pattern-major"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-coltrane-pattern-major",
+          "narrative": "The Coltrane 1-2-3-5 pattern is prescribed in its major-chord form over dominant seventh chords as a device for breaking up scalic lines in fast-tempo passages: 'He used a 1 2 3 5 pattern (the 1st, 2nd, 3rd and 5th degrees of the scale) and varied the order of the sequence to create different melodies. Here I'm playing it in reverse over the G7 chord: 5 (D), 3 (B), 2 (A) and 1 (G). Coltrane patterns are a useful way to break up scalic lines and create interest while playing diatonically' (Ch. 1, p. 17). The reverse (5-3-2-1) ordering is endorsed alongside the forward (1-2-3-5), giving two distinct directional variants.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7/ii-chord-coltrane-pattern-minor",
+            "dom7/v-chord-rhythmic-subdivision"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-dual-analysis-multiple-readings",
+          "narrative": "Maintaining multiple simultaneous valid analytical readings of a dominant seventh melodic line is prescribed as an advanced practice skill: 'The F7 altered line can be analysed in two ways: an Ebm7b5 arpeggio over the whole bar, or a Gbm triad for the first half of the bar and an Ebm7b5 arpeggio inversion for the second half' (Ch. 6, p. 82). The solo study methodology explicitly supports this: 'There is usually more than one way to think about a phrase played over a chord, so see if you come up with a different interpretation to me' (Ch. 6, p. 79). This principle elevates the practitioner from pattern memorization to genuine harmonic understanding.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-gsharp-m7b5-arpeggio",
+            "dom7/v-chord-color-tone-triad-pair"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-open-voiced-triad-experimentation",
+          "narrative": "Open-voiced or spread versions of dominant seventh upper-structure triads are prescribed in the chapter assignments as a practice direction for internalizing fretboard connections: 'Try experimenting with using open-voiced or spread versions of the triads' (Ch. 6, p. 79). Listed alongside specific triad pairs like Ab+D and Ab+B, this instruction frames open voicings as an extension of the closed-position cycling exercises from Chapter 5, directing the practitioner toward melodic range and neck-crossing navigation as distinct from positional triad drills.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-positional-cycling",
+            "dom7/v-chord-triad-stacking"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-free-improvisation-triad-internalization",
+          "narrative": "Free improvisation with upper-structure triads over dominant seventh chord progressions is prescribed as the final stage of the internalization process: 'Spend time practising free improvisation with the triads to understand them better and to help connect them on the fretboard. This exercise will prove useful for other scale sounds too' (Ch. 6, p. 79). This prescription sits at the top of the learning hierarchy — after positional cycling, common-tone chaining, stacking, and open-voiced experimentation — signaling that mechanical exercises are preparation for context-responsive creative deployment, not the endpoint.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-open-voiced-triad-experimentation",
+            "dom7/v-chord-positional-cycling"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-guide-tone-preservation",
+          "narrative": "Over an altered dominant chord, preserving the guide tones (3rd and 7th) is prescribed as the non-negotiable constraint on arpeggio selection: 'The defining tones of a Bb7alt chord are the 3rd and 7th (F and Ab), so if we use arpeggios from the Bb Altered scale that contain those intervals we can stay close to the dominant sound and introduce some cool altered extensions. Only two chords contain both notes: E7 and G#m7b5' (Ch. 4, p. 54). This is the altered-scale instantiation of the book's master shared-tone substitution principle — the guide tones are the harmonic floor that cannot be abandoned regardless of how outside the line becomes.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-gsharp-m7b5-arpeggio",
+            "dom7alt/v-chord-tritone-substitute"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-altered-scale-definition",
+          "narrative": "The altered scale is prescribed as the primary outside-sounding scale choice over altered dominant chords, with its parent-scale relationship to melodic minor made explicit as the analytical frame: 'The altered scale is the seventh mode of the melodic minor scale and one of the most commonly used when soloing over dominant chords. Typically used over an altered dominant chord, it creates an outside sound which is then resolved when the progression moves to the I chord' (Ch. 4, p. 53). The frame that Bb Altered is the seventh mode of B Melodic Minor (Ch. 4, p. 53) is the practical reframing technique for identifying available arpeggios.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-guide-tone-preservation",
+            "dom7alt/v-chord-gsharp-m7b5-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-gsharp-m7b5-arpeggio",
+          "narrative": "The G#m7b5 arpeggio is prescribed as the best candidate to spell out a Bb7alt sound because it preserves both guide tones and highlights three altered extensions simultaneously: 'The table below shows which intervals of Bb7alt are highlighted when you play a G#m7b5 arpeggio: G# B D F# = b7 b9 3 b13 relative to Bb' (Ch. 4, p. 54). The practical endorsement is unambiguous: 'Of the two options, the G#m7b5 arpeggio is probably the best candidate' (Ch. 4, p. 54). The arpeggio simultaneously maps to the b7, b9, major 3rd, and b13 — four of the five defining tones of the altered dominant.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-guide-tone-preservation",
+            "dom7alt/v-chord-tritone-substitute"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-tritone-substitute",
+          "narrative": "The E7 arpeggio is prescribed over Bb7alt as a tritone substitute option that preserves guide tones: 'E7 is the tritone substitute of Bb7' (Ch. 4, p. 54), and 'G#m7b5 is related to E7, as it can be viewed as an arpeggio built on the 3rd of E7' (Ch. 4, p. 54). The tritone relationship means the 3rd and 7th of Bb7 (F and Ab) map to the 7th and 3rd of E7 (D# and G#), preserving guide-tone function while displacing the root by a tritone. This substitution relationship connects the harmonic substitution lattice to the altered dominant's characteristic outside quality.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-gsharp-m7b5-arpeggio",
+            "dom7alt/v-chord-guide-tone-preservation"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-shell-voicing-anchor",
+          "narrative": "Shell voicings are prescribed specifically for altered dominant contexts to anchor the harmonic identity beneath extended melodic material: 'A shell voicing consists of the root and defining 3rd and 7th intervals of a chord. An E7 shell voicing would therefore be E, G# and D' (Ch. 4, p. 55). The shell voicing appears in Chapter 1 as a melodic skeleton device and returns in Chapter 4 as the harmonic floor for the altered dominant system. Reducing the chord to its three defining tones ensures the guide tones are never lost even when the melodic line ventures into altered extension territory.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-guide-tone-preservation",
+            "dom7/v-chord-m7b5-on-3rd"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-four-note-enclosure-suspension",
+          "narrative": "Four-note chromatic enclosures are prescribed over altered dominant chords specifically to suspend arrival on a chord tone until a metrically strong position: 'The final example of this chapter begins with a four-note chromatic enclosure (discussed in Chapter Two). In Example 4o the purpose of the enclosure is to suspend the 3rd of the Fm7 chord until beat 3, before the line continues with an Abmaj7 arpeggio' (Ch. 4, p. 61). The enclosure delays resolution to beat 3, producing forward momentum and harmonic tension without departing from the chord's guide-tone framework.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-guide-tone-preservation",
+            "dom7/v-chord-four-note-enclosure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-augmented-triad-resolution",
+          "narrative": "Resolving augmented triads is prescribed as a bop-derived stylistic device over altered dominant chords: 'The resolution of augmented triads is a common bop trait that has carried over into more modern styles' (Ch. 4, p. 60). The Abaug arpeggio appears in Chapter 3's prescribed arpeggio set over C7(b9,b13) (Ch. 3, p. 44), and C7#5 is endorsed as another useful arpeggio that is not diatonic to F Harmonic Minor but can be constructed from a C7 triad with an added augmented 5th (Ch. 3, p. 52). Resolution of the augmented triad requires stepwise voice-leading to a target chord tone.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-gsharp-m7b5-arpeggio",
+            "aug/v-chord-resolution"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-altered-diminished-bridge",
+          "narrative": "The B major triad is prescribed as a bridge between the altered and diminished scales over dominant seventh chords because it is shared by both systems: 'The B major triad is not unique to the diminished sound since it is also diatonic to F# Melodic Minor (AKA the F Altered scale). The B major triad gives us the #11 (B), b7 (D#) and b9 (F#) intervals against an F root. Combined with the D major triad, we also have a 13th and a 3rd' (Ch. 5, p. 72). This cross-scale membership gives the practitioner a pivot point for moving between diminished (13b9) and altered (b9, sharp-11, b7) color families within the same dominant context.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-guide-tone-preservation",
+            "dom7/v-chord-diminished-scale-upper-structure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7b9",
+          "function_role": "v-chord-harmonic-minor-arpeggio-set",
+          "narrative": "A specific set of arpeggios is prescribed over the dominant V7(b9,b13) chord derived from harmonic minor: 'The arpeggios I recommend are: Cmaj, Edim, Gdim, Abaug, Bbdim, C7, Edim, Abmaj7#5' (Ch. 3, p. 44). These arpeggios will convey a C7 (b9, b13) sound (Ch. 3, p. 44), which is the characteristic dominant color produced by the harmonic minor scale built on the IV. The explicit listing as a prescriptive set — rather than a theoretical derivation — makes this immediately actionable as a selection rule for harmonic minor V-chord playing.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/v-chord-9-chromatic-passing-note",
+            "dom7/v-chord-harmonic-minor-pull"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7b9",
+          "function_role": "v-chord-9-chromatic-passing-note",
+          "narrative": "Adding the #9 as a chromatic passing note alongside the b9 over a dominant V7(b9) chord is prescribed as a characteristic trick with explicit voice-leading rationale: 'The dominant 7th line in this example uses a common trick — which is to add in the #9 as well as the b9. In this instance the #9 is an Eb, which sounds great over the C7 chord. It functions a bit like a chromatic passing note, as it leads nicely to E — the 3rd of C7' (Ch. 3, p. 47). The #9 acts as an approach note to the major 3rd, and the chromatic passing note rule of Chapter 2 (off-beat placement) governs its rhythmic position.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/v-chord-harmonic-minor-arpeggio-set",
+            "dom7/v-chord-chromatic-off-beat-placement"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7b9",
+          "function_role": "v-chord-bbm7b5-non-diatonic-arpeggio",
+          "narrative": "The Bbm7b5 arpeggio is prescribed over a C7(b9,b13) chord as a non-diatonic option constructible from harmonic minor scale tones: 'Strictly speaking, Bbm7b5 is not a diatonic chord of F Harmonic Minor, but it is possible to construct this arpeggio with notes from the scale. Bbm7b5: Bb Db E Ab. Using Bbm7b5 over the C7 chord imposes the intervals of the b7, b9, 3 and #5. They sound great!' (Ch. 3, p. 50). The construction method — rerooting scale tones from an alternate degree — is the non-diatonic arpeggio construction rule applied to a specific harmonic minor dominant context.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/v-chord-harmonic-minor-arpeggio-set",
+            "dom7alt/v-chord-gsharp-m7b5-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7b9",
+          "function_role": "v-chord-enclosure-diatonic-above-chromatic-below",
+          "narrative": "The two-note enclosure formula of diatonic-above and chromatic-below is prescribed specifically over the harmonic minor V chord: 'the lick played over the Gm7 encloses the chord tone with a diatonic note above and a chromatic note below. The same idea is applied first to the root, then the 3rd' (Ch. 3, p. 47). This is the canonical enclosure ordering from Chapter 2 — chromatic note below and a diatonic note above (Ch. 2, p. 32) — applied within the harmonic minor context where b9 and b13 are in play, giving the enclosure a darker coloring than over a diatonic dominant.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/v-chord-9-chromatic-passing-note",
+            "dom7/v-chord-two-note-enclosure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7b9",
+          "function_role": "v-chord-triad-pairs-no-common-notes",
+          "narrative": "Using triad pairs with no notes in common is prescribed over dominant V7(b9) and minor-key contexts as a modern device producing angular, unresolved melodic lines: 'Pairing triads like this creates a very strong melodic structure. Modern jazz saxophonists such as George Garzone and Michael Brecker often solo using pairs of triads that have no notes in common, which creates an angular, unresolved sound' (Ch. 3, p. 51). The no-notes-in-common constraint maximizes intervallic distance between the two triads, generating maximum tension relative to the underlying harmonic minor harmony.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/v-chord-harmonic-minor-arpeggio-set",
+            "dom7/v-chord-color-tone-triad-pair"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7b9",
+          "function_role": "v-chord-motif-based-navigation",
+          "narrative": "The motif-based approach to chord navigation is prescribed alongside the target-note approach as a complementary strategy for harmonic minor V-chord contexts: 'Notice that the transition from Gm7 to C7 is accomplished with a motif. The descending Bbmaj7 arpeggio motif is repeated using the descending E diminished arpeggio. This is a different approach to moving from one chord to the next by targeting chord tones. It's good to have both motif-based and target note ideas in your arsenal of lines' (Ch. 3, p. 48). The motif unifies line construction across the chord change without requiring a specific target tone.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7b9/v-chord-9-chromatic-passing-note",
+            "dom7/v-chord-motif-repeat-with-alteration"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7b5",
+          "function_role": "v-chord-guide-tone-substitution",
+          "narrative": "The m7b5 arpeggio is prescribed as the most effective altered dominant substitution because it simultaneously contains the guide tones and highlights multiple altered extensions: 'G#m7b5 is related to E7, as it can be viewed as an arpeggio built on the 3rd of E7. Of the two options, the G#m7b5 arpeggio is probably the best candidate to spell out a Bb7alt sound' (Ch. 4, p. 54). Over any dominant seventh chord, the m7b5 rooted on the 3rd adds the 9th, preserves the 3rd, and includes the 5th without adding the root: 'playing a m7b5 chord on the 3rd of a dominant 7 chord causes us to avoid playing the root (G) and adds the rich-sounding 9th (A)' (Ch. 1, p. 15).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7b5/v-chord-bbm7b5-construction",
+            "dom7alt/v-chord-gsharp-m7b5-arpeggio"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7b5",
+          "function_role": "v-chord-bbm7b5-construction",
+          "narrative": "The Bbm7b5 arpeggio over a C7(b9) chord is prescribed as a non-diatonic option constructed by rerooting harmonic minor scale tones: 'Bbm7b5 is not a diatonic chord of F Harmonic Minor, but it is possible to construct this arpeggio with notes from the scale. Bbm7b5: Bb Db E Ab — imposes the intervals of the b7, b9, 3 and #5. They sound great!' (Ch. 3, p. 50). The construction method — reading the scale from an alternate root — is the general principle of non-diatonic constructed arpeggio applied to a specific m7b5 instance, with the #5 (Ab) adding the altered outside coloring.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7b5/v-chord-guide-tone-substitution",
+            "dom7b9/v-chord-harmonic-minor-arpeggio-set"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "m7b5",
+          "function_role": "ii-chord-half-diminished-dual-reading",
+          "narrative": "In minor II-V-I contexts, the m7b5 arpeggio admits multiple analytical readings over altered dominant bars: 'The F7 altered line can be analysed in two ways: an Ebm7b5 arpeggio over the whole bar, or a Gbm triad for the first half of the bar and an Ebm7b5 arpeggio inversion for the second half' (Ch. 6, p. 82). This multiple-valid-readings principle applies to m7b5 arpeggios deployed in altered dominant contexts — the practitioner may conceptualize the same notes as either a complete m7b5 or a combined triad plus arpeggio inversion, depending on which frame produces clearer melodic narrative.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "m7b5/v-chord-guide-tone-substitution",
+            "dom7alt/v-chord-guide-tone-preservation"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dim7",
+          "function_role": "v-chord-harmonic-minor-arpeggio",
+          "narrative": "Diminished seventh arpeggios — Edim, Gdim, Bbdim — are prescribed as primary melodic material over a dominant V7(b9,b13) chord derived from harmonic minor: 'The arpeggios I recommend are: Cmaj, Edim, Gdim, Abaug, Bbdim, C7, Edim, Abmaj7#5' (Ch. 3, p. 44). The harmonic minor pull function extends this to the solo analysis context: 'Bar 4 — Uses the harmonic minor on Bb7 to pull towards the Eb7 (in this case playing the pattern of a Ddim arpeggio)' (Ch. 6, p. 82). The diminished arpeggio encodes the b9, #9, and leading tone simultaneously, making it a highly efficient carrier of harmonic minor tension.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dim7/v-chord-diminished-scale-interlocking",
+            "dom7b9/v-chord-harmonic-minor-arpeggio-set"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dim7",
+          "function_role": "v-chord-diminished-scale-interlocking",
+          "narrative": "The diminished seventh chord's structural role as one half of the interlocking pair that constitutes the half-whole diminished scale is prescribed as the conceptual entry point for the entire diminished scale system: 'The diminished scale can be viewed as two interlocking diminished 7th chords that repeat symmetrically in minor 3rd intervals. One of the best ways to use a synthetic scale like this is to pick out and isolate the triads it contains' (Ch. 5, p. 63). The construction rule is explicit: 'To construct an F Half Whole Diminished scale, you combine F diminished and Gb diminished arpeggios' (Ch. 5, p. 64).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dim7/v-chord-harmonic-minor-arpeggio",
+            "dom7/v-chord-diminished-scale-upper-structure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "aug",
+          "function_role": "v-chord-resolution",
+          "narrative": "Augmented triad resolution is prescribed as a bop-characteristic device over V chords: 'The resolution of augmented triads is a common bop trait that has carried over into more modern styles' (Ch. 4, p. 60). The Abaug arpeggio appears in Chapter 3's prescribed arpeggio set over C7(b9,b13) (Ch. 3, p. 44). C7#5 is endorsed as another useful arpeggio that is not diatonic to F Harmonic Minor but can be constructed from a C7 triad with an added augmented 5th (Ch. 3, p. 52). Resolution of the augmented triad requires stepwise voice-leading to a target chord tone, consistent with the book's broad counterpoint rule.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7alt/v-chord-augmented-triad-resolution",
+            "dom7b9/v-chord-harmonic-minor-arpeggio-set"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj",
+          "function_role": "upper-structure-diminished-triad-color",
+          "narrative": "Major triads embedded in the half-whole diminished scale are prescribed as melodic upper-structure material for their coloristic function over dominant seventh chords: 'The most common sound associated with this scale is probably the 13b9. Guitarists generally think of this as an upper-structure triad placed above a dominant 7th chord. E.g. F713b9 is a D major triad over an F7 chord' (Ch. 5, p. 66). The D major triad produces the 13th extension over F7, the Ab triad produces the b9 and #9, and the B major triad produces the #11, b9, and b7. Each major triad is prescribed for its specific color function, not as an interchangeable option.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-color-tone-triad-pair",
+            "dom7/v-chord-diminished-scale-upper-structure"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj",
+          "function_role": "upper-structure-altered-triad-b9-sharp11",
+          "narrative": "The combination of F and B major triads in first inversion is prescribed over F7 to highlight the sharp-11 and b9 extensions: 'The F7 line uses first inversion F major and B major triads. This combination highlights the #11 and b9 extensions' (Ch. 6, p. 75). This is a specific instance of the color-tone triad pair prescription where the practitioner chooses triads whose interval content maps directly onto the desired altered extensions. The first-inversion specification adds a voice-leading constraint, ensuring the highest note of each triad carries the color tone.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-color-tone-triad-pair",
+            "dom7alt/v-chord-altered-diminished-bridge"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "maj7sharp5",
+          "function_role": "v-chord-harmonic-minor-non-diatonic",
+          "narrative": "The Abmaj7#5 arpeggio is prescribed over C7(b9,b13) as a non-diatonic but scale-compatible option derived from F harmonic minor, appearing in the author's recommended arpeggio list (Ch. 3, p. 44). The C7#5 variant is endorsed independently: 'The latter is another useful arpeggio that is not diatonic to F Harmonic Minor, but can be constructed from a C7 triad with an added augmented 5th' (Ch. 3, p. 52). Both arpeggios leverage the augmented 5th degree of the harmonic minor scale, generating the characteristic b13 and sharp-5 color that distinguishes harmonic minor from natural or melodic minor dominant sound.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "aug/v-chord-resolution",
+            "dom7b9/v-chord-harmonic-minor-arpeggio-set"
+          ]
+        },
+        {
+          "source_work_id": "modern-jazz-guitar-concepts",
+          "chord_quality": "dom7sus4",
+          "function_role": "v-chord-sus4-tension",
+          "polarity": "proscriptive",
+          "narrative": "The sus4 sound produced by playing the 11th (C) over a G7 dominant chord is explicitly identified as a potential problem requiring conscious intent: 'Playing a C over a G7 chord will suggest a G7sus4 sound. This might be desirable in some instances but not in others' (Ch. 1, p. 23). The proscription is conditional — the sus4 is not forbidden absolutely, but its deployment requires deliberate choice because it weakens the dominant's resolution drive by replacing the major 3rd (the guide tone) with the suspended 4th. This aligns with the guide-tone preservation rule that governs all arpeggio selection in the book.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dom7/v-chord-sus4-avoidance",
+            "m7/ii-chord-chord-tone-omission"
+          ]
+        }
+      ]
     },
     {
       "id": "jerry-bergonzi",
@@ -22705,7 +23515,1284 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "convergence-pivot",
+          "narrative": "The dominant seventh chord is identified as the most load-bearing chord type in the entire convergence system. Martino writes that 'The 7th chord having the all important tritone host the largest and most flexible of all the chord types. (7th bs, 7b 9, 7th #5, 7th #9, 7th 9s)' (p. 4). The system was 'conceived at the II-V cadence,' specifically 'noticing all the chord possibilities on the final 5th chord in the cadence' (p. 4). Practitioners are directed to rotate multiple scale colors over this chord type as the primary compositional act.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-pivot",
+            "dominant-seventh/variant-expansion"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "tritone-host",
+          "narrative": "The tritone is designated the 'central interval of harmonic significance of the 2-5 cadence,' described as the 'mysterious tritone interval' (p. 17). The dominant seventh chord is the structural vessel for this tritone, making it the pivot point for all 24 convergence scales. Every chord-on-chord approach is mediated through 'a five chord with a tritone' that precedes the target chord (p. 66). The practitioner is directed to use 'chromatic tones to resolve the tritone' during scale application (p. 69).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 17; Ch. 8, p. 66, p. 69"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/convergence-pivot",
+            "dominant-seventh/chromatic-tritone-resolution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "multi-scale-rotation-target",
+          "narrative": "The instruction to deploy many different scale colors over a single dominant seventh chord is one of the book's defining practical directives. Martino states his practice came 'from listening to John Coltrane, Yusef Lateef and others caused me to try using many different scale \"color\" types on one chord (7th)' (p. 4). Scales and their chords 'may be combined (several of them together) in several rotas varying their order and making more interesting musical usuage of color (A,—»; +, 0, 7th)' (p. 4). This rotation distinguishes advanced convergence usage from simple single-scale application.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/convergence-pivot",
+            "dominant-seventh/scale-color-substitution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "scale-color-substitution",
+          "narrative": "All five harmonic color categories — major, minor, augmented, dominant, and diminished — are prescribed as valid approach colors for the dominant seventh chord. Martino equates these colors to 'the green, blue, black, red & yellow of the color spectrum' (p. 4). The practitioner is directed to rotate scales across these five categories over a single V7 chord, creating a richer harmonic approach than any single scale permits. The Scale Justification Sheets document all 24 applicable scales for this purpose (p. 17).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4; Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/multi-scale-rotation-target",
+            "dominant-seventh/tritone-host"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh-flat-nine",
+          "function_role": "convergence-approach-variant",
+          "narrative": "The 7♭9 voicing is explicitly catalogued as one of the dominant seventh chord's variant forms in the convergence system. Martino lists it among the expanded chord types that make the dominant seventh 'the largest and most flexible of all the chord types': '7b 9' appears in the enumeration of dominant variants including '7th bs, 7b 9, 7th #5, 7th #9' (p. 4). This chord type carries both the tritone and the lowered ninth's chromatic tension, amplifying the gravitational pull toward the target tonic.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/convergence-pivot",
+            "dominant-seventh-sharp-nine/convergence-approach-variant"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh-sharp-five",
+          "function_role": "convergence-approach-variant",
+          "narrative": "The 7♯5 voicing is explicitly listed among the dominant seventh variants that the convergence system deploys. Martino includes '7th #5' in his catalogue of flexible dominant chord forms (p. 4), treating the augmented fifth as an additional chromatic tension note within the V7 structure. The raised fifth contributes an augmented-scale color to the dominant sound, expanding the range of scale approaches available when convergence targets are being approached through this chord type.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/convergence-pivot",
+            "dominant-seventh-flat-nine/convergence-approach-variant"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh-sharp-nine",
+          "function_role": "convergence-approach-variant",
+          "narrative": "The 7♯9 voicing is catalogued alongside the other dominant seventh variants as a valid convergence approach chord. Martino includes '7th #9' in his enumeration of dominant forms that the system treats as its primary terrain (p. 4). The sharpened ninth introduces a minor-third quality above the dominant root while retaining the tritone, creating a chromatic tension that intensifies the tonal gravity pull toward the resolution target.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/convergence-pivot",
+            "dominant-seventh-flat-nine/convergence-approach-variant"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "chord-on-chord-predecessor",
+          "narrative": "The convergence system establishes a specific rule for chord-on-chord approach: any main target chord 'can be usually preceded by a five chord with a tritone. This interval participates in this five or dominant-seventh chord as well as another seventh chord a flatted 5th from its root' (p. 66, Ch. 8). The dominant seventh chord is therefore prescribed as the standard predecessor in chord-on-chord convergence, and its tritone-substitute (a dominant seventh built a tritone away) is simultaneously validated. This rule covers both major and minor target chords.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 8, p. 66"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-host",
+            "dominant-seventh/tritone-substitution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "tritone-substitution",
+          "narrative": "The tritone substitute for the dominant seventh is explicitly validated in the chord-on-chord rule: a dominant seventh chord 'a flatted 5th from its root' participates in the same tritone interval and can substitute for the primary V7 (p. 66). The Circle of Gravities (Chapter 8) maps these tritone relationships systematically, serving as a 'navigational tool for chord-on-chord motion.' Any target chord can therefore be approached by either the direct V7 or its tritone-equivalent V7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 8, p. 66"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/chord-on-chord-predecessor",
+            "dominant-seventh/tritone-host"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "tonal-convergence-destination",
+          "narrative": "The major tonality is one of the two primary tonal destinations in the convergence system. The book's primary worked example uses Bb7 as 'a standard V convergent chord to EP minor & major tonalities' (p. 4), establishing that major keys are targets toward which all 24 scales are directed. The ear-priming procedure specifies 'brainwash your ear with the tonality (F major in this case) with several cadences into the key' (p. 18), with F major serving as the paradigmatic resolution target throughout Chapters 2–4.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4; Ch. 2, p. 18"
+            }
+          ],
+          "cross_ref": [
+            "major/convergence-destination",
+            "minor/tonal-convergence-destination"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "tonal-convergence-destination",
+          "narrative": "The minor tonality is the co-equal primary tonal destination alongside major. Martino establishes Bb7 as 'a standard V convergent chord to EP minor & major tonalities' (p. 4), confirming that the entire 24-scale engine applies to minor keys as well as major. Chapter 8 addresses convergence specifically 'on the Seventh Chord, Minor Chord,' treating the minor chord as the endpoint of the system's chord-on-chord approach procedures.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4; Ch. 8, summary"
+            }
+          ],
+          "cross_ref": [
+            "minor/scale-with-major-third-approach",
+            "major/tonal-convergence-destination"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "scale-with-major-third-approach",
+          "narrative": "A specific handling rule is prescribed when a scale containing a major third is applied to a minor target chord. Martino states: 'Scale #3 has a major 3rd already in it so it has to used as above to embellish the 5th of the F minor' (p. 70, Ch. 8). Rather than abandoning the scale due to the major-minor conflict, the practitioner is directed to redirect the scale toward the fifth of the minor chord, effectively using the V of the minor chord as the approach point. This resolves the tonal mismatch without discarding the scale.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 8, p. 70"
+            }
+          ],
+          "cross_ref": [
+            "minor/tonal-convergence-destination",
+            "major/scale-color-embellishes-minor-fifth"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "half-diminished",
+          "function_role": "convergence-scale-color",
+          "narrative": "The half-diminished color forms the first half of Scale #15's bipartite structure: 'The scale has one half of its length yielding diminish color' (p. 32, Ch. 3). Scale #15 is categorized as a 'half-diminished / half-whole-tone' scale, where the diminished portion provides approach tension and the whole-tone portion provides smooth motion into the resolution. This makes half-diminished color a prescribed component of convergence approach vocabulary.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 32"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/leading-tone-function",
+            "diminished-half-whole/convergence-scale-color"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "half-diminished",
+          "function_role": "leading-tone-function",
+          "narrative": "Scale #15's leading-tone function is explicitly prescribed as the mechanism by which its half-diminished color resolves. Martino writes that 'This scale is another type scale which has the E natural starting & ending notes which at the end of the scale functions as the leading tone into F (the desired tonal destination)' (p. 32, Ch. 3). The E natural — which is the major seventh of F — acts as the semitone leading tone, and the half-diminished color of the scale generates the tension that this leading tone then resolves.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 32"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/convergence-scale-color",
+            "dominant-seventh/tritone-host"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "diminished-half-whole",
+          "function_role": "convergence-scale-color",
+          "narrative": "Scale #4 is the H-W (half-whole) diminished type, defined with 'an interval structure half, whole, half, whole, half, whole, half, whole' (p. 21, Ch. 2). This is one of two distinct diminished scale types in the 24-scale system, and its specific interval formula is given to distinguish it from the W-H type. Its inclusion in the Scale Justification Sheets confirms it as a prescribed convergence approach color for the target tonality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 21"
+            }
+          ],
+          "cross_ref": [
+            "diminished-whole-half/convergence-scale-color",
+            "half-diminished/convergence-scale-color"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "diminished-whole-half",
+          "function_role": "convergence-scale-color",
+          "narrative": "Scale #5 is the W-H (whole-half) diminished type, distinguished from Scale #4 by its reversed interval symmetry. Martino describes it as having 'a W,H,W,H,W,H,W,H step symmetry. It permits ascending diminish color to a point of convergence (F major in this case)' (p. 22, Ch. 2). The ascending motion characteristic of the W-H pattern is specifically noted as the reason it 'permits' convergence, making the choice between H-W and W-H diminished a matter of directional color.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 22"
+            }
+          ],
+          "cross_ref": [
+            "diminished-half-whole/convergence-scale-color",
+            "half-diminished/convergence-scale-color"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "scale-color-convergence-approach",
+          "narrative": "The major scale color is one of the five prescribed chromatic approach colors in the system. Scale #16 exemplifies major color with its raised fourth: 'This scale, is a major scale with a raised 4th in it. The 4th is the major 3rd of the V chord, also the scale begins on the 7th of the V chord of F major' (p. 33, Ch. 3). This Lydian-like construction is prescribed as a valid convergence approach precisely because its raised fourth aligns the scale's most characteristic tone with the V chord's major third, strengthening the dominant function.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 33"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/lydian-raised-fourth"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "lydian-raised-fourth",
+          "narrative": "Scale #16's raised fourth is specifically analyzed as corresponding to the V chord's major third, providing a structural rationale for using a Lydian-mode approach over dominant function. Martino notes that the scale 'begins on the 7th of the V chord of F major' (p. 33), meaning the starting note of the scale is the leading tone to the target key. This double alignment — the raised fourth as V-chord major third, and the first note as the leading tone — makes Scale #16 a particularly well-justified convergence approach.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 33"
+            }
+          ],
+          "cross_ref": [
+            "major/scale-color-convergence-approach",
+            "dominant-seventh/tritone-host"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "dorian-mode-convergence",
+          "narrative": "The Dorian mode is explicitly prescribed as a valid convergence scale for approaching a major tonal center. Martino writes that 'This scale is simply a dorian mode of the F major' (p. 50, Ch. 4), identifying Scale #20 as Dorian built on the second degree of F major. The pedagogical point is that 'starting on a different mode of it' — the target key — is a valid convergence approach, because the modal content belongs to the destination key. Dorian is thus a prescribed minor-color approach to a major tonal center.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 4, p. 50"
+            }
+          ],
+          "cross_ref": [
+            "minor/tonal-convergence-destination",
+            "minor/jazz-melodic-minor-ii-convergence"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "jazz-melodic-minor-ii-convergence",
+          "narrative": "The Jazz melodic minor scale is prescribed as a substitute II-convergence scale based on enharmonic pitch equivalence. Martino states: 'the G Jazz melodic minor scale has the same notes as this scale so it may be used as a II convergence scale' (p. 50, Ch. 4). This establishes a key rule: any scale sharing pitches with a mode of the target key qualifies as a convergence approach, regardless of its nominal tonic. G Jazz melodic minor thus provides an alternative minor-color approach to F major.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 4, p. 50"
+            }
+          ],
+          "cross_ref": [
+            "minor/dorian-mode-convergence",
+            "minor/tonal-convergence-destination"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "final-note-voice-leading",
+          "narrative": "A universal voice-leading constraint is prescribed for all scales applied over dominant seventh approach chords: 'The last note of all the scales in this system are only a whole or half step away from the Ist, 3rd, or 5th or root of the desired tonal destination' (p. 22, Ch. 2). This rule validates every one of the 24 scales — regardless of its harmonic color — as a legitimate convergence approach, because the mandatory half/whole-step arrival onto a chord tone of the target guarantees smooth resolution regardless of the scale's internal color.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 22"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/convergence-pivot",
+            "dominant-seventh/chromatic-tritone-resolution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "chromatic-tritone-resolution",
+          "narrative": "Chromatic tones are prescribed as the mechanism for resolving the tritone embedded in the dominant seventh chord. Martino's core technique rule states: 'It is just a matter of using chromatic tones to resolve the tritone' (p. 69, Ch. 8). This directive bridges scale application and chord resolution: the chromatic scale's tones — the very material described as universally available under the tonal gravity law — are the specific tools for executing tritone resolution within the V7 structure.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 8, p. 69"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-host",
+            "dominant-seventh/final-note-voice-leading"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "turnback-application",
+          "narrative": "The dominant seventh chord in turnback contexts is one of the three primary deployment sites for convergence scales. Martino directs that 'The usuage of these scales in turnbacks, cadences and cycles (which comprise all music) in Jazz yields a wider source of ideas for the improvisor-composer-arranger' (p. 4, Ch. 1). Turnbacks are thus prescribed as a structural location where the full 24-scale convergence vocabulary should be applied over dominant seventh chords, expanding beyond the single-scale approach.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/cadence-application",
+            "dominant-seventh/cycle-application"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "cadence-application",
+          "narrative": "The cadence — particularly the II-V cadence — is the foundational structural context where convergence scales over dominant seventh chords are prescribed. The system was 'conceived at the II-V cadence, noticing all the chord possibilities on the final 5th chord in the cadence' (p. 4, Ch. 1). Cadences are one of three structural locations (along with turnbacks and cycles) where the 24-scale convergence vocabulary 'yields a wider source of ideas' (p. 4). The V7 in a cadential II-V is the paradigmatic application site for the entire system.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/turnback-application",
+            "dominant-seventh/cycle-application"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "cycle-application",
+          "narrative": "Cycle progressions are prescribed as the third primary deployment site for convergence scales over dominant seventh chords. Martino writes that the scales 'in turnbacks, cadences and cycles (which comprise all music) in Jazz yields a wider source of ideas' (p. 4, Ch. 1). The Circle of Gravities introduced in Chapter 8 is the navigational tool for traversing cycle motion, mapping tritone relationships so that practitioners can apply chord-on-chord convergence through successive dominant seventh relationships in a systematic cycle.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4; Ch. 8, summary"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/turnback-application",
+            "dominant-seventh/cadence-application"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "tetrachord-bridge-resolution",
+          "narrative": "The final tetrachord of a convergence scale is prescribed as the structural convergence mechanism into a major tonal center. Martino demonstrates this with the statement 'The last tetrachord of this scale is an F major scale' (p. 50, Ch. 4), showing that a convergence scale's closing four notes replicate the upper tetrachord of the target major key. This rule gives the practitioner a concrete structural landmark — the last four notes — where the approach scale merges into the target key's sonic identity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 4, p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "dominant-seventh/final-note-voice-leading"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "ear-priming-target",
+          "narrative": "Before any convergence scale is played, the practitioner must prime the ear toward the major tonal destination with active listening. Martino is explicit: 'Before playing each scale in this system, you should brainwash your ear with the tonality (F major in this case) with several cadences into the key' (p. 18, Ch. 2). This pre-execution ear-priming is mandatory — it is not optional preparation but a prerequisite condition establishing the tonal gravity pull that makes convergence perceptible. The major key is the attentional anchor throughout the approach process.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 18"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/sound-projection-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "sound-projection-target",
+          "narrative": "The sound-projection technique requires the performer to mentally arrive at the major tonal destination before physically executing the approach. Martino prescribes: 'When converging on a tonality project yourself sound wise to it already having your attention (sound attention) on it and on the chord or scale you are using' (p. 20, Ch. 2). The major tonal center is the target of this mental projection — the practitioner must psychoacoustically inhabit the destination key while still playing approach material, a form of bidirectional tonal attention that governs the quality of the convergence.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 20"
+            }
+          ],
+          "cross_ref": [
+            "major/ear-priming-target",
+            "major/tonal-convergence-destination"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "chord-member-mode-extraction",
+          "narrative": "The foundational chord-scale relationship rule prescribes a specific analytical method for validating any scale's relationship to the dominant seventh chord: 'Each chord represents a member chord sound of one of the modes of the scale it comes from' (p. 17, Ch. 2). Applied to the dominant seventh, this means every V7 chord encountered belongs to a parent scale as a modal chord, and that parent scale can therefore be used as a convergence approach. This rule is the engine behind the Scale Justification Sheets, generating 24 valid approach scales by tracing each scale back to its modal V7 chord member.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/convergence-pivot",
+            "dominant-seventh/scale-color-substitution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "chord-extraction-for-resolution",
+          "narrative": "Practitioners are explicitly directed to 'Extract all possible chords from all scales for resolution purposes' (p. 20, Ch. 2). Applied to dominant seventh function, this means every one of the 24 approach scales must be mined for its embedded dominant-quality chord voicings, which are then available as independent resolution vehicles. This rule converts the scalar approach into a harmonic resource library: every scale contains within it chord forms that participate in the dominant-to-tonic convergence, and the practitioner must actively identify and deploy these.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 20"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/chord-member-mode-extraction",
+            "dominant-seventh/multi-scale-rotation-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "chromatic-approach-acceptance",
+          "narrative": "A radical prescriptive stance licenses any chromatic note as a valid approach to a major tonal center when five governing conditions are met. Martino states: 'There are no wrong notes when factors such as fixation on a key center, Vantage Point, Interval Tonics, Resolution are considered along with a certain Confidence within the artist himself. The entire chromatic scale is at our disposal thanks to Great Nature' (p. 31, Ch. 3). Major key convergence thus prescribes consciousness-governed chromatic freedom rather than scale-bounded constraint, treating all twelve tones as available approach material.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/ear-priming-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "chromatic-approach-acceptance",
+          "narrative": "The 'no wrong notes' principle applies equally to minor tonal centers as to major. The system establishes that when key center fixation, Vantage Point, Interval Tonics, Resolution, and artist confidence are properly calibrated, 'The entire chromatic scale is at our disposal' (p. 31, Ch. 3) — including over minor key targets. Chapter 8's convergence on the minor chord extends this philosophy through chord-on-chord procedures, demonstrating that even the harmonic conflict between a major-third scale and a minor target can be managed through redirecting the scale to the fifth of the minor chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31; Ch. 8, p. 70"
+            }
+          ],
+          "cross_ref": [
+            "minor/tonal-convergence-destination",
+            "minor/scale-with-major-third-approach"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "scale-interoperability",
+          "narrative": "All 24 scales in the system are prescribed as freely interchangeable in their ordering over any dominant seventh convergence context. Martino states: 'It is possible to use this scale from any note within it. All scales in this system may be connected together in different orders for convergence into a tonal center' (p. 30, Ch. 3). This rule eliminates any mandatory sequence, granting the practitioner full ordering freedom and supporting the characteristic compositional move of rotating scales in varied rotas. No fixed approach order is required or recommended.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 30"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/multi-scale-rotation-target",
+            "dominant-seventh/scale-color-substitution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "modal-reentry-approach",
+          "narrative": "Convergence scales may begin on any mode of the target major key, not exclusively the root. Martino demonstrates this rule: 'This scale is an example of being within the same scale of (F major) the key you are converging however starting on a different mode of it' (p. 50, Ch. 4). This modal re-entry rule expands the available approach material from the seven modes of the target key, each of which generates its own convergence scale with a different harmonic color while retaining all the pitches of the destination key.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 4, p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "minor/dorian-mode-convergence"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "consciousness-governed-application",
+          "narrative": "The governing rule for applying convergence to a major tonal center is consciousness rather than formula. Martino directs: 'This system does not dictate to the student what to do other than increase his or her consciousness. You shape the raw material or resources to your desired needs' (p. 50, Ch. 4). This means the practitioner's awareness of the five governing factors — key center, Vantage Point, Interval Tonics, Resolution, and confidence — is the actual mechanism of convergence over major targets, not a prescribed sequence of scales or voicings.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 4, p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/chromatic-approach-acceptance",
+            "major/ear-priming-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "ii-v-genesis-application",
+          "narrative": "The II-V cadence is the structural matrix within which the convergence system was conceived and from which all its procedures derive. Martino locates the genesis: 'It was at this final juncture (II-V) where my convergence system was conceived, noticing all the chord possibilities on the final 5th chord in the cadence' (p. 4, Ch. 1). The V chord (dominant seventh) at the II-V junction is therefore the original application site, and all 24 scales are justified by their relationship to this cadential V7. Every other deployment context — turnbacks, cycles, chord-on-chord — is an extension of this II-V generative moment.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/cadence-application",
+            "dominant-seventh/tritone-host"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "tonal-gravity-exertion",
+          "narrative": "The tonal gravity law directly governs how the dominant seventh chord functions in the convergence system. Martino writes: 'A tonal gravity law is created once you start to play music (in a key). The key of the music exerts a gravity pull on all other chords no matter what they may be' (p. 4, Ch. 1). The dominant seventh's tritone is the concentrated expression of this gravitational pull, making it the chord type most visibly governed by tonal gravity. The practitioner must understand this gravity — not merely the scale pattern — as the source of the chord's convergent power.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-host",
+            "dominant-seventh/convergence-pivot"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "tonal-gravity-destination",
+          "narrative": "The major key center is the gravitational attractor in the tonal gravity law. Martino articulates that 'The energy amassed in a jazz improviso's solo has to be climatically released by arrival \"Home\" to the overall key center' (p. 4, Ch. 1). The major key center — the 'Home' — is the target toward which all chromatic tones exert their cadential pull. The practitioner's entire technical apparatus, from scale rotation to chord-on-chord approach, is designed to intensify and ultimately satisfy this gravitational pull toward the major tonal center.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/ear-priming-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "scale-color-rota-construction",
+          "narrative": "The rota construction rule prescribes that scales 'may be combined (several of them together) in several rotas varying their order' (p. 4, Ch. 1). Over the dominant seventh chord, this means the practitioner must construct multiple orderings of convergence scales — not a single fixed sequence — to achieve the 'more interesting musical usuage of color' that distinguishes advanced application. The rota principle treats scale combination as a compositional craft, with color palette management (major, minor, augmented, dominant, diminished) as the primary creative variable.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/multi-scale-rotation-target",
+            "dominant-seventh/scale-interoperability"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "plunging-process-target",
+          "narrative": "The ultimate technical goal of the system is described as the ear 'becoming accustomed to hearing new harmonic & linear motion until it is completely familiar with a plunging Process into a tonal destination from any note, scale or chord in the chromatic scale (Universe)' (p. 26, Ch. 2). The major tonal center is the target of this plunging process — the destination into which the practitioner must be able to drop from any chromatic starting point. This prescribes fluency, not formula: the measure of mastery is the ability to land in the major key from anywhere.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 26"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/sound-projection-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "plunging-process-target",
+          "narrative": "The plunging process applies equally to minor tonal destinations. The system is described as teaching 'how to get into a major or minor key variating different scales (24) and chords (many) and their innumerable permutation & chord inversions' (p. 23, Ch. 2). Minor keys are co-equal targets of the plunging process, and the practitioner must develop the same chromatic drop fluency for minor destinations as for major. Chapter 8's specific treatment of minor chord convergence demonstrates the additional procedures required when a scale's color conflicts with the minor target quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 23; Ch. 8, summary"
+            }
+          ],
+          "cross_ref": [
+            "minor/tonal-convergence-destination",
+            "minor/scale-with-major-third-approach"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "24-scale-bombardment",
+          "narrative": "The Scale Justification Sheets procedure prescribes a complete bombardment of any target chord with all 24 scales: 'This convergence system shows a fixed bombardment of any type chord that we want to give \"tonal significance\" to then bombard it with 24 scales, a mixture of them, their ideas and constituent chords' (p. 17, Ch. 2). Over dominant seventh chords, this bombardment is the primary pedagogical exercise — the practitioner works through all 24 scales systematically to develop tonal significance awareness and identify the full palette of available approach colors.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/scale-color-substitution",
+            "dominant-seventh/multi-scale-rotation-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "360-degree-convergence-center",
+          "narrative": "The 360-degree compass metaphor positions the major key center as the gravitational attractor at the center of the entire system. Martino writes: 'You might call this system the astrological charting of a key center because the 360° circle is used & the key center lies at the middle which represents the person or key acted upon. You are bombarding this person, or in this case key center with 24 scales & their constituent chords' (p. 33, Ch. 3). The major tonal center is thus the fixed, stationary hub, while all 24 scales are directional vectors converging upon it from every harmonic angle.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 33"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/plunging-process-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "circle-of-gravities-navigation",
+          "narrative": "The Circle of Gravities is prescribed as the navigational instrument for chord-on-chord motion through tritone-related dominant seventh chords. The book-level summary establishes that 'The Circle of Gravities (Chapter 8) maps tritone relationships systematically, serving as a navigational tool for chord-on-chord motion.' Practitioners are directed to use this circle to understand how dominant seventh chords relate to and transit between one another through tritone connections, enabling systematic chord-on-chord convergence across any key cycle.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 8, summary"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-host",
+            "dominant-seventh/tritone-substitution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "tonal-significance-establishment",
+          "narrative": "The goal of applying the 24 scales to a dominant seventh chord is specifically to give it 'tonal significance' — the harmonic weight needed to justify the chord's convergent function. The convergence system 'shows a fixed bombardment of any type chord that we want to give \"tonal significance\" to' (p. 17, Ch. 2). Tonal significance is not inherent in the chord voicing alone but is established through the scale bombardment process: it is a quality the practitioner confers through systematic approach, making the dominant seventh chord a consciously loaded harmonic actor rather than a formulaic pivot.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/24-scale-bombardment",
+            "dominant-seventh/tonal-gravity-exertion"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "permutation-inversion-target",
+          "narrative": "The system prescribes working through 'innumerable permutation & chord inversions' of scales and chords when approaching major tonal centers. Martino summarizes: 'this system is about how to get into a major or minor key variating different scales (24) and chords (many) and their innumerable permutation & chord inversions' (p. 23, Ch. 2). For major targets, this means the practitioner should not settle for a single scale approach or a single chord voicing but should systematically explore the full inversion and permutation space available within the 24-scale framework.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 23"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/360-degree-convergence-center"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "half-diminished",
+          "function_role": "scale-15-bipartite-structure",
+          "narrative": "Scale #15's prescribed use requires understanding its bipartite color structure: the first half yields half-diminished color and the second half yields whole-tone color. Martino states: 'The scale has one half of its length yielding diminish color' (p. 32, Ch. 3). This structural rule means the practitioner must apply Scale #15 with awareness of this color shift at the midpoint — the first half generates tension through diminished color while the second half smooths into resolution through whole-tone motion. The two halves function as a self-contained tension-release arc.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 32"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/convergence-scale-color",
+            "half-diminished/leading-tone-function"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "scale-11-tritone-application",
+          "narrative": "Scale #11 is prescribed as a personal approach scale for dominant-function contexts, built around 'an E-Bb tritone' (p. 28, Ch. 3). The descending tritone-based construction of this scale makes it a natural fit over dominant seventh chords, which contain the same tritone interval as one of their defining characteristics. Martino identifies this as 'My own personal scale,' signaling that practitioners may develop or adopt personal scales validated by their tritone content, so long as the scale satisfies the universal last-note resolution rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 28"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tritone-host",
+            "dominant-seventh/scale-interoperability"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "chord-on-chord-minor-convergence",
+          "narrative": "Chapter 8 applies the chord-on-chord convergence framework specifically to the minor chord as a target, establishing that the procedures developed for dominant seventh approach work symmetrically for minor target chords. The chapter is titled 'Convergence on the Seventh Chord, Minor Chord,' treating both chord types as equal recipients of the chord-on-chord approach procedure. For minor targets, additional rules apply — particularly the major-third scale embellishment redirect (p. 70) — but the fundamental structure of preceding-V7-with-tritone applies universally.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 8, summary; Ch. 8, p. 70"
+            }
+          ],
+          "cross_ref": [
+            "minor/tonal-convergence-destination",
+            "minor/scale-with-major-third-approach"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "chromatic-resource-expansion",
+          "narrative": "The pedagogical mission of the system is explicitly tied to expanding the dominant seventh chord's harmonic resource to the full chromatic scale. Martino states: 'The important factor is the expanding of hearing tolerance increasing the musicians ear awareness to the entire tonal resources of the chromatic scale' (p. 4, Ch. 1). Applied to the dominant seventh, this means every one of the twelve chromatic tones has a relationship to the V7 chord's convergent function, and the practitioner must train the ear to hear these relationships rather than relying on a fixed palette of approach scales.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/24-scale-bombardment",
+            "dominant-seventh/tonal-gravity-exertion"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "convergence-home-arrival",
+          "narrative": "The major key center is the convergence system's definition of 'Home' — the point of climactic harmonic release. Martino writes: 'The energy amassed in a jazz improvisors solo has to be climatically released by arrival \"Home\" to the overall key center' (p. 4, Ch. 1). The major key center is not merely a scale tonic but a psychoacoustic destination toward which all improvisational energy is directed. The entire 24-scale apparatus exists to make this homeward arrival more richly prepared — not to delay or avoid it, but to approach it from every possible chromatic angle.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/tonal-gravity-destination"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "parent-scale-mode-membership",
+          "narrative": "Every dominant seventh chord is prescribed as belonging to the modal family of its parent scale, and this membership determines the approach scales available. The rule states: 'Each chord represents a member chord sound of one of the modes of the scale it comes from' (p. 17, Ch. 2). For dominant seventh chords, this means the practitioner must identify the parent scale of each V7 encountered, locate its modal position within that scale, and then treat all modes of that parent scale as potential convergence approach materials. The V7's modal membership is the entry point into the full 24-scale system.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/chord-member-mode-extraction",
+            "dominant-seventh/scale-interoperability"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "expanded-hearing-tolerance-target",
+          "narrative": "The major tonal center serves as the pedagogical reference point against which expanded hearing tolerance is measured. The system's goal of 'expanding of hearing tolerance increasing the musicians ear awareness to the entire tonal resources of the chromatic scale' (p. 4, Ch. 1) is measured by the practitioner's ability to hear increasingly distant chromatic approach scales as convergent toward the major key. The major tonal center is the stable fixed point that makes the expansion of hearing tolerance measurable — as more remote approach sounds are heard as convergent, the practitioner's tonal awareness has grown.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/chromatic-approach-acceptance"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "raw-material-chord-extraction",
+          "narrative": "Every scale in the system is prescribed as 'raw material for convergent ideas within a piece of music as well as many chordal sounds extracted from them' (p. 4, Ch. 1). Applied to dominant seventh function, this means the practitioner does not merely play scales over V7 chords but extracts chord voicings from each approach scale — including dominant-quality voicings — to create harmonic as well as linear convergence. This transforms the scale approach into a chord vocabulary generation process, with the dominant seventh as the most fruitful extraction target.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/chord-extraction-for-resolution",
+            "dominant-seventh/chord-member-mode-extraction"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "vantage-point-approach",
+          "narrative": "The Vantage Point is prescribed as one of the five governing factors that make chromatic freedom over minor tonal centers available. Martino lists it among the conditions required for 'no wrong notes': 'factors such as fixation on a key center, Vantage Point, Interval Tonics, Resolution are considered along with a certain Confidence within the artist himself' (p. 31, Ch. 3). For minor key convergence, the Vantage Point — the chromatic starting position relative to the minor key center — determines which of the 24 scales offers the most direct approach vector. Understanding one's Vantage Point relative to the minor tonic is a prerequisite for effective convergence.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "minor/tonal-convergence-destination",
+            "minor/chromatic-approach-acceptance"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "vantage-point-approach",
+          "narrative": "For major tonal centers, the Vantage Point is one of the five governing conditions that must be understood before chromatic freedom can be exercised. The system identifies Vantage Point as a specific factor alongside key center, Interval Tonics, Resolution, and confidence (p. 31, Ch. 3). The Vantage Point relative to the major tonal center determines which convergence approach angle is most direct at any given moment, functioning as the practitioner's real-time positional awareness within the 360-degree compass around the major key center.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/360-degree-convergence-center"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "scale-7-through-24-application",
+          "narrative": "The Scale Justification Sheets apply all 24 scales to a target chord in order to establish tonal significance. The system's scope rule states: 'Remember this system is about how to get into a major or minor key variating different scales (24) and chords (many) and their innumerable permutation & chord inversions' (p. 23, Ch. 2). For dominant seventh target chords, this means the practitioner should work through not only the most obvious scale choices but all 24, including those with unexpected color (augmented scales, exotic constructions like Scale #11 and #15), to develop the full convergence vocabulary.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 23"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/24-scale-bombardment",
+            "dominant-seventh/scale-color-substitution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "interval-tonic-resolution",
+          "narrative": "Interval Tonics are prescribed as one of the five governing factors that must be understood for free chromatic approach to major tonal centers. The concept appears in Martino's list: 'factors such as fixation on a key center, Vantage Point, Interval Tonics, Resolution are considered' (p. 31, Ch. 3). Interval Tonics represent the pitch relationships that define each chromatic note's cadential pull toward the major key center — the scalar and intervallic identity of approach tones that determines their gravitational weight. Understanding Interval Tonics enables the practitioner to use any chromatic pitch as an informed, directional approach to the major tonic.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/chromatic-approach-acceptance"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "interval-tonic-resolution",
+          "narrative": "Interval Tonics govern chromatic approach to minor tonal centers with the same prescriptive force as they do for major. The 'no wrong notes' license — contingent on understanding Interval Tonics among other factors (p. 31, Ch. 3) — applies equally to minor key convergence. For minor targets, Interval Tonics must account for the characteristic minor intervals (minor third, minor sixth, minor seventh) as cadential relationships, in addition to the chromatic passing tones and scale colors that define the approach material from the 24-scale system.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "minor/tonal-convergence-destination",
+            "minor/chromatic-approach-acceptance"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "all-chromatic-relationship",
+          "narrative": "The tonal gravity law establishes that every chromatic note has a relationship to every remaining tone: 'A single note removed from the chromatic scale has a relationship to every remaining tone. If the tone represents a tonality or key center, all remaining intervals chords and scales have a certain type of converginal relationship in a cadential motion sense to this key center' (p. 4, Ch. 1). Applied to dominant seventh function, this means the V7 chord has cadential convergence relationships to every other chromatic chord and pitch, making the entire chromatic scale available as approach material in any dominant seventh context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tonal-gravity-exertion",
+            "dominant-seventh/chromatic-resource-expansion"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "ascending-diminished-approach",
+          "narrative": "The W-H diminished scale (Scale #5) is specifically prescribed for ascending dominant approach contexts. Martino notes that the W-H symmetry 'permits ascending diminish color to a point of convergence (F major in this case)' (p. 22, Ch. 2). The word 'permits' signals a prescriptive rule: the ascending direction of the W-H diminished scale is the feature that validates its use as a convergence approach to a dominant seventh or tonal target. Its ascending motion carries the harmonic momentum forward toward the convergence point.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 22"
+            }
+          ],
+          "cross_ref": [
+            "diminished-whole-half/convergence-scale-color",
+            "diminished-half-whole/convergence-scale-color"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "scale-16-v-chord-alignment",
+          "narrative": "Scale #16 is prescribed for major tonal center approach specifically because of its structural alignment with the V chord of the target major key. Martino specifies: 'This scale, is a major scale with a raised 4th in it. The 4th is the major 3rd of the V chord, also the scale begins on the 7th of the V chord of F major' (p. 33, Ch. 3). For major key convergence, this double alignment — raised 4th as the V chord's major third, and starting note as the V chord's leading tone — is the prescribed mechanism of justification. Scale #16 is validated by how precisely its structure mirrors the dominant chord's convergent function.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 33"
+            }
+          ],
+          "cross_ref": [
+            "major/lydian-raised-fourth",
+            "major/scale-color-convergence-approach"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "enharmonic-equivalence-substitution",
+          "narrative": "Enharmonic pitch equivalence is prescribed as a validation mechanism for substituting scales in minor convergence contexts. The rule demonstrated for G Jazz melodic minor — 'the G Jazz melodic minor scale has the same notes as this scale so it may be used as a II convergence scale' (p. 50, Ch. 4) — applies equally to minor key target approaches: any scale sharing pitches with a recognized convergence scale for a minor tonal center may substitute for it. The criterion is note-for-note equivalence, not scale name or theoretical category.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 4, p. 50"
+            }
+          ],
+          "cross_ref": [
+            "minor/jazz-melodic-minor-ii-convergence",
+            "minor/dorian-mode-convergence"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "improvisor-composer-arranger-resource",
+          "narrative": "The convergence scales over dominant seventh chords are prescribed as a shared resource for improvisors, composers, and arrangers — not merely a soloist's tool. Martino states that the scale usage 'in turnbacks, cadences and cycles (which comprise all music) in Jazz yields a wider source of ideas for the improvisor-composer-arranger' (p. 4, Ch. 1). This triple attribution prescribes that the dominant seventh's convergence vocabulary is a compositional and arranging resource as much as an improvisational one, applicable across all music-making roles and structural contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/turnback-application",
+            "dominant-seventh/cadence-application"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "mistake-reframing-generative",
+          "narrative": "Within major key convergence contexts, mistakes are prescribed as creative generative events rather than failures. Martino writes: 'I do not believe in perfection of the moment. I do believe in a readiness or nowness to fill a moment in time with something spontaneously prepared at the moment needed. A mistake is a new field, a new octave' (p. 50, Ch. 4). For major key contexts, this means a note that misses the tonal target is reframed as a new vantage point from which to approach the major center by a different convergence vector, converting error into an unexpected approach opportunity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 4, p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/consciousness-governed-application",
+            "major/chromatic-approach-acceptance"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "harmonic-color-spectrum-pivot",
+          "narrative": "The dominant seventh chord is positioned as the pivot where the five harmonic color categories intersect. Martino equates the five harmonic colors — major, minor, augmented, dominant, diminished — to 'the green, blue, black, red & yellow of the color spectrum' (p. 4, Ch. 1), and it is specifically over the dominant seventh chord that practitioners are instructed to combine all five colors by rotating through scales of each category. The V7 chord is thus the prism through which the harmonic color spectrum is deployed, making it the site of maximum color diversity in the convergence system.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/scale-color-substitution",
+            "dominant-seventh/multi-scale-rotation-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "coltrane-lateef-influence-application",
+          "narrative": "The multi-scale approach over major tonal centers was directly inspired by Coltrane and Lateef's practice. Martino writes: 'from listening to John Coltrane, Yusef Lateef and others caused me to try using many different scale \"color\" types on one chord (7th)' (p. 4, Ch. 1). This prescribes the multi-scale approach as a validated practice descended from documented jazz masters, giving the practitioner a genealogical license for the otherwise unconventional approach of applying diminished, augmented, and other non-diatonic scales over major-destination dominant seventh chords.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "dominant-seventh/multi-scale-rotation-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "scale-justification-sheet-application",
+          "narrative": "The Scale Justification Sheets are the formal pedagogical instrument through which each of the 24 scales is validated as a legitimate approach to a dominant seventh target chord. The practitioner works through all 24 sheets, applying each scale to the target chord and confirming that the universal last-note resolution rule is satisfied — 'the last note of all the scales in this system are only a whole or half step away from the Ist, 3rd, or 5th or root of the desired tonal destination' (p. 22, Ch. 2). Systematic completion of the Sheet exercise for each scale over each dominant seventh chord type is the prescribed mastery pathway.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 2, p. 22; Ch. 2, summary"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/24-scale-bombardment",
+            "dominant-seventh/tonal-significance-establishment"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "five-factor-governance",
+          "narrative": "Full chromatic freedom over minor tonal centers requires conscious mastery of five specific governing factors. Martino explicitly lists them: 'factors such as fixation on a key center, Vantage Point, Interval Tonics, Resolution are considered along with a certain Confidence within the artist himself' (p. 31, Ch. 3). For minor key contexts, all five factors must be simultaneously active — key center fixation on the minor tonic, the minor key's characteristic Vantage Point, Interval Tonics calibrated to minor intervals, awareness of the Resolution goal, and the artist's internalized confidence. Missing any factor invalidates the chromatic freedom claim.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "minor/tonal-convergence-destination",
+            "minor/chromatic-approach-acceptance"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "five-factor-governance",
+          "narrative": "The five governing factors — key center, Vantage Point, Interval Tonics, Resolution, and artist confidence — are all required simultaneously for full chromatic freedom over major tonal centers. This is the foundational prescriptive condition of the 'no wrong notes' philosophy (p. 31, Ch. 3). The system does not offer a formula for meeting these conditions but rather prescribes developing the consciousness to monitor and maintain all five simultaneously. Major key convergence is therefore a practice of cultivated awareness rather than rule-following — the five factors together constitute a state of prepared readiness.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "major/chromatic-approach-acceptance",
+            "major/consciousness-governed-application"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "embedded-chord-rota-variation",
+          "narrative": "When extracting chords from approach scales over dominant seventh convergence contexts, the practitioner is directed to vary the ordering of those extracted chords just as the scales themselves are varied. The rota principle — 'scales & their chords may be combined (several of them together) in several rotas varying their order' (p. 4, Ch. 1) — applies to the chord forms extracted from the scales, not merely the scales themselves. This creates a two-level rota system: scale ordering varied at the top level, chord voicing ordering varied within each scale's extracted chords.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/scale-color-rota-construction",
+            "dominant-seventh/chord-extraction-for-resolution"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "dorian-enharmonic-approach",
+          "narrative": "The Dorian mode and G Jazz melodic minor scale are prescribed as interchangeable II-convergence approaches to an F major tonal center based on their shared pitch content. Martino demonstrates: 'Also the G Jazz melodic minor scale has the same notes as this scale so it may be used as a II convergence scale' (p. 50, Ch. 4), where 'this scale' is the Dorian mode on G. For major tonal center approach, this establishes that the same pitch set can be conceptualized either as the Dorian mode of the target key or as a Jazz melodic minor scale from the target key's second degree, and both framings are equally valid convergence approaches.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 4, p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/modal-reentry-approach",
+            "minor/jazz-melodic-minor-ii-convergence"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "dominant-seventh",
+          "function_role": "confidence-activated-chromatic-freedom",
+          "narrative": "The artist's confidence is prescribed as the fifth and most personal of the governing factors that activate full chromatic freedom over dominant seventh convergence contexts. Martino includes 'a certain Confidence within the artist himself' (p. 31, Ch. 3) as a co-equal factor alongside the theoretical conditions of key center, Vantage Point, Interval Tonics, and Resolution. This means that technical knowledge of the 24-scale system is insufficient without the internalized confidence to deploy chromatic approach material without hesitation — confidence is a prescribed prerequisite, not a byproduct.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 3, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "dominant-seventh/tonal-significance-establishment",
+            "dominant-seventh/tonal-gravity-exertion"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "major",
+          "function_role": "scale-raw-material-for-convergent-ideas",
+          "narrative": "Every scale in the 24-scale system is prescribed as 'raw material for convergent ideas within a piece of music as well as many chordal sounds extracted from them' (p. 4, Ch. 1). For major tonal center application, this dual prescription — scales as linear approach material AND as chord voicing sources — means the practitioner should not treat scales as merely melodic devices but as generative libraries from which major-key convergence material (both linear and harmonic) is continuously drawn. The phrase 'raw material' implies active shaping and extraction rather than passive application.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 1, p. 4"
+            }
+          ],
+          "cross_ref": [
+            "major/tonal-convergence-destination",
+            "major/permutation-inversion-target"
+          ]
+        },
+        {
+          "source_work_id": "system-of-tonal-convergence",
+          "chord_quality": "minor",
+          "function_role": "circle-of-gravities-minor-navigation",
+          "narrative": "The Circle of Gravities serves as the navigational instrument for chord-on-chord convergence to minor target chords just as it does for dominant seventh approach. Chapter 8 treats both 'the Seventh Chord, Minor Chord' as co-equal targets of the chord-on-chord convergence framework, and the Circle of Gravities is introduced in this chapter as the systematic map of tritone relationships that governs all such motion. For minor chord targets, the Circle indicates which dominant seventh chords (direct V7 and tritone substitute) are the standard predecessors.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "system-of-tonal-convergence",
+              "citation": "Ch. 8, summary"
+            }
+          ],
+          "cross_ref": [
+            "minor/chord-on-chord-minor-convergence",
+            "dominant-seventh/circle-of-gravities-navigation"
+          ]
+        }
+      ]
     },
     {
       "id": "brent-vaartstra",
@@ -23672,7 +25759,1371 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "tonic-arrival",
+          "narrative": "The major 7 chord (Imaj7) is the stable arrival point in ii-V-I cadences, and the defining intervals that mark its quality are the major 3rd and major 7th. Vaartstra instructs: \"The 3rds and 7ths define the chords in this progression. The 3rd and 7th are pivotal in defining whether a chord is major, minor, dominant, half-diminished, or fully diminished.\" When navigating into a Imaj7, guide-tone voice leading requires the 7th of the preceding V7 to resolve by step to the 3rd of the Imaj7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 37 — '3rds and 7ths define chord quality'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 37 — 'Voice leading definition'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/pre-tonic-tension",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "guide-tone-target",
+          "narrative": "The 3rd and 7th of the Imaj7 are the guide tones that a player must land on when resolving a ii-V-I. Vaartstra writes: \"Guide tones are notes within a chord structure that both help define a chord, and can be used to transition to another chord melodically.\" The prescribed practice is to \"play them isolated with either half notes or quarter notes through the entire form of a song,\" locking in the resolution targets before adding melodic decoration.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 36 — 'Guide tones definition'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 38 — 'Guide tones practice method'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/guide-tone-departure",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "minimal-change-pivot",
+          "narrative": "When the I chord shifts to its parallel i minor (as in On Green Dolphin Street bars 1–3), Vaartstra prescribes adjusting only the quality-defining intervals. \"The only difference between a major 7 chord and a minor 7 chord is the minor has a b3 and a b7. Make this adjustment and you are good to go!\" (Ch. 8, p. 122). This is the minimal-change voice-leading principle applied specifically to the Imaj7 → imin7 substitution, keeping all non-defining tones constant.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 122 — 'Cmaj7 vs Cmin7 improv adjustment'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 129 — 'minimal note changes between chords'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/tonic-minor-substitute",
+            "dominant-7/chromatic-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "extension-color-tone",
+          "narrative": "Vaartstra explicitly licenses upper extensions over any 7th chord, including Imaj7: \"Most chords in jazz are labeled as 7 chords. But this doesn't mean you can't add or target extensions and alterations of these chords. Utilizing the 9th, 11th and 13th can have a powerful effect.\" (Ch. 8, p. 132). The 9th, 11th, and 13th of a major 7 chord are available color tones in improvisation, expanding the improviser's note palette beyond strict chord-tone arpeggios.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 132 — 'extensions beyond 7th chords'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/extension-color-tone",
+            "minor-7/extension-color-tone"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "new-key-center-tonic",
+          "narrative": "In pieces with rapid key-center modulations (e.g., All the Things You Are), each Imaj7 represents a momentary tonic arrival. Vaartstra's rule: \"The V chord is always your secret weapon for resolving to a new key center.\" (Ch. 10, p. 160). Every major 7 chord that is the target of a V7 or ii-V pair should be heard as a fresh tonic, and the improviser should orient their phrase toward it as an arrival, not merely pass through it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 160 — 'V chord resolves to new key'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 158 — 'vi chord starts cycling 4ths'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/secondary-dominant-tonicization",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "subdominant-IVmaj7",
+          "narrative": "The IVmaj7 functions as a subdominant that can pivot into the parallel iv minor, tonicizing C minor. Vaartstra explains: \"In bar 25 we start with the IV chord. It transitions to a iv minor chord, which you could analyze as a jump into the key of C minor.\" (Ch. 4, p. 63). The IVmaj7 is therefore a structural signpost: its guide tones (major 3rd and major 7th) must be honored, but the player should anticipate the impending quality shift to minor that follows.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 63 — 'iv minor harmonic function'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/iv-minor-substitute",
+            "dominant-7/secondary-dominant-tonicization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "pre-tonic-tension",
+          "narrative": "The dominant 7 chord (V7) is the primary tension chord in jazz harmony, defined by Root-3-5-b7, and its 7th resolves by step to the 3rd of the following tonic. Vaartstra declares: \"When it comes to jazz, there is no more important chord progression to know than the ii-V-I… The ii-V-I is the cornerstone chord progression in jazz.\" (Ch. 2, p. 34). The V7's b7 descending to the Imaj7's 3rd is the core voice-leading mechanism every improviser must internalize first.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 34 — 'ii-V-I as cornerstone'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 37 — '7th resolves to 3rd in ii-V-I'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/tonic-arrival",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "guide-tone-departure",
+          "narrative": "The guide tones of the V7 (its 3rd and b7) are the two notes that change most meaningfully when resolving to Imaj7. Vaartstra specifies: \"Notice how the 7th of each chord resolves to the 3rd of the next chord. It happens to work perfectly this way because the chords are cycling in 4ths.\" (Ch. 2, p. 37). The prescribed practice is to play these guide tones in half or quarter notes through the entire form before adding any melodic elaboration.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 37 — '7th resolves to 3rd in ii-V-I'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 38 — 'Guide tones practice method'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/guide-tone-target",
+            "minor-7/guide-tone-exchange"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "diatonic-minor-conversion",
+          "narrative": "Any diatonic minor chord may be freely converted to a dominant 7 in jazz practice. Vaartstra states: \"it is entirely normal and acceptable to turn minor chords in the diatonic series into dominant 7th chords.\" (Ch. 6, p. 95). In Sweet Georgia Brown, the vi minor is converted to VI7, initiating a long chain of resolving dominants; players should recognize this conversion as a generative harmonic device applicable across the entire repertoire.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 95 — 'diatonic minor to dominant conversion'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 33 — 'Minor IV chord to dominant'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/convertible-to-dominant",
+            "dominant-7/cycle-dominant-chain"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "secondary-dominant-tonicization",
+          "narrative": "A dominant 7 acting as V of a non-tonic diatonic chord is a secondary dominant, and its arrival temporarily tonicizes that chord. Vaartstra defines: \"A secondary dominant is when a dominant 7 chord acts as a V chord of a diatonic chord other than the tonic. We call this 'tonicization.'\" (Ch. 4, p. 62). The improviser should treat the chord following the secondary dominant as a momentary tonic and orient guide-tone lines accordingly.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 62 — 'secondary dominant definition'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 78 — 'ii-V of diatonic chords'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/new-key-center-tonic",
+            "minor-7/tonicization-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "cycle-dominant-chain",
+          "narrative": "Extended cycles of dominant 7 chords each resolving a fourth up are a foundational harmonic movement. In Sweet Georgia Brown, Vaartstra summarizes: \"bars 1-13 are just a long cycle of dominant 7th chords resolving to the I chord.\" (Ch. 6, p. 95). Players must internalize the Mixolydian scale (formula: 1-2-3-4-5-6-b7) as the pitch collection for each dominant in the chain, applying it as a resource pool rather than a linear exercise.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 95 — 'cycle of dominant 7ths'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 98 — 'Mixolydian as major with b7'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/mixolydian-pitch-collection",
+            "major-7/tonic-arrival"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "mixolydian-pitch-collection",
+          "narrative": "The Mixolydian scale is the prescribed pitch collection for dominant 7 chords. Vaartstra instructs: \"The easiest way to think of a Mixolydian scale is a major scale with a b7… Formula: 1-2-3-4-5-6-b7.\" (Ch. 6, p. 98). Crucially, this scale must not be treated as a linear drill: \"They aren't notes that are meant to be played in order… They are simply pitch collections which map out the note choices you can use to make melodies over a particular chord.\" (Ch. 6, p. 99).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 98 — 'Mixolydian scale definition'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 99 — 'scales as pitch collections'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/cycle-dominant-chain",
+            "dominant-7/extension-color-tone"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "tritone-substitute",
+          "narrative": "A dominant 7 chord may be replaced by the dominant 7 chord whose root lies a tritone away, since they share guide tones. Vaartstra defines: \"a tritone substitution, meaning, a chord is being substituted by another chord with a root a tritone interval away. In most cases, a tritone substitution replaces one dominant 7 chord for another dominant 7.\" (Ch. 8, p. 122). The cycle-of-fourths analytical tool helps identify when a tritone sub is operative, since the sub's root approaches the tonic by half step rather than a perfect fifth.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 122 — 'bIImaj7 as tritone/chromatic sub'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/backdoor-substitute",
+            "major-7/tonic-arrival"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "backdoor-substitute",
+          "narrative": "The bVII7 chord may substitute for V7 by approaching the tonic by whole step from below, functioning as a backdoor dominant. Vaartstra defines: \"A backdoor dominant is a dominant 7th chord that substitutes the V7 chord for a bVII7 chord approaching the I chord by a whole step. This works because the bVII7 has a lot of notes in common with an altered V7 chord. Example: Bb7-Cmaj7.\" (Ch. 11, p. 177). This device can be expanded to a full backdoor ii-V by prepending the ii chord of the bVII7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 177 — 'backdoor dominant definition'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 178 — 'backdoor ii-V concept'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/tritone-substitute",
+            "minor-7/backdoor-ii-pre-dominant"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "dual-interpretation-pivot",
+          "narrative": "A single dominant 7 chord may simultaneously carry two functional readings, and players should hold both in mind rather than locking into one. Vaartstra models this: \"there are two ways to perceive the Ab7 in bar 8. You can think of it as a V7 of the IV chord (fairly common), or you can recognize it as a backdoor dominant moving into the I chord in bar 10.\" (Ch. 11, p. 177). This dual-interpretation mindset is the advanced analytical posture the book prescribes for harmonically complex standards.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 177 — 'Ab7 dual interpretation'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/backdoor-substitute",
+            "dominant-7/secondary-dominant-tonicization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "chromatic-descending-approach",
+          "narrative": "Dominant 7 chords may descend chromatically as a turnaround device targeting a VI7 chord. Vaartstra explains: \"we are just dealing with a series of chromatically descending dominant 7th chords that are targeting the VI7 chord. From there the VI7 logically concludes to a ii-V-I to the parent tonic.\" (Ch. 6, p. 97). The player should recognize this as a reductive 'backdoor I7-VI7-ii-V-I' device to avoid being thrown by the surface-level chromaticism.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 97 — 'descending chromatic approach'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 97 — 'backdoor I7-VI7-ii-V-I'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/cycle-dominant-chain",
+            "dominant-7/backdoor-substitute"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "extension-color-tone",
+          "narrative": "Upper extensions (9th, 11th, 13th) are fully available over dominant 7 chords. Vaartstra licenses them broadly: \"Most chords in jazz are labeled as 7 chords. But this doesn't mean you can't add or target extensions and alterations of these chords. Utilizing the 9th, 11th and 13th can have a powerful effect.\" (Ch. 8, p. 132). The dominant 7(b9) variant in particular is structurally linked to the diminished 7 chord as its rootless equivalent, expanding note choice further.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 132 — 'extensions beyond 7th chords'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 141 — 'Diminished 7 as rootless dominant b9'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/mixolydian-pitch-collection",
+            "diminished-7/rootless-dominant-b9-sub"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "relational-analysis-required",
+          "narrative": "No dominant 7 chord should be analyzed in isolation; its function is entirely contextual. Vaartstra's governing principle: \"To understand the function of a chord, you must look at both the chord that comes before it and after it.\" (Ch. 4, p. 61). This relational rule applies especially to dominant 7 chords, which may simultaneously function as V7, secondary dominant, backdoor dominant, tritone sub, or converted diatonic minor depending on context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 61 — 'chord function depends on context'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 79 — 'harmony analysis approach'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/dual-interpretation-pivot",
+            "dominant-7/secondary-dominant-tonicization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "pre-dominant-ii",
+          "narrative": "The minor 7 chord as ii is the pre-dominant chord in the cornerstone ii-V-I, and the player must be able to recognize it and begin voice-leading toward the V7 immediately. Vaartstra states: \"The ii-V-I is the cornerstone chord progression in jazz… you need to be able to recognize it right away, and of course, know how to improvise over it.\" (Ch. 2, p. 34). The ii's guide tone (its 7th) resolves by step to the 3rd of the following V7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 34 — 'ii-V-I as cornerstone'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 37 — 'Voice leading definition'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/pre-tonic-tension",
+            "major-7/tonic-arrival"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "guide-tone-exchange",
+          "narrative": "The ii minor 7's guide tones (3rd and b7) are the starting material for the ii-V-I voice-leading chain. Vaartstra explains: \"In jazz, the guide tones are almost always the 3rds and 7ths of each chord.\" (Ch. 2, p. 36). When the ii resolves to V7, the b7 of the ii moves stepwise (often by half step) toward the guide tones of the V7, and the improviser should practice these paired resolutions in isolated half or quarter notes before adding melodic ornamentation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 36 — 'Guide tones are 3rds and 7ths'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 37 — '7th resolves to 3rd in ii-V-I'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/guide-tone-departure",
+            "major-7/guide-tone-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "tonic-minor-substitute",
+          "narrative": "The I major chord may be substituted by its parallel i minor 7 as a coloristic device (as in On Green Dolphin Street). Vaartstra teaches minimal adjustment: \"The only difference between a major 7 chord and a minor 7 chord is the minor has a b3 and a b7. Make this adjustment and you are good to go!\" (Ch. 8, p. 122). This substitution pattern — I to i minor — is identified as a recurring compositional technique players will encounter across the repertoire.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 122 — 'i minor substitution on I chord'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 122 — 'Cmaj7 vs Cmin7 improv adjustment'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/minimal-change-pivot",
+            "minor-7/minor-third-key-center-shift"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "iv-minor-substitute",
+          "narrative": "The minor iv chord functions as a brief tonicization of the parallel minor key and is a common substitute for the V7 at specific structural moments. Vaartstra explains: \"musicians will play an Abmin6, which functions as the minor IV chord. In our All of Me study, we talked about how you can perceive the minor iv as a quick jump into the minor tonic key. You can also turn that Abmin6 into a ii-V (Abmin7-Db7).\" (Ch. 5, p. 80). The minor iv may also reduce to a single dominant (e.g., Db7 alone).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 80 — 'minor iv chord function'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 63 — 'iv minor harmonic function'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/secondary-dominant-tonicization",
+            "major-7/subdominant-IVmaj7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "avoid-major-intervals",
+          "polarity": "proscriptive",
+          "narrative": "When improvising over the iv minor chord, playing major 3rds or major 7ths is explicitly forbidden because they contradict the chord's quality. Vaartstra warns: \"Don't be playing major thirds or major 7ths!\" (Ch. 4, p. 63). The defining change from IVmaj7 to iv minor is precisely the b3 and b7, and failing to adjust these intervals produces a quality mismatch that is audible and incorrect in the harmonic context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 63 — 'iv minor chord caution'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/subdominant-IVmaj7",
+            "minor-7/iv-minor-substitute"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "convertible-to-dominant",
+          "narrative": "Any diatonic minor 7 chord — including ii, iii, and vi — may be converted to a dominant 7, a standard jazz harmonic practice. Vaartstra states: \"jazz musicians are constantly turning minor chords into dominant 7 chords. You'll see that happen a lot more throughout our studies!\" (Ch. 2, p. 33). Players should expect and recognize this conversion in any standard they study, treating it not as an anomaly but as a generative expansion device.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 33 — 'Minor IV chord to dominant'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 95 — 'diatonic minor to dominant conversion'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/diatonic-minor-conversion",
+            "dominant-7/cycle-dominant-chain"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "backdoor-ii-pre-dominant",
+          "narrative": "A minor 7 chord can precede the backdoor dominant (bVII7) to form a complete backdoor ii-V. Vaartstra explains: \"The ii chord is being added in front of the backdoor dominant. Therefore, the Bbmin7-Eb7 is really acting as a backdoor ii-V into the Fmaj7.\" (Ch. 11, p. 178). The improviser should recognize this minor 7 not as a tonic minor substitute but as the ii of a backdoor dominant resolution, orienting note choices toward the bVII7's pitch world.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 178 — 'backdoor ii-V concept'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/backdoor-substitute",
+            "major-7/tonic-arrival"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "tonicization-target",
+          "narrative": "A minor 7 chord that is the resolution point of a ii-V (including secondary dominants) should be heard as a momentary tonic. Vaartstra teaches: \"Remember, the most important thing to pay attention to when trying to understand the harmony of a song is where the chords are going. If we look at a Gmin7(b5) and a C7(b9) as separate chords, they are confusing. But if we look at them as resolving to an Fmin7, then we have something functional to understand.\" (Ch. 5, p. 79).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 79 — 'harmony analysis approach'"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/minor-ii-pre-dominant",
+            "dominant-7/secondary-dominant-tonicization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "minor-third-key-center-shift",
+          "narrative": "A key center shift a minor 3rd up from the parent tonic — landing on a new minor tonic — is a recurring compositional pattern players must internalize. Vaartstra notes: \"There are other standards you will come across that have key center changes a minor 3rd up from the parent tonic. This is a common compositional technique in jazz standards, and you will likely see it again the more you study them.\" (Ch. 8, p. 124). In On Green Dolphin Street, the I → Eb (minor 3rd) is the signature example.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 124 — 'key center a minor 3rd up'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/tonic-minor-substitute",
+            "major-7/new-key-center-tonic"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "arpeggio-voice-led-entry",
+          "narrative": "Arpeggios over minor 7 chords should connect from the previous chord by entering on whichever chord tone is nearest to the last note played, not necessarily the root. Vaartstra prescribes: \"Whatever the last note played in a particular bar was, I move to the nearest chord tone of the next chord. You'll notice that often this note is even the same note as the previous bar.\" (Ch. 4, p. 65). The arpeggio then continues in order from that entry point (e.g., 3rd-5th-7th-Root).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 65 — 'chord tone arpeggio voice leading rule'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 65 — 'arpeggio order rule'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/guide-tone-target",
+            "dominant-7/guide-tone-departure"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "hybrid-ii-borrowed-minor",
+          "narrative": "In a hybrid ii-V-I, the ii chord is borrowed from the parallel minor key (becoming min7(b5)) while the progression resolves to a major I chord — creating an expressive surprise. Vaartstra defines: \"A hybrid ii-V-I is when a minor ii-V-i is mixed with a major ii-V-I. The ii and V are borrowed from the minor key, but they resolve to the major I. Example: Dmin7(b5)-G7(b9)-Cmaj7.\" (Ch. 11, p. 179). The minor quality of the ii signals an impending minor resolution that is subverted by the major tonic.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 179 — 'hybrid ii-V-I definition'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 180 — 'hybrid ii-V-I expressive effect'"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/minor-ii-pre-dominant",
+            "dominant-7/pre-tonic-tension"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "cycle-of-4ths-minor-ii-v",
+          "narrative": "A closing cycle-of-fourths can be built entirely from minor ii-V pairs rather than dominant ones, requiring a shift in scale and note-choice orientation. Vaartstra notes: \"This cycle of 4ths is different than we have seen before in that they are a series of minor ii-V's.\" (Ch. 11, p. 179). The minor 7 chords in this cycle are pre-dominant preparations whose half-diminished ii partners signal the minor-key harmonic environment throughout.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 179 — 'cycle of 4ths minor ii-Vs'"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/minor-ii-pre-dominant",
+            "dominant-7/cycle-dominant-chain"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "half-diminished",
+          "function_role": "minor-ii-pre-dominant",
+          "narrative": "The half-diminished chord (min7b5) is the ii chord in a minor key ii-V-i progression, formula Root-b3-b5-b7. Vaartstra teaches that when Gmin7(b5) precedes C7(b9) resolving to Fmin7, the half-diminished is functional only when understood in relation to its resolution target: \"if we look at them as resolving to an Fmin7, then we have something functional to understand.\" (Ch. 5, p. 79). Its b5 is the interval that most clearly signals the minor ii context versus a plain minor 7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 79 — 'harmony analysis approach'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 64 — '7th chord formulas'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/pre-tonic-tension",
+            "minor-7/tonicization-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "half-diminished",
+          "function_role": "hybrid-ii-minor-borrowed",
+          "narrative": "In a hybrid ii-V-I, the half-diminished chord (min7b5) is borrowed from the parallel minor as the ii chord, then resolves through V7(b9) to a major I chord for an expressive surprise. Vaartstra specifies: \"A hybrid ii-V-I is when a minor ii-V-i is mixed with a major ii-V-I. The ii and V are borrowed from the minor key, but they resolve to the major I. Example: Dmin7(b5)-G7(b9)-Cmaj7.\" (Ch. 11, p. 179). The half-diminished quality sets up the listener's expectation of a minor resolution, making the major arrival unexpected.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 179 — 'hybrid ii-V-I definition'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 180 — 'hybrid ii-V-I expressive effect'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/hybrid-ii-borrowed-minor",
+            "major-7/tonic-arrival"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "half-diminished",
+          "function_role": "iii-b5-dual-reading",
+          "narrative": "A half-diminished chord may be read dually: as the ii of a minor ii-V, and simultaneously as a iiib5 within the parent tonal center. Vaartstra explains: \"The Gmin7(b5) can also be thought of as the iiib5 (adding a b5 to the iii minor) and a VI7… if we combine this understanding with the ii-V of ii concept everything ties together.\" (Ch. 5, p. 79). This dual reading is the advanced analytical posture that equips the improviser to hear the same chord two functional ways at once.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 79 — 'iii(b5)-VI7 reinterpretation'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/dual-interpretation-pivot",
+            "half-diminished/minor-ii-pre-dominant"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "half-diminished",
+          "function_role": "locrian-pitch-collection",
+          "narrative": "The Locrian mode (H-W-W-H-W-W-W) is the theoretical pitch collection built on the 7th scale degree and forms the scale basis for the half-diminished chord. Vaartstra identifies it as the 7th mode in the modal system (Ch. 7). As with all scales in this method, Locrian must be treated as a \"pitch collection\" — a non-ordered set of available note choices — rather than a scale to be run linearly: \"They are simply pitch collections which map out the note choices you can use.\" (Ch. 6, p. 99).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 7 — 'seven modes listed'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 99 — 'scales as pitch collections'"
+            }
+          ],
+          "cross_ref": [
+            "half-diminished/minor-ii-pre-dominant",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "diminished-7",
+          "function_role": "rootless-dominant-b9-sub",
+          "narrative": "A diminished 7 chord functions as a rootless dominant 7(b9) substitute because all pitch classes are shared except the bass root. Vaartstra demonstrates: \"F#dim7: F#-A-C-Eb / D7(b9): D-F#-A-C-Eb. You can think of the F#dim7 as a rootless D7(b9).\" (Ch. 9, p. 141). The improvisation instruction follows directly: \"Remember that it is being substituted for the VI7b9 chord, so any of those chord tones will serve you well.\" (Ch. 9, p. 145).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 141 — 'Diminished 7 as rootless dominant b9'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 145 — 'Improv note choice over diminished'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/extension-color-tone",
+            "diminished-7/chromatic-passing-bass"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "diminished-7",
+          "function_role": "chromatic-passing-bass",
+          "narrative": "Beyond its dominant substitution role, the diminished 7 chord simultaneously functions as a chromatic passing chord whose bass note connects two diatonic harmonies by half step. Vaartstra specifies: \"on a compositional level the F#dim7 is functioning as more than just a substitution. It's also creating a chromatic passing note, in this case the bass note, to connect the I chord with the ii chord.\" (Ch. 9, p. 142). The improviser holds both functions in mind: harmonic substitution and voice-leading bass motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 142 — 'Chromatic passing function of diminished'"
+            }
+          ],
+          "cross_ref": [
+            "diminished-7/rootless-dominant-b9-sub",
+            "diminished-7/whole-half-scale-resource"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "diminished-7",
+          "function_role": "whole-half-scale-resource",
+          "narrative": "The Whole-Half diminished scale is the prescribed pitch collection for improvising over diminished 7 chords. Vaartstra defines: \"It's called the 'Whole-Half' diminished because the intervallic formula for this scale is: W-H-W-H-W-H-W. The scale is based on alternating whole steps and half steps.\" (Ch. 9, p. 145). As a pitch collection (not a linear exercise), this 8-note scale maps the available note choices over any diminished 7 or its dominant b9 equivalent.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 145 — 'Whole-Half diminished scale formula'"
+            }
+          ],
+          "cross_ref": [
+            "diminished-7/rootless-dominant-b9-sub",
+            "dominant-7/extension-color-tone"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "diminished-7",
+          "function_role": "passing-diminished-connector",
+          "narrative": "A diminished 7 chord may function purely as a chromatic connector between two diatonic chords without substituting for any specific dominant. Vaartstra explains in the context of All the Things You Are: \"In this case, the biii diminished isn't necessarily replacing anything. Its primary job is to connect the iii chord to the ii chord chromatically.\" (Ch. 10, p. 161). This passing function is distinct from the rootless dominant b9 substitution role and requires different analytical framing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 161 — 'passing diminished connects chromatically'"
+            }
+          ],
+          "cross_ref": [
+            "diminished-7/chromatic-passing-bass",
+            "diminished-7/rootless-dominant-b9-sub"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "diminished-7",
+          "function_role": "target-chord-tones-for-improv",
+          "narrative": "When improvising over a diminished 7 that substitutes for a dominant b9, the player should target the chord tones of the underlying dominant — not merely the surface diminished shape. Vaartstra instructs: \"Remember that it is being substituted for the VI7b9 chord, so any of those chord tones will serve you well.\" (Ch. 9, p. 145). This means treating the diminished as a transparent window onto the dominant b9's harmonic content for melodic note selection.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 145 — 'Improv note choice over diminished'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 141 — 'Diminished chord as dominant substitute'"
+            }
+          ],
+          "cross_ref": [
+            "diminished-7/rootless-dominant-b9-sub",
+            "diminished-7/whole-half-scale-resource"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "ii-before-v-expansion",
+          "narrative": "Wherever a V chord appears, a ii chord can almost always be added in front of it to expand it into a full ii-V. Vaartstra gives the rule: \"The basic chord change in bar 6 is a simple G7 which acts as a V chord moving into Cmaj7, the new I chord. However, sometimes musicians will add a ii in front of it (Dmin7), making it a short ii-V-I. Where there is a V chord, you can almost always add a ii in front of it.\" (Ch. 10, p. 158). This expansion principle is universally applicable across the jazz repertoire.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 158 — 'adding ii before V'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 78 — 'ii-V of diatonic chords'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/pre-dominant-ii",
+            "dominant-7/secondary-dominant-tonicization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "cycling-fourths-vi-initiator",
+          "narrative": "In All the Things You Are, the vi minor 7 initiates the diatonic cycle of fourths, making the vi chord the structural starting point rather than the tonic I. Vaartstra explains: \"Notice that it starts with the vi chord. This vi chord starts a long cycle of 4ths all the way through the Dbmaj7 in bar 5. Everything here is diatonically pure to the key center.\" (Ch. 10, p. 158). The player must hear this vi as the launch point of the cycle, not as a passing chord, and calibrate phrase direction accordingly.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 158 — 'vi chord starts cycling 4ths'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/new-key-center-tonic",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "dorian-modal-context-exclusion",
+          "narrative": "In modal contexts like So What, there are no dominant 7 chords functioning as V7 resolutions — the entire harmonic environment is built on the Dorian mode and its parent key, with functional ii-V-I motion absent. Vaartstra states: \"Modal harmony is not based on 'functional harmony.' So far in this book, every jazz standard has used harmonic movement based on either the Major or Minor Diatonic Series of 7th chords.\" (Ch. 7, p. 102). The player must recognize which system is operative and switch approaches accordingly.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 7, p. 102 — 'modal vs functional harmony'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/dorian-pitch-collection",
+            "major-7/tonic-arrival"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "dorian-pitch-collection",
+          "narrative": "In modal contexts, the minor 7 chord (Dm7 in So What) is governed by the Dorian mode rather than guide tones. Vaartstra specifies: \"Because So What is based on modal harmony, there is no need to identify the guide tones… the best way to improvise over modal harmony is by using modes.\" (Ch. 7, p. 103). The Dorian formula (W-H-W-W-W-H-W, scale tones 1-2-b3-4-5-6-b7) is the pitch collection, and playing means choosing notes from it selectively, not running the scale linearly.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 7, p. 103 — 'guide tones omitted for modal tunes'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 7, p. 108 — 'Dorian mode formula'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/pre-dominant-ii",
+            "dominant-7/dorian-modal-context-exclusion"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "avoid-scale-running-modal",
+          "polarity": "proscriptive",
+          "narrative": "Playing modes as linear scale runs is explicitly prohibited in modal improv contexts. Vaartstra warns: \"this doesn't mean you should play the scales like scales. You should just use them as note choices, and sometimes thinking of them in the context of different modes can be helpful.\" (Ch. 7, p. 111). Miles Davis's sparse, space-conscious approach to D Dorian over So What is presented as the aesthetic model — phrase, leave space, expand — explicitly contrasting with mechanical scale-running.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 7, p. 111 — 'modes as note choices, not scales'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 7, p. 114 — 'Miles Davis style characteristics'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/dorian-pitch-collection",
+            "dominant-7/mixolydian-pitch-collection"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "avoid-crowding-over-changes",
+          "polarity": "proscriptive",
+          "narrative": "Over harmonically dense or confusing dominant chord changes, filling space with as many notes as possible is explicitly proscribed. Vaartstra states: \"Often times our instinct as improvisers in these situations is to fill up space and play as many notes over each chord as possible. But in reality, this is the last thing we want to do, both for survival and musical reasons.\" (Ch. 8, p. 127). The prescriptive counterpart is to keep it simple, ask what the defining notes are, and adjust only 3rds and 7ths.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 127 — 'keep it simple over confusing changes'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 127 — 'defining notes / chord difference question'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/mixolydian-pitch-collection",
+            "dominant-7/relational-analysis-required"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "real-book-changes-standard",
+          "narrative": "For jazz standards like Stella by Starlight that have evolved chord changes, players must use the Real Book version rather than the original published changes. Vaartstra is explicit: \"If you were to learn the chord changes from the original version, you wouldn't be playing the same stuff as other jazz musicians will on gigs and jam sessions.\" (Ch. 11, p. 168). This applies to any major 7 chords in the evolved changes that differ from the original film harmony.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 168 — 'chord changes vs. original version'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/relational-analysis-required",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "cycle-of-major-thirds-bridge",
+          "narrative": "In Have You Met Miss Jones, the bridge navigates key centers moving in a cycle of major thirds (Bb–Gb–D–Ab), and the practical navigation strategy is to reframe each pair of chords as a ii-V-I in its own momentary key center. Vaartstra prescribes: \"Instead of looking at it as a mishmash of seemingly unrelated chords, you can just look at it as a bunch of ii-V-I's in different key centers.\" (Ch. 9, p. 143). The dominant 7 in each ii-V-I pair is the pivot chord that establishes the new key.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 143 — 'Bridge as stacked ii-V-Is'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 144 — 'Bridge key centers move in 3rds'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/new-key-center-tonic",
+            "dominant-7/secondary-dominant-tonicization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "stepwise-key-center-entry",
+          "narrative": "When moving between rapidly modulating dominant-anchored key centers (e.g., the bridge of Have You Met Miss Jones), entering each new key center with a half step or whole step at bar boundaries creates smooth melodic flow. Vaartstra teaches: \"I do my best to enter into each new key center by half steps or whole steps. I'm referring to the first and last notes of connecting bars. This isn't a rule or mandatory by any means, but it does allow for a smooth flow in the lines.\" (Ch. 9, p. 147).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 147 — 'Connecting key centers by half/whole step'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/cycle-of-major-thirds-bridge",
+            "dominant-7/relational-analysis-required"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "phrase-separation-at-modulation",
+          "narrative": "Rather than forcing stepwise connection across rapidly modulating key centers, ending a phrase on a held note and starting a new phrase in the next key is equally valid. Vaartstra validates: \"It's also perfectly fine to not connect the key centers together… I ended on a half note and started a new line in the next bar. Nothing wrong with that. As long as your line doesn't sound like it's unnaturally starting and stopping, this can be a great solution.\" (Ch. 9, p. 148).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 9, p. 148 — 'Disconnecting lines between key centers'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/stepwise-key-center-entry",
+            "dominant-7/cycle-of-major-thirds-bridge"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "composing-solos-practice-tool",
+          "narrative": "Composed solos over major 7 tonic chords and their surrounding changes are a prescribed practice method for developing jazz language. Vaartstra explains: \"My goal when composing solos is to slow the improvisation process down and give myself the space to dream up precisely what I would like to improvise.\" (Ch. 10, p. 163). The composed solo need not be written down: \"Just compose it on your instrument and memorize it\" — the act of slow composition trains phrase construction over tonic chord arrivals.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 163 — 'composing solos practice'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 163 — 'solo composition instruction'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/tonic-arrival",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "contrafact-chord-outlining",
+          "narrative": "A contrafact melody composed over dominant 7 chord changes must outline those changes through chord tones while remaining singable and thematically coherent. Vaartstra prescribes: \"My goal was to create a sing-able melody. This is the kind of contrafact I suggest you compose. Try to keep it simple. The exercise here is to create a strong melody that both outlines the chord changes appropriately while expressing a theme.\" (Ch. 5, p. 83). Chord-tone outlining over dominant harmonies is the primary compositional obligation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 83 — 'contrafact melody goals'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 5, p. 82 — 'improvisation as composition'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/composing-solos-practice-tool",
+            "dominant-7/mixolydian-pitch-collection"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "lick-transposition-12-keys",
+          "narrative": "All licks and patterns over dominant 7 chords must be taken through all 12 keys for full internalization. Vaartstra mandates: \"I always suggest taking things through all 12 keys. It's a powerful practice that not only helps you internalize musical information, but it also enables you to become stronger in keys you may be weaker at.\" (Ch. 6, p. 101). This applies equally to Mixolydian patterns, chord-tone exercises, and transcribed licks over dominant harmonies.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 101 — 'practicing licks in 12 keys'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/mixolydian-pitch-collection",
+            "dominant-7/cycle-dominant-chain"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "strong-melody-licenses-outside",
+          "narrative": "Even when playing outside the chord changes over a major 7 tonic, a strong melodic line with intentional resolution makes the departure sound valid. Vaartstra states: \"You could even play outside of the chord changes, but if your improvised melody is strong and you resolve it confidently, it's going to sound intentional and pleasing to the ear.\" (Ch. 3, p. 47). The major 7 tonic resolution is the required landing point that retroactively justifies any harmonic departure.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 3, p. 47 — 'Melody guides outside playing'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/tonic-arrival",
+            "dominant-7/relational-analysis-required"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "three-chorus-melody-scaffold",
+          "narrative": "The three-chorus melody exercise is the prescribed practice protocol for developing melodic improvisation over minor key standards with minor 7 tonic chords. Vaartstra specifies three stages: \"The first chorus, just play the melody completely straight… The second chorus, embellish the melody… The third chorus, reference the melody.\" (Ch. 3, p. 49). This scaffolding method ensures the improviser maintains the tune's identity even during free departure, anchoring the minor 7 tonality through melodic reference.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 3, p. 49 — 'Three-chorus melody exercise'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/dorian-pitch-collection",
+            "major-7/composing-solos-practice-tool"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "bossa-nova-straight-eighth-context",
+          "narrative": "In Bossa Nova standards, dominant 7 chord changes are played with straight eighth notes, not a swing feel. Vaartstra states: \"when it comes to jazz standards, many of them are played with a swing feel, meaning the eighth notes are swung. However, in the case of a Bossa Nova, the eighth notes are played straight.\" (Ch. 3, p. 41). This rhythmic rule governs the entire harmonic surface — including dominant 7 approach chords — and must be observed before attempting melodic improvisation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 3, p. 41 — 'Bossa Nova eighth notes'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/relational-analysis-required",
+            "minor-7/three-chorus-melody-scaffold"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "iv-vii-dual-reading-context",
+          "narrative": "A dominant 7 chord functioning as VII within a minor key context (the iv-VII relationship) may simultaneously be interpreted as V of the relative major (a ii-V reading). Vaartstra prescribes holding both: \"There are two ways to look at this. I suggest you think about both approaches. The most accurate description of the relationship of these two chords to the rest of the progression is the iv-VII relationship to the parent key center. But you can also consider those two chords as a ii-V of the relative major.\" (Ch. 3, p. 46).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 3, p. 46 — 'iv-VII vs ii-V interpretation'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/dual-interpretation-pivot",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "key-change-ii-v-i-recognition",
+          "narrative": "A key center change is confirmed when a ii-V-I progression appears in the new key, since ii-V-I is textbook diatonic moving harmony. Vaartstra explains: \"this is a key center change because Db major is by no means diatonic to C minor. What makes this even more apparent is that it's a ii-V-I, which is textbook diatonic moving harmony.\" (Ch. 3, p. 47). The arrival on the new Imaj7 or imin7 should be treated as a fresh tonal center with its own scale and guide-tone logic.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 3, p. 47 — 'Key change to Db major'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/new-key-center-tonic",
+            "dominant-7/pre-tonic-tension"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "ear-first-identification",
+          "narrative": "Dominant 7 chords in a standard must be identified by ear during the Transfer stage of the LIST process: first identify the bass root, then determine quality. Vaartstra instructs: \"if you can identify that the bass player is playing a concert Eb note for the first chord, then all you have to do is figure out what quality it is… The trick is to combine knowledge of building chord progressions and ear training together to identify the quality of the chords (major, minor, dominant...etc.)\" (Ch. 1, p. 18). Sheet music is a check, not a crutch.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 1, p. 18 — 'Pro tip: bass note identification'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 1, p. 18 — 'Chord quality identification by ear'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/tonic-arrival",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "ear-first-identification",
+          "narrative": "Major 7 chords as tonic arrivals must be internalized aurally before working with notation. Vaartstra's LIST process requires singing the melody and bass root before touching the instrument: \"Be sure that you can sing the melody of the standard, both along with the recording and on your own, before you learn it on your instrument.\" (Ch. 1, p. 17). The major 7 tonic quality is confirmed by combining theoretical knowledge with trained ear recognition — hearing the major 3rd and major 7th as the defining intervals.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 1, p. 17 — 'Sing step: proof of internalization'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 1, p. 18 — 'Chord quality identification by ear'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/ear-first-identification",
+            "minor-7/pre-dominant-ii"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "relative-minor-pivot",
+          "narrative": "The relative minor key area within a major key standard requires recognizing the relative minor vi chord as a structural pivot point. Vaartstra notes in the context of Sweet Georgia Brown: \"Starting in the second half of bar 24 we begin to transition into the relative minor key. What's the relative minor to Ab major? F minor.\" (Ch. 6, p. 96). The player must switch scale and chord-tone orientation to the relative minor's pitch world at this structural marker.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 6, p. 96 — 'relative minor key area'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 2, p. 32 — 'Relative keys definition'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/tonic-arrival",
+            "minor-7/tonicization-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "note-map-scaffold-before-improv",
+          "narrative": "Before improvising over harmonically dense dominant 7 passages in complex standards (like Stella by Starlight), mapping out all available notes is a prescribed preparatory step. Vaartstra recommends: \"it can be beneficial to take a step back and map out the notes we have available to us. While scales are not musical by themselves, they can help us conceptualize which notes we can choose from. From there, we can start to build melodies and make sense of how to connect the harmony in our lines.\" (Ch. 11, p. 181).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 181 — 'note map as improv tool'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/avoid-crowding-over-changes",
+            "dominant-7/mixolydian-pitch-collection"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "quarter-note-solo-isolation",
+          "narrative": "Over harmonically demanding dominant 7 sequences, practicing improvisation using only quarter notes removes rhythmic complexity and isolates harmonic navigation as the sole focus. Vaartstra prescribes: \"I stick to a quarter note rhythm in all of my note choices. I take out the rhythmic component from my improvisation and just focus on navigating the changes.\" (Ch. 11, p. 184). This technique builds harmonic security before adding rhythmic variety back into the improvisation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 184 — 'quarter note solo exercise'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/note-map-scaffold-before-improv",
+            "dominant-7/avoid-crowding-over-changes"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "unresolved-ii-v-evasion",
+          "narrative": "When a standard begins with a series of unresolved ii-V progressions that evade the I major 7 chord, the player must navigate the evasion without forcing an arrival. Vaartstra identifies this in Stella by Starlight: \"we have a series of unresolved ii-V chord progressions within the first 8 bars… The key center is being eluded to, yet never comes home.\" (Ch. 11, p. 177). The improviser should recognize this ambiguity as the tune's defining harmonic character and phrase accordingly, without prematurely anchoring to a tonic.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 177 — 'unresolved ii-V progressions'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/dual-interpretation-pivot",
+            "major-7/tonic-arrival"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "chromatic-approach-non-structural",
+          "narrative": "Chromatic approach notes over dominant 7 chords are non-structural — they are passing melodic connectors, not chord tones or extensions. Vaartstra defines: \"the note in question does not represent a basic chord tone, extension or alteration, but is simply chromatically approaching a diatonic note. In some cases, they are connecting two diatonic notes together.\" (Ch. 4, p. 65). Players should understand these as melodic decorations (labeled 'CA') rather than as harmonic anchors when analyzing or creating lines.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 4, p. 65 — 'chromatic approach note'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 130 — 'chromatic passing tone definition'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/mixolydian-pitch-collection",
+            "diminished-7/chromatic-passing-bass"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "motif-over-dense-changes",
+          "narrative": "When navigating harmonically dense passages with shifting minor 7 chords, creating and repeating a short motif (a rhythmic or melodic cell) is a prescribed strategy for generating coherence without harmonic overload. Vaartstra defines: \"In music, a motif is a short rhythmic or melodic passage that is repeated or evoked in various parts of a composition.\" (Ch. 8, p. 127). The motif's repetition and variation produce thematic identity across chord changes without requiring continuous harmonic recomputation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 127 — 'motif definition'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/dorian-pitch-collection",
+            "dominant-7/avoid-crowding-over-changes"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "bars-29-32-non-diatonic-departure",
+          "narrative": "When a standard deliberately departs from cycle-of-fourths motion at a specific passage (as in All the Things You Are bars 29-32), the player should reframe the non-diatonic chords as IV-to-ii connectors rather than expecting functional ii-V resolution. Vaartstra explains: \"The IV chord needs to connect to the ii chord. There are many different ways to do that, but Jerome Kern chose to do it this way. The result is some beautiful harmonic movement that departs from the cycling 4ths solution.\" (Ch. 10, p. 161). The song ends with a simple ii-V-I in the parent key.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 161 — 'bars 29-32 harmonic summary'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/cycling-fourths-vi-initiator",
+            "dominant-7/relational-analysis-required"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "descending-bass-half-step-voice-leading",
+          "narrative": "Slash chords with descending bass lines over dominant 7 chord sequences use half-step bass connections for smooth voice leading. Vaartstra explains: \"In bar 17, the second Dmin7 has a C in the bass which connects to the Bmin7(b5) by a half step. In bar 19, the second Amin7 has a G in the bass which connects by a half step to the F#min7(b5).\" (Ch. 8, p. 125). The player on any instrument should recognize the descending bass logic as a voice-leading guide for their own melodic choices.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 8, p. 125 — 'descending bass line half-step connection'"
+            }
+          ],
+          "cross_ref": [
+            "dominant-7/stepwise-key-center-entry",
+            "half-diminished/minor-ii-pre-dominant"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "color-coded-secondary-tonal-center",
+          "narrative": "Major 7 chords appearing as secondary tonal centers (IV, V-as-major, VI-as-major) should be mapped back to their function within the parent key as part of a systematic analytical framework. Vaartstra's color-coding strategy: \"Blue = Bb major (parent key) / Green = D minor (iii chord of parent) / Orange = Eb major (IV chord of parent) / Purple = F major (V major of parent)\" (Ch. 11, p. 175). This mapping allows dual-function reading — local tonic and parent-key scale degree simultaneously.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 175 — 'color-coding key center strategy'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/new-key-center-tonic",
+            "dominant-7/secondary-dominant-tonicization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "minor-7",
+          "function_role": "quarter-note-solo-harmonic-focus",
+          "narrative": "Over complex minor 7 chord changes in standards like Stella by Starlight, the quarter-note solo exercise isolates harmonic navigation from rhythmic elaboration. Vaartstra prescribes: \"This means I stick to a quarter note rhythm in all of my note choices. I take out the rhythmic component from my improvisation and just focus on navigating the changes.\" (Ch. 11, p. 184). This technique is especially valuable over minor ii-V sequences where simultaneous rhythmic and harmonic demands exceed the student's current capacity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 11, p. 184 — 'quarter note solo exercise'"
+            }
+          ],
+          "cross_ref": [
+            "minor-7/pre-dominant-ii",
+            "half-diminished/minor-ii-pre-dominant"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "dominant-7",
+          "function_role": "six-tools-consolidation",
+          "narrative": "Six improvisation tools are prescribed for navigating dominant 7 chords and their surrounding changes: guide tones, melody, chord tones, contrafact, motifs, and transcribed licks. Vaartstra consolidates: \"Guide tones… Use the melody… Use the chord tones. The root and 5th are up for grabs too… Write a contrafact… Use motifs… Write your own licks, or transcribe them.\" (Ch. 10, p. 162). This is the master toolkit — all six tools should be applied to any standard as an integrated practice regimen.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 10, p. 162 — 'six improvisation tools'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/composing-solos-practice-tool",
+            "dominant-7/contrafact-chord-outlining"
+          ]
+        },
+        {
+          "source_work_id": "jazz-standards-playbook",
+          "chord_quality": "major-7",
+          "function_role": "jazz-standards-as-harmonic-vehicles",
+          "narrative": "Every major 7 tonic chord in a jazz standard is best understood as part of a vehicle for improvisation exploration, not an end in itself. Vaartstra frames the pedagogy: \"Jazz standards are the vehicles that jazz musicians use to improvise. To become a better jazz musician, it is imperative that we study them and explore their unique harmonic worlds.\" (Ch. 12, p. 188). The harmonic and rhythmic principles attached to any given Imaj7 resolution are transferable to hundreds of other standards that share the same patterns.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 12, p. 188 — 'Jazz standards as vehicles'"
+            },
+            {
+              "source": "jazz-standards-playbook",
+              "citation": "Ch. 12, p. 188 — 'Standards chosen for harmonic lessons'"
+            }
+          ],
+          "cross_ref": [
+            "major-7/tonic-arrival",
+            "dominant-7/relational-analysis-required"
+          ]
+        }
+      ]
     },
     {
       "id": "alan-de-mause",
@@ -24505,7 +27956,1566 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "oom-pah-bass-foundation",
+          "narrative": "The root/fifth oom-pah pattern is the foundational accompaniment for major chords, placing alternating root and fifth beneath each chord. The book states: \"Under the first chord, C, there is a bass note C, the root of the C major scale. It is followed by G, the fifth note of the scale\" (Ch. 5, p. 76). When the melody already contains the major third, the bass uses root or fifth — \"when the melody is a major or minor third, the bass note is either a root or fifth\" (Ch. 5, p. 83). This prevents redundant third-doubling and keeps the bass harmonically efficient.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/oom-pah-bass-foundation",
+            "dominant7/oom-pah-bass-foundation",
+            "major/third-placement-in-bass"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, pp. 76, 83"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "third-placement-in-bass",
+          "narrative": "When the melody does not contain the major third of a major chord, the arranger must supply it in the bass to identify the chord's quality. The book prescribes: \"when the melody is other than a third, the third is used in the bass to harmonically identify the chord\" (Ch. 5, p. 83). The major third is always four half steps above the root — \"In half-step measurement a major third is always four half steps\" (Ch. 5, p. 80). Locating it via the major scale (count three scale steps up from the root) is the recommended method.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/third-placement-in-bass",
+            "major/oom-pah-bass-foundation",
+            "major7/third-placement-in-bass"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, pp. 80, 83"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "parallel-thirds-harmonization",
+          "narrative": "Major chords are harmonized by placing a diatonic third below each melody note, a texture familiar from informal sing-alongs. The book instructs: \"A simple way of harmonizing the melody is to use a note that is three scale steps below the melody\" (Ch. 6, p. 91). Because thirds fall on adjacent strings, free stroke is mandatory — \"Since thirds are on adjacent strings, the free stroke must be used. To make the top melody note louder, just do it\" (Ch. 6, p. 91). Thirds alone rarely suffice for a full arrangement; bass must be added to complete the three-voice texture.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/parallel-thirds-harmonization",
+            "major/sixth-below-harmonization",
+            "major7/parallel-thirds-harmonization"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, pp. 91–92"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "sixth-below-harmonization",
+          "narrative": "Diatonic sixths below the melody function as shadows or bass notes over major chords, and the key note must always stay on top. The book states: \"By convention, scales harmonized in sixths have the key note of each scale on top, with the harmony note a sixth below. If the key note were in the bottom position the ear would perceive the scale as being in a minor key rather than a major key\" (Ch. 8, p. 108). When the melody is the root of the chord, \"the sixth below is the third\" (Ch. 8, p. 104). Adjustments are made when the sixth implies an unwanted extension.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/sixth-below-harmonization",
+            "major/parallel-thirds-harmonization",
+            "major7/sixth-below-harmonization"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 8, pp. 104, 108"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "arpeggiation-accompaniment",
+          "narrative": "Arpeggiation is the natural accompaniment texture for major chords in slower tunes. The book specifies: \"For slower moving tunes, arpeggiation is a natural for fingerstyle playing. Don't forget to emphasize the melody note so that it won't get lost in the sea of eighth note soup\" (Ch. 10, p. 125). The canonical right-hand rule is: \"p plays the lower string(s), while i and m play the middle and higher strings\" (Ch. 6, p. 87). The arpeggio must not reach higher than the melody — \"watch that your choice of arpeggiation doesn't reach higher than the melody, which might obscure the melody and confuse the listener\" (Ch. 6, p. 89).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/arpeggiation-accompaniment",
+            "major7/arpeggiation-accompaniment",
+            "major/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, pp. 87, 89; Ch. 10, p. 125"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "walkdown-structural-device",
+          "narrative": "The walkdown — a descending bass line with a common tone on top — is a primary structural device for major chord stacks. The book defines it precisely: \"A walkdown is a descending bass line with a common tone on top of a chord stack. This is the device that keeps popping up in this tune along with its hook-like rhythm\" (Ch. 15, p. 181). This technique appears repeatedly across the Chapter 15 arrangements and is described as the structural hook that gives a piece its characteristic identity. Descending chromatic key changes use walkdown logic — \"The key changes from C to D moving chromatically by half step\" (Ch. 15, p. 167).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major7/walkdown-structural-device",
+            "dominant7/chromatic-bass-approach",
+            "major/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 15, pp. 167, 181"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "non-chord-tone-thirds-tolerance",
+          "narrative": "Non-chord-tone thirds below a major chord melody note are acceptable when they pass the ear test. The book counsels: \"Non-chord tones make for the interesting spice in an otherwise dull chord-tone-only dish. It's your ear and your decision\" (Ch. 6, p. 92). Adjustment to a nearby chord tone is optional, not mandatory — \"If you want to make the harmony for D nearby and a chord tone, use the perfect fifth of the G7 chord, A, four steps below\" (Ch. 6, p. 92). Overall effect takes precedence over mechanical chord-tone purity.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/non-chord-tone-thirds-tolerance",
+            "dominant7/non-chord-tone-thirds-tolerance"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, p. 92"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "two-note-sparse-voicing",
+          "narrative": "Major chords in self-accompanied arrangements can be reduced to two inner-voice notes without sacrificing fullness. The book affirms: \"A melody accompanied by two additional notes is often all you need to make an arrangement sound full, whether you are playing by yourself or with a group\" (Ch. 10, p. 125). This aligns with the governing aesthetic stated in Chapter 15: \"In all of the tunes here I like to imply more with less. Chords, for instance, are most often only two or three notes, and the melody is all-important\" (Ch. 15, p. 168). The two inner voices can be plucked with i and m, or struck together with p.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major7/two-note-sparse-voicing",
+            "minor7/two-note-sparse-voicing",
+            "dominant7/two-note-sparse-voicing"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 125; Ch. 15, p. 168"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major7",
+          "function_role": "diatonic-function-tonic",
+          "narrative": "Major seventh chords on scale degrees I and IV are the tonic and subdominant representatives in diatonic jazz harmony. The book catalogues: \"Two major sevenths I and IV\" as part of the four diatonic chord types (Ch. 9, p. 117). Because close-position major seventh voicings demand large finger spans, the book recommends open voicings: \"Unless you have long spidery fingers, you are probably more comfortable with these chords in either of the following standard alternate configurations... the third of the chord has been moved an octave higher\" (Ch. 9, p. 117). Think of each chord as independent moving voices, not static formations.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/diatonic-function-dominant",
+            "minor7/diatonic-function-supertonic",
+            "major7/open-voicing-preference"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 9, pp. 116–117"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major7",
+          "function_role": "open-voicing-preference",
+          "narrative": "Close-position major seventh chords are impractical for most guitarists and should be replaced with open-voicing alternatives. The book states: \"The configuration of the harmonized seventh scale pictured on page 116 is in close position. Unless you have long spidery fingers, you are probably more comfortable with these chords in either of the following standard alternate configurations... In the first case the third of the chord has been moved an octave higher, and in the second case both the third and fifth have been moved an octave higher\" (Ch. 9, p. 117). The guitar's role as a polyphonic instrument requires thinking in terms of independent voices and partial chord fragments rather than full barre grips.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major7/diatonic-function-tonic",
+            "minor7/open-voicing-preference",
+            "dominant7/open-voicing-preference"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 9, pp. 116–117"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major7",
+          "function_role": "chromatic-bass-continuity",
+          "narrative": "When moving from Gmaj7 to a dominant seventh, choosing a non-root bass note preserves chromatic line continuity. The book demonstrates: \"the lowest note of Gmaj7 in the first measure is D, the fifth, and the lowest note of G7(b5) is b5. This was done to continue the effect of chromatic movement from Gmaj7 to G7(b5) to Cmaj7\" (Ch. 10, p. 120). This illustrates the book's broader principle that voice leading by half step between chord changes creates smoother, more idiomatic movement than jumping to each chord root. The bass note choice — root, third, or fifth — is subordinate to the goal of chromatic continuity.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7flat5/chromatic-bass-approach",
+            "major7/open-voicing-preference",
+            "dominant7/voice-leading-resolution"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 120"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major7",
+          "function_role": "two-note-sparse-voicing",
+          "narrative": "Major seventh chords in solo fingerstyle arrangements are most often voiced as two or three notes, with melody primacy guiding which chord tones to retain. The book's aesthetic principle from Chapter 15 states: \"In all of the tunes here I like to imply more with less. Chords, for instance, are most often only two or three notes, and the melody is all-important\" (Ch. 15, p. 168). Two additional inner-voice notes suffice to make the arrangement sound full — \"A melody accompanied by two additional notes is often all you need\" (Ch. 10, p. 125). The major seventh color is implied rather than fully stated in the voicing.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/two-note-sparse-voicing",
+            "minor7/two-note-sparse-voicing",
+            "major7/open-voicing-preference"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 125; Ch. 15, p. 168"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "diatonic-function-dominant",
+          "narrative": "The dominant seventh chord on scale degree V is the sole dominant seventh in diatonic harmony and the primary engine of the cycle of fifths. The book specifies: \"One dominant seventh V\" among the four diatonic chord types (Ch. 9, p. 117), and further notes: \"The cycle often includes consecutive V7-I (dominant sevenths to major chords)\" (Ch. 9, p. 119). The V7–I resolution is driven by tritone pull — \"you can just feel the tug of the unresolved Bb and E (the tritone interval of a b5) being pulled by the A and F in the resolved F chord\" (Ch. 13, p. 156). This tension-and-release mechanism is the fundamental harmonic event of jazz.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major7/diatonic-function-tonic",
+            "dominant7/intro-gateway",
+            "dominant7/tritone-pull-resolution"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 9, pp. 117, 119; Ch. 13, p. 156"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "intro-gateway",
+          "narrative": "Every introduction must end on a dominant seventh (or its substitute) to create the harmonic gateway into the tune's first chord. The book states the rule unambiguously: \"The last chord of the intro must be a V7 or V7 substitute in order to move into the first chord of the tune itself\" (Ch. 14, p. 160). The same gateway principle governs turnarounds — \"turnarounds often start on a I chord and finish on a V7 or V7 substitute chord\" (Ch. 14, p. 164). Intros can begin on any chord but must arrive at V7 before handing off to the melody.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/turnaround-gateway",
+            "dominant7/tag-substitution",
+            "dominant7/ending-resolution"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, pp. 160, 164"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "turnaround-gateway",
+          "narrative": "Turnarounds — the two-measure setup between successive choruses — function as miniature intros and must terminate on V7. The book explains: \"whatever you would use as a two-measure intro of a tune you could use as a turnaround. Like introductions, turnarounds often start on a I chord and finish on a V7 or V7 substitute chord\" (Ch. 14, p. 164). This V7 gateway is structurally identical across intros, turnarounds, and tags, making the dominant seventh the universal hinge of jazz song architecture. When a modulation occurs between choruses, the V7 must belong to the incoming key, not the outgoing one.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/intro-gateway",
+            "dominant7/tag-substitution",
+            "dominant7/modulation-pivot"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, p. 164"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "tag-substitution",
+          "narrative": "To initiate a tag or coda, the final tonic chord is replaced by a dominant seventh, extending the harmonic motion and signaling continuation. The book prescribes: \"the replacement of the usual final I chord—E, here—with a V7 (or other substitute) chord is required. You have to listen up to hear what kind and how long of a tag it will be\" (Ch. 14, p. 164). This I→V7 substitution is the mechanical trigger for the coda and illustrates the broader principle that V7 functions as an open-ended gateway while I functions as a point of harmonic rest. Active listening to the ensemble cue determines how long the extension lasts.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/intro-gateway",
+            "dominant7/turnaround-gateway",
+            "major/tonic-arrival"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, p. 164"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "voice-leading-resolution",
+          "narrative": "Dominant seventh chords resolve most idiomatically when individual voices move by half step rather than the entire chord jumping by root motion. The book advises: \"Always playing chords with the root in the bass works, but may not be as smooth or interesting as moving by half-step or whole-step intervals or mixed movement\" (Ch. 13, p. 155). In V7–I contrary motion, \"As the top note descends by half step the root note has its own opposing pattern, not parallel to the top\" (Ch. 13, p. 156). The conceptual shift is to \"think of harmonic movement as several moving voices rather than a glob of dots on a chord box grid\" (Ch. 13, p. 156).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/tritone-pull-resolution",
+            "dominant7/intro-gateway",
+            "major7/chromatic-bass-continuity"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 13, pp. 155–156"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "tritone-pull-resolution",
+          "narrative": "The tritone interval embedded within the dominant seventh chord (between the third and b7) creates irresistible tension that resolves by half step to the tonic chord. The book names this mechanism: \"you can just feel the tug of the unresolved Bb and E (the tritone interval of a b5) being pulled by the A and F in the resolved F chord\" (Ch. 13, p. 156). Understanding this pull is foundational to voice-leading practice through the cycle of fifths — the book states that cycle practice \"familiarizes you with the sound of smooth harmonic movement, or voice leading\" (Ch. 13, p. 155). The tritone's resolution is the engine of all V7–I motion in jazz.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/voice-leading-resolution",
+            "dominant7/diatonic-function-dominant",
+            "major/tonic-arrival"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 13, pp. 155–156"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "ending-resolution",
+          "narrative": "Standard endings use V7–I, IV–I, or II–V7–I progressions, with the II–V7–I considered most idiomatic in jazz. The book lists: \"Endings end, and usually on a I chord. V7-I, IV-I, and especially II-V7-I are standard\" (Ch. 14, p. 163). The practical shortcut of using the tune's final measures as an intro is available: \"the last four- or eight measures of the tune itself can often be used, including the melody\" (Ch. 14, p. 160). The 2-in-1 trick further multiplies options — omitting the final V7 beat converts an intro directly into an ending.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/intro-gateway",
+            "minor7/ii-chord-pre-dominant",
+            "major/tonic-arrival"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, pp. 160, 163"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "modulation-pivot",
+          "narrative": "The minimum-time modulation borrows V7 from the incoming key for as little as two beats. The book teaches: \"You can modulate as fast as two beats. Presume you have ended a tune on the standard I chord and have used two beats doing it. You are moving to Db. Use the last two beats to borrow V7 (Ab7) from the upcoming new key, Db\" (Ch. 14, p. 165). Back-cycling extends this by working backwards through the cycle to F7 then C7 before the destination. The II–V7–I of the new key is the \"most common jazz progression unit\" for bridging keys (Ch. 14, p. 166).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/turnaround-gateway",
+            "minor7/ii-chord-pre-dominant",
+            "dominant7/intro-gateway"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, pp. 165–166"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "oom-pah-bass-foundation",
+          "narrative": "Root/fifth oom-pah bass applies to dominant seventh chords just as to major triads, but the book warns against rigid mechanical application in jazz. The book notes: \"Root/fifth is often associated with simple music, such as polka bands, country music and the like. Root/fifth is used in jazz too, but usually not in such a rigid oom-pah fashion\" (Ch. 10, p. 122). Mixed-rhythm bass — \"quarter, half or whole notes\" in varied combinations — is prescribed to de-emphasize the strict oom-pah feel (Ch. 5, p. 78). The effect of low-to-high alternation matters more than strict interval adherence.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/oom-pah-bass-foundation",
+            "minor/oom-pah-bass-foundation",
+            "dominant7/walking-bass-approach"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, p. 78; Ch. 10, p. 122"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "walking-bass-approach",
+          "narrative": "Chromatic approach notes define jazz walking bass and are especially applicable approaching dominant seventh chords. The book identifies: \"One of the most common bass note moves is approaching notes — especially chromatic passing\" (Ch. 10, p. 124). The bass-first conception rule is essential here — \"Think bass-plus-chord, not chord-plus-bass. It's best to conceive of a bass line first—planned or improvised—and then maybe add a chord\" (Ch. 11, p. 141). Modern walking bass style favors bigger intervals, broken time, and textural variety rather than constant four-on-the-floor motion.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/oom-pah-bass-foundation",
+            "dominant7/voice-leading-resolution",
+            "major7/chromatic-bass-continuity"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 124; Ch. 11, p. 141"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "tritone-accompaniment-texture",
+          "narrative": "Dominant seventh chords in sparse solo or small-ensemble settings can be accompanied exclusively by tritone dyads as inner voices. The book describes: \"The melodic line is primarily accompanied by tritones. This is the type of sparse playing that could easily fit in a trio or quartet setting\" (Ch. 15, p. 179). The rootless close-voicing system uses \"alternating pairs of fourths and tritones. The bottom note in each pair alternates between major or minor seventh to major third. There is no explicitly stated root or fifth of the chord\" (Ch. 10, p. 129). In ensemble contexts the bassist covers roots and fifths, freeing the guitarist for this sparse harmonic color.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/rootless-voicing-ensemble",
+            "dominant7/tritone-pull-resolution",
+            "dominant7/two-note-sparse-voicing"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 129; Ch. 15, p. 179"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "rootless-voicing-ensemble",
+          "narrative": "In ensemble settings where a bassist covers roots and fifths, dominant seventh chords should be voiced as rootless pairs of fourths and tritones. The book explains: \"This variation uses the same chords except the accompaniment is voiced so that the harmony moves in alternating pairs of fourths and tritones. The bottom note in each pair alternates between major or minor seventh to major third. There is no explicitly stated root or fifth of the chord. If you play in a group, the bassist will cover roots and fifths\" (Ch. 10, p. 129). This rootless approach produces maximum harmonic color with minimal string use and avoids register collision with the bass.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/tritone-accompaniment-texture",
+            "dominant7/voice-leading-resolution",
+            "major7/open-voicing-preference"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 129"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "two-note-sparse-voicing",
+          "narrative": "Dominant seventh chords in solo fingerstyle arrangements are most effectively voiced as two or three notes implying rather than fully stating the chord. The book's core aesthetic: \"In all of the tunes here I like to imply more with less. Chords, for instance, are most often only two or three notes, and the melody is all-important\" (Ch. 15, p. 168). \"A melody accompanied by two additional notes is often all you need to make an arrangement sound full\" (Ch. 10, p. 125). For dominant seventh chords specifically, the third and seventh (the tritone pair) are the most harmonically defining notes and the minimum implied voicing.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/rootless-voicing-ensemble",
+            "dominant7/tritone-accompaniment-texture",
+            "major7/two-note-sparse-voicing"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 125; Ch. 15, p. 168"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant9",
+          "function_role": "chromatic-intro-color",
+          "narrative": "Dominant ninth chords appear in intros as chromatic neighbor chords that move out of the home key for harmonic surprise. The book annotates: \"This intro starts solidly in F but immediately moves out of key for a little surprise. The first harmonic movement is chromatic, F to Eb9\" (Ch. 14, p. 160). The ninth extension adds color to the dominant without altering its functional role as a harmonic signal. The book confirms this flexibility: \"Approaching a chord from a half step above or below is another accepted way of moving the harmony\" (Ch. 15, p. 167).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/intro-gateway",
+            "dominant7/modulation-pivot",
+            "dominant13/chromatic-intro-color"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, p. 160; Ch. 15, p. 167"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant13",
+          "function_role": "intro-ending-convertibility",
+          "narrative": "The dominant thirteenth chord exemplifies the intro-to-ending convertibility rule: omitting the final V7/dominant-extension beat transforms an intro directly into an ending. The book demonstrates: \"What if you just didn't play the G13 on the third beat? Your intro would become an instant ending. It's no trick, it's just so. You've just multiplied your list of intros and endings by two\" (Ch. 14, p. 163). This technique generalizes to any dominant extension chord sitting at the V7 gateway position. The dominant thirteenth represents the richest coloring of V7 function without changing its structural gateway role.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/intro-gateway",
+            "dominant7/ending-resolution",
+            "dominant9/chromatic-intro-color"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, p. 163"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7sharp5",
+          "function_role": "altered-fifth-bass-adjustment",
+          "narrative": "The augmented fifth in dominant seventh sharp-five chords requires explicit adjustment of the bass fifth — the plain major scale method does not apply. The book states: \"Finding the perfect fifth of a chord by using a major scale whose letter name is the same as the chord works with major scales. It does not automatically work with scales (or chords) that have raised (sharped) or lowered (flatted) fifths not belonging to the major scale such as C7#5 or C7b5. The altering you need to do is in the chord's name. If the chord is c7#5, raise the fifth a half step\" (Ch. 5, p. 77). The chord symbol is the authoritative source for the altered interval; do not derive it mechanically from the major scale alone.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7flat5/altered-fifth-bass-adjustment",
+            "dominant7/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, p. 77"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7flat5",
+          "function_role": "altered-fifth-bass-adjustment",
+          "narrative": "The flatted fifth in dominant seventh flat-five chords requires lowering the bass fifth by a half step from its plain major-scale position. The book prescribes: \"if it is C7b5, lower the fifth a half step\" (Ch. 5, p. 77). The Chapter 10 voice-leading example demonstrates this in practice: \"the lowest note of G7(b5) is b5. This was done to continue the effect of chromatic movement from Gmaj7 to G7(b5) to Cmaj7\" (Ch. 10, p. 120). Choosing the b5 as the bass note thus serves double duty — it correctly states the altered chord quality while maintaining a chromatic descending bass line.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7sharp5/altered-fifth-bass-adjustment",
+            "dominant7/chromatic-bass-approach",
+            "major7/chromatic-bass-continuity"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, p. 77; Ch. 10, p. 120"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7flat5",
+          "function_role": "chromatic-bass-approach",
+          "narrative": "The flat-five bass note of a dominant seventh flat-five chord serves as a chromatic approach to the next chord's root, making bass note selection a voice-leading decision rather than a harmonic one. The book analyzes: \"the lowest note of Gmaj7 in the first measure is D, the fifth, and the lowest note of G7(b5) is b5. This was done to continue the effect of chromatic movement from Gmaj7 to G7(b5) to Cmaj7\" (Ch. 10, p. 120). This demonstrates that chord quality (including the altered fifth) and bass voice motion are interdependent decisions. Voice-leading logic — not mechanical root placement — determines the most effective bass note.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7flat5/altered-fifth-bass-adjustment",
+            "dominant7/walking-bass-approach",
+            "major7/chromatic-bass-continuity"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 120"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "augmented",
+          "function_role": "whole-tone-intro-color",
+          "narrative": "Augmented chords (dominant seventh sharp-five in context) provide whole-tone color in intro passages and are signalled by the whole-tone scale overlay. The book names this explicitly: \"The next moves cyclically to Am7b5, chromatically to Ab7 and Gm7, cyclically to C7 and stays on the final V7 with a little sprinkle of whole-tone scale thrown in at the C+7\" (Ch. 14, p. 160). The augmented seventh (C+7) functions here as a coloristically enriched V7 substitute, the plus sign indicating the raised fifth. Its whole-tone scale coloring marks the end of the intro's harmonic journey before arriving at the tune proper.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/intro-gateway",
+            "dominant7sharp5/altered-fifth-bass-adjustment"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, p. 160"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "oom-pah-bass-foundation",
+          "narrative": "Minor triads use the same root/fifth oom-pah bass structure as major chords. The book demonstrates: \"For Am, root/fifth is A, E\" (Ch. 5, p. 76). The minor third (three half steps above the root) distinguishes minor from major — \"The larger third, E is a major third, and the smaller third E flat is a minor third\" (Ch. 5, p. 79). To locate the minor third, \"you may refer to the minor scale (natural, harmonic, or melodic) of the same letter name as the chord, and count three scale steps up from the root\" (Ch. 5, p. 79). When the melody contains the minor third, the bass uses root or fifth only.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/oom-pah-bass-foundation",
+            "minor/third-placement-in-bass",
+            "minor7/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, pp. 76, 79"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "third-placement-in-bass",
+          "narrative": "When the minor chord melody does not contain the minor third, the arranger must supply it in the bass to identify the chord's quality. The book prescribes the general rule: \"when the melody is other than a third, the third is used in the bass to harmonically identify the chord\" (Ch. 5, p. 83). The minor third is always three half steps above the root — \"a minor third, three half steps\" (Ch. 5, p. 80). Conversely, \"If the melody in that measure already contains the major or minor third of the major or minor chord indicated above, no additional third is required\" (Ch. 5, p. 82). This prevents redundant thickness.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/third-placement-in-bass",
+            "minor7/third-placement-in-bass",
+            "minor/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, pp. 80, 82–83"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "parallel-thirds-harmonization",
+          "narrative": "Minor chord melodies are harmonized by a diatonic third below using the same free-stroke technique required for adjacent strings. The book's rule applies uniformly: \"A simple way of harmonizing the melody is to use a note that is three scale steps below the melody\" (Ch. 6, p. 91). Chord-tone matching evaluates whether the lower note belongs to the chord — \"When you are harmonizing a melody note with a note a third below, the lower note may or may not be part of the chord harmony indicated by the chord symbol above it\" (Ch. 6, p. 92). Non-chord tones are accepted if they pass the ear test without adjustment.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/parallel-thirds-harmonization",
+            "minor7/parallel-thirds-harmonization",
+            "minor/sixth-below-harmonization"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, pp. 91–92"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "sixth-below-harmonization",
+          "narrative": "Minor chord melodies harmonized with a sixth below follow the same chord-tone relationships as major chords, with the key note kept on top to preserve tonal clarity. The book states the dual-role principle: \"Sixths are very useful as they can serve, like thirds, as shadows to the melody or as bass notes\" (Ch. 8, p. 105). When the melody is the root of an Am chord, \"the sixth below is the third\" (Ch. 8, p. 104). Diatonic sixths may imply minor seventh extensions — \"the sixth below will be the minor seventh interval C, of the Dm7 chord\" (Ch. 8, p. 104) — and optional adjustment is available.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/sixth-below-harmonization",
+            "minor7/sixth-below-harmonization",
+            "minor/parallel-thirds-harmonization"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 8, pp. 104–105"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "non-chord-tone-thirds-tolerance",
+          "narrative": "Non-chord-tone thirds below minor chord melody notes are acceptable when the passing effect is brief and the ear accepts them as color. The book's general principle applies: \"One could argue that the B, as an eighth note, goes by so quickly that it does not jar the ear. Even melody notes are rarely all chord tones. In the big picture you need only to make the total effect sound like the chord indicated\" (Ch. 6, p. 92). Fast-moving non-chord-tone thirds register as spice rather than dissonance — \"Non-chord tones make for the interesting spice in an otherwise dull chord-tone-only dish. It's your ear and your decision\" (Ch. 6, p. 92).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/non-chord-tone-thirds-tolerance",
+            "minor7/non-chord-tone-thirds-tolerance"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, p. 92"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "diatonic-function-supertonic",
+          "narrative": "Minor seventh chords on scale degrees II, III, and VI are the three diatonic minor sevenths in jazz harmony. The book lists them: \"Three minor sevenths II, III and VI\" among the four diatonic chord types (Ch. 9, p. 117). The II minor seventh is especially prominent as the pre-dominant in the II–V7–I progression — \"the most common jazz progression unit is II-V7-I\" (Ch. 14, p. 166). The book recommends open voicings for all seventh chords to accommodate typical finger spans, moving the third or both third and fifth an octave higher (Ch. 9, p. 117).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/diatonic-function-dominant",
+            "major7/diatonic-function-tonic",
+            "minor7/ii-chord-pre-dominant"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 9, pp. 116–117"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "ii-chord-pre-dominant",
+          "narrative": "The II minor seventh chord is the most idiomatic jazz pre-dominant, always preceding V7 in the II–V7–I unit. The book identifies this progression as fundamental: \"the most common jazz progression unit is II-V7-I. Use it here then, by putting a II of the upcoming new key in front of the new key V7\" (Ch. 14, p. 166). This unit connects keys during modulations and serves as the preferred ending formula — \"Endings end, and usually on a I chord. V7-I, IV-I, and especially II-V7-I are standard\" (Ch. 14, p. 163). The II chord can be spotted embedded in intros: \"You can spot one in measure two, also\" (Ch. 14, p. 161).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/modulation-pivot",
+            "dominant7/ending-resolution",
+            "minor7/diatonic-function-supertonic"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, pp. 161, 163, 166"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "open-voicing-preference",
+          "narrative": "Minor seventh chords should be voiced in open position for practical playability, with the third or both third and fifth moved an octave higher. The book specifies: \"Unless you have long spidery fingers, you are probably more comfortable with these chords in either of the following standard alternate configurations... In the first case the third of the chord has been moved an octave higher, and in the second case both the third and fifth have been moved an octave higher\" (Ch. 9, p. 117). The guitar's role as a polyphonic instrument — \"Think of the guitar as a miniature orchestra where melody, rhythm, harmony and counterpoint are played at the same time\" (Ch. 9, p. 114) — favors partial chord fragments over full close-position grips.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major7/open-voicing-preference",
+            "dominant7/open-voicing-preference",
+            "minor7/two-note-sparse-voicing"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 9, pp. 114, 117"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "third-placement-in-bass",
+          "narrative": "When the melody of a minor seventh chord does not contain the minor third, the bass must supply it to identify the chord quality. The book's rule applies to both major and minor: \"when the melody is other than a third, the third is used in the bass to harmonically identify the chord\" (Ch. 5, p. 83). When the melody already contains the third, \"no additional third is required\" (Ch. 5, p. 82). For minor seventh chords, the minor third (three half steps) plus the seventh creates the characteristic minor seventh color and its presence in the bass confirms the chord's identity even with a sparse melody.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/third-placement-in-bass",
+            "major7/diatonic-function-tonic",
+            "minor7/diatonic-function-supertonic"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, pp. 82–83"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "two-note-sparse-voicing",
+          "narrative": "Minor seventh chords in solo fingerstyle arrangements can be reduced to two or three note implied voicings. The book's governing aesthetic: \"In all of the tunes here I like to imply more with less. Chords, for instance, are most often only two or three notes, and the melody is all-important\" (Ch. 15, p. 168). Two inner-voice notes suffice — \"A melody accompanied by two additional notes is often all you need to make an arrangement sound full\" (Ch. 10, p. 125). For minor seventh chords, the minor third and seventh together most efficiently imply the chord's quality with minimal finger commitment.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major7/two-note-sparse-voicing",
+            "dominant7/two-note-sparse-voicing",
+            "minor7/open-voicing-preference"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 125; Ch. 15, p. 168"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "sixth-below-extension-awareness",
+          "narrative": "When the melody is the fifth of a minor seventh chord, the diatonic sixth below implies the minor seventh, and the arranger must decide whether to retain or adjust this extension. The book explains: \"If the melody is the fifth of the chord, as A (3) in the case of the first note of the second measure, the sixth below will be the minor seventh interval C, of the Dm7 chord. The chord symbol above it is a simple triad, Dm. The minor seventh interval is contained in the C scale, so it is not a clash. You can change the C to D if you wish to keep the sound to a simple Dm chord\" (Ch. 8, p. 104). The minor seventh extension is diatonic and therefore not a clash, but adjustment to the fifth is available.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor7/sixth-below-harmonization",
+            "minor/sixth-below-harmonization",
+            "minor7/non-chord-tone-thirds-tolerance"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 8, p. 104"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "non-chord-tone-thirds-tolerance",
+          "narrative": "Non-chord-tone thirds below minor seventh chord melody notes are evaluated by ear rather than mechanical rejection. The book counsels: \"Non-chord tones make for the interesting spice in an otherwise dull chord-tone-only dish. It's your ear and your decision\" (Ch. 6, p. 92). Brief passing non-chord-tone thirds on eighth notes are specifically defended — \"One could argue that the B, as an eighth note, goes by so quickly that it does not jar the ear. Even melody notes are rarely all chord tones\" (Ch. 6, p. 92). The final arbiter is always whether \"the total effect sound like the chord indicated\" (Ch. 6, p. 92).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/non-chord-tone-thirds-tolerance",
+            "major/non-chord-tone-thirds-tolerance",
+            "minor7/sixth-below-extension-awareness"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, p. 92"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "parallel-thirds-harmonization",
+          "narrative": "Minor seventh chord melodies are harmonized with a diatonic third below using the same free-stroke technique as major chords. The book's general instruction applies: \"A simple way of harmonizing the melody is to use a note that is three scale steps below the melody\" (Ch. 6, p. 91). The synthesis assignment requires: \"Write a solo guitar arrangement primarily using a third paralleling the melody. Include bass accompaniment with a rhythm independent of the melody\" (Ch. 7, p. 97). For minor seventh chords, diatonic thirds tend to stay within the minor tonality when the scale and chord symbol are properly matched.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/parallel-thirds-harmonization",
+            "major/parallel-thirds-harmonization",
+            "minor7/sixth-below-extension-awareness"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, p. 91; Ch. 7, p. 97"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7b5",
+          "function_role": "diatonic-function-vii",
+          "narrative": "The half-diminished seventh chord (minor seventh flat-five) appears on scale degree VII as the single half-diminished chord in diatonic jazz harmony. The book specifies: \"One half-diminished seventh VII\" among the four diatonic chord types (Ch. 9, p. 117). Its appearance in intros is documented: \"The next moves cyclically to Am7b5\" (Ch. 14, p. 160), demonstrating its use as a chromatic passing chord. The half-diminished chord is also identified implicitly in the cycle exercises as the natural VII of the major scale, moving to V7 in the diatonic cycle.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "diminished7/ascending-chromatic-connector",
+            "dominant7/diatonic-function-dominant",
+            "minor7/diatonic-function-supertonic"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 9, p. 117; Ch. 14, p. 160"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7b5",
+          "function_role": "chromatic-passing-in-intro",
+          "narrative": "The half-diminished chord appears as a chromatic passing chord in intro construction, moving from chromatic to cyclic motion. The book annotates a specific intro: \"This intro starts solidly in F but immediately moves out of key for a little surprise. The first harmonic movement is chromatic, F to Eb9. The next moves cyclically to Am7b5, chromatically to Ab7 and Gm7, cyclically to C7\" (Ch. 14, p. 160). This demonstrates that the half-diminished chord participates in both chromatic and cycle motion contexts. Its flatted fifth creates a tritone with the root that drives motion forward harmonically.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "diminished7/ascending-chromatic-connector",
+            "minor7b5/diatonic-function-vii",
+            "dominant7/intro-gateway"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, p. 160"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "diminished7",
+          "function_role": "ascending-chromatic-connector",
+          "narrative": "The diminished seventh chord is the standard connector chord for ascending chromatic root movement, filling the half-step gap between diatonic harmonies. The book states plainly: \"In many cases the diminished seventh chord is the in-between, the hamburger helper of ascending harmonic movement\" (Ch. 10, p. 120). Its symmetrical structure (all minor thirds) allows it to be used on any ascending chromatic pass without creating jarring dissonance. This makes it the practical default choice when chromatic root motion ascends rather than descends.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor7b5/diatonic-function-vii",
+            "dominant7/chromatic-bass-approach",
+            "diminished7/chromatic-substitution"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 120"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "diminished7",
+          "function_role": "chromatic-substitution",
+          "narrative": "The diminished seventh chord functions as a chromatic substitute that enables smooth voice-leading between diatonic harmonies moving in half steps. The book's analysis of ascending harmony: \"In many cases the diminished seventh chord is the in-between, the hamburger helper of ascending harmonic movement\" (Ch. 10, p. 120). As an in-between chord, its symmetrical structure — stacked minor thirds — means any of its four notes can function as the root of an equivalent diminished seventh a minor third away. The book's ear-first principle applies here: \"Ultimately, whatever sounds good to the ear will probably work\" (Ch. 15, p. 167).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "diminished7/ascending-chromatic-connector",
+            "minor7b5/chromatic-passing-in-intro",
+            "dominant7/intro-gateway"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 120; Ch. 15, p. 167"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major6",
+          "function_role": "deceptive-cadence-bvi-substitute",
+          "narrative": "A major sixth chord on the flattened sixth scale degree (bVI) is used as a deceptive cadence substitute, opening new harmonic possibilities within a diatonic cycle. The book describes: \"a bVI (Ab6) of the C scale is inserted. This deceptive cadence opens up several possibilities\" (Ch. 15, p. 167). This deceptive cadence technique follows diatonic cycle-of-fifths movement through the scale — \"A major scale can within itself provide cyclical movement\" (Ch. 15, p. 167) — before the bVI diverts the expected resolution. The bVI6 substitution is an example of the broader principle that chromatic and diatonic elements can be freely mixed.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/walkdown-structural-device",
+            "dominant7/modulation-pivot",
+            "major6/chromatic-neighbor-use"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 15, p. 167"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major6",
+          "function_role": "chromatic-neighbor-use",
+          "narrative": "Major sixth chords can function as chromatic neighbor chords approaching targets by half step above or below. The book states the general rule: \"Approaching a chord from a half step above or below is another accepted way of moving the harmony\" (Ch. 15, p. 167). The specific use of Ab6 as bVI in a C major context demonstrates that the major sixth quality does not restrict a chord from chromatic approach use — the quality follows the melodic and harmonic logic of the moment. The book's flexibility principle governs: \"Don't let the chord quality get in the way of your analysis\" (Ch. 15, p. 167).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major6/deceptive-cadence-bvi-substitute",
+            "dominant9/chromatic-intro-color",
+            "major7/chromatic-bass-continuity"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 15, p. 167"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "tonic-arrival",
+          "narrative": "The major tonic chord is the expected resolution target of V7–I motion and the standard landing point for endings and tags. The book states: \"Endings end, and usually on a I chord. V7-I, IV-I, and especially II-V7-I are standard\" (Ch. 14, p. 163). Tags are initiated by replacing this I chord with V7 — \"the replacement of the usual final I chord with a V7 (or other substitute) chord is required\" (Ch. 14, p. 164). The major tonic is the point of harmonic rest from which all further motion departs, making its voicing and bass note choices relatively unconstrained compared to the approach chords.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/ending-resolution",
+            "dominant7/tag-substitution",
+            "dominant7/tritone-pull-resolution"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 14, pp. 163–164"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "bass-rhythm-counterpoint",
+          "narrative": "When a major chord underlies a busy, many-noted melody, the bass should use longer note values for rhythmic contrast. The book prescribes: \"If the rhythm of the melody is busy and many-noted, you can complement it by playing longer notes in the bass. When the melody is made up of longer note values, you can play a busier bass part\" (Ch. 4, p. 74). This counterpoint principle elevates bass-rhythm choice from mechanical fill to expressive decision — \"Changing the bass accompaniment rhythm can change the mood or character of a piece\" (Ch. 3, p. 56). The bass-as-drumlike-accompaniment frame applies to major chord contexts throughout the blues and jazz repertoire.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/bass-rhythm-counterpoint",
+            "dominant7/oom-pah-bass-foundation",
+            "major7/chromatic-bass-continuity"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 3, p. 56; Ch. 4, p. 74"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "bass-rhythm-counterpoint",
+          "narrative": "Minor chord bass accompaniment rhythm functions as an expressive mood-shaping variable, not merely a structural support. The book states: \"Using a constant quarter-note bass isn't necessarily the best way. It's just another way. Play the same blues section with a constant half-note bass... Changing the bass accompaniment rhythm can change the mood or character of a piece\" (Ch. 3, p. 56). For minor chords, the choice between driving quarter-note bass and slower half-note bass changes the emotional weight of the minor tonality. Bass rhythm choice is identified as \"often the first decision made\" when approaching a melody (Ch. 3, p. 56).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/bass-rhythm-counterpoint",
+            "minor7/oom-pah-bass-foundation",
+            "minor/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 3, p. 56"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "alternating-octaves-bass",
+          "narrative": "Major chord bass notes can be placed in alternating lower and higher octaves for a ragtime or folk blues stylistic effect. The book introduces: \"You can even place a repeated note in alternating lower and higher octaves. You will find this in traditional ragtime and folk blues styles\" (Ch. 4, p. 73). However, a voice-crossing caveat applies: \"Alternating octaves work best with tunes that are pitched in a higher range so that the bass note of the lower octave is not higher than the melody note, which would confuse the listener\" (Ch. 4, p. 73). The technique is explicitly linked to stylistic context and is not appropriate for all chord environments.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/oom-pah-bass-foundation",
+            "minor/oom-pah-bass-foundation",
+            "dominant7/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 4, p. 73"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "alternating-octaves-voice-crossing-avoidance",
+          "narrative": "Alternating octave bass notes over major chords must not rise above the melody register, or voice crossing will confuse the listener about which note is the melody. The book warns: \"Alternating octaves work best with tunes that are pitched in a higher range so that the bass note of the lower octave is not higher than the melody note, which would confuse the listener\" (Ch. 4, p. 73). This is one of the book's explicit negative rules — the higher octave bass note must remain subordinate to the melody note in register. Tune selection and key choice directly affect whether the alternating-octaves technique is viable.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/alternating-octaves-bass",
+            "major/bass-rhythm-counterpoint"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 4, p. 73"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "thumb-bass-free-stroke-only",
+          "narrative": "When playing bass notes beneath a major chord melody, the thumb must use only free stroke — rest stroke is explicitly forbidden for the bass thumb. The book states: \"Generally the thumb does not use the rest stroke as it can easily overpower the melody being played with the i, m, or a fingers\" (Ch. 1, p. 18). This rule governs all chord types where bass and melody coexist in the fingerstyle texture. The thumb's free stroke keeps bass volume subordinate to the melody, which is the governing balance principle of the entire method.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/thumb-bass-free-stroke-only",
+            "dominant7/thumb-bass-free-stroke-only",
+            "major7/thumb-bass-free-stroke-only"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 1, p. 18"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "thumb-bass-free-stroke-only",
+          "narrative": "Bass notes beneath minor chord melodies require the same free-stroke-only thumb rule as all other chord types. The book's governing rule: \"Generally the thumb does not use the rest stroke as it can easily overpower the melody being played with the i, m, or a fingers\" (Ch. 1, p. 18). Simultaneously, the melody must use rest stroke for projection — \"Continue to play the melody with the i, m, or a finger. To keep the melody projecting over the accompaniment, use the rest stroke. Simultaneously use a free stroke with the thumb\" (Ch. 3, p. 51). These two techniques must operate concurrently in all minor chord two-voice passages.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/thumb-bass-free-stroke-only",
+            "dominant7/thumb-bass-free-stroke-only"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 1, p. 18; Ch. 3, p. 51"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "thumb-bass-free-stroke-only",
+          "narrative": "Bass notes beneath dominant seventh chord melodies require free stroke only from the thumb, as rest stroke would overpower the melody. The book's universal rule: \"Generally the thumb does not use the rest stroke as it can easily overpower the melody being played with the i, m, or a fingers\" (Ch. 1, p. 18). For adjacent-string situations involving dominant seventh voicings, the further rule applies: \"When you play two notes on adjacent strings you have to use two free strokes. Otherwise, if you use a rest stroke on the higher string, it cancels out the lower string\" (Ch. 3, p. 52). Both rules protect the melody's primacy over the bass texture.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/thumb-bass-free-stroke-only",
+            "minor/thumb-bass-free-stroke-only"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 1, p. 18; Ch. 3, p. 52"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "arpeggio-ceiling-rule",
+          "narrative": "Arpeggiation of major chords must not extend above the melody note or the listener will lose track of which voice is the melody. The book prohibits: \"watch that your choice of arpeggiation doesn't reach higher than the melody, which might obscure the melody and confuse the listener\" (Ch. 6, p. 89). When a melody leaps unpredictably over a major chord, arpeggiation should be abandoned entirely — \"If you notice that the melody of the tune you wish to arrange continually leaps up and down wildly, abandon arpeggiation for that particular tune and choose another accompaniment technique\" (Ch. 6, p. 90). The melody's supremacy determines the arpeggio's upper boundary.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/arpeggio-ceiling-rule",
+            "major7/arpeggiation-accompaniment",
+            "major/arpeggiation-accompaniment"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, pp. 89–90"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "arpeggio-ceiling-rule",
+          "narrative": "Arpeggio texture over minor chords is subject to the same upper-boundary ceiling as major chords — the arpeggio must not exceed the melody register. The book states: \"watch that your choice of arpeggiation doesn't reach higher than the melody, which might obscure the melody and confuse the listener\" (Ch. 6, p. 89). For minor chord arpeggios in slower tunes, the book further requires: \"Don't forget to emphasize the melody note so that it won't get lost in the sea of eighth note soup\" (Ch. 10, p. 125). Melody emphasis within the arpeggio — projecting it through touch pressure or stroke angle — maintains melodic clarity regardless of chord quality.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/arpeggio-ceiling-rule",
+            "minor/arpeggiation-accompaniment"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, p. 89; Ch. 10, p. 125"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "rigid-root-fifth-avoided-in-jazz",
+          "narrative": "Strict root/fifth oom-pah bass is explicitly discouraged for dominant seventh chords in jazz contexts, where it sounds mechanical and stylistically inappropriate. The book warns: \"Root/fifth is often associated with simple music, such as polka bands, country music and the like. Root/fifth is used in jazz too, but usually not in such a rigid oom-pah fashion\" (Ch. 10, p. 122). Mixed-rhythm bass — \"quarter, half or whole notes\" in varied combinations — is the prescribed alternative (Ch. 5, p. 78). The effect of low-to-high alternation is what matters, not strict interval adherence: \"Keeping a strict pattern of root/seventh is not as important as long as the effect (low to high alternation) is there\" (Ch. 10, p. 123).",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/oom-pah-bass-foundation",
+            "dominant7/walking-bass-approach",
+            "major/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, p. 78; Ch. 10, pp. 122–123"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major7",
+          "function_role": "constant-bass-doubling-avoided",
+          "narrative": "Constant doubling of bass notes beneath major seventh chords is a vintage jazz convention that should be avoided in modern style unless a period effect is intended. The book specifies: \"Today the bass doesn't often play four quarter notes to the bar, especially during the first and last chorus. Older-style bass playing included much doubling of two same notes per measure. Unless you, as the guitarist/bassist, want to recreate vintage jazz, avoid constant doubling\" (Ch. 11, p. 141). This rule applies across chord types but is most relevant for major seventh tonic chords where the bass tendency to linger is strongest. Modern style favors bigger intervals, broken time, and textural variety.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/oom-pah-bass-foundation",
+            "major7/chromatic-bass-continuity",
+            "minor7/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 11, p. 141"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "constant-bass-doubling-avoided",
+          "narrative": "Constant bass note doubling beneath minor seventh chords is a vintage jazz practice that modern style avoids. The book states: \"Today the bass doesn't often play four quarter notes to the bar, especially during the first and last chorus. Unless you, as the guitarist/bassist, want to recreate vintage jazz, avoid constant doubling\" (Ch. 11, p. 141). The doubled-bass style is specifically attributed to swing-era practice: \"These measures have doubled bass notes, a style used by musicians playing upright bass in the swing era of jazz\" (Ch. 10, p. 121). When doubling is used intentionally, it signals a period style choice, not a default approach.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major7/constant-bass-doubling-avoided",
+            "dominant7/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 121; Ch. 11, p. 141"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "thirds-require-bass-completion",
+          "narrative": "Parallel thirds harmonization alone is insufficient to carry a major chord arrangement for a full song — bass must be added to complete the three-voice texture. The book declares: \"A melody harmonized only in thirds can progress by itself for a section of a tune, but probably not for the entire song. Put the bass back in. Even a simple root/root and root/fifth bass can turn the melody with thirds into a full three-part arrangement of melody, harmony and bass\" (Ch. 6, p. 92). The three-voice hierarchy — melody, harmony, bass — is the governing textural standard; thirds supply only the middle voice and leave the bass absent without explicit action.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/parallel-thirds-harmonization",
+            "minor/thirds-require-bass-completion",
+            "major/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 6, p. 92"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "thirds-require-bass-completion",
+          "narrative": "Parallel thirds over minor chord sections require bass addition for the full three-voice texture, just as with major chords. The book's rule is quality-neutral: \"A melody harmonized only in thirds can progress by itself for a section of a tune, but probably not for the entire song. Put the bass back in\" (Ch. 6, p. 92). For minor chord contexts, a root/fifth bass specifically confirms the minor quality — the fifth for A minor is E (Ch. 5, p. 76) — while the melody's minor third in the thirds texture already signals the minor color. Bass confirms the harmonic foundation the thirds texture cannot supply alone.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/thirds-require-bass-completion",
+            "minor/parallel-thirds-harmonization",
+            "minor/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 5, p. 76; Ch. 6, p. 92"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "moving-tenths-swing-device",
+          "narrative": "Moving tenths beneath major chord melodies are the primary self-accompaniment device borrowed from swing-era stride piano practice. The book identifies the source: \"Moving tenths in the left hand was one of the primary accompanying devices of pianists in the swing era. Fats Waller, Willie 'The Lion' Smith, Art Tatum, Teddy Wilson, and many others made this the style. Within reason, you can emulate it on the guitar. The pianists mentioned often kept almost constant quarter-note moving tenths going with the melody. You should be able to manage at least half notes\" (Ch. 10, p. 127). The tenth — an octave-displaced third — functions as a bass note with its own independent rhythm distinct from the melodic line.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/moving-tenths-swing-device",
+            "dominant7/moving-tenths-swing-device",
+            "major/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 127"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "moving-tenths-swing-device",
+          "narrative": "Moving tenths beneath minor chord melodies adapt the swing-era piano stride device to the guitar, with the tenth functioning as an independent bass voice. The book defines the interval: \"An octave plus a major or minor third ten scale steps below (or above) the melody note is a tenth\" (Ch. 7, p. 98), covering both major and minor chord contexts. The independence principle is critical — \"the tenth does often function as a bass note, but only infrequently does it move parallel to the melodic rhythm. More often it has its own independent rhythm\" (Ch. 7, p. 98). For minor chords, the minor tenth (octave-displaced minor third) is used, maintaining the minor tonality in the bass.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/moving-tenths-swing-device",
+            "dominant7/moving-tenths-swing-device",
+            "minor7/sixth-below-extension-awareness"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 7, pp. 97–98"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "moving-tenths-swing-device",
+          "narrative": "Moving tenths beneath dominant seventh chord melodies provide the swing-era stride piano texture on guitar. The bebop improvisation context demonstrates: \"The melody below has been turned into a bebop improvisation based on the harmony of Rhythm Changes. Half note duration tenths are used in the bass\" (Ch. 7, p. 99). The pianistic ideal — \"almost constant quarter-note moving tenths\" (Ch. 10, p. 127) — is adapted for guitar to at least half notes. For dominant seventh chords, the tenth is derived from the chord's major or minor third, ensuring the bass voice continues to imply the chord quality harmonically.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/moving-tenths-swing-device",
+            "minor/moving-tenths-swing-device",
+            "dominant7/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 7, pp. 98–99; Ch. 10, p. 127"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "spread-texture-accompaniment",
+          "narrative": "The spread texture — bass alternating up a fourth then down a fifth, placing a tenth beneath the melody — is an idiomatic fingerstyle accompaniment for major chord melodies. The book defines it precisely: \"The root bass notes alternate in moving up a fourth and then down a fifth. Each new bass note is a tenth interval from the melody note above. The bass moves from low to high. This makes a good spread, sounding truly like a bass accompaniment to a melody high above\" (Ch. 13, p. 157). This texture creates a sense of space and register separation between melody and bass that block-chord voicings cannot achieve.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/voice-leading-resolution",
+            "major/moving-tenths-swing-device",
+            "major7/chromatic-bass-continuity"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 13, p. 157"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "spread-texture-accompaniment",
+          "narrative": "The spread texture is demonstrated specifically in the context of cycle-of-fifths dominant seventh chord movement. The book's voice-by-voice analysis: \"The simple C triad and the following Bb notes together make up C7. The following F9 has the G note in common with C. The middle voice moves by half step from E to Eb. The bottom line travels from C, the root, to A, the third of F9, by Bb, the 7 of the C7 note. The final lower line move is to F, the root\" (Ch. 13, p. 156). The spread's root alternation pattern (up a fourth, down a fifth) creates a tenth from the melody above for each dominant seventh in the cycle.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/spread-texture-accompaniment",
+            "dominant7/voice-leading-resolution",
+            "dominant7/tritone-pull-resolution"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 13, pp. 156–157"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "register-placement-ensemble",
+          "narrative": "In ensemble settings with electric bass, major chord voicings must be moved to the upper four or five strings to avoid register collision. The book prescribes: \"If you play low-pitched, walking four-to-the-bar chords and your partner plays a walking bass line, it results in a muddy tangle of sounds in both texture and pitch. The solution is simple: play your rhythm part, whether constant or comping, higher on the board on the top four or at most five strings\" (Ch. 11, p. 135). This register separation rule applies whether playing constant rhythm or comping, and governs major chord voicings in all ensemble contexts where bass is present.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/register-placement-ensemble",
+            "minor7/register-placement-ensemble",
+            "major7/open-voicing-preference"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 11, p. 135"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "register-placement-ensemble",
+          "narrative": "Dominant seventh chord voicings in ensemble with electric bass must be placed on the upper four or five strings to avoid low-register muddiness. The book's register rule: \"play your rhythm part, whether constant or comping, higher on the board on the top four or at most five strings\" (Ch. 11, p. 135). For dominant seventh chords, the rootless tritone/fourth voicing system (Ch. 10, p. 129) naturally facilitates high voicing since it omits the root and fifth — the notes that tend to pull voicings into the low register. The bassist's coverage of roots and fifths frees the guitarist to voice exclusively in the upper register.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/register-placement-ensemble",
+            "dominant7/rootless-voicing-ensemble",
+            "minor7/register-placement-ensemble"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 129; Ch. 11, p. 135"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor7",
+          "function_role": "register-placement-ensemble",
+          "narrative": "Minor seventh chord voicings in ensemble contexts must be placed on the upper strings to avoid register collision with the electric bass. The book prescribes the universal ensemble rule: \"play your rhythm part, whether constant or comping, higher on the board on the top four or at most five strings\" (Ch. 11, p. 135). For minor seventh chords specifically, open voicings with the third or fifth moved an octave higher (Ch. 9, p. 117) naturally facilitate upper-register placement. The bass-first conception rule further ensures that bass lines and chord voicings are planned as complementary voices rather than competing register occupants.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/register-placement-ensemble",
+            "dominant7/register-placement-ensemble",
+            "minor7/open-voicing-preference"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 9, p. 117; Ch. 11, p. 135"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "comping-density-in-holes",
+          "narrative": "When comping behind a soloist over major chord sections, density should increase in melodic holes and decrease when the soloist is active. The book states: \"play more when the soloist is not playing, and play less when he is. Play more when there are 'holes' to be filled, and don't step all over the soloist when he is playing busily\" (Ch. 11, p. 135). This density-responsive comping principle applies to all chord types but is especially relevant for major chord vamps where the temptation to fill with full voicings is greatest. Good accompanying is described as \"transparent to the ear in the sense that it neither stands out nor draws attention to itself\" (Ch. 11, p. 131).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/comping-density-in-holes",
+            "minor7/comping-density-in-holes",
+            "major/two-note-sparse-voicing"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 11, pp. 131, 135"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "comping-density-in-holes",
+          "narrative": "Comping over dominant seventh chord sections should be denser in the soloist's rests and sparser when the soloist is playing. The book's rule: \"play more when the soloist is not playing, and play less when he is. Play more when there are 'holes' to be filled\" (Ch. 11, p. 135). For dominant seventh chords specifically, the tritone's inherent tension makes even a single-note punctuation harmonically active — the book notes that single-line accompaniment is a valid stylistic option: \"For variety, try accompanying with a single line\" (Ch. 11, p. 139). The dominant seventh's functional tension means sparse comping retains full harmonic power.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/comping-density-in-holes",
+            "dominant7/tritone-accompaniment-texture"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 11, pp. 135, 139"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "half-step-approach-chord",
+          "narrative": "Any major chord can be approached from a half step above or below as a chromatic neighbor technique. The book states: \"Approaching a chord from a half step above or below is another accepted way of moving the harmony\" (Ch. 15, p. 167). The descending chromatic key change demonstrates this: \"The key changes from C to D moving chromatically by half step. Don't let the chord quality get in the way of your analysis\" (Ch. 15, p. 167). This flexibility — treating any chord quality as approachable by chromatic neighbor motion — is central to the book's chromatic harmony system and applies equally to major, minor, and dominant chords as targets.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/half-step-approach-chord",
+            "dominant7/chromatic-bass-approach",
+            "major6/chromatic-neighbor-use"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 15, p. 167"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "half-step-approach-chord",
+          "narrative": "Minor chords are approachable from a half step above or below as chromatic neighbor chords, regardless of the apparent key or quality mismatch. The book's permissive rule: \"Approaching a chord from a half step above or below is another accepted way of moving the harmony\" (Ch. 15, p. 167). The instruction to not let chord quality interfere with chromatic analysis — \"Don't let the chord quality get in the way of your analysis\" (Ch. 15, p. 167) — extends this to minor chords as both approach chords and targets. This chromatic neighbor motion is part of the book's broader ear-first framework: \"Ultimately, whatever sounds good to the ear will probably work\" (Ch. 15, p. 167).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/half-step-approach-chord",
+            "minor7/ii-chord-pre-dominant"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 15, p. 167"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "melody-bass-overlap-resolution",
+          "narrative": "When a melody note merges with the top voice of a two-note bass accompaniment over a major chord, this overlap is a valid arrangement solution, not a voice-leading error to fix. The book reframes the situation: \"Often the melody may merge with and become the top part of the two note bass accompaniment. It's not a problem, it's a solution\" (Ch. 10, p. 126). This principle applies to all chord types and reflects the book's governing aesthetic that musical effect and coherence outrank mechanical voice-independence. The overlap confirms rather than weakens the major chord harmony when the shared note is a chord tone.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/melody-bass-overlap-resolution",
+            "dominant7/melody-bass-overlap-resolution"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 126"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "melody-bass-overlap-resolution",
+          "narrative": "Melody-bass voice overlap over minor chords is treated as a valid arrangement solution reflecting the pragmatic approach of the book. The book's universal reframe: \"Often the melody may merge with and become the top part of the two note bass accompaniment. It's not a problem, it's a solution\" (Ch. 10, p. 126). This is especially applicable in minor chord passages where the shared note between melody and bass often falls on the minor third or root, reinforcing the chord identity rather than obscuring it. Effect and musical coherence matter more than strict polyphonic independence.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/melody-bass-overlap-resolution",
+            "minor7/non-chord-tone-thirds-tolerance"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 126"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "melody-bass-overlap-resolution",
+          "narrative": "Voice overlap between melody and bass inner voices over dominant seventh chords is treated as a valid solution rather than a problem to resolve. The book states: \"Often the melody may merge with and become the top part of the two note bass accompaniment. It's not a problem, it's a solution\" (Ch. 10, p. 126). For dominant seventh chords, where sparse two-note voicings typically emphasize the third and seventh, overlap is common and structurally functional — the shared note usually reinforces the tritone content that defines the dominant quality. The book's governing principle applies: effect and musical coherence outrank mechanical voice-counting.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/melody-bass-overlap-resolution",
+            "dominant7/two-note-sparse-voicing"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 126"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "swing-feel-tempo-application",
+          "narrative": "Swing feel applied to major chord contexts is tempo-dependent: it works best at slower to medium tempos and should not be exaggerated. The book prescribes: \"This shuffle rhythm works best for slower-to-medium blues and jazz. When the tempo is very fast, play eighth notes more evenly\" (Ch. 2, p. 42). At medium tempo over major chord arrangements, the book specifically warns: \"don't over-exaggerate, as the tune should be played at least at a medium tempo or faster\" (Ch. 8, p. 111). Swing feel is notated as straight eighth notes but performed with triplet-based long-short interpretation — \"eighth notes with a swing time feel are written as straight eighth notes\" (Ch. 12, p. 149).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "minor/swing-feel-tempo-application",
+            "dominant7/swing-feel-tempo-application"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 2, p. 42; Ch. 8, p. 111; Ch. 12, p. 149"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "swing-feel-tempo-application",
+          "narrative": "Swing feel over minor chord sections follows the same tempo-sensitivity rules as major chord sections. The book's governing rule: \"This shuffle rhythm works best for slower-to-medium blues and jazz. When the tempo is very fast, play eighth notes more evenly\" (Ch. 2, p. 42). The blues — which frequently employs minor chord territory — is the primary context for swing application at appropriate tempos. The basic jazz pulse underlying all chord types is: \"a quarter note, on top of which is a melody based on a steady pulse of eighth notes\" (Ch. 2, p. 39), with the swing feel layered over this structure at qualifying tempos.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/swing-feel-tempo-application",
+            "dominant7/swing-feel-tempo-application"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 2, pp. 39, 42"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "swing-feel-tempo-application",
+          "narrative": "Swing feel over dominant seventh chord sections is tempo-dependent and must not be applied at fast tempos where even eighth notes are required. The book specifies: \"This shuffle rhythm works best for slower-to-medium blues and jazz. When the tempo is very fast, play eighth notes more evenly\" (Ch. 2, p. 42). The off-beat accent — \"One trademark of jazz phrasing is the use of accent on the off-beats (up-beats)\" (Ch. 12, p. 149) — is especially characteristic over dominant seventh chords where the harmonic tension heightens the expressive impact of rhythmic displacement. Rhythmic displacement (anticipation and delay) is \"another trademark of jazz\" (Ch. 12, p. 152).",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/swing-feel-tempo-application",
+            "minor/swing-feel-tempo-application",
+            "dominant7/voice-leading-resolution"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 2, p. 42; Ch. 12, pp. 149, 152"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "sixth-below-major-tonality-preservation",
+          "narrative": "When harmonizing major chord melodies with sixths below, the key note must remain on top to preserve the listener's perception of major tonality. The book establishes: \"By convention, scales harmonized in sixths have the key note of each scale on top, with the harmony note a sixth below. If the key note were in the bottom position the ear would perceive the scale as being in a minor key rather than a major key\" (Ch. 8, p. 108). This is a foundational voicing rule with acoustical justification — the top note is the defining tonal reference, and placing a non-key note on top changes the perceived mode of the harmonization.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/sixth-below-harmonization",
+            "minor/sixth-below-harmonization",
+            "major/parallel-thirds-harmonization"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 8, p. 108"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "minor",
+          "function_role": "sixth-below-major-tonality-preservation",
+          "narrative": "Sixth-below harmonization of minor chord melodies requires awareness that placing a non-key note on top will shift the perceived tonality. The book's rule states: \"If the key note were in the bottom position the ear would perceive the scale as being in a minor key rather than a major key\" (Ch. 8, p. 108). In minor chord contexts, this rule becomes nuanced — if the arranger wants to preserve the minor quality, the convention of key-note-on-top still applies, but the expected top note may differ depending on whether the melody is functioning within a relative or parallel minor tonality. Adjustments to diatonic sixths are always available to correct unwanted modal implications.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/sixth-below-major-tonality-preservation",
+            "minor/sixth-below-harmonization"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 8, p. 108"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "dominant7",
+          "function_role": "anticipation-delay-bass-rhythm",
+          "narrative": "Anticipation and delay of bass notes beneath dominant seventh chords break the mechanical four-on-the-floor pattern and introduce characteristic jazz feel. The book prescribes: \"Leading with a bass note is a way to give variety to accompaniment instead of just chugging along with four bass notes to a measure\" (Ch. 10, p. 124). The complementary technique: \"The opposite of leading with the lower line is trailing or delaying it. This too steers away from heaviness\" (Ch. 10, p. 124). Rhythmic displacement — \"anticipation and delay of the formal written notes\" — is identified as \"another trademark of jazz\" (Ch. 12, p. 152), making these bass rhythm devices expressive as well as structural.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "major/bass-rhythm-counterpoint",
+            "minor/bass-rhythm-counterpoint",
+            "dominant7/oom-pah-bass-foundation"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, pp. 124; Ch. 12, p. 152"
+            }
+          ]
+        },
+        {
+          "source_work_id": "complete-fingerstyle-jazz-guitar-book",
+          "chord_quality": "major",
+          "function_role": "anticipation-delay-bass-rhythm",
+          "narrative": "Anticipating or delaying bass notes beneath major chord sections creates rhythmic variety and prevents mechanical heaviness in the accompaniment. The book identifies anticipation: \"Leading with a bass note is a way to give variety to accompaniment instead of just chugging along with four bass notes to a measure\" (Ch. 10, p. 124). The complementary delay: \"The opposite of leading with the lower line is trailing or delaying it. This too steers away from heaviness\" (Ch. 10, p. 124). These rhythmic displacement devices are applicable across chord types whenever the bass risks becoming drone-like rather than expressive.",
+          "provenance": "extracted",
+          "cross_ref": [
+            "dominant7/anticipation-delay-bass-rhythm",
+            "minor/bass-rhythm-counterpoint"
+          ],
+          "references": [
+            {
+              "source": "complete-fingerstyle-jazz-guitar-book",
+              "citation": "Ch. 10, p. 124"
+            }
+          ]
+        }
+      ]
     },
     {
       "id": "barry-galbraith",
@@ -25371,7 +30381,1169 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-anchor",
+          "narrative": "Warnock prescribes Dm7 as the mandatory starting point for all ii V I study, stating \"To begin, here are four chords that fit over the ii V I progression\" (p. 4). The Dm7 voicing is the first shape students must memorize and the harmonic anchor from which all subsequent technique—rhythms, approach chords, scale compatibility—is introduced and measured.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 4 — ii V I chord shapes"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-target",
+            "maj7/i-chord-resolution"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-freddie-green-quarter-pulse",
+          "narrative": "The Freddie Green rhythm prescribes that Dm7—along with every chord in the progression—must be voiced as a quarter-note chord on every beat: \"The rhythm is all quarter notes, meaning you play one chord per beat\" (p. 5). Students are told to first internalize this rhythm in isolation with a metronome before applying it over a backing track, establishing the quarter-pulse habit on the ii chord before any syncopation is introduced.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 5 — Freddie Green rhythm definition"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-freddie-green-quarter-pulse",
+            "maj7/i-chord-freddie-green-quarter-pulse"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-charleston-placement",
+          "narrative": "The Charleston rhythm prescribes a specific syncopated placement for the Dm7 voicing: \"This rhythm places the first chord on beat 1 of each bar, then the second chord is on the & of 2, between beats 2 and 3 in each bar\" (p. 6). This placement is non-negotiable as a named, rule-governed pattern that must be learned exactly before mixing with other rhythms.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 6 — Charleston rhythm definition"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-charleston-placement",
+            "maj7/i-chord-charleston-placement"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-comping-rhythm-mix",
+          "narrative": "Once the Freddie Green and Charleston rhythms are individually secured on Dm7, Warnock prescribes combining them: \"mix the Freddie Green and Charleston rhythms together to expand on this idea in your comping\" (p. 6). This mixing phase is explicitly positioned as the transition from imitation to original comping and must not be attempted before both rhythms are internalized separately.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 6 — mixing comping rhythms"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-comping-rhythm-mix",
+            "maj7/i-chord-comping-rhythm-mix"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-approach-from-above",
+          "narrative": "For approach chord practice, students are directed to begin with above-approach on the Dm7 shape: \"The first exercise features approach chords from above, where you play the same shape one fret higher, then resolve into your target chord from there\" (p. 12). The mechanical rule is absolute—the entire Dm7 voicing moves up exactly one fret before resolving, not individual notes.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 12 — Approach from above mechanics"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-approach-from-above",
+            "maj7/i-chord-approach-from-above"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-approach-from-below",
+          "narrative": "The below-approach direction is introduced as a second required practice stage for the Dm7 target: \"You can also work approach chords from below and resolve into your target chord from there in your comping\" (p. 13). Warnock prescribes this only after the above-approach is secure, enforcing the sequence: above first, then below, then mixed.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 13 — Approach from below direction"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-approach-from-above",
+            "dom7/v-chord-approach-from-below"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-approach-mandatory-resolution",
+          "polarity": "proscriptive",
+          "narrative": "Warnock establishes that an approach chord applied to the Dm7 target must always resolve: \"Approach chords are where you play a chromatic chord one fret above or below the target chord you're aiming for\" (p. 11), with the resolution being non-negotiable. Leaving the approach unresolved is implicitly proscribed—the resolution step is constitutive of the technique itself, not optional.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Approach chord definition"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-approach-mandatory-resolution",
+            "maj7/i-chord-approach-mandatory-resolution"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-tension-release-function",
+          "narrative": "Warnock prescribes the harmonic purpose of approach chords over Dm7 as one of tension and release: \"Approach chords bring a tension and release sound to your comping, jazzing up your chords along the way\" (p. 11). This framing positions chromatic displacement of the Dm7 voicing as the primary mechanism for creating harmonic motion within a comping context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Approach chord tension/release function"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-tension-release-function",
+            "maj7/i-chord-tension-release-function"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-bass-first-picking",
+          "narrative": "Warnock prescribes the bass-first picking pattern for Dm7 in contexts without a bassist: \"The first picking exercise separates the bass from the melody. This type of comping pattern is helpful when there's no bassist in your group, when you play solo guitar, or for technical development\" (p. 9). The bass-first approach must be learned before the melody-first pattern is introduced.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 3, p. 9 — Bass-melody separation pattern"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-melody-first-picking",
+            "dom7/v-chord-bass-first-picking"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-melody-first-picking",
+          "narrative": "The melody-first picking pattern is prescribed for Dm7 in chord melody and chord soloing contexts: \"Bringing out the melody is useful for comping, chord soloing, and especially chord melody playing\" (p. 10). This pattern is the second in the prescribed learning sequence—it must follow mastery of the bass-first pattern before being practiced independently.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 3, p. 10 — Melody-first comping uses"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-bass-first-picking",
+            "dom7/v-chord-melody-first-picking"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-scale-compatibility",
+          "narrative": "Warnock explicitly prescribes the tonic major scale as the correct soloing tool over Dm7: \"Because all 3 chords in a ii V I are in the parent key, so Dm7-G7-Cmaj7 are all in C major, you can use the tonic major scale to solo over all of those chords\" (p. 14). Dm7 is singled out by name in this rule, confirming that scale substitution per chord change is not the method's approach.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — ii V I scale compatibility"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-scale-compatibility",
+            "maj7/i-chord-scale-compatibility"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-mixing-chords-and-single-notes",
+          "narrative": "In the mixed-solo system, Dm7 voicings must be combined with single-note lines in a four-stage progressive sequence: \"learn the solo as written... replace the single notes with your own soloing lines... keep the single notes as written... replace both the chords and single notes\" (p. 23). The chord layer over Dm7 is never to be abandoned but progressively loosened from notation toward free improvisation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 7, p. 23 — study sequence for mixed solo"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-mixing-chords-and-single-notes",
+            "maj7/i-chord-mixing-chords-and-single-notes"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-anchor",
+          "narrative": "The G7 voicing is prescribed as the second chord in the foundational ii V I shape set: \"To begin, here are four chords that fit over the ii V I progression\" (p. 4). As the V chord, G7 is the harmonic pivot of the progression—the point of maximum tension before resolution—and must be memorized as a discrete shape before comping rhythms or approach chords are applied to it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 4 — ii V I chord shapes"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-anchor",
+            "maj7/i-chord-anchor"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-freddie-green-quarter-pulse",
+          "narrative": "Over the V chord, the Freddie Green rhythm requires an unbroken quarter-note pulse: \"The rhythm is all quarter notes, meaning you play one chord per beat\" (p. 5). Warnock prescribes that students accent beats 2 and 4 across all chord qualities including G7: \"accent the 2nd and 4th chords/beats in each bar. This imitates the hi-hat and helps you bring a higher level of swing to the rhythm\" (p. 5).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 5 — Freddie Green rhythm definition; Freddie Green accent rule"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-freddie-green-quarter-pulse",
+            "maj7/i-chord-freddie-green-quarter-pulse"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-charleston-placement",
+          "narrative": "The Charleston syncopation is prescribed for the G7 chord placement: beats 1 and the & of 2 are the required rhythmic positions. Warnock states this rhythm is \"based on the dance from the 1920s\" and gives the structural rule: \"places the first chord on beat 1 of each bar, then the second chord is on the & of 2\" (p. 6). This is the second required rhythm students learn before mixing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 6 — Charleston rhythm definition"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-charleston-placement",
+            "maj7/i-chord-charleston-placement"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-approach-from-above",
+          "narrative": "Above-approach is prescribed as the first approach-chord direction practiced over the G7 target shape: \"play the same shape one fret higher, then resolve into your target chord from there\" (p. 12). The entire G7 voicing must be transposed one fret up—not individual voices—reflecting the book's mechanical rule that the shape is preserved unchanged during displacement.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 12 — Approach from above mechanics"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-approach-from-below",
+            "min7/ii-chord-approach-from-above"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-approach-from-below",
+          "narrative": "Below-approach to G7 is the second direction in the prescribed sequence: \"You can also work approach chords from below and resolve into your target chord from there in your comping\" (p. 13). Warnock instructs students to complete above-approach first before proceeding, encoding below-approach as the necessary second stage in the three-phase practice arc (above → below → mixed).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 13 — Approach from below direction"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-approach-from-above",
+            "min7/ii-chord-approach-from-below"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-approach-mandatory-resolution",
+          "polarity": "proscriptive",
+          "narrative": "Approach chords applied to the G7 voicing must resolve without exception: \"Approach chords are where you play a chromatic chord one fret above or below the target chord you're aiming for\" (p. 11), and the approach is incomplete without resolution into the target. An unresolved approach chord at the V position is implicitly proscribed—the technique is defined by its resolution, not its displacement alone.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Approach chord definition"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-approach-mandatory-resolution",
+            "maj7/i-chord-approach-mandatory-resolution"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-approach-directions-mixed",
+          "narrative": "Once above and below approaches are separately practiced on G7, Warnock prescribes combining them: \"When ready, mix this pattern with the approach chords from above to double your fun with this workout\" (p. 13). The mixing step is the synthesis endpoint of the approach-chord system and is not to be attempted until both individual directions are secure.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 13 — Mixing approach directions"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-approach-directions-mixed",
+            "maj7/i-chord-approach-directions-mixed"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-bass-first-picking",
+          "narrative": "The bass-first picking pattern is prescribed for G7 as the first picking hand variation to internalize: \"Start by learning the bass first pattern, then melody first pattern, then blend them together to take things to the next level in your comping\" (p. 9). Warnock positions this technique as necessary for solo guitar and bassless settings, requiring students to learn it before the melody-first pattern.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 3, p. 9 — Learning order for patterns"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-melody-first-picking",
+            "min7/ii-chord-bass-first-picking"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-melody-first-picking",
+          "narrative": "The melody-first picking pattern is prescribed for G7 after the bass-first pattern is secure, with defined use cases: \"Bringing out the melody is useful for comping, chord soloing, and especially chord melody playing\" (p. 10). Warnock also prescribes a further step: \"Work this pattern as written, then play with the rhythms and take it to other keys if you're ready\" (p. 9), requiring transposition once internalized.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 3, p. 10 — Melody-first comping uses; p. 9 — Pattern variation and transposition"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-bass-first-picking",
+            "min7/ii-chord-melody-first-picking"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-scale-compatibility",
+          "narrative": "G7 is explicitly named as one of the three chords covered by the tonic major scale: \"Dm7-G7-Cmaj7 are all in C major, you can use the tonic major scale to solo over all of those chords\" (p. 14). Students are not instructed to switch to a Mixolydian or altered scale over G7; the single tonic major scale is the prescribed soloing choice across all three changes.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — ii V I scale compatibility"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-scale-compatibility",
+            "maj7/i-chord-scale-compatibility"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-tension-release-function",
+          "narrative": "Warnock prescribes approach chords over G7 specifically for their tension-and-release harmonic function: \"Approach chords bring a tension and release sound to your comping, jazzing up your chords along the way\" (p. 11). The V chord is the natural location where chromatic tension before resolution most strongly reinforces the progression's inherent harmonic motion toward the I chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Approach chord tension/release function"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-tension-release-function",
+            "maj7/i-chord-tension-release-function"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-rhythm-variation-after-internalization",
+          "narrative": "Once approach chords over G7 are mechanically secure, Warnock prescribes rhythmic and picking variation as a required self-extension step: \"feel free to change the rhythms and picking patterns when comfortable to expand this approach chord exercise even further\" (p. 13). This two-stage rule—first secure the shapes, then vary the execution—governs all comping exercises in the method.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 13 — Rhythm/pattern variation rule"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-rhythm-variation-after-internalization",
+            "maj7/i-chord-rhythm-variation-after-internalization"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-mixing-chords-and-single-notes",
+          "narrative": "In the mixed-solo texture system, G7 voicings are prescribed as part of the harmonic layer that must be combined with single-note lines: \"By learning how to mix chords and single notes in your solos, you're prepared to jam in a duo or pianoless trio down the road\" (p. 22). The four-stage sequence—imitate, substitute single notes, substitute chord rhythms, improvise both—applies to G7 as to all chords in the progression.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 7, p. 22 — mixing chords and single notes"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-mixing-chords-and-single-notes",
+            "maj7/i-chord-mixing-chords-and-single-notes"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-anchor",
+          "narrative": "Cmaj7 is prescribed as the resolution target of the ii V I—the I chord students must memorize from the first lesson: \"To begin, here are four chords that fit over the ii V I progression, with the Cmaj7 and Cmaj9 being two colors of the Cmaj7 sound\" (p. 4). It is the harmonic goal toward which all tension—comping rhythms, approach chords—ultimately resolves.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 4 — ii V I chord shapes"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-anchor",
+            "dom7/v-chord-anchor"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-color-expansion-to-maj9",
+          "narrative": "Warnock explicitly prescribes enriching the Cmaj7 lead-sheet symbol with the Cmaj9 voicing, citing real-world performance convention: \"In jazz, you normally see the simplest chord symbol written on a lead sheet, then you as the performer color that chord from there. So, it's good to get used to seeing Cmaj7 but playing the Cmaj9 color as it imitates a real-life musical situation\" (p. 11). Students must apply this coloring convention habitually.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Lead sheet chord simplification rule"
+            }
+          ],
+          "cross_ref": [
+            "maj9/i-chord-anchor",
+            "maj7/i-chord-anchor"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-freddie-green-quarter-pulse",
+          "narrative": "The Freddie Green rhythm is prescribed for Cmaj7 as for all chords: \"The rhythm is all quarter notes, meaning you play one chord per beat\" (p. 5), with the added rule to \"accent the 2nd and 4th chords/beats in each bar. This imitates the hi-hat\" (p. 5). The I chord receives the same unbroken quarter-note treatment, reinforcing metric regularity at the resolution point.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 5 — Freddie Green rhythm definition; Freddie Green accent rule"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-freddie-green-quarter-pulse",
+            "dom7/v-chord-freddie-green-quarter-pulse"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-charleston-placement",
+          "narrative": "Charleston rhythm placement applies to Cmaj7 at the resolution bar: beat 1 and the & of 2 are the prescribed positions. The structural rule—\"places the first chord on beat 1 of each bar, then the second chord is on the & of 2\" (p. 6)—applies uniformly across all three chords including the I chord, and must be mastered as a named technique before mixing with Freddie Green.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 6 — Charleston rhythm definition"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-charleston-placement",
+            "dom7/v-chord-charleston-placement"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-approach-from-above",
+          "narrative": "Approach chords from above are prescribed for the Cmaj7 target shape as the first direction to practice: \"play the same shape one fret higher, then resolve into your target chord from there\" (p. 12). The Cmaj7 (or Cmaj9) voicing is the destination of the approach—the mechanical rule that the shape is preserved while displaced one fret applies to the I chord as to all others.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 12 — Approach from above mechanics"
+            }
+          ],
+          "cross_ref": [
+            "maj7/i-chord-approach-from-below",
+            "dom7/v-chord-approach-from-above"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-approach-from-below",
+          "narrative": "Below-approach is the second prescribed direction for the Cmaj7 target: \"You can also work approach chords from below and resolve into your target chord from there in your comping\" (p. 13). Students may not combine approach directions until both above and below have been individually practiced—the three-stage sequence (above → below → mixed) governs the I chord as it does all targets in the progression.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 13 — Approach from below direction"
+            }
+          ],
+          "cross_ref": [
+            "maj7/i-chord-approach-from-above",
+            "min7/ii-chord-approach-from-below"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-scale-compatibility",
+          "narrative": "The tonic major scale is prescribed as the correct scale over Cmaj7 as part of the unified ii V I soloing approach: \"Dm7-G7-Cmaj7 are all in C major, you can use the tonic major scale to solo over all of those chords\" (p. 14). The I chord is the tonal center named in the rule, anchoring the scale choice for the entire progression.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — ii V I scale compatibility"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-scale-compatibility",
+            "dom7/v-chord-scale-compatibility"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-mixing-chords-and-single-notes",
+          "narrative": "Cmaj7 voicings participate in the mixed-solo texture as part of the chord layer that must be combined with single-note lines: \"By learning how to mix chords and single notes in your solos, you're prepared to jam in a duo or pianoless trio down the road\" (p. 22). The four-stage progressive study sequence culminates in freely improvising both chord rhythms and single notes over the changes, with Cmaj7 as the harmonic resolution point.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 7, p. 22 — mixing chords and single notes; p. 23 — study sequence for mixed solo"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-mixing-chords-and-single-notes",
+            "dom7/v-chord-mixing-chords-and-single-notes"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj9",
+          "function_role": "i-chord-color-substitution",
+          "narrative": "Cmaj9 is prescribed as the required color substitution for the written Cmaj7 symbol: \"it's good to get used to seeing Cmaj7 but playing the Cmaj9 color as it imitates a real-life musical situation\" (p. 11). This is not presented as optional ornamentation but as the standard jazz performance practice of extending minimal lead-sheet symbols, and students must habitually apply it.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Lead sheet chord simplification rule"
+            }
+          ],
+          "cross_ref": [
+            "maj7/i-chord-color-expansion-to-maj9",
+            "maj7/i-chord-anchor"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj9",
+          "function_role": "i-chord-lead-sheet-convention",
+          "narrative": "Warnock presents Cmaj9 as the concrete demonstration of a broader jazz convention: \"In jazz, you normally see the simplest chord symbol written on a lead sheet, then you as the performer color that chord from there\" (p. 11). Cmaj9 is the specific example cited, establishing the pattern that reading Cmaj7 but voicing Cmaj9 is not an error but a required performer competency in jazz.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Lead sheet chord simplification rule"
+            }
+          ],
+          "cross_ref": [
+            "maj7/i-chord-color-expansion-to-maj9",
+            "maj9/i-chord-color-substitution"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj9",
+          "function_role": "i-chord-approach-from-above",
+          "narrative": "Because Cmaj9 is the prescribed voicing color for the I chord, approach chords from above operate on the Cmaj9 shape when it substitutes for Cmaj7: the rule is that \"you play the same shape one fret higher, then resolve into your target chord from there\" (p. 12). The Cmaj9 voicing is thus the approach-chord target in real performance, not the notated Cmaj7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 12 — Approach from above mechanics; p. 11 — Lead sheet chord simplification rule"
+            }
+          ],
+          "cross_ref": [
+            "maj9/i-chord-approach-from-below",
+            "maj7/i-chord-approach-from-above"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj9",
+          "function_role": "i-chord-approach-from-below",
+          "narrative": "Below-approach applies equally to the Cmaj9 shape as the prescribed voicing color for the I chord. Since the approach-chord rule operates on \"the same shape\" (p. 12), and Cmaj9 is prescribed as the performer's I chord color, the below-approach technique targets the Cmaj9 voicing when the student applies the technique in a real performance context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 13 — Approach from below direction; p. 11 — Lead sheet chord simplification rule"
+            }
+          ],
+          "cross_ref": [
+            "maj9/i-chord-approach-from-above",
+            "maj7/i-chord-approach-from-below"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "approach-chord-one-fret-displacement",
+          "narrative": "All approach chords—regardless of the target quality—are executed via chromatic one-fret displacement of the entire voicing shape: \"Approach chords are where you play a chromatic chord one fret above or below the target chord you're aiming for\" (p. 11). The mechanical rule is precise: move the whole shape, not individual voices, by exactly one fret, preserving the voicing structure intact.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Approach chord definition; Approach chromatic displacement"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/approach-chord-resolution-mandatory",
+            "chromatic/approach-chord-shape-preserved"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "approach-chord-resolution-mandatory",
+          "polarity": "proscriptive",
+          "narrative": "Resolution of every approach chord is non-negotiable: an approach chord that does not resolve into the target chord is structurally incomplete. Warnock states this as a definitional rule—an approach chord is inherently a two-part move (displacement + resolution)—and the parallel proscription in the melodic domain reinforces the same principle: \"If you leave things hanging and don't resolve the pattern by playing all 4 notes, you sound like you made a mistake\" (p. 18).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Approach chord definition; Ch. 6, p. 18 — mandatory pattern resolution"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/approach-chord-one-fret-displacement",
+            "chromatic/134-pattern-resolution-mandatory"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "approach-chord-shape-preserved",
+          "narrative": "The approach chord technique requires preserving the target chord's voicing shape intact during displacement: \"you play the same shape one fret higher\" (p. 12). No re-voicing or fingering alteration of the chord occurs—only the fret position changes by one, making the technique purely positional and applicable to any chord quality without modification.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 12 — Approach from above mechanics"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/approach-chord-one-fret-displacement",
+            "chromatic/approach-chord-resolution-mandatory"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "approach-direction-sequence-prescribed",
+          "narrative": "The order in which approach directions are practiced is explicitly prescribed: above first, below second, combined third. Warnock states: \"Start with the approach chords from above, then from below, then mix both together to take your comping to the next level today\" (p. 11). This sequence is not a suggestion but a structural rule governing how the student moves through the approach-chord system.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 11 — Approach chord sequence order"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/approach-chord-one-fret-displacement",
+            "chromatic/approach-chord-resolution-mandatory"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "134-pattern-universal-trigger",
+          "narrative": "The 134 chromatic ornament is prescribed as universally applicable across all scale shapes, strings, and keys: \"This pattern is used whenever you have a 134 fingering on any string, any key, and in any scale\" (p. 17). The trigger condition is purely fingering-based, not key- or chord-quality-specific, making the rule a mechanical rather than harmonic prescription.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 6, p. 17 — 134 pattern application rule"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/134-pattern-resolution-mandatory",
+            "chromatic/134-pattern-rhythm-free"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "134-pattern-resolution-mandatory",
+          "polarity": "proscriptive",
+          "narrative": "Warnock issues an unambiguous proscription against leaving the 134 ornament unresolved: \"The essential item is that you resolve the pattern to the 3rd finger. If you leave things hanging and don't resolve the pattern by playing all 4 notes, you sound like you made a mistake\" (p. 18). This is the only explicit proscription in the book formulated in terms of sounding wrong rather than merely being stylistically inadvisable.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 6, p. 18 — mandatory pattern resolution"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/134-pattern-universal-trigger",
+            "chromatic/approach-chord-resolution-mandatory"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "134-pattern-rhythm-free",
+          "narrative": "Rhythmic placement of the 134 ornament is explicitly released from constraint: \"The rhythms you use aren't that important, meaning you have a lot of freedom to experiment with rhythms when using the 134 pattern\" (p. 18). This prescribes rhythmic freedom as an active principle—students are instructed to explore rhythmic variations—subject only to the non-negotiable resolution rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 6, p. 18 — rhythm freedom in pattern"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/134-pattern-resolution-mandatory",
+            "chromatic/134-pattern-universal-trigger"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "134-pattern-overplay-before-restraint",
+          "narrative": "Warnock prescribes deliberate saturation of the 134 ornament as the first phase of its acquisition: \"It can take time to get this new chromatic ornament into your ears, so overplay it in the beginning. When your ears get used to this sound, you can pull back and add the 134 pattern here and there in a more musical way in your solos\" (p. 19). This earn-before-restraint rule is a positive prescription, not a warning—students must overplay before they may restrain.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 6, p. 19 — overplaying to internalize ornament"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/134-pattern-resolution-mandatory",
+            "chromatic/134-pattern-rhythm-free"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "134-pattern-position-insertion-6th-string-shape",
+          "narrative": "Warnock gives precise positional instruction for inserting the 134 ornament within the 6th-string major scale shape: \"you play up the 6th string shape as is, then you add in the 134 pattern on the way down on strings 3 and 4, where the 134 fingerings lie in this shape\" (p. 19). The direction of scale movement and the specific strings are both prescribed, not left to the student to discover.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 6, p. 19 — applying pattern to scale shapes"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/134-pattern-universal-trigger",
+            "chromatic/134-pattern-practice-sequence"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "134-pattern-practice-sequence",
+          "narrative": "The integration sequence for the 134 ornament follows a three-phase prescription: isolated position with metronome, then combined across both scale shapes technically, then free application over backing track. Warnock states: \"Work this position with a metronome, then combine it in your technical studies with the 6th-string shape. When ready, solo over the backing track\" (p. 20). No phase may be skipped.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 6, p. 20 — practice sequence for positions"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/134-pattern-universal-trigger",
+            "chromatic/134-pattern-position-insertion-6th-string-shape"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "scales-insufficient-without-ornaments",
+          "narrative": "Warnock prescribes chromatic ornamentation as the required next step beyond scale knowledge, not an optional add-on: \"The next step beyond playing scales is the most essential to bring a jazz sound to your solos, and that's adding chromatic ornaments\" (p. 17). Scale competency alone is explicitly declared insufficient for authentic jazz phrasing—ornaments are mandatory for stylistic authenticity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 6, p. 17 — scales vs. chromatic ornaments"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/134-pattern-universal-trigger",
+            "chromatic/chromatic-ornaments-as-tension-release"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "chromatic",
+          "function_role": "chromatic-ornaments-as-tension-release",
+          "narrative": "The book defines chromatic ornaments by their structural harmonic function: \"Chromatic ornaments bring a tension and release sound to your playing by introducing organized chromaticism and resolution in the shape of patterns\" (p. 17). The word \"organized\" is load-bearing—chromatic notes are not random passing tones but structured pattern-units with predictable resolution behavior, and students must understand this framing before applying them.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 6, p. 17 — chromatic ornaments defined"
+            }
+          ],
+          "cross_ref": [
+            "chromatic/scales-insufficient-without-ornaments",
+            "chromatic/134-pattern-resolution-mandatory"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-solo-practice-before-metronome",
+          "narrative": "For initial chord acquisition, Warnock prescribes solo practice before any external timing device: \"Start by playing these chords on your own, memorize them, and then add in a metronome when ready\" (p. 4). This sequencing—unaccompanied familiarization before metronomic constraint—is the first stage of the method's universal practice protocol and applies to the Dm7 voicing as the first chord students encounter.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 4 — ii V I chord shapes"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-solo-practice-before-metronome",
+            "maj7/i-chord-solo-practice-before-metronome"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-solo-practice-before-metronome",
+          "narrative": "The universal practice protocol prescribes solo practice before metronome for G7 alongside all other ii V I shapes: \"Start by playing these chords on your own, memorize them, and then add in a metronome when ready\" (p. 4). The memorization step is required before external timing is introduced, ensuring students do not rely on the metronome as a crutch during initial shape acquisition.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 4 — ii V I chord shapes"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-solo-practice-before-metronome",
+            "maj7/i-chord-solo-practice-before-metronome"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-solo-practice-before-metronome",
+          "narrative": "Cmaj7 follows the same acquisition protocol as the other ii V I chords: memorize solo before adding metronome before adding backing track. Warnock prescribes this sequence universally: \"Start by playing these chords on your own, memorize them, and then add in a metronome when ready. From there, get these chords onto the backing track\" (p. 4). No stage may be skipped or reordered.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 2, p. 4 — ii V I chord shapes"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-solo-practice-before-metronome",
+            "dom7/v-chord-solo-practice-before-metronome"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-rhythm-variation-after-internalization",
+          "narrative": "Warnock prescribes rhythmic variation on Cmaj7 as a required self-extension step once shapes are secure: \"feel free to change the rhythms and picking patterns when comfortable to expand this approach chord exercise even further\" (p. 13). Additionally, the pattern variation rule extends to transposition: \"Work this pattern as written, then play with the rhythms and take it to other keys if you're ready\" (p. 9).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 4, p. 13 — Rhythm/pattern variation rule; Ch. 3, p. 9 — Pattern variation and transposition"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-rhythm-variation-after-internalization",
+            "dom7/v-chord-rhythm-variation-after-internalization"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-scale-shape-1-sixth-string",
+          "narrative": "Shape 1 of the major scale—rooted on the 6th string—is prescribed as the first scale position to memorize and apply over the ii V I including Dm7: \"here's the 6th-string C major scale to memorize and add to your solos over the backing track\" (p. 14). Students must not proceed to Shape 2 until Shape 1 is memorized and applied over the backing track as a solo tool.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — Major Scale Shape 1 root; Shape 1 practice method"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-scale-shape-2-fifth-string",
+            "dom7/v-chord-scale-shape-1-sixth-string"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-scale-shape-2-fifth-string",
+          "narrative": "Shape 2—rooted on the 5th string—is prescribed as the second positional shape to add to soloing over the ii chord: \"Here's the second major scale shape from the 5th string to learn, memorize, work with a metronome and solo with over the backing tracks when ready\" (p. 15). The same two-phase protocol (memorize then apply) is repeated for this shape, and combination with Shape 1 follows only afterward.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 15 — Major Scale Shape 2 root"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-scale-shape-1-sixth-string",
+            "dom7/v-chord-scale-shape-2-fifth-string"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-scale-shape-1-sixth-string",
+          "narrative": "Shape 1 (6th-string root) covers G7 as part of the single-scale ii V I soloing principle: \"Because all 3 chords in a ii V I are in the parent key... you can use the tonic major scale to solo over all of those chords\" (p. 14). Students memorize and apply the shape over the whole progression—including G7—before learning Shape 2, following the prescribed one-at-a-time acquisition order.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — Major Scale Shape 1 root; ii V I scale compatibility"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-scale-shape-2-fifth-string",
+            "min7/ii-chord-scale-shape-1-sixth-string"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-scale-shape-2-fifth-string",
+          "narrative": "Shape 2 (5th-string root) is the second positional shape prescribed for soloing over G7: \"Here's the second major scale shape from the 5th string to learn, memorize, work with a metronome and solo with over the backing tracks when ready\" (p. 15). After both shapes are individually mastered, Warnock prescribes combining them: \"From there, solo over the backing track with this scale shape, then with the 6-string shape only, then mix both together\" (p. 15).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 15 — Major Scale Shape 2 root; combining both shapes"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-scale-shape-1-sixth-string",
+            "min7/ii-chord-scale-shape-2-fifth-string"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-scale-shape-1-sixth-string",
+          "narrative": "Shape 1 (6th-string C major) is the first positional scale fingering prescribed for soloing over Cmaj7—the tonic chord: \"here's the 6th-string C major scale to memorize and add to your solos over the backing track\" (p. 14). The choice of C major as the named scale anchors Shape 1 to the I chord's tonic, making the I chord the harmonic reference point for the entire scale system.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — Major Scale Shape 1 root"
+            }
+          ],
+          "cross_ref": [
+            "maj7/i-chord-scale-shape-2-fifth-string",
+            "min7/ii-chord-scale-shape-1-sixth-string"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-scale-shape-2-fifth-string",
+          "narrative": "Shape 2 (5th-string root) extends coverage of the Cmaj7 soloing context to a second position: \"Here's the second major scale shape from the 5th string to learn, memorize, work with a metronome and solo with over the backing tracks when ready\" (p. 15). Both shapes ultimately cover the same tonic major scale and the same three chords; their combination is prescribed to achieve full-neck soloing fluency over the I chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 15 — Major Scale Shape 2 root"
+            }
+          ],
+          "cross_ref": [
+            "maj7/i-chord-scale-shape-1-sixth-string",
+            "dom7/v-chord-scale-shape-2-fifth-string"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-scale-metronome-before-backing-track",
+          "narrative": "The two-phase practice protocol for scale shapes over Cmaj7 requires metronome work before backing track application: \"Start by memorizing the scale shape, then working it with a metronome. As soon as you're ready, you know the scale but it's not perfect, throw on the backing track and solo with this scale over the C major ii V I\" (p. 14). Applied improvisation is prescribed before technical perfection is achieved—a deliberate anti-perfectionist stance.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — Shape 1 practice method"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-scale-metronome-before-backing-track",
+            "dom7/v-chord-scale-metronome-before-backing-track"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-scale-metronome-before-backing-track",
+          "narrative": "The same anti-perfectionist two-phase protocol applies to soloing over Dm7: memorize and drill with metronome, then apply over backing track before the shape is perfect. Warnock's precise instruction—\"As soon as you're ready, you know the scale but it's not perfect, throw on the backing track\" (p. 14)—prescribes early imperfect application as the pedagogically correct approach for the ii chord as for all others.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — Shape 1 practice method"
+            }
+          ],
+          "cross_ref": [
+            "maj7/i-chord-scale-metronome-before-backing-track",
+            "dom7/v-chord-scale-metronome-before-backing-track"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-scale-metronome-before-backing-track",
+          "narrative": "G7 is covered by the same positional scale shapes and the same two-phase practice protocol: metronome first, then backing track application before perfection is achieved. The instruction to \"throw on the backing track\" before the scale is perfect (p. 14) applies to soloing over the entire ii V I including G7, embedding the principle that applied playing precedes technical mastery in the method's core prescription.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 5, p. 14 — Shape 1 practice method"
+            }
+          ],
+          "cross_ref": [
+            "maj7/i-chord-scale-metronome-before-backing-track",
+            "min7/ii-chord-scale-metronome-before-backing-track"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-mixed-solo-imitation-first",
+          "narrative": "In the mixed-solo chapter, the Dm7 chord layer must first be learned as written before any substitution: \"Start by learning the solo as written with a metronome and then work it over the backing track\" (p. 23). This imitation-first rule applies to both the chord and single-note layers over Dm7, establishing the notated solo as the required reference model before improvised substitution is permitted.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 7, p. 23 — study sequence for mixed solo"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-mixed-solo-imitation-first",
+            "maj7/i-chord-mixed-solo-imitation-first"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-mixed-solo-imitation-first",
+          "narrative": "The four-stage progressive study sequence prescribes imitation before improvisation for all chord qualities including G7: \"learn the solo as written... replace the single notes with your own soloing lines... keep the single notes as written and you make up the chords and chord rhythms... replace both the chords and single notes\" (p. 23). The G7 chord hit is part of the notated model that must be reproduced accurately at Stage 1.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 7, p. 23 — study sequence for mixed solo"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-mixed-solo-imitation-first",
+            "maj7/i-chord-mixed-solo-imitation-first"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-mixed-solo-imitation-first",
+          "narrative": "The Cmaj7 chord at the resolution point of the mixed solo must be learned as written in Stage 1 of the four-stage sequence: \"Start by learning the solo as written with a metronome and then work it over the backing track\" (p. 23). The written chord voicing at the I chord position is the model that anchors the student's harmonic understanding before the chord rhythm layer is freely improvised in Stage 3.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 7, p. 23 — study sequence for mixed solo"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-mixed-solo-imitation-first",
+            "dom7/v-chord-mixed-solo-imitation-first"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-picking-hand-as-primary-variable",
+          "narrative": "Warnock prescribes the picking hand—not chord shape changes—as the primary variable for advancing comping technique over Dm7: \"Often times you learn chords and then strum and pluck them without altering the picking. This is leaving a lot of room to explore in your comping by expanding on your picking hand approach to these chords\" (p. 9). Students are instructed to treat the picking approach as the uncharted territory in their development.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 3, p. 9 — Expanding picking hand approach"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v-chord-picking-hand-as-primary-variable",
+            "maj7/i-chord-picking-hand-as-primary-variable"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-picking-hand-as-primary-variable",
+          "narrative": "The prescription to treat the picking hand as the primary variable in comping development applies to G7 as to all ii V I voicings: \"This is leaving a lot of room to explore in your comping by expanding on your picking hand approach to these chords\" (p. 9). The G7 shape is held constant while the picking pattern (bass-first, melody-first, or blended) becomes the dimension of variation and growth.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 3, p. 9 — Expanding picking hand approach"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-picking-hand-as-primary-variable",
+            "maj7/i-chord-picking-hand-as-primary-variable"
+          ]
+        },
+        {
+          "source_work_id": "beginners-guide-to-jazz-guitar",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-picking-hand-as-primary-variable",
+          "narrative": "Cmaj7 is the target chord at which the bass-first and melody-first patterns converge in the picking hand development system: \"Start by learning the bass first pattern, then melody first pattern, then blend them together to take things to the next level in your comping\" (p. 9). The blending step—where both patterns are used over the same Cmaj7 shape—represents the synthesis point of the picking hand curriculum.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Warnock, Matt - Beginner's Guide to Jazz Guitar",
+              "citation": "Ch. 3, p. 9 — Learning order for patterns; Expanding picking hand approach"
+            }
+          ],
+          "cross_ref": [
+            "min7/ii-chord-picking-hand-as-primary-variable",
+            "dom7/v-chord-picking-hand-as-primary-variable"
+          ]
+        }
+      ]
     },
     {
       "id": "jerry-coker",
@@ -36571,7 +42743,1627 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-dorian-scale-source",
+          "narrative": "The ii chord in a major-key ii-V-I is unambiguously a minor seventh: \"The naturally occurring ii-V-I in a major key, using seventh chords, involves a minor seven for ii\" (Ch. 2, p. 9). Dorian is the prescribed scale: \"we might choose D Dorian for Dm7\" (Ch. 2, p. 9). The author notes these modal choices are \"really all the same set of tones (modally related to each other),\" motivating the chord-tone-first teaching sequence before scale work.",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "major-seventh/i-chord-tonic-resolution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 9 — ii-V-I chord quality definition"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-arpeggio-through-ninth",
+          "narrative": "The foundational ear-training exercise for the ii chord is arpeggio construction through the ninth: \"we really just use the first, third, fifth, and seventh tones of a scale—Dorian for the minor seventh—which become the root, 3rd, 5th, and 7th of the chord\" (Ch. 2, p. 14). Extended to Cm9 for the chord-tone-only exercise, the player maps \"these chordal members on the fretboard\" to \"start to hear the chord changes in our single-note lines\" (Ch. 2, p. 14). This is framed as a stepping stone: \"It is not an improvisational end-goal in itself\" (Ch. 2, p. 15).",
+          "cross_ref": [
+            "dominant-seventh/v-chord-arpeggio-through-ninth",
+            "major-seventh/i-chord-arpeggio-through-ninth"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 14-15 — Arpeggio construction rule and chord-tone exercise"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "chord-within-chord-am9-over-dm7",
+          "narrative": "A signature improvisational move is to solo over Dm7 using Am9 arpeggio tones: \"from the 5th on up in this Dm13 arpeggio, we have exactly the tones of Am9—A, C, E, G, and B\" (Ch. 6, p. 55). The prescription is to \"try something purely within Am9 chord tones, basically in their own arpeggio form\" (Ch. 6, p. 55). This chord-within-chord strategy places the improviser in the extensions of the original chord by beginning on its 5th and ascending.",
+          "cross_ref": [
+            "minor-seventh/ii-chord-dorian-scale-source",
+            "dominant-seventh/dm7-substitution-over-g7sus4"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 55 — Chord-within-chord improv strategy"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "dorian-scale-extension-through-thirteenth",
+          "narrative": "Extensions on the minor seventh chord are derived from the Dorian scale: \"Let's start with the minor seven chord, using the Dorian scale to derive the full gamut of its tones (this works better than the natural minor scale by the time we get to the chordal 13th, which will be determined by the scalar 6th)\" (Ch. 6, p. 55). The author maps how \"the scale's 6th becomes the chord's 13th\" and how \"Dm7, extended, becomes Dm13\" (Ch. 6, p. 55), making Dorian the definitive source for all minor seventh extensions.",
+          "cross_ref": [
+            "minor-seventh/ii-chord-dorian-scale-source",
+            "minor-seventh/chord-within-chord-am9-over-dm7"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 55 — Chord extensions via Dorian scale"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "minor-tonic-dorian-minor-ii-v-i",
+          "narrative": "In the minor ii-V-i context the minor seventh serves as tonic chord (i chord), with Dorian prescribed as the associated scale: \"the Dorian for the im7\" (Ch. 2, p. 10). The minor seventh's chord tones in this context are 1, b3, 5, b7, and the improviser's expectation is resolution from the altered dominant V chord into this minor tonic color.",
+          "cross_ref": [
+            "half-diminished/iim7b5-minor-ii-locrian-scale",
+            "dominant-seventh-altered/v-chord-minor-ii-v-strong-preference"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 10 — Minor scale options for ii-V-i"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "sus4-equivalent-substitute-for-dominant",
+          "narrative": "The 7sus4 chord is defined as equivalent to a minor seventh built on its 5th: \"The 7sus4 chord is very much like a minor seven chord built on its 5th\" (Ch. 6, p. 66). This means \"D minor seven ideas can typically fit hand-in-glove with G7sus4, and that gives us a different angle for our improvisation\" (Ch. 6, p. 69). Playing Dm7 ideas over G7sus4 \"tends to lead us to those higher-numbered tones\" — the 9th, 11th, and 13th of the suspended chord.",
+          "cross_ref": [
+            "dominant-seventh-sus4/unresolved-jazz-usage",
+            "dominant-seventh-sus4/mixolydian-with-4th-caution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 66-69 — Minor 7th on 5th equals 7sus4; Dm7 arpeggio substitution on G7sus4"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "rootless-shell-for-walking-bass-context",
+          "narrative": "The shell voicing for the minor seventh chord strips the chord to 3rd and 7th only: \"it's the root, 3rd, and 7th of a chord that really define its main type, and we're talking about breaking various kinds of chords down to these essential tones (and then leaving off the root, to boot)\" (Ch. 5, p. 48). The result is \"very compact, easy-to-play, and flexible little two-string voicings that can still serve to outline a chord progression, especially when put together with the walking line of a bassist\" (Ch. 5, p. 48). Middle strings are specified for optimal blend.",
+          "cross_ref": [
+            "dominant-seventh/shell-voicing-tritone-sub-inversion",
+            "major-seventh/shell-voicing-rootless"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 5, p. 48 — Two-note shell definition"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-natural-mixolydian",
+          "narrative": "The natural dominant seventh is the V chord in major-key ii-V-I, and Mixolydian is its default scale: \"we might choose... G Mixolydian for G7\" (Ch. 2, p. 9). Mixolydian is defined as \"the Bb major scale with a b7th instead of a natural major 7th\" (Ch. 11, p. 145). The arpeggio rule follows: \"we really just use the first, third, fifth, and seventh tones of a scale—Mixolydian for the dominant seventh chords\" (Ch. 2, p. 14), giving the improviser root, 3rd, 5th, and b7.",
+          "cross_ref": [
+            "dominant-seventh/lydian-dominant-raised-fourth-avoidance",
+            "dominant-seventh-altered/natural-to-altered-shift-device"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 9; Ch. 11, p. 145 — Modal unity of ii-V-I; Bb Mixolydian defined"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "lydian-dominant-raised-fourth-avoidance",
+          "narrative": "When the natural 4th of Mixolydian risks clashing with the chordal 3rd, Lydian dominant is the remedy: \"avoiding the natural 4th or chordal 11th, which could clash with the 3rd\" (Ch. 6, p. 55). The chapter reinforces this as \"the Mixolydian with a raised 4th degree, which avoids the potential clash of the natural 4th sustained against the chord (and also accommodates a #11th, the lone alteration that'll fit in with this type of dominant seven)\" (Ch. 8, p. 93). Lydian dominant is thus the preferred upgrade over plain Mixolydian whenever 4th-degree tension arises.",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "dominant-seventh-sus4/mixolydian-with-4th-caution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 55; Ch. 8, p. 93 — Lydian dominant for dominant extensions; Lydian dominant vs. Mixolydian"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "central-scale-choice-battleground",
+          "narrative": "The dominant seventh is identified as \"the most significant musical application in jazz\" for scale deployment: \"Without a doubt, the most significant musical application in jazz is the use of scales and modes over dominant seven type chords. The flexibility you have seems limitless. Once that b7th note is introduced in a chord, we have all kinds of options as to which type of scale or sound we wish to use. A lot of a person's style and identification will be based on this fact\" (Ch. 10, p. 142). This positions the dominant seventh as the defining chord type for a player's improvisational identity.",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "dominant-seventh-altered/super-locrian-all-tension-tones"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 10, p. 142 — Many scales over G7 dominant"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "bebop-dominant-scale-charlie-parker",
+          "narrative": "The bebop dominant scale adds a natural major 7th passing tone to Mixolydian, creating an eight-note scale: \"This has the natural or major 7th as well as the b7th and was a favorite of Charlie Parker\" (Ch. 10, p. 142). It is classified as a specialty tool requiring mastery but resisting overuse—paired with the diminished scale under the same restraint caveat. The attribution to Parker signals this as an historically sanctioned bebop vocabulary choice.",
+          "cross_ref": [
+            "dominant-seventh/diminished-scale-mastery-restraint",
+            "dominant-seventh/v-chord-natural-mixolydian"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 10, p. 142 — Bebop dominant scale"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "diminished-scale-mastery-restraint",
+          "narrative": "The diminished (half-step/whole-step) scale over the dominant seventh is presented with a mastery imperative paired with a restraint caveat: \"All jazz musicians need to get command of this sound. There could be a place for this in practically every jazz tune. Don't overuse this scale, but you should definitely master it\" (Ch. 10, p. 143). The H-W formula—\"half step, whole step, half step, whole step, etc.\" (Ch. 11, p. 145)—produces an octatonic scale that covers the dominant seventh and its tension tones simultaneously.",
+          "cross_ref": [
+            "dominant-seventh/bebop-dominant-scale-charlie-parker",
+            "dominant-seventh/three-fret-equivalence-four-keys"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 10, p. 143; Ch. 11, p. 145 — Diminished scale mastery imperative; Bb diminished scale formula"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "three-fret-equivalence-four-keys",
+          "narrative": "One diminished scale fingering pattern covers four keys due to the scale's symmetrical structure: \"The same exact patterns and fingerings occur three frets above and below. So this scale will work for C, Db (or Eb), F# (or Gb), and A because these keys are three half steps apart\" (Ch. 11, p. 152). This three-fret equivalence rule drastically reduces the memorization burden and is a defining efficiency of diminished-scale technique on guitar.",
+          "cross_ref": [
+            "dominant-seventh/diminished-scale-mastery-restraint",
+            "diminished/harmonic-minor-over-diminished-chord"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 152 — Diminished scale three-fret equivalence"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "shell-voicing-tritone-sub-inversion",
+          "narrative": "Tritone-substitute dominant seventh chords share the same shell voicing as the original chord with 3rd and 7th swapped in register: \"we could also see that the Bb7 and E7 examples give us the exact same thing for their shells. They are tritone substitutes of one another, and this is one place where they 'meet.' Although for Bb7, the chordal 7th is on the bottom and the 3rd is on top, and vice versa for E7\" (Ch. 5, p. 49). This physical identity on the fretboard is a direct consequence of the shared tones at the b5 pivot.",
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-chromatic-bass",
+            "minor-seventh/rootless-shell-for-walking-bass-context"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 5, p. 49 — Tritone substitutes share shell shape"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "tritone-substitution-chromatic-bass",
+          "narrative": "Tritone substitution is defined as \"the replacement of a chord with another one of the same kind rooted a tritone away from the original (a distance of three whole steps)\" (Ch. 3, p. 17). The sonic result is chromatic bass motion instead of circle-of-fifths motion: \"we now have a chromatic root movement to get where we're going—actually a pretty common sound in many styles and tunes\" (Ch. 3, p. 17). The b5 chord is the pivot: \"a simple 7b5 chord is the place where a dominant chord and its tritone substitute meet—where they are note-for-note the same\" (Ch. 3, p. 17).",
+          "cross_ref": [
+            "dominant-seventh/shell-voicing-tritone-sub-inversion",
+            "dominant-seventh/whole-iiv-tritone-sub-bebop"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 3, p. 17 — Tritone Substitution Definition; Tritone Sub Chromatic Root Motion"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "whole-iiv-tritone-sub-bebop",
+          "narrative": "In bebop harmony the tritone substitution extends beyond a single chord to an entire ii-V pair: \"let's look at a device common in bebop harmony—the use of a whole ii-V unit as a tritone substitution for the first two chords in a ii-V-I, sometimes with the original pair played first, and the subs worked in before it resolves\" (Ch. 3, p. 18). The resulting Bm7 chord is noted for its maximum harmonic distance: it \"has an A natural as its 7th and gets us sonically further than we've been from any kind of Bb7 (which will always contain an Ab)\" (Ch. 3, p. 18).",
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-chromatic-bass",
+            "minor-seventh/ii-chord-dorian-scale-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 3, p. 18 — Whole ii-V as Tritone Sub (Bebop)"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "turnaround-parallel-chromatic-voicing",
+          "narrative": "In turnarounds, tritone substitution produces parallel chromatic motion while retaining harmonic function: \"The Db13 used in place of a G7#9 results in virtually the same chord (with a different bass note, perhaps), but still the overall concept leads to a new sound for our turnaround, with chromatic, parallel movement of this dominant thirteen voicing. It may seem like random fret-by-fret sliding around with one chord shape, but it is not—it is logically linked to the more circle-of-fifths-based motion that was there in the first place, and it functions similarly in terms of harmonic direction\" (Ch. 3, p. 18).",
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-chromatic-bass",
+            "dominant-seventh/bvi-natural-v-altered-minor-blues"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 3, p. 18 — Tritone Turnarounds — Parallel Chromatic Motion"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "bvi-natural-v-altered-minor-blues",
+          "narrative": "In minor blues the bVI chord is a natural dominant and the V chord that follows is altered: \"Where we see B9 to D7#9, this reflects the normal pattern of a natural dominant for the bVI chord leading to an altered dominant for the V\" (Ch. 3, p. 21). The pair creates directed tension toward the minor tonic, and the author gives an example alternative: \"Another option here would be B13 leading to D7b5, for example\" (Ch. 3, p. 21). This bVI-natural → V-altered sequence is a stylistic rule particular to minor blues form.",
+          "cross_ref": [
+            "dominant-seventh-altered/v-chord-minor-ii-v-strong-preference",
+            "minor-blues/i-iv-minor-v-dominant-structure"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 3, p. 21 — Natural vs. Altered Dominant Rule"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "pentatonic-minor-bluesy-vs-mixolydian-jazzy",
+          "narrative": "Over a single dominant seventh chord the player may switch between minor pentatonic (bluesy) and Mixolydian (jazzy): \"You can use these two sounds over one dominant chord—in this case, we'll use A7. I call the effect of the minor pentatonic bluesy and the Mixolydian jazzy. It's good to have options, and the goal is to be able to switch scales in the middle of a passage without a chord change\" (Ch. 10, p. 134). This mid-passage switching capability is the practical skill objective, not merely knowing both scales.",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "dominant-seventh/central-scale-choice-battleground"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 10, p. 134 — Pentatonic vs. Mixolydian over dominant"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "four-tension-tones-boundary-rule",
+          "narrative": "The exact inventory of altered dominant tones is fixed at four: \"Bob Conti used to tell me there were four tension tones—b5, #5, b9, #9—and that's it. The rest of the tones are already in the dominant key that you're in. Learning to work those tension tones is what it's all about\" (Ch. 11, p. 145). Any combination of these four marks the boundary between a natural and an altered dominant; no other tones qualify as tension tones under this taxonomy.",
+          "cross_ref": [
+            "dominant-seventh-altered/super-locrian-all-tension-tones",
+            "dominant-seventh-altered/natural-to-altered-shift-device"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 145 — Four tension tones rule"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "half-step-outside-tritone-sub-logic",
+          "narrative": "Moving a half step above the target chord before resolving into it borrows from tritone-substitution logic: \"leading back into the chord from a half step above it can have some of the same mojo as V-I resolution—i.e., like a G7 heading home to Cmaj7. G7 could pretty naturally be replaced by a Db dominant seven chord, its tritone substitute, and having Db major seven there instead gives the whole thing a new flavor\" (Ch. 7, p. 86). The prescription is to use this outside device briefly and quickly return to the chord zone.",
+          "cross_ref": [
+            "major-seventh/half-step-outside-excursion",
+            "dominant-seventh/tritone-substitution-chromatic-bass"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 7, p. 86 — Tritone sub / Dbmaj7 outside rationale"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "chromatic-enclosure-strong-beat-chord-tone",
+          "narrative": "Chromatic enclosure around dominant seventh chord tones requires that strong beats always land on basic chord tones: \"any note placed on beats 1 or 3 here is a basic chord tone (the root, 5th, and 3rd respectively)\" (Ch. 6, p. 64). The technique uses all twelve chromatic pitches to circle target tones: \"It starts off on D, the natural 9th for C7, connecting it by half step to the root, then moving similarly down from the 7th to the 5th (Bb to G) and further downwards to create a chromatic enclosure of the 3rd (circling around E before landing on it)\" (Ch. 6, p. 64).",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "dominant-seventh/bebop-enclosure-targeting"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 64 — Chromatic enclosure technique"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "b5-polyphonic-shared-tones-pivot",
+          "narrative": "The dominant seventh b5 chord is the theoretical cornerstone of tritone substitution: \"If we analyze the E7#9 chord... and the Bb13b5 chord... What's the only difference between these two chords? The Bb root note of the second chord! Bb happens to be the b5 of the key of E, which is the cornerstone and principle of this lesson\" (Ch. 11, p. 145). The near-identical tone content between a dominant chord and its tritone substitute is grounded in this b5 identity, which justifies the entire substitution system.",
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-chromatic-bass",
+            "dominant-seventh/shell-voicing-tritone-sub-inversion"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 145 — Dominant b5 polyphonic principle"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "straight-four-comping-felt-more-than-heard",
+          "narrative": "The Freddie Green straight-4 style constrains the dominant seventh to small voicings at low volume: \"As for chord voicings, this is usually a good place to be moderate or minimal in size, and some small root-3rd-and-7th kind of chord shapes can work very nicely for the texture\" (Ch. 5, p. 46). Volume is explicit: \"'Felt more than heard' is the classic description of its role in the swing-era big band, and in other scenarios it could be more obnoxious than tasty if we play it on top of our bandmates\" (Ch. 5, p. 47). Release timing must approximate the swing feel of the quarter note—not sustained, not chopped.",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "minor-seventh/rootless-shell-for-walking-bass-context"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 5, p. 46-47 — Straight-4 voicing size; Straight-4 volume and context"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "jazz-blues-ii-v-substitution",
+          "narrative": "Jazz blues substitutes ii-V motion for the expected V-IV: \"Example 1 outlines the changes as they are typically thought of in jazz, with ii-V chord motion (Cm7 to F7) where we might have expected V-IV (F7 to Bb7), and a VI chord thrown in to boot (G7)\" (Ch. 2, p. 13). This recontextualization of dominant seventh chords within ii-V cells is the defining difference between jazz and rock/blues forms, and \"the official chord progression may be just a framework—a harmonic direction or set of possibilities\" (Ch. 2, p. 13).",
+          "cross_ref": [
+            "minor-seventh/ii-chord-dorian-scale-source",
+            "dominant-seventh/v-chord-natural-mixolydian"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 13 — Jazz blues ii-V substitution; Chord progression as framework"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "v-chord-minor-ii-v-strong-preference",
+          "narrative": "In a minor ii-V-i context the dominant V chord strongly prefers altered status: \"for a minor ii-V-i, the tendency is strong for that V chord to be an altered dominant (this is the case generally for V-i motion from a dominant seven to a minor chord, although there are exceptions)\" (Ch. 4, p. 31). This is the book's single strongest prescriptive rule for scale selection, linking minor harmonic context directly to the altered (super Locrian) sound as the expected default.",
+          "cross_ref": [
+            "dominant-seventh-altered/super-locrian-all-tension-tones",
+            "half-diminished/iim7b5-minor-ii-locrian-scale"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 31 — Minor ii-V altered dominant rule"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "natural-to-altered-shift-device",
+          "narrative": "A common jazz device shifts a dominant seventh from natural (Mixolydian) to altered (super Locrian) immediately before V-I resolution: \"A common harmonic move in jazz progressions is for a dominant seven chord to change from natural to altered before it resolves in a V-I direction... This gives it a sense of extra angle, urgency, or momentum to get to the next chord\" (Ch. 4, p. 32). The scalar mechanism is explicit: \"for both D7 and G7, we first played from a corresponding Mixolydian scale and then switched to the super Locrian (or 'altered') scale\" (Ch. 4, p. 33).",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "dominant-seventh-altered/super-locrian-all-tension-tones"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 32-33 — Natural-to-altered dominant shift device; Mixolydian to super Locrian scale switch"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "super-locrian-all-tension-tones",
+          "narrative": "Super Locrian is the master tool capturing all four tension tones: \"The super Locrian mode for G is G-Ab-Bb-Cb-Db-Eb-F. Numerically, that looks like 1-b2-b3-b3-b5-b6-b7. It basically has all the altered notes: b5, #5, b9, and #9\" (Ch. 11, p. 160). Critically, \"it's also important to note the 1, 3, and b7, which create a dominant seven chord without the perfect 5th tone of the scale\" (Ch. 11, p. 160). The practical mnemonic: super Locrian is \"a melodic minor scale that's built a half step higher than the root of the altered dominant chord over which you're playing\" (Ch. 11, p. 160).",
+          "cross_ref": [
+            "dominant-seventh-altered/natural-to-altered-shift-device",
+            "dominant-seventh/four-tension-tones-boundary-rule"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 160 — Super Locrian formula and Ab melodic minor identity"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "altered-scale-applied-in-turnaround",
+          "narrative": "The altered (super Locrian) scale is prescribed for altered dominant chords within turnarounds: \"we'll now try playing through this progression with changing scales to reflect each new chord. Let's say for now that we'll keep the Bb major scale for both our Bbmaj7 and Cm7, and we'll use an altered (or super Locrian) scale for our altered F7 and G7 chords\" (Ch. 1, p. 6). This establishes the turnaround as the first practical context for altered-scale deployment, confirming the altered dominant as the default expectation for any chord symbol lacking further qualification in that harmonic position.",
+          "cross_ref": [
+            "dominant-seventh-altered/natural-to-altered-shift-device",
+            "major-seventh/i-chord-tonic-resolution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 1, p. 6 — Altered scale application"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "gap-in-standard-altered-scalar-theory",
+          "narrative": "The author identifies a real gap in standard scalar theory for certain altered dominant voicings: \"Thinking of F harmonic minor (or its fifth mode, from C) does not give us the possibility of Eb/D#, and thinking of C half-whole diminished imposes an A-natural where we're using Ab in these phrases. The C altered scale (mode of melodic minor) doesn't allow for our natural 5th, the G that is certainly involved here, and whole tone is surely not it (doesn't even give us a flatted or raised 9th)!\" (Ch. 4, p. 35). The prescription is to \"improvise\" the scalar information when no single scale supplies all required tones.",
+          "cross_ref": [
+            "dominant-seventh-altered/super-locrian-all-tension-tones",
+            "dominant-seventh/four-tension-tones-boundary-rule"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 35 — Gap in standard altered scalar info"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "minor-shape-multi-chord-degree-mapping",
+          "narrative": "A single melodic shape maps to multiple chord types across the altered-dominant spectrum: \"For use of this little phrase in multiple situations, it is handy to be aware of exactly how it relates to each chord. We could say, for example, that it starts on the 9th of a minor chord, the 13th of a natural dominant, the #9th of an altered dominant, or the 11th (seems like an added 4th) of a minor seven b5 chord (could be called half-diminished)\" (Ch. 6, p. 62). This multi-role awareness is presented as the practical tool for adapting a single melodic cell across related chord types.",
+          "cross_ref": [
+            "dominant-seventh-altered/super-locrian-all-tension-tones",
+            "half-diminished/iim7b5-minor-ii-locrian-scale"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 62 — Minor shape multi-chord versatility"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "bb-melodic-minor-unified-scalar-ground",
+          "narrative": "Multiple chord types—altered dominant, Lydian dominant, and others—share a common scalar parent: \"The scalar common ground between these chords, as they are, is basically the Bb melodic minor scale. If we start from the note A, this becomes the A altered (or super Locrian) scale, and starting from Bb produces the Eb Lydian dominant scale\" (Ch. 6, p. 62). This unification under one melodic-minor parent scale is a powerful reduction: mastering one parent scale unlocks multiple chord-type solutions simultaneously.",
+          "cross_ref": [
+            "dominant-seventh-altered/super-locrian-all-tension-tones",
+            "major-seventh-sharp-eleven/lydian-dominant-extension-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 62 — Bb melodic minor common scalar ground"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "i-chord-tonic-resolution",
+          "narrative": "The major seventh is the tonic resolution chord in major-key ii-V-I: \"a major seven for I\" (Ch. 2, p. 9). The 7th-to-3rd voice-leading rule culminates here—the b7 of the V chord resolves to the 3rd of the major seventh I chord. The book frames this resolution as the gravitational endpoint of the entire ii-V-I system, with guide-tone motion the most audible indicator: \"there's a tendency for the 7th of a chord to lead to the 3rd of the next one, whether directly, or bouncing off of another note in between\" (Ch. 2, p. 9).",
+          "cross_ref": [
+            "minor-seventh/ii-chord-dorian-scale-source",
+            "dominant-seventh/v-chord-natural-mixolydian"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 9 — ii-V-I chord quality definition; 7th-to-3rd voice leading rule"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "half-step-outside-excursion",
+          "narrative": "A major seventh chord a half step above the target can function as an outside excursion before resolving: \"leading back into the chord from a half step above it can have some of the same mojo as V-I resolution—i.e., like a G7 heading home to Cmaj7. G7 could pretty naturally be replaced by a Db dominant seven chord, its tritone substitute, and having Db major seven there instead gives the whole thing a new flavor\" (Ch. 7, p. 86). The rule is brevity: the outside excursion is \"momentarily escaping the zone of the chord\" and then quickly returning (Ch. 7, p. 86).",
+          "cross_ref": [
+            "dominant-seventh/half-step-outside-tritone-sub-logic",
+            "major-seventh/i-chord-tonic-resolution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 7, p. 86 — Half-step outside; Tritone sub / Dbmaj7 outside rationale"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "chord-melody-melody-on-top-rule",
+          "narrative": "In chord-melody playing the melody note must always be the highest voice: \"The main thing to remember in chord melody is to always have the melody of the tune or song on top of the chords as the highest sounding pitch. This is similar to a piano player playing the melody with the right hand and the chords with the left\" (Ch. 13, p. 196). This is named a \"cardinal\" technique and applies across all chord families, but is identified as a primary organizing rule for the major seventh tonic chord in standards interpretation.",
+          "cross_ref": [
+            "major-seventh/melody-within-chord-technique",
+            "major-seventh/jazz-101-family-substitution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 13, p. 196 — Chord melody rule: melody on top"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "melody-within-chord-technique",
+          "narrative": "A second chord-melody technique holds a chord shape and picks internal notes: \"I call this type of approach 'melody within the chord.' You hold the chord shape and pick notes in the middle of the chord without moving your left hand from the chord shape\" (Ch. 13, p. 195). This contrasts with the standard chord-melody rule (melody always on top) and offers a distinct textural option where inner-voice movement creates melodic interest within a sustained harmony.",
+          "cross_ref": [
+            "major-seventh/chord-melody-melody-on-top-rule",
+            "major-seventh/jazz-101-family-substitution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 13, p. 195 — Melody within the chord technique"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "jazz-101-family-substitution",
+          "narrative": "Any major seventh chord may be exchanged for another chord from the major family without changing harmonic function: \"instead of playing a C major chord, we've made it a C6. Instead of playing an E minor chord, we've played an Em7, etc. This type of thinking is what I call 'Jazz 101.' You can exchange, replace, or substitute any chord with another chord from the same family\" (Ch. 13, p. 201). The three families are major, minor, and dominant; same-family substitution is the foundational embellishment move in jazz standards interpretation.",
+          "cross_ref": [
+            "major-seventh/i-chord-tonic-resolution",
+            "minor-seventh/ii-chord-dorian-scale-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 13, p. 201 — Chord embellishment / Jazz 101"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7#11",
+          "function_role": "lydian-dominant-extension-source",
+          "narrative": "The maj7#11 chord is generated by stacking thirds up the Lydian scale: \"This chord is very related to the Lydian scale, equivalent to a major scale with a raised 4th degree, which could be used to generate the chord when played upwards in 3rd intervals\" (Ch. 6, p. 56). For improvisation, the B minor pentatonic scale is prescribed as a shortcut: \"If we remove the tonic and 5th from C Lydian (when sustained in a medium or high range, these two tones can actually be dissonant against parts of the chord), we're left with another familiar formation useful for the situation—the B minor pentatonic scale\" (Ch. 6, p. 57).",
+          "cross_ref": [
+            "dominant-seventh/lydian-dominant-raised-fourth-avoidance",
+            "dominant-seventh-altered/bb-melodic-minor-unified-scalar-ground"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 56-57 — maj7#11 and Lydian relationship; B minor pentatonic on Cmaj7#11"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "sus4",
+          "function_role": "unresolved-jazz-usage",
+          "narrative": "The 7sus4 chord in jazz typically does not resolve the suspended 4th back to the major 3rd: \"In jazz, we're pretty much talking about the 7sus4, and the chord is more likely than in other styles to stay as-is (not reverting to the use of the major 3rd)\" (Ch. 6, p. 66). This unresolved suspension is specifically a jazz-style convention, distinguishing the harmonic function from classical and popular usage where the 4th is \"hanging with a tendency to move back down to the 3rd\" (Ch. 6, p. 66).",
+          "cross_ref": [
+            "minor-seventh/sus4-equivalent-substitute-for-dominant",
+            "dominant-seventh-sus4/mixolydian-with-4th-caution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 66 — 7sus4 definition and jazz usage"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "sus4",
+          "function_role": "mixolydian-with-4th-caution",
+          "narrative": "Over 7sus4 the relationship to the 4th and 3rd is inverted from the standard dominant situation: \"When playing over the regular dominant seven, we need to be careful how we land on the scale's 4th degree because of its potential clash with the chordal 3rd... But that is no issue with the 7sus4! That 4th tone is right there in the chord, and now we may even have to be cautious in how we involve the scalar 3rd\" (Ch. 6, p. 68). Mixolydian is still applicable but the 3rd rather than the 4th now requires handling care.",
+          "cross_ref": [
+            "dominant-seventh-sus4/unresolved-jazz-usage",
+            "dominant-seventh/lydian-dominant-raised-fourth-avoidance"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 68 — Mixolydian on 7sus4, 4th vs. 3rd caution"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "sus4",
+          "function_role": "sus4-inner-voice-half-step-device",
+          "narrative": "A brief sus4 treatment creates inner-voice melodic motion within chord changes: \"In measures 2 and 3, F7 and Bb7 are both given a brief sus4 treatment, letting the chordal 3rd move up a half step to the 4th and back, for a momentary 7sus4 sound\" (Ch. 8, p. 90). This half-step 3rd-to-4th suspension is prescribed as an inner-voice device to add melodic interest without changing the underlying harmonic function, and pairs with the #9/b9 interchange for related inner-voice motion.",
+          "cross_ref": [
+            "dominant-seventh-sus4/unresolved-jazz-usage",
+            "dominant-seventh/#9-b9-inner-voice-interchange"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 90 — Sus4 inner-voice device"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "#9-b9-inner-voice-interchange",
+          "narrative": "The #9 and b9 alterations on a dominant seventh are interchangeable as inner-voice devices: \"7#9 and 7b9 chords are often interchangeable, and late in measure 4 we take advantage of that principle, using first a Bb7#9b5 voicing and right after it a Bb7b9#5. This creates some melodic motion from the b9th tone to the #9th on the high E string\" (Ch. 8, p. 90). The prescription is to use this exchange for micro-melodic voice leading within a sustained dominant color, not as a harmonic pivot.",
+          "cross_ref": [
+            "dominant-seventh-sus4/sus4-inner-voice-half-step-device",
+            "dominant-seventh/four-tension-tones-boundary-rule"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 90 — #9 / b9 interchangeability"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7b5",
+          "function_role": "iim7b5-minor-ii-locrian-scale",
+          "narrative": "The minor ii chord is a half-diminished (minor seventh flat-5): \"the ii chord is a minor seven with a b5th (sometimes referred to as 'half-diminished')\" (Ch. 2, p. 10). Locrian is the prescribed scale: \"the Locrian scale for the iim7b5 (amounts to the same notes as natural minor from the tonic)\" (Ch. 2, p. 10). This chord quality is distinguished from the minor seventh ii chord in major-key contexts by the presence of the flat-5, which signals the minor harmonic environment and expects an altered dominant to follow.",
+          "cross_ref": [
+            "dominant-seventh-altered/v-chord-minor-ii-v-strong-preference",
+            "minor-seventh/minor-tonic-dorian-minor-ii-v-i"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 10 — Minor ii-V-i chord qualities; Minor scale options for ii-V-i"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7b5",
+          "function_role": "multi-chord-degree-mapping-minor-shape",
+          "narrative": "A single melodic shape can be understood as starting on the 11th of a half-diminished chord: \"it starts on the 9th of a minor chord, the 13th of a natural dominant, the #9th of an altered dominant, or the 11th (seems like an added 4th) of a minor seven b5 chord (could be called half-diminished)\" (Ch. 6, p. 62). This mapping puts the improviser in command of a single cell usable across all four chord types, treating the half-diminished as one node in a larger cross-quality vocabulary network.",
+          "cross_ref": [
+            "half-diminished/iim7b5-minor-ii-locrian-scale",
+            "dominant-seventh-altered/minor-shape-multi-chord-degree-mapping"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 6, p. 62 — Minor shape multi-chord versatility"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dim7",
+          "function_role": "harmonic-minor-over-diminished-chord",
+          "narrative": "Because the diminished chord is found within the harmonic minor scale, that scale applies over it: \"Since a diminished chord can be found in the harmonic minor scale, we can also use the harmonic minor scale over the diminished chord\" (Ch. 11, p. 154). The author provides the A harmonic minor triad chart—Am, Bø, C+, Dm, E, F, G°—confirming the diminished seventh on the 7th degree as the source chord. The rule extends: any scale can be played over the chords it generates.",
+          "cross_ref": [
+            "diminished/three-fret-symmetry-three-shapes",
+            "dominant-seventh/diminished-scale-mastery-restraint"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 154 — Diminished chord = harmonic minor"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dim7",
+          "function_role": "three-fret-symmetry-three-shapes",
+          "narrative": "The diminished chord repeats every three half steps, yielding only three distinct shapes: \"If we analyze the diminished chord, we find that it repeats itself every three half steps. In other words, B, D, F, and G# are all three half steps (or frets) apart, and the chords are built from the same four notes. In these examples, both the B and G# diminished chords could be thought of as the same chord\" (Ch. 11, p. 154). This means only three unique diminished chord voicings exist on the guitar, covering all twelve roots through transposition.",
+          "cross_ref": [
+            "diminished/harmonic-minor-over-diminished-chord",
+            "dominant-seventh/three-fret-equivalence-four-keys"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 154 — Diminished chord three-fret symmetry"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "whole-tone-chord-generation",
+          "narrative": "The whole tone scale generates a family of augmented and altered dominant chord types, and only two mutually exclusive whole tone scales exist: \"The first thing to understand is that there are really only two whole tone scales, and with that, you have the entire system covered\" (Ch. 12, p. 176). From one scale: \"A7(no 5th), A9(no 5th), A7b5, A7#5, A9b5, A9#5, etc.\" (Ch. 12, p. 177). The prescription is to deploy this as a specialty color over dominant chords where augmented and flat/sharp-5 sounds are desired.",
+          "cross_ref": [
+            "dominant-seventh/central-scale-choice-battleground",
+            "dominant-seventh-altered/super-locrian-all-tension-tones"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 12, p. 176-177 — Whole tone scale: only two scales; Whole tone scale: chord harmony breakdown"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "guide-tone-7th-to-3rd-voice-leading",
+          "narrative": "The 7th-to-3rd guide-tone movement is the most important melodic voice-leading rule across the ii-V-I: \"there's a tendency for the 7th of a chord to lead to the 3rd of the next one, whether directly, or bouncing off of another note in between\" (Ch. 2, p. 9). This is demonstrated concretely as \"a fundamental move between Am7b5 and D7b9—the 7th of the first chord (G) leading to the 3rd of the next (F#)\" (Ch. 3, p. 22). The rule applies universally across all chord types in the progression and is the spine of bebop melodic construction.",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "major-seventh/i-chord-tonic-resolution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 9; Ch. 3, p. 22 — 7th-to-3rd voice leading rule; Guide Tone Voice Leading"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "guide-tone-aim-for-the-change",
+          "narrative": "The core targeting strategy is to identify tones that most clearly signal chord changes and aim for them at key moments: \"we can take this one notch further and seek to dig into the progression by emphasizing the notes that most bring out the change from chord to chord. With some awareness of which tones these are for a certain tune, we can aim for them at key places within our melodic lines\" (Ch. 3, p. 22). The half-step 3rd shift from Bb to B natural marking a Gm-to-G7 change is given as the most audible single-note change signal.",
+          "cross_ref": [
+            "minor-seventh/guide-tone-7th-to-3rd-voice-leading",
+            "dominant-seventh/chromatic-enclosure-strong-beat-chord-tone"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 3, p. 22 — Aim for the Change; Half-Step 3rd — Gm to G7 Signal"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "soloist-implies-substitute-changes",
+          "narrative": "A soloist may imply tritone-substitute harmony in their lines independently of what the rhythm section is playing: \"a soloist may at times imply such substitute chord changes in their line, whether or not that particular harmony has been laid out by their bandmates or in the song itself\" (Ch. 3, p. 18). This establishes improvisational autonomy as a sanctioned practice—the player is not obligated to match the stated changes and may superimpose substitute harmony as an expressive device.",
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-chromatic-bass",
+            "dominant-seventh/whole-iiv-tritone-sub-bebop"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 3, p. 18 — Soloing — Implying Substitute Harmony"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "tonicization-generates-local-cell",
+          "narrative": "Any chord in a progression can serve as a temporary tonic, generating a local ii-V-I cell: \"if we're playing a progression that is basically in the key of C, but at some point we find the chords Gm7-C7-Fmaj7, we have just come across a ii-V-I in F within the tune\" (Ch. 2, p. 9). The prescription is to recognize these transient cells and redirect scale and chord-tone choices to the tonicized key for those measures, then return to the home key.",
+          "cross_ref": [
+            "minor-seventh/ii-chord-dorian-scale-source",
+            "major-seventh/i-chord-tonic-resolution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 9 — Tonicization within progressions"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "natural-dominant-decision-skeletal-symbol",
+          "narrative": "When a chord symbol offers no alteration detail, the player must decide between natural and altered: \"Nowhere is this truer than with dominant seven chords—the kind that may be named simply as 'F7' or 'Bb7.' With these, where there is no further detail given, the biggest decision for each is whether it will be a natural or altered dominant\" (Ch. 4, p. 30). This interpretive decision is the central improviser's responsibility when reading lead sheets, and the minor-context rule and natural-to-altered device are the key guides.",
+          "cross_ref": [
+            "dominant-seventh-altered/v-chord-minor-ii-v-strong-preference",
+            "dominant-seventh-altered/natural-to-altered-shift-device"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 30 — Natural vs. altered dominant decision"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "rootless-extended-voicing-mobility",
+          "narrative": "Rootless voicings for the dominant seventh increase mobility without sacrificing harmonic clarity: \"Throughout, we're using mainly voicings that seem like familiar chord shapes with the usual root on the bottom omitted (from the A or low E strings), which can be helpful for mobility. A couple of them actually have the root included on top. In a band setting, the bass generally covers these chordal roots anyway, and leaving them off is often a good way to vary the texture\" (Ch. 8, p. 90). This ensemble-role logic underpins the rootless voicing practice throughout the book.",
+          "cross_ref": [
+            "dominant-seventh/straight-four-comping-felt-more-than-heard",
+            "minor-seventh/rootless-shell-for-walking-bass-context"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 90 — Inner-voice motion: rootless voicings"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "altered-chord-b7-enables-alteration",
+          "narrative": "The b7 in the dominant seventh formula opens the door to all subsequent alterations: \"C7 = 1-3-5-b7, or C-E-G-Bb, taken from the scale of C major. The Bb or b7th is characteristic of the foundation of this chord family. Its presence opens the door for the free use of these altered notes\" (Ch. 13, p. 188). The formula-modification system then prescribes raising or lowering the 5th or 9th to generate specific altered voicings—the b7 is the enabling ingredient that distinguishes the dominant family from major.",
+          "cross_ref": [
+            "dominant-seventh/four-tension-tones-boundary-rule",
+            "dominant-seventh/central-scale-choice-battleground"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 13, p. 188 — Altered chord construction"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "dual-root-string-organizing-rule",
+          "narrative": "Every chord type including the major seventh is systematized as two voicings differentiated by root-string location: \"there are two chord shapes, or voicings, for each chord. One chord has its root or bass note on the sixth string and the other on the fifth string. The reason for this is so that you can always have the next chord coming up in a progression close by. You don't want to have to shift way up and down the fretboard all the time, especially when the song or tune has a fast tempo\" (Ch. 13, p. 183). This dual-voicing system is the book's primary anti-position-shift strategy.",
+          "cross_ref": [
+            "major-seventh/chord-melody-melody-on-top-rule",
+            "dominant-seventh/rootless-extended-voicing-mobility"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 13, p. 183 — Two chord forms per root"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "movable-shape-12-key-transposition",
+          "narrative": "All non-open-string major seventh voicings are movable across all twelve keys by fret shift: \"all chord shapes are movable when you're not using open-string voicings. You know that all these chords in this lesson are C chords right? If you move them up two frets, they become D chords of the same nature\" (Ch. 13, p. 183). The transposition analogy to barre chord shifting is explicit, making the movable-shape principle the primary chord-vocabulary multiplier in the system.",
+          "cross_ref": [
+            "major-seventh/dual-root-string-organizing-rule",
+            "dominant-seventh/rootless-extended-voicing-mobility"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 13, p. 183 — Movable chord shapes"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "circle-of-fourths-resolution-free-chord-choice",
+          "narrative": "Movement by a fourth is the strongest resolution interval, enabling free chord choice: \"The beauty of the 4th principle in making a change with chords is that it allows you to pick any chord. Why? The answer is resolution. It's a nice resolution to move chords by a 4th (D to G, G to C, C to F, F to Bb, etc.)\" (Ch. 13, p. 201). The circle of fourths is defined in fretboard terms as five frets / five half steps up, making it directly actionable on guitar.",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "dominant-seventh-sus4/unresolved-jazz-usage"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 13, p. 201 — 4th and half-step resolution logic; Circle of fourths chord movement"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "comping-density-sparse-guide-tones",
+          "narrative": "Comping density is the primary dynamic lever, and the ii chord participates in the sparse-end spectrum: \"These tones are all 3rds or 7ths of the chords... We shouldn't forget that if we want to allow the texture to be on the thin side, we could go as far as to lay out entirely while a soloist holds forth, at least for a while!\" (Ch. 8, p. 94). The prescription moves from full voicings through guide-tone pairs to silence, with the intensity of the musical conversation determining the density level.",
+          "cross_ref": [
+            "dominant-seventh/rootless-extended-voicing-mobility",
+            "minor-seventh/rootless-shell-for-walking-bass-context"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 94 — Comping density as dynamic tool; Sparse comping: 3rds and 7ths only"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "pentatonic-simple-over-complex-changes",
+          "narrative": "A pentatonic approach from the key of the tune can override complex chord-by-chord analysis: \"These short phrases are made up almost entirely of Bb major scale tones (which are, in fact, all within Bb major pentatonic)... However, both by its sound and by how we'd find it on the fretboard, it makes even more sense to just call it a groovy little mostly-Bb-major idea that works!\" (Ch. 8, p. 96). The prescription elevates tonal feel over theoretical exactitude when navigating complex changes at speed.",
+          "cross_ref": [
+            "dominant-seventh/central-scale-choice-battleground",
+            "dominant-seventh/pentatonic-minor-bluesy-vs-mixolydian-jazzy"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 96 — Simple ideas over complex changes"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "scales-starting-point-not-method",
+          "polarity": "proscriptive",
+          "narrative": "The book's central proscription against scale-as-method thinking applies most forcefully to the dominant seventh: \"The trouble is, scales do not tell the whole story when it comes to improvising—not even about note choice. They can initially free us up by giving us a place to start that at least doesn't sound bad, but then trap us into a box of limitations if we consider any one scale to be the total 'how-to' of playing on a certain chord or progression\" (Ch. 8, p. 92). This warning is the book's clearest proscriptive statement and is located immediately after the dominant-scale taxonomy.",
+          "cross_ref": [
+            "dominant-seventh/central-scale-choice-battleground",
+            "dominant-seventh/bebop-dominant-scale-charlie-parker"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 92 — Scales as starting point, not ceiling"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "blues-distortion-proscribed-in-jazz-context",
+          "polarity": "proscriptive",
+          "narrative": "Extreme blues-style techniques are explicitly proscribed when working on jazz vocabulary over dominant chords: \"there are certain ways that jazz guitar players tend to delve into their bluesy side, usually without the more extreme bending, sliding, shaking, or distorted screaming that can be found in the rock or blues genres... In playing jazz, we may want to play the blues, but without sounding as though we showed up at the wrong gig!\" (Ch. 4, p. 36). The author reinforces this as a pedagogical stance: suppress blues gestures \"for the moment, study the vocabulary of the style, and look for expressiveness in their choice of notes and rhythms\" (Ch. 4, p. 37).",
+          "cross_ref": [
+            "dominant-seventh/pentatonic-minor-bluesy-vs-mixolydian-jazzy",
+            "dominant-seventh/central-scale-choice-battleground"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 36-37 — Jazz blues stylistic boundary rule; Blues devices hiding jazz vocabulary"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "chord-tone-improv-stepping-stone",
+          "narrative": "Chord-tone-only improvisation is prescribed as a developmental floor, not an endpoint: \"In this lesson, we try, as an exercise, to solo on the progression with basic chord tones only and nothing else. In the process, we can begin to map out these chordal members on the fretboard (beyond where they sit in familiar chord shapes) and start to hear the chord changes in our single-note lines\" (Ch. 2, p. 14). The explicit caveat: \"It is not an improvisational end-goal in itself (even if it may yield some tasty licks), since in the long run we will surely allow ourselves to use other tones\" (Ch. 2, p. 15).",
+          "cross_ref": [
+            "minor-seventh/ii-chord-arpeggio-through-ninth",
+            "dominant-seventh/v-chord-arpeggio-through-ninth"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 14-15 — Chord-tone-only improv exercise rationale; Chord-tone exercise scope and limits"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-arpeggio-through-ninth",
+          "narrative": "The arpeggio formula for the dominant seventh is root, 3rd, 5th, and b7 from the Mixolydian scale, extended through the 9th for the chord-tone exercise: \"we'll call it... G79... for the sake of this exercise\" (Ch. 1, p. 6). Arpeggio construction follows the rule: \"we really just use the first, third, fifth, and seventh tones of a scale—Mixolydian for the dominant seventh chords\" (Ch. 2, p. 14). The 9th extension (A over G7) is reclassified as a chord extension: \"A is the 9th for a G7\" (Ch. 2, p. 9).",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "major-seventh/chord-tone-improv-stepping-stone"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 2, p. 14; Ch. 1, p. 6 — Arpeggio construction rule; Chord-tone-only improv approach"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "three-tritone-sub-principles-sequenced",
+          "narrative": "A three-step method organizes tritone substitution practice: \"We'll use three principles or procedures: 1) turning dominant seven chords from natural to altered before resolving down a 5th, 2) the use of a tritone substitute, or dominant seven chord three steps removed from another one, to turn it into an altered dominant, and 3) the cyclical practicing of short melodic ideas to have them ready for use on different roots or in different keys\" (Ch. 7, p. 74). This sequences the conceptual, harmonic, and practical-execution dimensions of substitution into an ordered method.",
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-chromatic-bass",
+            "dominant-seventh-altered/natural-to-altered-shift-device"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 7, p. 74 — Tritone substitution three principles"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "baby-strides-v-i-resolution-focus",
+          "narrative": "Instead of trying to play on every chord in a progression, targeting V-I resolutions to each key area is offered as an alternative: \"as an alternative to the tones-on-every-chord method, try focusing on the resolution (the 'leading in') to each new major key with simple, very short V-I lines that you may already play in other settings. We still wind up playing something on nearly every chord, if not all of them, but it's a different way of getting our bearings\" (Ch. 7, p. 84). This reframes the dominant seventh as a directional arrow rather than a chord to be exhaustively covered.",
+          "cross_ref": [
+            "major-seventh/i-chord-tonic-resolution",
+            "dominant-seventh/tonicization-generates-local-cell"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 7, p. 84 — Baby strides — V-I focus method"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "skip-chord-tones-fast-changes",
+          "narrative": "In jazz, not every chord change in a fast progression needs to be addressed: \"It's important to know in jazz that you don't have to play notes for every chord that comes up in a tune. Sometimes there are several changes at fast tempos, and it seems impossible to keep up. You can spot chords and target your areas so you don't have to worry about every chord\" (Ch. 12, p. 172). This licenses selective attention over the dominant seventh when tempo or density makes chord-by-chord playing impractical.",
+          "cross_ref": [
+            "dominant-seventh/pentatonic-simple-over-complex-changes",
+            "dominant-seventh/baby-strides-v-i-resolution-focus"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 12, p. 172 — Jazz: skipping chord tones in fast changes"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "sequential-practice-same-chord-type",
+          "narrative": "When a progression contains the same dominant seventh chord type repeating through multiple keys, sequential practice focuses vocabulary development: \"since we have the same kind of chords repeatedly, we can focus on some things to play just for those two chords and practice moving them around to different keys as needed. In this way, sequential progressions present a nice opportunity for clearly targeted practice\" (Ch. 7, p. 70). The prescription is to build a small vocabulary cell and cycle it through keys rather than attempting wholesale repertoire.",
+          "cross_ref": [
+            "dominant-seventh/tritone-substitution-chromatic-bass",
+            "dominant-seventh-altered/natural-to-altered-shift-device"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 7, p. 70 — Sequential ii-V practice strategy"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "pentatonic-mixing-five-overlapping-positions",
+          "narrative": "Multiple pentatonic scale positions from different keys are simultaneously available over minor seventh chord territory: \"The idea behind all of this is knowing you can use other pentatonic scales and shapes from other keys. You can see these positions overlapping when you're improvising\" (Ch. 12, p. 165). The foundational spelling is given: \"A minor pentatonic scale. It's spelled A-C-D-E-G, which is 1-b3-4-5-b7 in the key of A\" (Ch. 12, p. 164). Five overlapping positions are prescribed for fluent pentatonic mixing across the fretboard.",
+          "cross_ref": [
+            "minor-seventh/ii-chord-dorian-scale-source",
+            "dominant-seventh/pentatonic-simple-over-complex-changes"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 12, p. 164-165 — Pentatonic mixing: scale spellings; Pentatonic mixing: five overlapping positions"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "four-pentatonics-from-one-major-scale",
+          "narrative": "A single diatonic major scale conceals up to four minor pentatonic scales: \"The C diatonic major scale (C-D-E-F-G-A-B) contains three minor pentatonic scales within it: A minor, D minor, and E minor. If you include the 11th or #5th note (F# or G# respectively), which is a common and useful sound in jazz, you can use the B minor pentatonic scale as well. This gives you four different pentatonic scales that are built from the C major scale\" (Ch. 10, p. 126). The practical application: these four pentatonics are all valid improvisational options simultaneously over any chord related to that key.",
+          "cross_ref": [
+            "minor-seventh/pentatonic-mixing-five-overlapping-positions",
+            "dominant-seventh/pentatonic-simple-over-complex-changes"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 10, p. 126 — Pentatonics within diatonic major"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "chord-shape-as-melodic-skeleton",
+          "narrative": "Chord shapes function as melodic frameworks that hide scale patterns: \"A simple but effective way to create melodies is to use chord shapes. The objective in creating melodies... is to avoid sounding as though you're practicing a scale or even playing through a scale. I try to play in a way that hides the sound of the scale. In these examples, not every note is part of the chord shape, but the shape is the grid or model for the melodic idea\" (Ch. 10, p. 128). This applies across all chord types but is positioned in the context of dominant-seventh scale variety.",
+          "cross_ref": [
+            "dominant-seventh/central-scale-choice-battleground",
+            "dominant-seventh/scales-starting-point-not-method"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 10, p. 128 — Chord shape melody concept"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "chromatic-riff-half-step-resolution-to-key",
+          "narrative": "Chromatic displacement of riffs over altered dominant and other chord contexts must resolve back to in-key targets: \"You can take any riff and repeat it chromatically up the fretboard a half step (one fret) at a time... The trick is to resolve the line by ending on notes that lie firmly in key. You can target notes up the neck and end up there\" (Ch. 11, p. 148). Resolution is non-negotiable: \"it's important to know you can try and reverse every idea... The important thing to be aware of is how you resolve and finish these lines\" (Ch. 11, p. 150).",
+          "cross_ref": [
+            "dominant-seventh-altered/super-locrian-all-tension-tones",
+            "dominant-seventh/half-step-outside-tritone-sub-logic"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 148-150 — Chromatic ascending riffs technique; Descending chromatic riff resolution rule"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7alt",
+          "function_role": "g-super-locrian-db-blues-scale-bridge",
+          "narrative": "Super Locrian bridges diminished harmony and altered dominant via melodic minor: \"G diminished going into a G super Locrian connecting with the next bar. (Ab melodic minor has the same notes as the G super Locrian scale)\" (Ch. 11, p. 147). This enharmonic identity — super Locrian equals melodic minor built a half step above the root — is the practical memory hook for deploying the altered scale, and its connection to G diminished confirms the two-chord-type versatility of the single scale.",
+          "cross_ref": [
+            "dominant-seventh-altered/super-locrian-all-tension-tones",
+            "diminished/harmonic-minor-over-diminished-chord"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 147 — G super Locrian / Db blues scale"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "comping-upbeat-emphasis-anticipation",
+          "narrative": "The two core rhythmic devices of jazz comping are upbeat emphasis and chord anticipation: \"there's a strong emphasis on upbeats in this kind of playing (the 'ands' of each beat we count in a measure). And along with that, many chords that we think of as coming in on beats 1 or 3 of a 4/4 measure can actually get anticipated, or played one short 8th note earlier\" (Ch. 1, p. 4). Anticipation is further specified: \"by hitting each chord on the 'and' before its official time, we already take a step towards viable jazz comping. (Remember that if it's part of an overall swung groove, the 'and' is later in the beat!)\" (Ch. 1, p. 4).",
+          "cross_ref": [
+            "dominant-seventh/straight-four-comping-felt-more-than-heard",
+            "dominant-seventh/comping-defined-variable-rhythmic"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 1, p. 4 — Upbeat emphasis in comping; Chord anticipation technique"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "comping-defined-variable-rhythmic",
+          "narrative": "Comping over all chord types including the dominant is defined as variable rather than mechanical: \"Comping is the main form of chordal accompaniment in straight-ahead jazz and is usually quite variable in its rhythms and chord voicings. Like single-note improvisation, it involves constant choices on the part of the musician and requires a feel for the style\" (Ch. 1, p. 4). The further texture rule: \"there is usually a mix of downbeats and upbeats, and also of sustained and short chords\" (Ch. 1, p. 4), distinguishing jazz comping from uniform strumming.",
+          "cross_ref": [
+            "dominant-seventh/comping-upbeat-emphasis-anticipation",
+            "dominant-seventh/straight-four-comping-felt-more-than-heard"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 1, p. 4 — Comping defined"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "swing-feel-three-techniques",
+          "narrative": "Three named techniques shape swing feel over dominant chords without changing the notated rhythm: playing behind the beat (\"lay back on it on purpose, in a hip, often relaxed kind of way, which is different than dragging or falling behind\"), playing straight 8ths (\"especially good advice if someone is over-exaggerating the swung timing\"), and accenting upbeats (\"a jazzer might at least even this out a bit with some accent on the 'ands' in an 8th-note flow\") (Ch. 8, p. 100). These are explicitly distinguished from rhythmic variation — they are \"explorations of the feel with which one basic idea can be played\" (Ch. 8, p. 101).",
+          "cross_ref": [
+            "dominant-seventh/comping-upbeat-emphasis-anticipation",
+            "dominant-seventh/ballad-feel-arpeggio-attack"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 100-101 — Swing feel: three practical tips; Feel vs. notated rhythm"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "maj7",
+          "function_role": "ballad-feel-arpeggio-attack",
+          "narrative": "Ballad feel prescribes a specific rhythmic subdivision and chord attack distinct from swing: \"the ballad feel often entails a particular mix of even 8ths and triplets for the underlying division\" (Ch. 8, p. 102). The chord attack changes: \"We may allow ourselves a more arpeggiated touch on a few chords in this situation, more so than we usually would at a swinging tempo. That is, they may be sounded with a looser sweep across the strings... (think 'brrring' instead of 'chung')\" (Ch. 8, p. 102). This applies particularly to major seventh tonic chords where the harmonic rhythm is slower.",
+          "cross_ref": [
+            "dominant-seventh/swing-feel-three-techniques",
+            "major-seventh/i-chord-tonic-resolution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 102 — Ballad rhythmic subdivision; Ballad comping: arpeggiated touch"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "one-tone-harmonization-single-note-through-changes",
+          "narrative": "A single note can be harmonized across an entire chord progression by finding versions of each chord with that note on top: \"attempting to harmonize one single note with all the chords in a progression—or at least a good part of it. This means choosing a note (probably in the key of the tune, but not always), looking for versions of the chords with that note at the top, and playing them in sequence\" (Ch. 7, p. 76). This one-tone harmonization exercise develops the ability to voice dominant and other chords around any given melody note.",
+          "cross_ref": [
+            "major-seventh/chord-melody-melody-on-top-rule",
+            "dominant-seventh/comping-defined-variable-rhythmic"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 7, p. 76 — Harmonizing one tone — definition"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "slash-chord-notation-avoidance-default-patch",
+          "polarity": "proscriptive",
+          "narrative": "The proscription against defaulting to the standard chord shape when reading slash chord notation is explicit: \"When we see a slash chord on a chart, it can be a mistake to assume that we should go to the first place on the fretboard we usually think of for the main chord and then try to change the bass note\" (Ch. 7, p. 82). The slash chord system designates bass note only: \"'D over G' or 'E-flat major seven over F' and are used to designate chords for which the note under the slash is in the bass\" (Ch. 7, p. 82). The improviser must find an appropriate voicing rather than patching a default shape.",
+          "cross_ref": [
+            "dominant-seventh/rootless-extended-voicing-mobility",
+            "major-seventh/dual-root-string-organizing-rule"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 7, p. 82 — Slash chord definition; Slash chord voicing caution"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "enclosure-bebop-targeting-technique",
+          "narrative": "Enclosure—arranging notes around a target to create the bebop sound—is prescribed as an essential technique: \"When we use the term 'targeting' in music, we mean to say that we've picked out a note that we're aiming for. We basically arrange notes around that targeted note in a way that makes it sound as though we were heading in that direction\" (Ch. 12, p. 178). The bebop application: \"To get that bebop sound in jazz, the enclosure is one sure way\" (Ch. 12, p. 179). The only constraint is resolution: \"Pick any note on the fretboard and devise a way to get to it\" (Ch. 12, p. 180).",
+          "cross_ref": [
+            "dominant-seventh/chromatic-enclosure-strong-beat-chord-tone",
+            "dominant-seventh/guide-tone-aim-for-the-change"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 12, p. 178-180 — Enclosure: concept and targeting defined; Enclosure: bebop sound technique; Free form targeting"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "hemiola-rhythmic-tension-over-blues-scale",
+          "narrative": "Hemiola applied to blues-scale figures creates rhythmic tension over dominant seventh chord vamps: \"Hemiola refers to rhythmic figures that repeat as if to imply a certain meter, while being played in a different meter\" (Ch. 7, p. 72). The mechanical rule: \"if we start at the tonic, go up to the 5th tone and back, turn around on the bottom note again, and so on, the result is a unit of eight 8th notes, which will start at the same place in a 4/4 measure each time. If we leave off that top note in our up-and-down pattern, we get a six-note figure, again implying three over four\" (Ch. 7, p. 72).",
+          "cross_ref": [
+            "dominant-seventh/swing-feel-three-techniques",
+            "dominant-seventh/pentatonic-minor-bluesy-vs-mixolydian-jazzy"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 7, p. 72 — Hemiola definition; Blues scale hemiola groupings"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "constant-phrase-shape-fixed-rhythm-variable-pitch",
+          "narrative": "The Constant Phrase Shape method applies a fixed rhythmic figure to dominant and other chords, varying pitch: \"we choose a short melodic rhythm to play repeatedly through a song form or chord progression. We come up with it without being specific about pitch and then fill in the blanks with notes as we go, appropriate to the harmonies at hand. The key element is that the rhythmic figure must stay the same, and the notes must fit into its framework\" (Ch. 4, p. 24). The deeper lesson: \"it really has everything to do with note choice after all. It forces us to listen for which tones of the present scale or chord sound good\" (Ch. 4, p. 24).",
+          "cross_ref": [
+            "dominant-seventh/comping-defined-variable-rhythmic",
+            "dominant-seventh/swing-feel-three-techniques"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 24 — Constant Phrase Shape method; Phrase shape sharpens note choice"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "changing-rhythmic-shape-row-of-tones",
+          "narrative": "The Changing Rhythmic Shape method takes a fixed row of tones and reshapes them rhythmically: \"We begin by selecting a series of tones that can work over a given harmony, in the order we will play them for a single musical idea (not just a scale to be drawn from)... Next, we see how many different ways we can come up with to rhythmically shape this row of tones, so as to make a nice statement within a particular groove\" (Ch. 4, p. 26). The available rhythmic tools include \"grouping the tones in swung 8ths, stretching them out, adding some little slide-ins, or using triplets\" (Ch. 4, p. 26). This complements the Constant Phrase Shape by inverting the fixed/variable relationship.",
+          "cross_ref": [
+            "dominant-seventh/constant-phrase-shape-fixed-rhythm-variable-pitch",
+            "dominant-seventh/swing-feel-three-techniques"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 26 — Changing Rhythmic Shape method; Rhythmic approaches enumerated"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "skating-blues-scale-through-chord-changes",
+          "narrative": "The 'skating' technique applies blues-scale material through chord changes in a stylistically fitting way: \"the very last phrase is an exception, with some earthier blues scale material that 'skates' through the chords, in a stylistically fitting way\" (Ch. 4, p. 29). This licenses the blues scale as an occasional override of chord-specific scale choices, provided it is used as a stylistic seasoning rather than a substitute for jazz vocabulary acquisition. The skating technique contrasts with the proscription against extreme blues gestures.",
+          "cross_ref": [
+            "dominant-seventh/pentatonic-minor-bluesy-vs-mixolydian-jazzy",
+            "dominant-seventh/blues-distortion-proscribed-in-jazz-context"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 29 — Blues scale skating through chords"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "call-response-symmetrical-form-requirement",
+          "narrative": "Call and response phrasing over chord progressions including dominant changes requires a symmetrical formal container: \"Structurally, this could happen in different ways. It doesn't need to be in the context of a 12-bar blues, but some kind of symmetrical form is helpful, like so many tunes have, with four- or eight-bar sections that can easily be divided into one-, two-, or four-bar chunks for our call and response\" (Ch. 4, p. 28). Without structural symmetry, the call-response relationship loses its formal meaning.",
+          "cross_ref": [
+            "dominant-seventh/constant-phrase-shape-fixed-rhythm-variable-pitch",
+            "dominant-seventh/changing-rhythmic-shape-row-of-tones"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 28 — Call and response structural rule"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "lick-scale-degree-formula-versatility",
+          "narrative": "The Lick is defined by scale-degree formula 1-2-3-4-2-7-1, most naturally over minor/Dorian contexts but adaptable to many chord types: \"it seems most obvious as a minor line, using tones 1, 2, 3, 4, 2, 7, and 1 of a minor (or Dorian!) scale, starting and ending with the tonic, or the root of a minor chord. But the reality is that this unit, defined by its particular interval pattern, can fit into many scales, chords, and situations, often in more than one way\" (Ch. 5, p. 52). Its interval-driven identity makes it usable across dominant, minor, and major contexts.",
+          "cross_ref": [
+            "minor-seventh/ii-chord-dorian-scale-source",
+            "dominant-seventh/central-scale-choice-battleground"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 5, p. 52 — The Lick — scale-degree formula"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "reverse-swing-blues-attitude-device",
+          "narrative": "A 'reverse swing' rhythmic figure — eighth followed by quarter in a triplet feel — conveys blues attitude within a jazz context without resorting to extreme guitar techniques: \"at the beginning of the second full measure, there's a figure that I sometimes think of as 'reverse swing'—an 8th and then a quarter note in a triplet, effectively giving us a short first half of the beat and a longer second half. Played with a certain attack at slower tempos, it can convey quite a blues attitude!\" (Ch. 4, p. 37). This is positioned as the acceptable alternative to the proscribed extreme blues gestures.",
+          "cross_ref": [
+            "dominant-seventh/blues-distortion-proscribed-in-jazz-context",
+            "dominant-seventh/changing-rhythmic-shape-row-of-tones"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 4, p. 37 — Reverse swing rhythmic figure"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "neighbor-notes-jazz-essential-blues-sparse",
+          "narrative": "Half-step neighbor notes — one fret above or below any scale tone — are essential in jazz but used sparingly in blues: \"The term 'half step neighbors' refers to all the notes that are one fret (or a half step) above or below any note in any scale you're playing. For the jazz musician, it's a must to incorporate this into your music. For a blues player, you might want to use this sparingly\" (Ch. 12, p. 162). This genre-specific application rule positions neighbor notes as a defining feature of jazz melodic vocabulary over dominant chords.",
+          "cross_ref": [
+            "dominant-seventh/chromatic-enclosure-strong-beat-chord-tone",
+            "dominant-seventh/enclosure-bebop-targeting-technique"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 12, p. 162 — Half Step Neighbors defined; Neighbors: jazz vs. blues usage"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "interval-jumping-riff-transposition",
+          "narrative": "Taking a melodic riff and repeating it at different interval positions creates harmonic variety within a dominant or progression context: \"By 'interval jumping with riffs,' I simply mean taking a line and repeating it at another position. You could move it a half step (one fret), whole step (two frets), minor 3rd (three frets), major 3rd (four frets), etc.\" (Ch. 12, p. 170). Resolution logic applies: \"Two common resolutions were used to create these lines. The V chord in the key of A is E. The E or E7 chord resolves smoothly into an A chord. A half step down resolution is nice too\" (Ch. 12, p. 172).",
+          "cross_ref": [
+            "dominant-seventh-altered/chromatic-riff-half-step-resolution-to-key",
+            "dominant-seventh/sequential-practice-same-chord-type"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 12, p. 170-172 — Interval jumping with riffs; Playing down two whole steps: resolution logic"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "one-key-difference-nearby-keys-free-expression",
+          "narrative": "When improvising in one key, nearby keys sharing only one different note are compatible: \"there's only one note difference between the key of A, E, and D; D has two sharps, A has three, and E has four. Remember that we're talking about jazz, and jazz is meant to represent free expression. So when you're jamming in A, you can improvise in D or E because these keys have only one note difference between them, and that one note won't sound bad, especially if you're flying over passages\" (Ch. 12, p. 174). This key-proximity rule licenses free pentatonic mixing across related minor and dominant centers.",
+          "cross_ref": [
+            "minor-seventh/four-pentatonics-from-one-major-scale",
+            "dominant-seventh/pentatonic-simple-over-complex-changes"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 12, p. 174 — Playing off the five: one-note difference rule"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "diatonic-vs-root-interval-chord-change-categories",
+          "narrative": "Chord changes are classified into two categories for navigation: diatonic changes (chords within a key) and root-interval movements (fourths, fifths, steps, half-steps): \"For me, there are two main areas for chord-change consideration. One of those areas involves common root movements, such as up a 4th, down a step, etc. The other is what I call diatonic changes. Diatonic changes are the ones found within the key. In other words, the chords of C major are Cmaj7, Dm7, Em7, Fmaj7, G7, Am7, and Bm7b5\" (Ch. 13, p. 201). The five interval categories are: down a half step, down a minor 3rd, up a minor 3rd, up a 4th, up a b5th.",
+          "cross_ref": [
+            "dominant-seventh/circle-of-fourths-resolution-free-chord-choice",
+            "major-seventh/jazz-101-family-substitution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 13, p. 201 — Diatonic vs. non-diatonic changes; Five chord-change intervals"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "min7",
+          "function_role": "quartal-voicing-outside-patterns-guitar-native",
+          "narrative": "Quartal voicings exploit guitar's native string tuning for outside-sounding patterns: \"most neighboring pairs of strings are tuned a perfect 4th apart (all except strings 3 and 2, the G and B strings, which are a major 3rd apart). That is, if you play a note at the same fret of two different strings, next to each other, you've got a perfect 4th, unless you're on the second and third strings together\" (Ch. 8, p. 89). Quartal lines require finger-rolling technique: \"Multiple notes at the same fret will likely require some rolling of the fingers\" (Ch. 8, p. 89), and generate outside-sounding patterns via minor-3rd displacement of three-note quartal units.",
+          "cross_ref": [
+            "minor-seventh/rootless-shell-for-walking-bass-context",
+            "dominant-seventh/rootless-extended-voicing-mobility"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 89 — Perfect 4th on guitar strings; Quartal fingering strategy; Quartal outside playing pattern"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "transcription-fret-shift-transposition",
+          "narrative": "Transcribed ii-V-I lines are transposed to other keys by fret shift: \"The whole idea could be transposed to different keys for use in all kinds of songs. If we wanted to use it for a ii-V-I in Bb major, for example, we could simply move the whole thing down seven frets on the guitar—or learn to play it on a different string set\" (Ch. 8, p. 99). This fret-shift method treats transcription lines exactly like barre chord shapes, making the guitar's physical geometry the vehicle for vocabulary generalization across all keys.",
+          "cross_ref": [
+            "dominant-seventh/sequential-practice-same-chord-type",
+            "major-seventh/movable-shape-12-key-transposition"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 8, p. 99 — Transcription: transposing ii-V-I lines"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "minor-third-rule-major-to-minor-scale-shift",
+          "narrative": "Moving a major scale or riff up three frets converts it to the minor of the same root: \"One convenient habit many guitarists have is to move a major scale up three frets (or a minor 3rd), which turns the sound into the minor of that same key\" (Ch. 10, p. 132). This minor-third rule mirrors the three-fret equivalence of the diminished scale and the minor-3rd quartal displacement rule, making it a consistent physical-geometry principle across multiple technique domains.",
+          "cross_ref": [
+            "dominant-seventh/sequential-practice-same-chord-type",
+            "dominant-seventh/three-fret-equivalence-four-keys"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 10, p. 132 — Major-to-minor shift: minor 3rd rule"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "mode-background-chord-determines-sound",
+          "narrative": "Modes over the dominant and all other chord types are distinguished not by note content but by the background chord: \"The C major scale has no sharps or flats, and so it is with the D Dorian minor scale. Since both of these sounds come from the same notes, what determines the difference? The answer is the chord or bass note being played in the background. What you have in the background affects the way the notes sound\" (Ch. 10, p. 122). This background-chord principle is the foundation of the modal-playing approach that permeates the scale-over-chord system.",
+          "cross_ref": [
+            "dominant-seventh/v-chord-natural-mixolydian",
+            "minor-seventh/ii-chord-dorian-scale-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 10, p. 122 — Modes defined by background chord"
+            }
+          ]
+        },
+        {
+          "source_work_id": "goldmine-100-jazz-lessons",
+          "chord_quality": "dom7",
+          "function_role": "whole-step-tension-riff-displacement",
+          "narrative": "Whole-step chromatic displacement of riffs creates mid-solo tension over dominant chord contexts: \"You can take virtually any riff and apply this line of thinking. Try moving up whole steps (two frets at a time). You can create an interesting moment of tension in the middle of a solo\" (Ch. 11, p. 149). This whole-step variant complements the half-step displacement rule and shares the same resolution-to-key requirement, giving the player two chromatic displacement levels for graduated tension building.",
+          "cross_ref": [
+            "dominant-seventh-altered/chromatic-riff-half-step-resolution-to-key",
+            "dominant-seventh/interval-jumping-riff-transposition"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Heussenstamm & Silbergleit, Goldmine 100 Jazz Lessons",
+              "citation": "Ch. 11, p. 149 — Whole-step chromatic variation"
+            }
+          ]
+        }
+      ]
     },
     {
       "id": "benson",


### PR DESCRIPTION
## Summary

Six-master Stage B cluster draining the remaining tractable backlog (s1-s4 done, prescriptive content present):

| Master | Notes | Proscriptive |
|---|---:|---:|
| jens-larsen | 73 | 5 |
| ted-dunbar | 75 | 0 |
| brent-vaartstra | 71 | 3 |
| alan-de-mause | 87 | 9 |
| matt-warnock | 68 | 4 |
| heussenstamm-silbergleit | 95 | 3 |

Cluster total: **469 notes, 24 proscriptive**.

## Pipeline notes

- **Warnock**: extraction hit a transient 401 mid-stream; salvaged 68 complete entries from the partial response. No re-run needed.
- **Heussenstamm**: model used spelled-out vocab (`dominant-seventh` etc.); normalized to canonical voicings.json names (`dom7`, `min7`, etc.) before injection.
- **Bruno**: SKIPPED. *The Art of Picking* is a right-hand technique manual; extraction produced 61 entries but all chord_quality values were technique-shape labels (`major-triad`, `bebop-line`, `double-stop`, etc.). Same call as Bertoncini and Galbraith — out-of-scope for usage_notes.

## Pipeline

cyberpower runs:
- `2026-05-28T15-05-20-larsen-modern-jazz-guitar-concepts`
- `2026-05-29T06-30-11-dunbar-system-of-tonal-convergence`
- `2026-05-29T06-51-17-vaartstra-jazz-standards-playbook`
- `2026-05-29T06-51-18-de-mause-fingerstyle-jazz`
- `2026-05-28T15-05-20-warnock-beginners-guide`
- `2026-05-28T15-05-20-heussenstamm-goldmine-100-jazz-lessons`

Extraction model: sonnet.

## Validation

Schema 24/24 pass.

Refs #457, #459, #471.