### PR TITLE
feat(#457): Stage B — Fisher 3-vol jazz-guitar-method (220 entries)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -14298,6 +14298,4206 @@
             }
           ]
         }
+      ],
+      "usage_notes": [
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "tonic-i",
+          "narrative": "Fisher establishes IMaj7 as the foundational tonic chord of the harmonized major scale, produced by stacking four diatonic 3rds on the first scale degree: 'If we stack them four notes high, we get 7th chords.' The IMaj7 chord anchors all diatonic ii-V-I progressions in the method, and the student is directed to practice it in multiple fingerboard positions using the chord-scale approach. In Roman-numeral transposition, learning 'CMaj7-Amin7-FMaj7-G7' as I-vi-IV-V in C ensures instant rekeying to any of twelve keys.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 54: 'we stack 3rds on top of each scale degree … If we stack them four notes high, we get 7th chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 56: 'CMaj7-Amin7-FMaj7-G7 … all of these chords are natural to the key of C'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-iv",
+            "min7/supertonic-ii",
+            "dom7/dominant-v"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "tonic-iv",
+          "narrative": "Fisher's harmonized major scale produces two Maj7 chords per key — on the I and IV degrees — making IVMaj7 a second tonic-function color alongside IMaj7. The student is explicitly told 'Every Maj7 chord has two major scale choices to use for improvising,' meaning both the I-major and IV-major parent scales are available. This dual-choice rule is unique to Maj7 among all diatonic chord qualities and must be memorized as a fixed constraint before improvising.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'Every Maj7 chord has two major scale choices to use for improvising'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'harmonizing any major scale always produces two Maj7 chords (I and IV)'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i",
+            "min7/supertonic-ii"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher issues the method's most load-bearing voicing proscription directly against dropping the 3rd or 7th from any Maj7 voicing: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords.' For Maj7 specifically, the major 3rd distinguishes it from min7 and dom7, and the major 7th distinguishes it from Maj6. Roots, 5ths, and 9ths 'can be dropped in various combinations' without losing harmonic identity, but the 3rd-and-7th pair is non-negotiable.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            }
+          ],
+          "cross_ref": [
+            "min7/retain-guide-tones",
+            "dom7/retain-guide-tones",
+            "maj9/omit-root"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "formula-construction",
+          "narrative": "Fisher defines the Maj7 formula with explicit scale-degree notation: 'The formula for Maj7 chords is: Root-3-5-7. This means that we combine the root, 3rd, 5th and 7th degrees of the major scale to build the chord. Notice that what we have actually done is add the 7th degree to a major triad.' This additive construction model — triad plus extension — is the universal method the book uses to build every chord quality, and the student must apply it across all twelve keys by memorizing the major scales first.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'The formula for Maj7 chords is: Root-3-5-7'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'constructing larger chords is simply a matter of adding additional scale tones to the original triad'"
+            }
+          ],
+          "cross_ref": [
+            "maj6/formula-construction",
+            "min7/formula-construction",
+            "dom7/formula-construction"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "ionian-mode-source",
+          "narrative": "Fisher establishes that the Ionian mode — the first rotation of the parent major scale — is the prescribed improvisation scale over IMaj7: 'The C Ionian mode is used to improvise over CMaj7, the I chord.' This mode-to-chord correspondence is the derivative approach the book teaches, where each diatonic chord is paired with its corresponding mode by shared root. The student should treat Ionian as the default single scale choice over IMaj7 when using the derivative method.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 69: 'The C Ionian mode is used to improvise over CMaj7, the I chord'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 69: 'Each mode of the major scale corresponds to the diatonic chord that shares the same root'"
+            }
+          ],
+          "cross_ref": [
+            "min7/dorian-mode-source",
+            "dom7/mixolydian-mode-source",
+            "min7b5/locrian-mode-source"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "chord-scale-voice-leading",
+          "narrative": "Fisher instructs that when IMaj7 and IVMaj7 appear in a diatonic chord scale, the student should observe that 'each voice moves in a scale-wise motion (from root to root, 3rd to 3rd, etc.)' as the progression ascends. This scale-wise voice-leading principle applies to all chord scale motion and is the book's prescribed approach to smooth harmonic connection. Practicing chord scales 'until each voice in every chord is clear and balanced' is the explicit drill directive.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 54: 'each voice moves in a scale-wise motion (from root to root, 3rd to 3rd, etc)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 58: 'Practice each chord scale until each voice in every chord is clear and balanced'"
+            }
+          ],
+          "cross_ref": [
+            "min7/chord-scale-voice-leading",
+            "dom7/chord-scale-voice-leading"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj6",
+          "function_role": "tonic-color-substitute",
+          "narrative": "Fisher defines the Maj6 chord formula as 'Root-3-5-6' and provides concrete key examples: 'In the key of F this would be spelled F, A, C and D. In the key of C it would be C, E, G and A.' The Maj6 is taught as a close relative of Maj7, differing only in the 6th degree substituted for the 7th, and functions as a tonic color chord in jazz vocabulary. The additive construction model (major triad plus 6th scale degree) is consistent with the method's universal formula for all chord building.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 33: 'The formula for Maj chords is as follows: Root-3-5-6'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'constructing larger chords is simply a matter of adding additional scale tones to the original triad'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/formula-construction",
+            "maj9/omit-root"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj6",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher's universal voicing proscription applies equally to Maj6: the 3rd and 6th (functioning here as the primary color tones distinguishing Maj6 from a bare major triad) must not be dropped. While Fisher's explicit statement — 'it is generally not a good idea to drop 3rds and 7ths' — names the 7th, the underlying principle is that tone-defining intervals must be preserved; the 6th in Maj6 plays the same definitional role the 7th plays in Maj7. Roots and 5ths remain freely omissible.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/retain-guide-tones",
+            "min6/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "supertonic-ii",
+          "narrative": "Fisher positions the ii min7 chord as the primary pre-dominant in all ii-V-I patterns, which are described as the central building blocks of jazz harmony: 'many types of songs follow rather predictable patterns, and these patterns are usually described in Roman numerals' — with ii-V-I cited as the exemplary pattern. The student is instructed to learn every ii-V-I in Roman numerals as a 'universal key' pattern and transpose it to all twelve keys, making ii min7 the foundation of the method's transposition pedagogy.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 67: 'it is easier to see the nature of the progression if they say, ii-V-I in C'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 67: 'Learn all of your songs in Roman numerals. Then you will have learned the material in a universal key'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v",
+            "maj7/tonic-i",
+            "min7/mediant-iii"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "mediant-iii",
+          "narrative": "The iii min7 chord appears as the third degree of the harmonized major scale and is included in Fisher's chord-scale practice across all string sets. Fisher explains that three min7 chords are produced by harmonizing any major scale — on degrees ii, iii, and vi — and that 'every min7 chord has three major scale choices to use for improvising,' the largest palette of any chord quality in the method. The iii chord's Phrygian mode correspondence is implied by the derivative approach.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'harmonizing any major scale always produces … three min7 chords (ii, iii and vi)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'Every min7 chord has three major scale choices to use for improvising'"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii",
+            "min7/submediant-vi"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "submediant-vi",
+          "narrative": "Fisher's harmonized major scale produces vi min7 as the third diatonic minor seventh chord. In the book's example progression 'CMaj7-Amin7-FMaj7-G7,' Amin7 functions as vi and is shown to be improvisable with the C major scale because 'all of these chords are natural to the key of C.' The vi min7 participates in the progressional improvising framework where a single parent scale covers the entire diatonic progression.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 56: 'CMaj7-Amin7-FMaj7-G7 … all of these chords are natural to the key of C'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'harmonizing any major scale always produces … three min7 chords (ii, iii and vi)'"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii",
+            "min7/mediant-iii",
+            "maj7/tonic-i"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "three-scale-choices",
+          "narrative": "Fisher codifies a definitive rule for min7 improvisation: 'Every min7 chord has three major scale choices to use for improvising.' This gives min7 the widest palette of any chord quality in the method — compared with two for Maj7 and only one each for dom7 and min7b5. The three choices correspond to the three parent major scales for which a given minor 7th is the ii, iii, or vi chord respectively. The student must internalize all three parent-key derivations before claiming fluency over min7 changes.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'Every min7 chord has three major scale choices to use for improvising'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'harmonizing any major scale always produces … three min7 chords (ii, iii and vi)'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-iv",
+            "dom7/one-scale-choice",
+            "min7b5/one-scale-choice"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "dorian-mode-source",
+          "narrative": "Fisher identifies the Dorian mode as the prescribed improvisation scale for the ii min7 chord in the derivative approach: 'The D Dorian mode would be used over Dmin7, the ii chord.' Generated by playing the parent major scale from its second degree, Dorian is the most commonly encountered mode for ii min7 in the ii-V-I context. Fisher presents both the parallel approach (separate Dorian fingerings) and the derivative approach (relating Dorian back to the parent C major scale) as valid pedagogical methods.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 69: 'The D Dorian mode would be used over Dmin7, the ii chord'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 72: 'learn separate fingerings for each mode … This is known as the parallel-approach'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/ionian-mode-source",
+            "dom7/mixolydian-mode-source",
+            "min7b5/locrian-mode-source"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher's voicing proscription applies universally to min7: the minor 3rd and minor 7th must be retained in any voiced chord because 'these are the tones that define major, minor and dominant chords.' For min7 specifically, the minor 3rd distinguishes it from dom7 and Maj7; the minor 7th distinguishes it from min-maj7. Dropping either would make the chord's quality ambiguous. Roots, 5ths, and 9ths remain freely omissible to reduce string-count without identity loss.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/retain-guide-tones",
+            "dom7/retain-guide-tones",
+            "min7b5/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "chord-scale-voice-leading",
+          "narrative": "Fisher directs students to observe voice leading through min7 chords in the diatonic chord scale, noting that 'each voice moves in a scale-wise motion (from root to root, 3rd to 3rd, etc.)' across every chord change. Practicing chord scales that include ii min7 and vi min7 'in several other keys' is prescribed to develop the ear for smooth diatonic motion. The book also specifies that chord scales should be practiced across multiple string sets to expose the student to all diatonic min7 voicings.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 54: 'each voice moves in a scale-wise motion (from root to root, 3rd to 3rd, etc)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 58: 'play it in several other keys'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/chord-scale-voice-leading",
+            "dom7/chord-scale-voice-leading"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "non-diatonic-roman-notation",
+          "narrative": "Fisher provides a specific notational rule for min7 chords that appear in non-standard roles: 'if the root of the chord belongs in the key, but the chord type is different than usual (for instance, it should be min7, but now it's 7), it is necessary to indicate the new chord type.' The corollary is that a min7 functioning as ii in a new key area requires the parent key to shift: 'in measures three and four we would think of our parent key as F Major, so the progression is ii-V7-I.' This parent-key reorientation is the method's prescribed thinking tool for modulations.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 71: 'it should be min7, but now it's 7 … it is necessary to indicate the new chord type'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 71: 'in measures three and four we would think of our parent key as F Major, so the progression is ii-V7-I'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/secondary-dominant",
+            "min7/supertonic-ii"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "dominant-v",
+          "narrative": "Fisher establishes the V7 dominant seventh chord as the harmonic engine of all ii-V-I progressions and as the sole dominant-quality chord produced by harmonizing a major scale: 'harmonizing any major scale always produces … one dominant 7th chord (V7).' The student is directed to learn every ii-V-I pattern in Roman numerals for transposition, making V7 the pivot of the entire method's harmonic vocabulary. The Mixolydian mode is implied as its improvisation source through the derivative mode approach.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'harmonizing any major scale always produces … one dominant 7th chord (V7)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 67: 'ii-V-I in C … many types of songs follow rather predictable patterns'"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii",
+            "maj7/tonic-i",
+            "dom7/one-scale-choice"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "one-scale-choice",
+          "narrative": "Fisher issues a definitive constraint for dominant 7th improvisation: 'Every dominant 7th chord has one major scale choice.' This is the most restrictive palette in the diatonic system — half the options of Maj7 and one-third those of min7. The single available parent scale is the one whose fifth degree is the dominant root (i.e., the scale built a perfect 4th above the dom7 root, corresponding to Mixolydian mode). Students must memorize this one-choice rule to avoid using wrong scales over V7.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'Every dominant 7th chord has one major scale choice'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'it is safe to say … Every dominant 7th chord has one major scale choice'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-iv",
+            "min7/three-scale-choices",
+            "min7b5/one-scale-choice"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "mixolydian-mode-source",
+          "narrative": "Fisher's derivative approach pairs each diatonic chord with the mode sharing its root: for V7, this is Mixolydian (the fifth rotation of the parent major scale). The rule 'Each mode of the major scale corresponds to the diatonic chord that shares the same root' makes Mixolydian the prescribed improvisation scale for dom7 in a diatonic context. The student may also use the parallel approach — learning separate Mixolydian fingerings — as Fisher notes 'there are actually five separate approaches one could use.'",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 69: 'Each mode of the major scale corresponds to the diatonic chord that shares the same root'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 72: 'there are actually five separate approaches one could use'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/ionian-mode-source",
+            "min7/dorian-mode-source",
+            "min7b5/locrian-mode-source"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher's most emphatic voicing proscription is framed around dom7 as the clearest case: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords.' For dom7, the major 3rd and minor 7th together create the tritone that defines dominant function; removing either dissolves that functional identity. The student is permitted to drop the root, 5th, or 9th 'in various combinations' but never the 3rd-7th pair.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/retain-guide-tones",
+            "min7/retain-guide-tones",
+            "dom7/dominant-v"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "secondary-dominant",
+          "narrative": "Fisher explains that when a chord's root belongs in the key but its quality deviates from the diatonic norm — 'for instance, it should be min7, but now it's 7' — the Roman numeral must be adjusted to show the new chord type (e.g., 'Dmin7=ii, D7=II7'). This notation rule governs secondary dominants, where a dom7 temporarily tonicizes a non-tonic chord. The student is instructed that when approaching such a non-diatonic dom7, 'switch to the modal approach' for improvisation.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 71: 'it should be min7, but now it's 7 … it is necessary to indicate the new chord type'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 83: 'when you get to a chord that is not natural to the key, switch to the modal approach'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v",
+            "min7/non-diatonic-roman-notation"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "chord-scale-voice-leading",
+          "narrative": "The V7 chord concludes each ascending diatonic chord scale, and Fisher instructs students to observe that 'each voice moves in a scale-wise motion' from the preceding IVMaj7 through V7 to IMaj7. Practicing chord scales 'in several other keys' is prescribed as the method for internalizing smooth dominant-to-tonic motion. Fisher also requires that chord scales be mastered 'on various string sets' so that all voicings of V7 across the fingerboard are internalized alongside their voice-leading context.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 54: 'each voice moves in a scale-wise motion (from root to root, 3rd to 3rd, etc)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 58: 'chord scales that follow are shown on various string sets'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/chord-scale-voice-leading",
+            "min7/chord-scale-voice-leading"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "cycle-of-fourths-motion",
+          "narrative": "Fisher presents the cycle of 4ths as the governing logic for chord movement: 'One of the most common patterns in these styles is the movement of a 4th.' The V7-to-I resolution is the prototypical cycle-of-4ths move, with the dominant root lying a perfect 4th below the tonic. Students are directed to practice all exercises in cycle-of-4ths order (C, F, Bb, Eb, Ab, Db, Gb, B, E, A, D, G) to internalize this motion as automatic, ensuring that ii-V-I patterns can be transposed fluidly through all twelve keys.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 2, p. 16: 'One of the most common patterns in these styles is the movement of a 4th'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 2, p. 13: 'Construct them in the following order: C, F, B♭, E♭, A♭, D♭, G♭, B, E, A, D and G'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v",
+            "min7/supertonic-ii"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7b5",
+          "function_role": "leading-tone-vii",
+          "narrative": "Fisher identifies the vii min7b5 (half-diminished) chord as the seventh diatonic chord produced by harmonizing the major scale: 'harmonizing any major scale always produces … one min7b5 chord (vii).' This chord appears in the chord scale on the leading tone and participates in the voice-leading sequence alongside the other six diatonic chords. Fisher includes it explicitly in the scale-choice rule set alongside Maj7, min7, and dom7, giving it its own cardinality entry.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'harmonizing any major scale always produces … one min7b5 chord (vii)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 54: 'we stack 3rds on top of each scale degree … If we stack them four notes high, we get 7th chords'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v",
+            "min7/supertonic-ii",
+            "min7b5/one-scale-choice"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7b5",
+          "function_role": "one-scale-choice",
+          "narrative": "Fisher fixes the min7b5 improvisation palette at exactly one parent major scale choice: 'Every min7b5 chord has one major scale choice.' This places min7b5 in the same single-option category as dom7, in contrast to the broader choices available for Maj7 (two) and min7 (three). The one available parent scale is the major scale whose seventh degree is the min7b5 root (corresponding to Locrian mode), and the student is expected to memorize this as a hard rule before improvising over vii chords.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'Every min7b5 chord has one major scale choice'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'it is safe to say … Every min7‧5 chord has one major scale choice'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/one-scale-choice",
+            "maj7/tonic-iv",
+            "min7/three-scale-choices"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7b5",
+          "function_role": "locrian-mode-source",
+          "narrative": "In Fisher's derivative mode system, the Locrian mode — the seventh rotation of the parent major scale — corresponds to the vii min7b5 chord: 'Each mode of the major scale corresponds to the diatonic chord that shares the same root.' Since min7b5 has exactly one parent scale choice, Locrian is the sole prescribed improvisation scale in the diatonic context. Students using the parallel approach would learn a separate Locrian fingering; those using the derivative approach relate it to the parent major scale's seventh degree.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 69: 'Each mode of the major scale corresponds to the diatonic chord that shares the same root'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 77: 'Every min7b5 chord has one major scale choice'"
+            }
+          ],
+          "cross_ref": [
+            "min7b5/one-scale-choice",
+            "maj7/ionian-mode-source",
+            "min7/dorian-mode-source"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7b5",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher's universal proscription against dropping 3rds and 7ths applies to min7b5: the minor 3rd and minor 7th are the quality-defining tones that distinguish it from other chord types, and omitting either would make its half-diminished sound ambiguous. The diminished 5th (b5) is the additional color tone that distinguishes min7b5 from plain min7, and while Fisher does not call it out explicitly by name here, the general principle — 'these are the tones that define major, minor and dominant chords' — covers it by extension.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            }
+          ],
+          "cross_ref": [
+            "min7/retain-guide-tones",
+            "dom7/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj9",
+          "function_role": "omit-root",
+          "narrative": "Fisher explicitly permits the omission of the root from extended voicings: 'Roots, 5ths and 9ths can be dropped in various combinations.' For Maj9 chords (Maj7 + 9th extension), this means the root may be freely dropped — 'the combination of remaining voices can actually imply the missing sounds' — leaving a voicing that retains the 3rd, 5th, 7th, and 9th. This rootless approach is standard in jazz comping and aligns with Fisher's instruction that the guitar need not duplicate bass-register roots covered by a bassist.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations. The combination of remaining voices can actually imply the missing sounds'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'We get the extended notes (beyond the octave) by continuing the major scale up through a second octave'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/retain-guide-tones",
+            "dom13/omit-fifth-ninth"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj9",
+          "function_role": "extension-naming-convention",
+          "narrative": "Fisher establishes the rule that 'chords are usually named for the highest extension present,' which means a chord containing the 9th above a Maj7 shell is called Maj9 regardless of whether the 7th is explicitly voiced. The 9th itself is derived 'by continuing the major scale up through a second octave,' making it the natural first extension beyond the octave. Students must apply this naming convention consistently to avoid confusing Maj9 with Maj7add9 or other composite labels.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 31: 'Chords are usually named for the highest extension present'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'We get the extended notes (beyond the octave) by continuing the major scale up through a second octave'"
+            }
+          ],
+          "cross_ref": [
+            "dom13/extension-naming-convention",
+            "min9/extension-naming-convention"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min9",
+          "function_role": "omit-root",
+          "narrative": "Fisher's omission rule permits dropping the root from min9 voicings, as 'roots … can be dropped in various combinations' while 'the combination of remaining voices can actually imply the missing sounds.' For min9 (min7 + 9th), a rootless voicing retains the minor 3rd, 5th, minor 7th, and 9th — the full color identity of the chord without the doubled bass-register root. This practice is consistent with the book's broader directive that students must retain 3rds and 7ths as the non-negotiable quality definers.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'The combination of remaining voices can actually imply the missing sounds'"
+            }
+          ],
+          "cross_ref": [
+            "min7/retain-guide-tones",
+            "maj9/omit-root"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min9",
+          "function_role": "extension-naming-convention",
+          "narrative": "Fisher's naming rule — 'chords are usually named for the highest extension present' — applies to min9: a minor chord voiced with root, minor 3rd, 5th, minor 7th, and 9th is labeled min9 because the 9th is the highest extension. Extensions are derived 'by continuing the major scale up through a second octave,' and the 9th corresponds to the second scale degree in that second octave. Consistent application of this rule ensures the student can correctly read and write chord symbols in lead sheets and charts.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 31: 'Chords are usually named for the highest extension present'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'These are called extensions. Where do these notes come from? We get the extended notes (beyond the octave) by continuing the major scale up through a second octave'"
+            }
+          ],
+          "cross_ref": [
+            "maj9/extension-naming-convention",
+            "dom13/extension-naming-convention"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom13",
+          "function_role": "extension-naming-convention",
+          "narrative": "Fisher's naming convention — 'chords are usually named for the highest extension present' — establishes that a dominant voicing including the 13th (sixth scale degree in the second octave) is called dom13 even when lower extensions (9th, 11th) are implied but omitted. The 13th is the furthest extension reached by continuing the major scale through a second octave before returning to the root, making dom13 the richest standard extension name in Fisher's system. The student is expected to apply this naming rule consistently in reading and constructing chord symbols.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 31: 'Chords are usually named for the highest extension present. So, even though the 7 and 9 are part of the chord, it is still called min11'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'Many chords use notes that actually lie beyond a one octave major scale … these would include chords that have 9ths, 11ths and 13ths'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v",
+            "maj9/extension-naming-convention"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom13",
+          "function_role": "omit-fifth-ninth",
+          "narrative": "Fisher's general omission rule — 'Roots, 5ths and 9ths can be dropped in various combinations' — applies to dom13 voicings, where the 5th and 9th are the most commonly dropped tones to make the voicing guitaristically feasible. The critical 3rd and minor 7th (tritone pair defining dominant function) must be retained, along with the 13th itself (the highest extension and the label-defining tone). This creates the practical 'shell-plus-13th' voicing approach Fisher's method implicitly supports for extended dominant chords on guitar.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/retain-guide-tones",
+            "maj9/omit-root"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom11",
+          "function_role": "extension-stacking-source",
+          "narrative": "Fisher establishes the 11th as the second-level extension derived 'by continuing the major scale up through a second octave,' corresponding to the fourth scale degree in that octave. The dom11 chord results from adding this extension above a dom7 shell, and the naming rule — 'chords are usually named for the highest extension present. So, even though the 7 and 9 are part of the chord, it is still called min11' — provides the model for any dom11 label. The student is directed to construct all extensions by this additive second-octave procedure.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'these would include chords that have 9ths, 11ths and 13ths. These are called extensions. We get the extended notes (beyond the octave) by continuing the major scale up through a second octave'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 31: 'Chords are usually named for the highest extension present'"
+            }
+          ],
+          "cross_ref": [
+            "dom13/extension-naming-convention",
+            "dom7/dominant-v"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom11",
+          "function_role": "omit-root-fifth",
+          "narrative": "Applying Fisher's omission rule to dom11: roots and 5ths 'can be dropped in various combinations' because 'the combination of remaining voices can actually imply the missing sounds.' For a dom11 voicing on guitar, dropping both root and 5th leaves the 3rd, 7th, 9th, and 11th — a voicing that is both physically practical on a six-string and harmonically complete by Fisher's definition, since the indispensable 3rd and 7th remain. This approach prevents clutter while preserving the chord's identity and dominant function.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations. The combination of remaining voices can actually imply the missing sounds'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths'"
+            }
+          ],
+          "cross_ref": [
+            "dom13/omit-fifth-ninth",
+            "dom7/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "sus4",
+          "function_role": "pre-dominant-motion",
+          "narrative": "Fisher's foundational triad construction — 'Triads are built from the root, 3rd and 5th degrees of the major scale (R, 3, 5)' — provides the theoretical substrate from which suspended voicings derive. While Fisher does not name sus4 explicitly, the book's chord-scale framework and voice-leading rule ('each voice moves in a scale-wise motion') imply that suspended 4th voicings arise from scale-wise approach to the 3rd and function as pre-dominant motion into dom7. The student should treat any sus4 voicing as governed by the same guide-tone retention principle: the 4th (substituting the 3rd) and 7th are the defining tones.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 2, p. 18: 'Triads are built from the root, 3rd and 5th degrees of the major scale (R, 3, 5)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 54: 'each voice moves in a scale-wise motion (from root to root, 3rd to 3rd, etc)'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-v",
+            "dom7/chord-scale-voice-leading"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min6",
+          "function_role": "tonic-color-minor",
+          "narrative": "Fisher's general formula for sixth chords — defining Maj6 as 'Root-3-5-6' — provides the constructive model for min6 by analogy: a minor triad (R-b3-5) with an added major 6th scale degree. Fisher's voicing omission rules apply: roots and 5ths may be freely dropped while the minor 3rd and 6th (the defining color tones) must be retained. The additive construction method 'simply a matter of adding additional scale tones to the original triad' establishes the min6 formula as R-b3-5-6, a chord used for tonic minor color in jazz.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 33: 'The formula for Maj chords is as follows: Root-3-5-6'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'constructing larger chords is simply a matter of adding additional scale tones to the original triad'"
+            }
+          ],
+          "cross_ref": [
+            "maj6/tonic-color-substitute",
+            "min7/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min6",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher's universal proscription — 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords' — applies to min6 by structural logic: the minor 3rd is the defining interval distinguishing min6 from Maj6, and the added 6th is the extension giving the chord its name and character. Dropping the minor 3rd or the 6th would strip the chord of its quality identity. Roots and 5ths remain safely omissible.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            }
+          ],
+          "cross_ref": [
+            "maj6/retain-guide-tones",
+            "min7/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min-maj7",
+          "function_role": "formula-construction",
+          "narrative": "Fisher's chord-construction framework — 'constructing larger chords is simply a matter of adding additional scale tones to the original triad' — establishes the min-maj7 formula as R-b3-5-7 (minor triad plus major 7th). While Fisher does not explicitly name min-maj7, the book's construction pedagogy directly generates it: a minor triad (R-b3-5) plus the major 7th scale degree. The voicing rule applies here as it does everywhere: the minor 3rd and major 7th together define this chord's unique sound and must not be dropped.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'constructing larger chords is simply a matter of adding additional scale tones to the original triad'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 30: 'The formula for Maj7 chords is: Root-3-5-7'"
+            }
+          ],
+          "cross_ref": [
+            "min7/retain-guide-tones",
+            "maj7/formula-construction"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min-maj7",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher's most emphatic proscription — 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords' — applies with particular force to min-maj7, where the coexistence of a minor 3rd and major 7th creates the chord's characteristic unstable-yet-lush sound. Dropping either tone would collapse the chord into either a plain min7 (if the major 7th is dropped) or a Maj7 (if the minor 3rd is raised). The root and 5th remain freely omissible.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            }
+          ],
+          "cross_ref": [
+            "min7/retain-guide-tones",
+            "maj7/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "fingerstyle-simultaneous-voicing",
+          "narrative": "Fisher prescribes fingerstyle technique specifically for sounding multiple chord voices simultaneously: 'playing fingerstyle is the only way to sound the voices simultaneously. When strumming with a pick or your thumb the notes will always appear one after the other.' For Maj7 voicings, which often use four or more voices across non-adjacent strings, fingerstyle execution is the only method that produces the chord's full harmonic texture in a single instant rather than as an arpeggiated sequence. Fisher cross-references pages 87–88 for detailed right-hand guidance.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 88: 'playing fingerstyle is the only way to sound the voices simultaneously'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 31: 'Another consideration is how to execute these larger chords with the right hand. Most chords in this book can be played with a pick, while some work better when fingerpicked'"
+            }
+          ],
+          "cross_ref": [
+            "min7/fingerstyle-simultaneous-voicing",
+            "dom7/fingerstyle-simultaneous-voicing"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "fingerstyle-simultaneous-voicing",
+          "narrative": "Fisher's right-hand rule — 'playing fingerstyle is the only way to sound the voices simultaneously' — applies equally to min7 voicings. Four-note min7 chords spread across non-adjacent strings require simultaneous right-hand finger plucking with the p-i-m-a system Fisher introduces (thumb, first, middle, third fingers), contrasting with pick-based strumming where 'the notes will always appear one after the other.' The student is directed to use fingerstyle for harmonic contexts where simultaneous voice articulation matters.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 88: 'playing fingerstyle is the only way to sound the voices simultaneously'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 87: 'In the traditional methods the thumb and first three fingers are used'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/fingerstyle-simultaneous-voicing",
+            "dom7/fingerstyle-simultaneous-voicing"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "fingerstyle-simultaneous-voicing",
+          "narrative": "Fisher's simultaneous-voicing rule applies to dom7 chords as well: 'playing fingerstyle is the only way to sound the voices simultaneously.' Extended dominant chords (dom7, dom9, dom13) with tones spread across multiple strings require the p-i-m-a fingerstyle system to produce the full harmonic attack. Fisher notes that 'most chords in this book can be played with a pick, while some work better when fingerpicked,' implying that larger, spread dominant voicings fall into the fingerpicked category.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 88: 'playing fingerstyle is the only way to sound the voices simultaneously'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 31: 'Most chords in this book can be played with a pick, while some work better when fingerpicked'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/fingerstyle-simultaneous-voicing",
+            "min7/fingerstyle-simultaneous-voicing"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "locked-position-transposition",
+          "narrative": "Fisher directs that all chord voicings — including Maj7 — should be learned in locked position (no open strings) to enable transposition: 'Scales, arpeggios and licks are in locked position when they contain no open strings. This allows them to be moved around the fingerboard and played in other keys.' For Maj7, this means learning every voicing as a movable closed shape across all four string sets, so that a single fingering covers IMaj7 and IVMaj7 in any of twelve keys by shifting position without re-fingering.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 90: 'Scales, arpeggios and licks are in locked position when they contain no open strings. This allows them to be moved around the fingerboard and played in other keys'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 90: 'no matter what position you are in you can play in eleven different keys without shifting'"
+            }
+          ],
+          "cross_ref": [
+            "min7/locked-position-transposition",
+            "dom7/locked-position-transposition"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "locked-position-transposition",
+          "narrative": "Fisher's locked-position principle applies to all min7 voicings: closed shapes with no open strings allow the player to shift the entire voicing up or down the neck to any key without changing the fingering pattern. This is essential for ii min7, which must be playable in twelve keys for the ii-V-I transposition practice Fisher prescribes: 'over the next few days you transpose four or five tunes into six different keys.' Locked min7 chord shapes across all four string sets are the prerequisite for this transposition fluency.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 90: 'Scales, arpeggios and licks are in locked position when they contain no open strings'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 71: 'over the next few days you transpose four or five tunes into six different keys'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/locked-position-transposition",
+            "dom7/locked-position-transposition"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "locked-position-transposition",
+          "narrative": "Fisher's locked-position system is particularly critical for dom7 because V7 appears in every ii-V-I, which must be transposed to all twelve keys. Closed dom7 shapes across all four string sets enable the student to 'play in eleven different keys without shifting' from a single fingerboard position — the method's declared payoff for mastering locked-position fingerings. Fisher warns that over-reliance on locked position creates 'vertical thinking' that limits improvisation, so dom7 voicings should also be practiced with open-position horizontal movement.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 90: 'no matter what position you are in you can play in eleven different keys without shifting'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 90: 'when you use it to the exclusion of horizontal thinking it can severely limit your improvisational ideas'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/locked-position-transposition",
+            "min7/locked-position-transposition"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "multiple-fingerboard-positions",
+          "narrative": "Fisher mandates learning every chord — including IMaj7 and IVMaj7 — in multiple fingerboard positions as a core competency: 'A good jazz guitarist must be able to … play the chord changes in several areas of the fingerboard.' The three-step learning procedure further specifies: 'Learn the chord progression in two areas of the fingerboard (memorize both if possible).' This multi-position mastery for Maj7 is the prerequisite before learning the melody or beginning improvisation on any tune.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 85: 'play the chord changes in several areas of the fingerboard'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 59: 'Learn the chord progression in two areas of the fingerboard (memorize both if possible)'"
+            }
+          ],
+          "cross_ref": [
+            "min7/multiple-fingerboard-positions",
+            "dom7/multiple-fingerboard-positions"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "multiple-fingerboard-positions",
+          "narrative": "Fisher's three-step learning procedure — 'Learn the chord progression in two areas of the fingerboard' — applies equally to min7 as the ii chord in every ii-V-I. The requirement to know ii min7 in at least two positions before proceeding to melody or improvisation ensures that the student can navigate the chord changes fluidly whether in lower or upper register. Fisher's mastery checklist at the book's end confirms this: 'playing chord changes in at least two areas of the fingerboard' is an explicit exit criterion.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 59: 'Learn the chord progression in two areas of the fingerboard (memorize both if possible)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'playing chord changes in at least two areas of the fingerboard'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/multiple-fingerboard-positions",
+            "dom7/multiple-fingerboard-positions"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "multiple-fingerboard-positions",
+          "narrative": "Fisher requires V7 dominant chords to be mastered in multiple fingerboard positions as part of the three-step tune-learning procedure: 'Learn the chord progression in two areas of the fingerboard (memorize both if possible).' The book's final mastery checklist — 'playing chord changes in at least two areas of the fingerboard' — confirms this as a non-negotiable exit criterion. Since V7 anchors every ii-V-I, multi-position dom7 fluency is the single most consequential chord-position skill in the method.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 59: 'Learn the chord progression in two areas of the fingerboard (memorize both if possible)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'playing chord changes in at least two areas of the fingerboard'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/multiple-fingerboard-positions",
+            "min7/multiple-fingerboard-positions"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "progressional-improvisation-target",
+          "narrative": "Fisher's progressional improvising framework designates IMaj7 as the tonic resolution point over which the parent major scale sounds most consonant. In the example 'CMaj7-Amin7-FMaj7-G7,' the C major scale works over the entire diatonic progression because IMaj7 is its natural home. The student is directed to 'play the appropriate major scale up and back a few times' while listening to the chord background, 'just listen to the way the notes behave over the background chords' — making IMaj7 the anchor chord against which scale behavior is first internalized.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 56: 'You could improvise over this with the C Major scale because all of these chords are natural to the key of C'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 55: 'play the appropriate major scale up and back a few times … listen to the way the notes behave over the background chords'"
+            }
+          ],
+          "cross_ref": [
+            "min7/supertonic-ii",
+            "dom7/dominant-v"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "progressional-improvisation-target",
+          "narrative": "Fisher's progressional improvising approach covers min7 under the same parent-scale umbrella as all other diatonic chords: 'a single scale will work well (sound good) over an entire chord progression' when the progression is diatonic. This means that over ii min7 and vi min7 in a diatonic ii-V-I, the student should continue using the key's major scale without switching scales. The book prescribes limiting rhythmic options (whole notes through eighth notes) as the practice method for hearing how scale tones interact with each min7 chord in the background.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 55: 'a single scale will work well (sound good) over an entire chord progression'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 92: 'limiting rhythmic options … will help you really hear how the notes in a scale behave against the background chords'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/progressional-improvisation-target",
+            "dom7/progressional-improvisation-target"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "progressional-improvisation-target",
+          "narrative": "Fisher prescribes the parent major scale over V7 in a diatonic progression under the progressional improvising approach: 'a single scale will work well over an entire chord progression' when the chords are diatonic. However, when V7 appears as a non-diatonic secondary dominant, Fisher's mixed-tune rule overrides: 'when you get to a chord that is not natural to the key, switch to the modal approach.' The student must distinguish between diatonic V7 (stay in parent scale) and secondary dominant V7 (switch to the appropriate Mixolydian mode of the new key).",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 55: 'a single scale will work well (sound good) over an entire chord progression'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 83: 'when you get to a chord that is not natural to the key, switch to the modal approach'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/secondary-dominant",
+            "min7/progressional-improvisation-target"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "string-set-chord-scale",
+          "narrative": "Fisher explicitly prescribes practicing IMaj7 and IVMaj7 within chord scales across all four three-string sets (6-5-4, 5-4-3, 4-3-2, 3-2-1): 'the chord scales that follow are shown on various string sets and chosen for either their usefulness or interest level … Practice each chord scale until each voice in every chord is clear and balanced. Then, play it in several other keys.' This systematic cross-string-set drilling of Maj7 voicings is the method's prescribed path to expanded chord vocabulary.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 58: 'chord scales that follow are shown on various string sets … Practice each chord scale until each voice in every chord is clear and balanced. Then, play it in several other keys'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 58: 'Constructing chord scales up and down the fingerboard is one sure-fire way to make certain you are comfortable with diatonic harmony in any key'"
+            }
+          ],
+          "cross_ref": [
+            "min7/string-set-chord-scale",
+            "dom7/string-set-chord-scale"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "string-set-chord-scale",
+          "narrative": "Fisher directs students to practice all diatonic chord scales — including ii min7 and vi min7 — across all four string sets as the primary chord vocabulary expansion method: 'Constructing chord scales up and down the fingerboard is one sure-fire way to make certain you are comfortable with diatonic harmony in any key.' The vertical direction drill (across string sets) is also prescribed: 'learn chord scales in a vertical direction, across the string sets. This way you will learn all the diatonic chords in closer proximity.'",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 58: 'Constructing chord scales up and down the fingerboard is one sure-fire way to make certain you are comfortable with diatonic harmony in any key'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 76: 'learn chord scales in a vertical direction, across the string sets. This way you will learn all the diatonic chords in closer proximity'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/string-set-chord-scale",
+            "dom7/string-set-chord-scale"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "string-set-chord-scale",
+          "narrative": "Fisher prescribes drilling V7 dominant chords within ascending and descending chord scales across all string sets, noting that this approach ensures the student is 'comfortable with diatonic harmony in any key.' V7 always occupies the penultimate position in an ascending diatonic chord scale before resolving to IMaj7, making its smooth voice-leading connection — 'each voice moves in a scale-wise motion' — immediately audible. Fisher additionally prescribes vertical (cross-string-set) chord scale practice to see V7 in close proximity to its ii and I neighbors.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 58: 'Constructing chord scales up and down the fingerboard is one sure-fire way to make certain you are comfortable with diatonic harmony in any key'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 76: 'learn chord scales in a vertical direction, across the string sets'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/string-set-chord-scale",
+            "min7/string-set-chord-scale"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "open-position-prerequisite",
+          "narrative": "Fisher establishes open-position major chord mastery as the entry prerequisite for the entire method: 'You need to know the basic open-position chords as well as the standard barre chord fingerings. Changing from one chord to another should not be a problem. If you don't know these chords, learn them well before proceeding.' While open-position chords are pre-method prerequisites rather than jazz voicings per se, they represent the student's first encounter with major-quality chord shapes from which all subsequent Maj7 voicings are built by adding the 7th.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 1, p. 6: 'You need to know the basic open-position chords as well as the standard barre chord fingerings. Changing from one chord to another should not be a problem. If you don't know these chords, learn them well before proceeding'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/open-position-prerequisite",
+            "maj7/formula-construction"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "open-position-prerequisite",
+          "narrative": "Fisher prescribes mastery of both major and dominant 7th open-position barre forms as the prerequisite before beginning the method: 'You need to know the basic open-position chords as well as the standard barre chord fingerings.' The chapter presents dominant 7th barre forms on both sixth-string root and fifth-string root, establishing dom7 as the only chord quality besides major that is required as a prerequisite. This positions dom7 knowledge as foundational before any jazz harmony is introduced.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 1, p. 7: 'With the root on the sixth string … DOMINANT'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 1, p. 6: 'You need to know the basic open-position chords as well as the standard barre chord fingerings … learn them well before proceeding'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/open-position-prerequisite",
+            "dom7/dominant-v"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "modal-tune-improvisation",
+          "narrative": "Fisher defines modal tunes as 'usually based around very few chord changes, so improvisation is based on just a few scales. The melody is usually written in a single mode.' When a modal tune centers on a Maj7 chord (e.g., a long vamp on IMaj7), the prescribed improvisation approach is Ionian mode of the parent key — a single scale sustained throughout rather than chord-by-chord scale switching. This simplifies the beginner's task on modal tunes: identify the Maj7 root, apply the corresponding Ionian scale, and sustain it for the duration.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 80: 'Modal tunes are usually based around very few chord changes, so improvisation is based on just a few scales. The melody is usually written in a single mode'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 69: 'The C Ionian mode is used to improvise over CMaj7, the I chord'"
+            }
+          ],
+          "cross_ref": [
+            "min7/modal-tune-improvisation",
+            "maj7/ionian-mode-source"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "modal-tune-improvisation",
+          "narrative": "Fisher notes that modal tunes 'are usually based around very few chord changes,' and when a modal tune centers on a min7 chord (e.g., a Dorian vamp), the prescribed improvisation is the Dorian mode sustained throughout. The student is directed to 'switch to the modal approach' for chords requiring it, and for modal min7 contexts the derivative rule applies: play the parent major scale from the minor 7th chord's root for an octave. This single-mode thinking contrasts with the multi-chord scale-switching required on mixed tunes.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 80: 'Modal tunes are usually based around very few chord changes, so improvisation is based on just a few scales'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 83: 'when you get to a chord that is not natural to the key, switch to the modal approach'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/modal-tune-improvisation",
+            "min7/dorian-mode-source"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "key-change-scale-switch",
+          "narrative": "Fisher extends the diatonic improvisation rule to handle modulations: 'You can even use this approach when a tune moves briefly into another key. Just change scales to fit the new key.' When a progression moves to a new IMaj7 or IVMaj7 in a different key area, the student must identify the new parent key, switch to that major scale, and re-establish the diatonic thinking around the new Maj7 tonic. This scale-switching prescription for key changes is the book's primary modulation-handling tool for beginners.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 57: 'You can even use this approach when a tune moves briefly into another key. Just change scales to fit the new key'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 5, p. 71: 'in measures three and four we would think of our parent key as F Major, so the progression is ii-V7-I'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/secondary-dominant",
+            "min7/non-diatonic-roman-notation"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7b5",
+          "function_role": "chord-scale-voice-leading",
+          "narrative": "Fisher's chord-scale voice-leading rule — 'each voice moves in a scale-wise motion (from root to root, 3rd to 3rd, etc.)' — includes the vii min7b5 chord as part of the ascending diatonic chord scale sequence. The student is directed to practice chord scales 'until each voice in every chord is clear and balanced,' which means vii min7b5 must be voiced cleanly with its diminished 5th intact and each voice smoothly connecting to the neighboring vi min7 below and IMaj7 above (in the diatonic cycle). The b5 is a defining color tone that must not be omitted.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 54: 'each voice moves in a scale-wise motion (from root to root, 3rd to 3rd, etc)'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 58: 'Practice each chord scale until each voice in every chord is clear and balanced'"
+            }
+          ],
+          "cross_ref": [
+            "min7/chord-scale-voice-leading",
+            "dom7/chord-scale-voice-leading"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "two-octave-melody-requirement",
+          "narrative": "Fisher's definition of jazz guitarist competency requires melodic fluency across multiple octaves over all chord changes, including Maj7: 'A good jazz guitarist must be able to: Play a song's melody in two or three octaves.' The three-step tune-learning procedure reinforces this: 'Learn the melody. If you can, try to learn it an octave higher than written as well.' This means the student must be able to play melody notes over IMaj7 and IVMaj7 in both lower and upper register positions across the fingerboard.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 85: 'Play a song's melody in two or three octaves'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 59: 'Learn the melody. If you can, try to learn it an octave higher than written as well'"
+            }
+          ],
+          "cross_ref": [
+            "min7/two-octave-melody-requirement",
+            "dom7/two-octave-melody-requirement"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "two-octave-melody-requirement",
+          "narrative": "Fisher's melody-across-octaves requirement applies equally to dom7 changes: 'A good jazz guitarist must be able to: Play a song's melody in two or three octaves.' The mastery checklist at the book's end — 'being comfortable playing the melodies in two or three octaves' — confirms this as an exit criterion. Since V7 appears in every ii-V-I, the student must be able to navigate melody notes through the dominant chord in both low and high fingerboard positions without losing fluency or pitch accuracy.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 85: 'Play a song's melody in two or three octaves'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'being comfortable playing the melodies in two or three octaves'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/two-octave-melody-requirement",
+            "min7/two-octave-melody-requirement"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "two-octave-melody-requirement",
+          "narrative": "Fisher's melody mastery requirement covers all chord changes including ii min7: 'A good jazz guitarist must be able to … play a song's melody in two or three octaves.' Playing melody over min7 changes in multiple fingerboard positions is required before the student can consider the method complete. Fisher's three-step procedure specifies learning the melody 'ideally an octave higher than written,' which means the student must locate melody notes above ii min7 chord shapes in both lower and upper neck positions.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 85: 'Play a song's melody in two or three octaves'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 59: 'learn it an octave higher than written as well (memorize if possible)'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/two-octave-melody-requirement",
+            "dom7/two-octave-melody-requirement"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj9",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher's proscription against dropping 3rds and 7ths applies with full force to Maj9: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords.' In a Maj9 voicing, the major 3rd and major 7th define the major quality, while the 9th is the extended color tone. Dropping the major 7th would reduce the chord to Maj6/9 or add9; dropping the major 3rd would misidentify the quality. The root and 5th 'can be dropped in various combinations' to make the voicing guitaristically practical.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/retain-guide-tones",
+            "min9/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min9",
+          "function_role": "retain-guide-tones",
+          "polarity": "proscriptive",
+          "narrative": "Fisher's proscription covers min9 by the same logic as all minor chord types: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords.' For min9, the minor 3rd and minor 7th are the indispensable quality markers distinguishing it from Maj9, dom9, and min-maj9. The 9th itself — though the highest extension and label-defining tone — falls in the 'can be dropped' category by Fisher's rule, but dropping the minor 3rd or 7th is explicitly prohibited.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'it is generally not a good idea to drop 3rds and 7ths because these are the tones that define major, minor and dominant chords'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 3, p. 46: 'Roots, 5ths and 9ths can be dropped in various combinations'"
+            }
+          ],
+          "cross_ref": [
+            "min7/retain-guide-tones",
+            "maj9/retain-guide-tones"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "limiting-rhythmic-options-practice",
+          "narrative": "Fisher prescribes 'limiting rhythmic options' as the primary practice method for internalizing scale behavior over V7 chord changes: 'At first use only whole notes, then half notes, quarter notes and finally eighth notes.' This progression from whole to eighth notes over dom7 (in the ii-V-I context) is designed to isolate the student's ear — 'just listen to the way the notes behave over the background chords' — before introducing rhythmic complexity. Only after all note values are comfortable does the student 'play as freely as you want.'",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 59: 'At first use only whole notes, then half notes, quarter notes and finally eighth notes. Then play as freely as you want'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 92: 'limiting rhythmic options … will help you really hear how the notes in a scale behave against the background chords'"
+            }
+          ],
+          "cross_ref": [
+            "min7/limiting-rhythmic-options-practice",
+            "maj7/progressional-improvisation-target"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "limiting-rhythmic-options-practice",
+          "narrative": "Fisher's 'limiting rhythmic options' practice method applies to ii min7 in the context of ii-V-I improvisation: the student begins with only whole notes over the progression, progresses to half notes, quarter notes, and eighth notes, 'then play as freely as you want.' This method is prescribed because it 'will help you to break out of finger patterns that you automatically fall into and let you use more of the rhythmic tools that are available.' For min7 as the ii chord, this controlled progression develops genuine melodic hearing independent of automatic technical habits.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 6, p. 92: 'limiting rhythmic options … will help you to break out of finger patterns that you automatically fall into'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 4, p. 59: 'At first use only whole notes, then half notes, quarter notes and finally eighth notes'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/limiting-rhythmic-options-practice",
+            "maj7/progressional-improvisation-target"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "maj7",
+          "function_role": "solo-mastery-exit-criterion",
+          "narrative": "Fisher closes the method with an explicit exit-criterion checklist that includes fluency over all chord changes, including Maj7: 'Before moving on, you should be able to play all the tunes in this book. This means … improvising solos that reflect your understanding of the major scale and its modes.' For IMaj7 specifically, the student must be able to improvise using Ionian mode, construct solos with clear openings, bodies, and conclusions, and play through the chord in two or three octave positions before claiming mastery of the method.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'Before moving on, you should be able to play all the tunes in this book. This means … improvising solos that reflect your understanding of the major scale and its modes'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'melodic patterns with openings, bodies and conclusions'"
+            }
+          ],
+          "cross_ref": [
+            "min7/solo-mastery-exit-criterion",
+            "dom7/solo-mastery-exit-criterion"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "dom7",
+          "function_role": "solo-mastery-exit-criterion",
+          "narrative": "Fisher's mastery checklist requires improvising fluently over all chord changes — including V7 — as a non-negotiable exit criterion: 'improvising solos that reflect your understanding of the major scale and its modes; and melodic patterns with openings, bodies and conclusions.' For dom7, this means the student must have internalized the Mixolydian mode, applied the limiting-rhythmic-options method, and built at least one solo with a three-part arc before advancing. The checklist is stated without exception: 'you should be able to play all the tunes in this book.'",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'improvising solos that reflect your understanding of the major scale and its modes; and melodic patterns with openings, bodies and conclusions'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'Before moving on, you should be able to play all the tunes in this book'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/solo-mastery-exit-criterion",
+            "min7/solo-mastery-exit-criterion"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-1-beginning",
+          "chord_quality": "min7",
+          "function_role": "solo-mastery-exit-criterion",
+          "narrative": "Fisher's exit-criterion checklist implicitly covers ii min7 improvisation as part of full ii-V-I fluency: 'Before moving on, you should be able to play all the tunes in this book. This means … improvising solos that reflect your understanding of the major scale and its modes.' Since all tunes in the method contain ii min7 chords as part of ii-V-I patterns, the student must be able to navigate them cleanly using Dorian mode (or the parent major scale in progressional context) with melodic phrases that have identifiable openings, bodies, and conclusions.",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'Before moving on, you should be able to play all the tunes in this book'"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 1 (Beginning).pdf",
+              "citation": "Ch. 7, p. 95: 'improvising solos that reflect your understanding of the major scale and its modes'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/solo-mastery-exit-criterion",
+            "dom7/solo-mastery-exit-criterion"
+          ],
+          "provenance": "extracted"
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "tonic-i",
+          "narrative": "The I chord's major scale governs all melodic content over diatonic ii-V7-I progressions: \"use the major scale of the I chord. If the progression is Gmin7-C7-FMaj7, improvise using the F Major scale\" (Ch. 1, p. 8). The 3rd and 7th of the I chord are the essential tones that must be retained in any voicing, while roots and 5ths are expendable: \"two most essential notes in any chord are the 3rd and the 7th\" (Ch. 2, p. 17). Major 7th licks labelled for this chord type \"will work equally well with major 6th, major 9th and major 13th chords\" (Ch. 4, p. 60).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 17"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 60"
+            }
+          ],
+          "cross_ref": [
+            "major6/tonic-i",
+            "major9/tonic-i",
+            "major13/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "lick-target",
+          "narrative": "Eight sample major licks are provided specifically labelled for major 7th chords and must be transposed and applied immediately: \"Transpose them and Start using them immediately in songs you are learning\" (Ch. 4, p. 60). These licks transfer equally to major 6th, 9th, and 13th extensions through ear verification. The learn-transpose-apply cycle is non-negotiable — isolated study without real-song insertion is insufficient.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 60"
+            }
+          ],
+          "cross_ref": [
+            "major6/lick-target",
+            "major9/lick-target",
+            "major13/lick-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "upper-extension-source",
+          "narrative": "A Major 7th arpeggio rooted on the flat-7 of any V7 chord is the primary technique for voicing upper extensions: \"play the notes of a major 7th arpeggio rooted on the b7 degree of the V7 chord in any ii-V7-I progression\" (Ch. 3, p. 49). When applied over G7, an FMaj7 arpeggio yields A (9th), C (11th), and E (13th). Crucially, \"you don't have to start the major 7th arpeggio on the root\" (Ch. 3, p. 49), freeing entry to any arpeggio tone.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 49"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/upper-extension-target",
+            "dominant9/upper-extension-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major6",
+          "function_role": "tonic-i",
+          "narrative": "Major 6th chords are listed alongside major 7th, 9th, and 13th as valid extension-targets for major-type licks: \"These licks are labeled with major 7th chords but will work equally well with major 6th, major 9th and major 13th chords. Experiment and let your ear be your guide\" (Ch. 4, p. 60). The same 3rd-and-7th density floor applies — the 6th is an addable color tone, not a replacement for the essential tones. Context and ear, not theory alone, determine when the 6th is appropriate.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 60"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 34"
+            }
+          ],
+          "cross_ref": [
+            "major7/lick-target",
+            "major9/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major9",
+          "function_role": "tonic-i",
+          "narrative": "Major 9th chords are fully valid tonic-function voicings and share the lick vocabulary of the major 7th family: \"work equally well with major 6th, major 9th and major 13th chords\" (Ch. 4, p. 60). The 9th is classified as an omittable tone in any voicing — \"It is common to omit roots, 5ths, 9ths and 11ths in certain situations\" (Ch. 2, p. 17) — meaning the 9th adds color but does not anchor the chord's essential quality, which remains in the 3rd and 7th.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 60"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "major7/tonic-i",
+            "major13/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major13",
+          "function_role": "tonic-i",
+          "narrative": "Major 13th chords are grouped with major 7th, 6th, and 9th as equivalent targets for major-type licks: \"work equally well with major 6th, major 9th and major 13th chords\" (Ch. 4, p. 60). The 13th is an extension that provides jazz color; substitution must pass the context-and-ear gate — \"Just because a substitution is 'theoretically correct' doesn't mean it sounds good in every instance\" (Ch. 2, p. 34). Knowing multiple major voicings is explicitly linked to \"greater taste and variety\" (Ch. 2, p. 43).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 60"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 34"
+            }
+          ],
+          "cross_ref": [
+            "major7/tonic-i",
+            "major9/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "subdominant-ii",
+          "narrative": "The minor 7th chord occupies the ii slot of every ii-V7-I progression and is the point where the major scale of the I chord begins to be applied: \"use the major scale of the I chord\" even while the ii chord sounds (Ch. 1, p. 8). The root of the ii chord is a perfect fourth below the V7 root, and this root spacing is the minimum condition confirming the progression's identity: \"As long as the roots are a perfect 4th apart and the qualities appear as minor, dominant and major respectively, a ii-V7-I exists\" (Ch. 1, p. 7).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 7"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            }
+          ],
+          "cross_ref": [
+            "minor9/subdominant-ii",
+            "dominant7/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "lick-target",
+          "narrative": "Minor chord licks must follow the identical learn-transpose-apply discipline as all other chord families: \"learn, transpose and insert these into your solos as soon as possible!\" (Ch. 4, p. 64). Minor licks are chord-type-specific vocabulary — the book treats each chord type as its own lick family. Transposing to all twelve keys is non-negotiable; immediate insertion into real songs prevents licks from remaining inert theory.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 64"
+            }
+          ],
+          "cross_ref": [
+            "minor9/lick-target",
+            "min7b5/lick-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "rootless-voicing",
+          "narrative": "Rootless voicings on the ii chord (e.g., Dmin9 without root) are explicitly endorsed: \"roots have been omitted from both the Dmin9 and G9 voicings. This is to allow the use of more interesting chords\" (Ch. 3, p. 56). The ear is trained to imply the root internally, and the bass player covers it in ensemble: \"Playing rootless chords often Permits the use of more extensions in chord voicings\" (Ch. 3, p. 56). The 3rd and 7th must remain to preserve minor quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "minor9/rootless-voicing",
+            "dominant9/rootless-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor9",
+          "function_role": "subdominant-ii",
+          "narrative": "The minor 9th chord is the book's primary notated ii-chord voicing in string-set examples, appearing as Dmin9 throughout Chapter 3's chord-connection exercises: \"we will use Dmin9 (ii), G9 (V7), CMaj7 (I) and C6 (also I) as the material for ii-V7-I progressions\" (Ch. 3, p. 56). The 9th is an omittable extension — quality is carried by the 3rd and 7th — and the root is omitted in rootless voicings. All three string sets (6-5-4-3, 5-4-3-2, 4-3-2-1) must be covered.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "minor7/subdominant-ii",
+            "dominant9/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor9",
+          "function_role": "rootless-voicing",
+          "narrative": "Dmin9 is the specific rootless ii voicing used in the three-string-set chord-connection framework: \"roots have been omitted from both the Dmin9 and G9 voicings\" (Ch. 3, p. 56). Omitting the root allows more extensions to occupy the available strings and implies a bigger sound when paired with a bass player. The player must \"hear the root in your head when playing these chords\" — internal-root implication is a required ear-training discipline alongside the voicing technique.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "minor7/rootless-voicing",
+            "dominant9/rootless-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "dominant-v7",
+          "narrative": "The dominant 7th chord is the primary site of harmonic alteration and extension in the ii-V7-I framework: \"Any and all chords in a ii-V7-I progression can be altered or extended\" (Ch. 1, p. 7). Three extension techniques are prescribed specifically for the V7: Maj7 arpeggio from the b7, diminished triad substitution from the 3rd/5th/7th, and ascending scalar lines from chord tones (Ch. 3, pp. 49–53). The essential tones — 3rd and 7th — must be retained in any voicing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 7"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, pp. 49–53"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/dominant-v7",
+            "dominant7b9/dominant-v7",
+            "dominant9/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "lick-target",
+          "narrative": "Dominant licks are scoped specifically to unaltered dominant function and must be transposed and applied to solos: \"Here are some licks that will work well over unaltered dominant chords. Try using them over dominant 9th, 11th and 13th chords as well. Transpose them and apply them to your solos\" (Ch. 4, p. 68). The qualifier 'unaltered' is significant — altered dominants (7b5, 7#5, 7b9) each have separate treatment and may require different lick vocabulary.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 68"
+            }
+          ],
+          "cross_ref": [
+            "dominant9/lick-target",
+            "dominant11/lick-target",
+            "dominant13/lick-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "scale-choice",
+          "narrative": "Over an unaltered V7 in a diatonic ii-V7-I, the I-chord major scale is prescribed as the improvisation tool: \"use the major scale of the I chord\" (Ch. 1, p. 8). This rule is suspended immediately when the V7 contains any altered tone outside the major scale — \"all chords with a raised or lowered 5th, 9th or 11th would make this rule inapplicable\" (Ch. 1, p. 8). The Mixolydian mode (a major scale starting on the 5th degree) is implied as the dominant-specific colour in blues contexts (Ch. 5, p. 78).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 5, p. 78"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/scale-choice",
+            "dominant7b9/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7b5",
+          "function_role": "dominant-v7",
+          "narrative": "The 7b5 chord is defined by the formula Root-3-b5-b7: \"The dominant 7b5 chord is an extremely important sound in jazz. It is constructed from the following formula: Root-3-b5-b7. In the key of C this is C-E-Gb-Bb\" (Ch. 2, p. 18). This chord is explicitly framed as a V7 variant — \"it's the old familiar V7 chord, but with a b5\" — confirming its dominant function. The altered b5 places it outside any major scale, so the standard major-scale improvisation rule does not apply.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 18"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/dominant-v7",
+            "dominant7b9/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7b5",
+          "function_role": "scale-choice",
+          "polarity": "proscriptive",
+          "narrative": "The altered b5 of the 7b5 chord explicitly disqualifies the standard major-scale improvisation rule: \"all chords with a raised or lowered 5th (5, b5), 9th or 11th would make this rule inapplicable, because these altered tones are not diatonic\" (Ch. 1, p. 8). The book does not name an alternative scale here, but the proscription is categorical — the player must not use the I-chord major scale and must find a different tonal solution compatible with the altered 5th.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/scale-choice",
+            "dominant7b9/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7s5",
+          "function_role": "dominant-v7",
+          "narrative": "The 7#5 chord formula is Root-3-#5-b7: \"The dominant 7#5 chord is another very common sound in jazz. The formula for this chord is Root-3-#5-b7. In the key of G, this would be G-B-D#-F\" (Ch. 2, p. 21). It appears under multiple enharmonic symbols — 7+, 7aug, 7b13 — and the 9th is frequently added to produce 9#5 or 9+ variants. Its 'immediately recognizable' sound marks it as a distinct dominant colour requiring specific harmonic treatment.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 21"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/dominant-v7",
+            "dominant7b9/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7s5",
+          "function_role": "scale-choice",
+          "polarity": "proscriptive",
+          "narrative": "The raised 5th of the 7#5 chord places it outside any major scale and thus invalidates the standard diatonic improvisation rule: \"all chords with a raised or lowered 5th… would make this rule inapplicable, because these altered tones are not diatonic (not in the major scale)\" (Ch. 1, p. 8). As with 7b5, the book issues the proscription categorically without naming a replacement scale at this stage, deferring advanced alterations to later study.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 21"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/scale-choice",
+            "dominant7b9/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7b9",
+          "function_role": "dominant-v7",
+          "narrative": "The dominant 7b9 is defined by Root-3-5-b7-b9: \"Adding a lowered 9th to any dominant chord (7b9) gives a chord progression a very distinctive sound. Check out the formula: Root-3-5-b7-b9\" (Ch. 2, p. 24). In rootless form, this voicing exhibits minor-third symmetry: \"when you drop the root, you can move the same fingering around the fingerboard at intervals of a minor 3rd without changing the chord's quality\" (Ch. 2, p. 24). This symmetry is a practical shortcut for finding the same voicing in multiple positions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 24"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/dominant-v7",
+            "dominant7b5/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7b9",
+          "function_role": "rootless-voicing",
+          "narrative": "Dropping the root from a 7b9 voicing activates minor-third fingerboard symmetry — the most explicit positional shortcut in the book: \"you can move the same fingering around the fingerboard at intervals of a minor 3rd without changing the chord's quality\" (Ch. 2, p. 24). This makes rootless 7b9 a uniquely efficient voicing strategy. The ear must supply the implied root, as in all rootless voicings: \"Try to 'hear' the root in your head when playing these chords\" (Ch. 3, p. 56).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 24"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/rootless-voicing",
+            "dominant9/rootless-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7b9",
+          "function_role": "scale-choice",
+          "polarity": "proscriptive",
+          "narrative": "The lowered 9th of the 7b9 chord falls outside any standard major scale and triggers the altered-chord exception: \"all chords with a raised or lowered… 9th (9, b9) would make this rule inapplicable, because these altered tones are not diatonic\" (Ch. 1, p. 8). The I-chord major scale must not be used when any chord in the ii-V7-I carries this alteration. This proscription is absolute at this method level; advanced scale choices are deferred to future study.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/scale-choice",
+            "dominant7s5/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant9",
+          "function_role": "dominant-v7",
+          "narrative": "G9 is the book's primary notated V7 voicing in string-set chord-connection exercises: \"we will use Dmin9 (ii), G9 (V7), CMaj7 (I) and C6 (also I) as the material for ii-V7-I progressions\" (Ch. 3, p. 56). Dominant 9th chords receive rootless treatment identically to Dmin9: \"roots have been omitted from both the Dmin9 and G9 voicings\" (Ch. 3, p. 56). All three string sets must be navigated with this voicing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/dominant-v7",
+            "dominant11/dominant-v7",
+            "dominant13/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant9",
+          "function_role": "lick-target",
+          "narrative": "Dominant 9th chords are included in the scope of unaltered dominant licks: \"Try using them over dominant 9th, 11th and 13th chords as well. Transpose them and apply them to your solos\" (Ch. 4, p. 68). Lick extension to the 9th voicing is validated by ear, not just theory: \"Experiment and let your ear be your guide\" (Ch. 4, p. 60). The same transposition discipline applies — all twelve keys, immediate solo insertion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 68"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/lick-target",
+            "dominant11/lick-target",
+            "dominant13/lick-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant9",
+          "function_role": "rootless-voicing",
+          "narrative": "The G9 voicing in string-set examples is explicitly rootless: \"roots have been omitted from both the Dmin9 and G9 voicings. This is to allow the use of more interesting chords\" (Ch. 3, p. 56). Rootless dominant 9ths rely on the bass player or the ear to supply the root: \"If you play in a group setting, the bass player can take care of playing the roots. Sometimes a bigger sound can be obtained this way\" (Ch. 3, p. 56).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "minor9/rootless-voicing",
+            "dominant7b9/rootless-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant11",
+          "function_role": "lick-target",
+          "narrative": "Dominant 11th chords are listed alongside 9th and 13th as valid lick-transfer targets from the unaltered dominant family: \"Try using them over dominant 9th, 11th and 13th chords as well\" (Ch. 4, p. 68). The 11th is one of the alterable degrees — \"only notes that can be altered in any chord are the 5th, 9th and the 11th\" (Ch. 2, p. 17) — and when unraised it falls within diatonic major-scale territory, keeping the standard improvisation rule applicable.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 68"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant9/lick-target",
+            "dominant13/lick-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant11",
+          "function_role": "alteration-ceiling",
+          "narrative": "The 11th is one of only three chord degrees that may be raised or lowered: \"only notes that can be altered in any chord are the 5th, 9th and the 11th\" (Ch. 2, p. 17). A raised 11th (#11) falls outside the major scale and invokes the altered-chord exception, suspending the diatonic improvisation rule. No other scale degrees are alterable; altering the 3rd or 7th would change the chord's fundamental quality, violating the essential-tones floor.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 17"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/alteration-ceiling",
+            "dominant7b9/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant13",
+          "function_role": "lick-target",
+          "narrative": "Dominant 13th chords are the third member of the unaltered dominant extension group eligible to receive dominant licks: \"Try using them over dominant 9th, 11th and 13th chords as well\" (Ch. 4, p. 68). The Maj7-from-b7 arpeggio technique confirms the 13th's natural presence over V7: when an FMaj7 arpeggio is played over G7, \"E is the 13th\" (Ch. 3, p. 49). The 13th thus arises directly from the book's core V7 extension technique.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 68"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 49"
+            }
+          ],
+          "cross_ref": [
+            "dominant9/lick-target",
+            "dominant11/lick-target",
+            "major7/upper-extension-source"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant13",
+          "function_role": "upper-extension-target",
+          "narrative": "The 13th is the highest upper extension produced by the Maj7-from-b7 arpeggio technique: \"A is the 9th, C is the 11th and E is the 13th\" when an FMaj7 arpeggio is played over G7 (Ch. 3, p. 49). This places the 13th within the natural reach of the technique without requiring any alteration. It can be omitted when not needed — extensions are color tones, not essential tones — since the 3rd and 7th carry the chord's quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 49"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/upper-extension-source",
+            "major7/upper-extension-source"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "min7b5",
+          "function_role": "lick-target",
+          "narrative": "The half-diminished chord (min7b5) has its own dedicated lick family and is introduced as an unfamiliar sound requiring ear-training: \"There are many ways to improvise over min7b5 (half-diminished) chords. Here are just a few licks to help you get used to the sound\" (Ch. 4, p. 72). The learn-transpose-apply cycle applies identically. The chord is identified by both its formula name (min7b5) and its alternate label (half-diminished) to reinforce dual terminology recognition.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 72"
+            }
+          ],
+          "cross_ref": [
+            "minor7/lick-target",
+            "dominant7/lick-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "min7b5",
+          "function_role": "scale-choice",
+          "narrative": "The min7b5 chord contains an altered 5th (lowered), which places it outside any standard major scale and triggers the altered-chord exception: \"all chords with a raised or lowered 5th… would make this rule inapplicable\" (Ch. 1, p. 8). The book does not name a replacement scale for this chord at this stage; instead it provides licks to build familiarity with the sound — \"just a few licks to help you get used to the sound\" (Ch. 4, p. 72) — before more advanced scale choices are addressed.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 72"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/scale-choice",
+            "dominant7b9/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "diminished-substitution",
+          "narrative": "Over any V7 chord, a diminished triad starting on the 3rd, 5th, or 7th of that chord may be substituted to produce altered extensions: \"Play a diminished triad starting at the 3rd, 5th or 7th degree of the V7 chord in any ii-V7-I progression. For instance, if the V7 chord is G7, you can play a Bdim arpeggio, a Ddim arpeggio or an Fdim arpeggio\" (Ch. 3, p. 51). These tones produce altered extensions including the b9 and b11 (enharmonically the 10th) that resolve into the I chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 51"
+            }
+          ],
+          "cross_ref": [
+            "diminished/dominant-substitution",
+            "dominant7b9/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "diminished",
+          "function_role": "dominant-substitution",
+          "narrative": "Diminished triads function as melodic substitutes over dominant V7 chords when launched from the 3rd, 5th, or 7th of the V7: \"you can play a Bdim arpeggio, a Ddim arpeggio or an Fdim arpeggio. These tones will resolve nicely into the I chord. This technique produces extensions of the G7 chord, some of which are altered: Ab is the b9 and Cb is the b11\" (Ch. 3, p. 51). Three valid launch points give the player harmonic flexibility in accessing altered colours.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 51"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/diminished-substitution",
+            "dominant7b9/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "target-note-entry",
+          "narrative": "Improvised lines over the V7 must begin each phrase on a chord tone, with 3rds and 7ths preferred: \"Improvisors tend to use 3rds and 7ths the most, because these notes are what give a chord its distinctive quality\" (Ch. 2, p. 26). Ascending scalar lines from the V7's chord tones are a core traversal technique: \"play ascending scale-wise patterns starting from chord tones. Experiment on your own\" (Ch. 3, p. 53). Neighbor-tone approach (half-step or whole-step above or below) may precede the target.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 26"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 53"
+            }
+          ],
+          "cross_ref": [
+            "minor7/target-note-entry",
+            "major7/target-note-entry"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "target-note-entry",
+          "narrative": "Target-note technique applies at each chord change including the ii minor chord: \"begin each phrase you play with a note of the chord that you are improvising over. This is called spelling out the changes, targeting chord tones, or using target notes\" (Ch. 2, p. 26). The 3rd and 7th of the minor chord are the preferred phrase-start tones. Neighbor tones — \"notes one half step below and above the chord tone\" (Ch. 2, p. 31) — provide approach devices into those targets.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 26"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/target-note-entry",
+            "major7/target-note-entry"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "target-note-entry",
+          "narrative": "At the I chord resolution point, melodic lines must land on chord tones to spell out the changes: \"begin each phrase you play with a note of the chord… You may start your phrases from roots, 3rds, 5ths or 7ths of the chord\" (Ch. 2, p. 26). The 3rd and 7th of the I chord carry the major quality and are the strongest landing points. The target-note technique is the book's central improvisational prescription, applicable at every chord in the ii-V7-I.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 26"
+            }
+          ],
+          "cross_ref": [
+            "minor7/target-note-entry",
+            "dominant7/target-note-entry"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "comping-texture",
+          "narrative": "The swing comping rules apply equally across all chord types including the dominant: down strokes on downbeats, up strokes on upbeats, with damping during rests: \"strum down on the downbeats and to strum up on the upbeats. Also, try to damp the strings so that the chords don't sustain during the rests\" (Ch. 3, p. 47). Swing rhythm is implied not stated — \"Predictable rhythm parts are considered to be trite\" (Ch. 3, p. 47) — so accent placement must remain spontaneous.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 47"
+            }
+          ],
+          "cross_ref": [
+            "minor7/comping-texture",
+            "major7/comping-texture"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "comping-texture",
+          "narrative": "The identical swing comping discipline — downstroke on downbeats, upstroke on upbeats, damping during rests — applies at the ii minor chord: \"strum down on the downbeats and to strum up on the upbeats\" (Ch. 3, p. 47). When a keyboard player is present, guitar and keyboard must alternate comping roles: \"If both the guitarist and the keyboard player comp freely at the same time the tune will become like a harmonic can of worms\" (Ch. 3, p. 47). This social-role rule applies at every chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 47"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/comping-texture",
+            "major7/comping-texture"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "comping-texture",
+          "polarity": "proscriptive",
+          "narrative": "At the I major chord and across the entire comping context, mechanically predictable rhythm is explicitly prohibited: \"Predictable rhythm parts are considered to be trite, so the guitarist is left to accent various parts of each measure, usually with an element of surprise and with a spirit of improvisation\" (Ch. 3, p. 47). Sustained chords through rests are also prohibited: \"try to damp the strings so that the chords don't sustain during the rests\" (Ch. 3, p. 47).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 47"
+            }
+          ],
+          "cross_ref": [
+            "minor7/comping-texture",
+            "dominant7/comping-texture"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "no-double-comp",
+          "polarity": "proscriptive",
+          "narrative": "When a keyboard player is present, free simultaneous comping by guitar and keyboard is explicitly forbidden across all chord types including the dominant: \"If both the guitarist and the keyboard player comp freely at the same time the tune will become like a harmonic can of worms. Always listen carefully to what is going on around you\" (Ch. 3, p. 47). The prescription applies at every chord in the progression without exception.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 47"
+            }
+          ],
+          "cross_ref": [
+            "minor7/comping-texture",
+            "major7/comping-texture"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "string-set-coverage",
+          "narrative": "The dominant V7 voicing must be practiced on all three string sets (6-5-4-3, 5-4-3-2, 4-3-2-1) as part of the ii-V7-I chord-connection framework: \"we will divide the six strings of the guitar into three string sets… and find the different inversions of specific chords going up, down and across the fingerboard\" (Ch. 3, p. 56). Chapter 4 extends this by directing that ii-V7-I progressions \"move across the string sets\" (Ch. 4, p. 67) and must be transposed to all twelve keys.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 67"
+            }
+          ],
+          "cross_ref": [
+            "minor7/string-set-coverage",
+            "major7/string-set-coverage"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "string-set-coverage",
+          "narrative": "Minor ii chord voicings must be learned and connected across all three string sets: \"we will use Dmin9 (ii)… as the material for ii-V7-I progressions\" covering string sets 6-5-4-3, 5-4-3-2, and 4-3-2-1 (Ch. 3, p. 56). The position-naming system using the lowest root's string and finger (e.g., 6/2) applies: \"Read the scale and arpeggio fingerings from left to right, starting on the lowest string and moving to the highest\" (Ch. 1, p. 12).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 12"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/string-set-coverage",
+            "major7/string-set-coverage"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "string-set-coverage",
+          "narrative": "CMaj7 is the primary I-chord voicing used across all three string sets in chord-connection exercises: \"we will use Dmin9 (ii), G9 (V7), CMaj7 (I) and C6 (also I) as the material for ii-V7-I progressions\" (Ch. 3, p. 56). Knowing numerous ii-V7-I fingerings across all string sets is directly linked to musical quality: \"Knowing lots of fingerings will allow you to play with greater taste and variety\" (Ch. 2, p. 43).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 43"
+            }
+          ],
+          "cross_ref": [
+            "minor7/string-set-coverage",
+            "dominant7/string-set-coverage"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major6",
+          "function_role": "string-set-coverage",
+          "narrative": "C6 is listed alongside CMaj7 as an equivalent I-chord voicing option in the string-set chord-connection framework: \"we will use Dmin9 (ii), G9 (V7), CMaj7 (I) and C6 (also I) as the material for ii-V7-I progressions\" (Ch. 3, p. 56). The parenthetical \"also I\" confirms that major 6th and major 7th are interchangeable at the tonic function in this context, giving the player voicing variety at the resolution point.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 56"
+            }
+          ],
+          "cross_ref": [
+            "major7/string-set-coverage",
+            "major7/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "alteration-ceiling",
+          "narrative": "Only the 5th, 9th, and 11th may be raised or lowered in any dominant chord: \"the only notes that can be altered in any chord are the 5th, 9th and the 11th\" (Ch. 2, p. 17). The 3rd and 7th define the dominant quality and cannot be altered without changing the chord type entirely. This ceiling rule is universal — it applies to every chord quality, but has particular consequence for dominant voicings where alteration is most common.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/dominant-v7",
+            "dominant7b9/dominant-v7",
+            "dominant7s5/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "alteration-ceiling",
+          "narrative": "The alteration ceiling applies to major chord quality as well: \"only notes that can be altered in any chord are the 5th, 9th and the 11th\" (Ch. 2, p. 17). The major 7th (the chord's defining interval) cannot be raised or lowered without producing a different chord type. The practical consequence is that a raised 11th (Lydian colour) is available on a major chord without losing major quality, while the 3rd and 7th remain fixed.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/alteration-ceiling",
+            "minor7/alteration-ceiling"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "alteration-ceiling",
+          "narrative": "The minor chord's alterable degrees are identically limited to the 5th, 9th, and 11th: \"only notes that can be altered in any chord are the 5th, 9th and the 11th\" (Ch. 2, p. 17). Altering the b7 or minor 3rd would produce a different chord quality (e.g., min7b5 or dominant), violating the essential-tones floor. The rule that \"two most essential notes in any chord are the 3rd and the 7th\" (Ch. 2, p. 17) is the positive counterpart to this ceiling.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 17"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/alteration-ceiling",
+            "major7/alteration-ceiling"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "substitution-context-gate",
+          "polarity": "proscriptive",
+          "narrative": "Theoretical correctness alone does not justify a chord substitution over any dominant chord: \"context is everything. Just because a substitution is 'theoretically correct' doesn't mean it sounds good in every instance. Experimentation is the way we find out what works\" (Ch. 2, p. 34). This proscription applies universally but is especially relevant at the V7 position where multiple substitution options (7b5, 7#5, diminished triads, Maj7-from-b7) are available. Ear judgment is the final arbiter.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 34"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/dominant-v7",
+            "dominant7b9/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "substitution-context-gate",
+          "polarity": "proscriptive",
+          "narrative": "Chord substitution at the I major position must pass the context-and-ear gate: \"Just because a substitution is 'theoretically correct' doesn't mean it sounds good in every instance\" (Ch. 2, p. 34). This applies when, for example, substituting a slash chord (C6/9, C7/6) at the resolution point. \"Experimentation is the way we find out what works, and is a large part of the fun\" — the ear, not the theory, issues the final verdict.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 34"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/substitution-context-gate",
+            "major9/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "one-measure-compression",
+          "narrative": "The ii-V7-I can be compressed to one measure with each chord receiving one beat, or to three-beat patterns — both must be mastered: \"Once the examples in Lesson 3A get easier, challenge yourself with these. They are arranged in one-measure ii-V7-I patterns\" (Ch. 4, p. 71). The earlier pattern gives \"Each chord receives one beat\" across the three-chord progression (Ch. 4, p. 62). Both compressions must be transposed to all twelve keys, maintaining the same essential-tone and rootless principles.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 71"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 62"
+            }
+          ],
+          "cross_ref": [
+            "minor7/one-measure-compression",
+            "major7/one-measure-compression"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "blues-context",
+          "narrative": "In a 12-bar blues, the V7 chord (and I7, IV7) receives the blues scalar tools — minor pentatonic, blues scale, and Mixolydian mode — as interchangeable improvisational resources: \"This lesson begins with a review of the minor pentatonic scale, blues scale and Mixolydian mode fingerings\" (Ch. 5, p. 78). Jazz blues distinguishes itself from simple blues by using \"quite a few substitutions and passing chords\" (Ch. 5, p. 74), requiring additional harmonic literacy at the V7 position.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 5, p. 78"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 5, p. 74"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/scale-choice",
+            "dominant7/lick-target"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "mixolydian-tool",
+          "narrative": "Mixolydian mode is one of three prescribed scalar tools for blues soloing: \"review of the minor pentatonic scale, blues scale and Mixolydian mode fingerings. They appear here in the key of C, but you should practice transposing them\" (Ch. 5, p. 78). Mixolydian is the natural dominant-function scale (major scale from the 5th degree, preserving the b7) and is the most harmonically literal tool for unaltered dominant 7th chords in blues contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 5, p. 78"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/blues-context",
+            "dominant7/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "minor-pentatonic-tool",
+          "narrative": "The minor pentatonic scale is prescribed as a primary blues soloing tool over I-IV-V7 progressions: \"review of the minor pentatonic scale, blues scale and Mixolydian mode fingerings\" (Ch. 5, p. 78). The book's anti-positional prescription applies to all three scalar tools equally: \"we usually combine the various tools and utilize the entire fingerboard. This is because the ideas we hear in our heads don't always conform to organized fingering patterns\" (Ch. 5, p. 79).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 5, p. 78"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 5, p. 79"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/blues-context",
+            "dominant7/mixolydian-tool"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "positional-thinking",
+          "polarity": "proscriptive",
+          "narrative": "Organizing scalar tools into fixed positional patterns is explicitly identified as a beginner limitation to be overcome: \"At first, we tend to organize them into patterns in different areas of the fingerboard. In actual practice, we usually combine the various tools and utilize the entire fingerboard\" (Ch. 5, p. 79). The single-string practice method is the prescribed remedy: \"start learning all of your scales, modes and arpeggios up and down single strings\" (Ch. 9, p. 93).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 5, p. 79"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 9, p. 93"
+            }
+          ],
+          "cross_ref": [
+            "major7/scale-choice",
+            "minor7/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "hear-first",
+          "narrative": "The hear-first principle governs improvisation over all chord qualities including the I major: \"When you improvise, the ideal is to first hear an idea in your head, and then execute it\" (Ch. 9, p. 94). Singing along is the prescribed training mechanism: \"Singing along with what you are playing is a good way to begin training yourself to hear first… Eventually you will find that your singing initiates your solo ideas\" (Ch. 9, p. 94). The brain must lead the fingers, not vice versa.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 9, p. 94"
+            }
+          ],
+          "cross_ref": [
+            "minor7/hear-first",
+            "dominant7/hear-first"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "hear-first",
+          "narrative": "The hear-first principle applies at all chord positions including the ii minor: improvise by first hearing the idea internally, then executing it — \"the ideal is to first hear an idea in your head, and then execute it\" (Ch. 9, p. 94). The single-string improvisation exercise forces this by removing positional safety nets: \"record a progression and improvise using only one string. At first, your lack of familiarity will be evident, but after a while you may find that your ideas are radically different than usual\" (Ch. 9, p. 93).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 9, p. 94"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 9, p. 93"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/hear-first",
+            "major7/hear-first"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "hear-first",
+          "narrative": "Hear-first initiation is especially critical at the harmonically active V7 position, where multiple extension and alteration choices are available: \"the ideal is to first hear an idea in your head, and then execute it\" (Ch. 9, p. 94). Without mental initiation, the player will default to finger patterns rather than musical ideas. Singing along trains the ear to control the dominant's colour choices before the hand executes them.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 9, p. 94"
+            }
+          ],
+          "cross_ref": [
+            "major7/hear-first",
+            "minor7/hear-first"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "turnaround-context",
+          "narrative": "Dominant chords are central to turnarounds, which must be mastered with dedicated lick vocabulary: \"Create licks that you know will work over various turnarounds. This will help you make melodically smoother transitions back to the beginnings of your tunes\" (Ch. 8, p. 88). The guitarist selects which turnaround to play and other players react: \"it's up to the other players to react. For variety's sake, it pays to know a lot of different turnarounds\" (Ch. 7, p. 86). Four-measure turnarounds simply double the chord durations of two-measure equivalents.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 8, p. 88"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 7, p. 86"
+            }
+          ],
+          "cross_ref": [
+            "major7/turnaround-context",
+            "minor7/turnaround-context"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "turnaround-context",
+          "narrative": "The I major chord is the harmonic destination of every turnaround — \"a turnaround creates a smooth harmonic transition back to the first measure\" (Ch. 7, p. 86). Turnaround licks must be memorized and transposed: \"Memorize and transpose these and keep your ears open to those other players use\" (Ch. 7, p. 86). Variety in turnaround vocabulary \"will create unexpected twists and turns in an arrangement\" and functions effectively as both intro and ending material.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 7, p. 86"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/turnaround-context",
+            "minor7/turnaround-context"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "rhythm-changes-context",
+          "narrative": "The I major chord anchors the rhythm changes progression, which must first be internalized with familiar scales before advanced alterations are added: \"just become familiar with the sound of this progression\" (Ch. 6, p. 84). Rhythm changes improvisation begins with scales from earlier chapters and defers \"highly altered and extended\" scale choices to more advanced study. Play-along practice is prescribed: \"record yourself playing the changes, so that you can practice playing along\" (Ch. 6, p. 84).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 6, p. 84"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/rhythm-changes-context",
+            "minor7/rhythm-changes-context"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "rhythm-changes-context",
+          "narrative": "The V7 position in rhythm changes is where advanced alterations will eventually be required but are deferred at the intermediate stage: \"you'll find that rhythm changes are usually highly altered and extended, so that more interesting scales and improvisational devices can be used. For now, just become familiar with the sound of this progression\" (Ch. 6, p. 84). The I-chord major scale is the prescribed starting point before altered scale choices arrive later.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 6, p. 84"
+            }
+          ],
+          "cross_ref": [
+            "major7/rhythm-changes-context",
+            "dominant7b9/dominant-v7"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "arpeggio-foundation",
+          "narrative": "Arpeggios over major chords are defined as single-note chord tones sounded sequentially: \"George Van Eps once said 'arpeggios are melted chords and chords are frozen arpeggios.' Arpeggios are simply the notes of a chord sounded one at a time\" (Ch. 1, p. 12). Major 7th arpeggios are the most prominent: they are used both as melodic material over the I chord and, rooted on the b7 of V7, as the upper-extension technique. Arpeggio fingerings use the same position-naming system as scales (e.g., 6/2).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 12"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/upper-extension-source",
+            "major7/upper-extension-source"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "arpeggio-foundation",
+          "narrative": "Minor 7th arpeggios follow the same 'melted chord' principle: \"Arpeggios are simply the notes of a chord sounded one at a time\" (Ch. 1, p. 12). They are classified as chord-specific melodic material and are subject to the same single-string practice discipline for escaping positional thinking: \"start learning all of your scales, modes and arpeggios up and down single strings\" (Ch. 9, p. 93). Arpeggios of the ii chord also directly spell out the ii-chord tones that target-note technique demands.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 12"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 9, p. 93"
+            }
+          ],
+          "cross_ref": [
+            "major7/arpeggio-foundation",
+            "dominant7/arpeggio-foundation"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "arpeggio-foundation",
+          "narrative": "Dominant 7th arpeggios provide the chord-tone foundation from which ascending scale-wise lines must depart: \"play ascending scale-wise patterns starting from chord tones\" (Ch. 3, p. 53). The Maj7-from-b7 arpeggio is the primary upper-extension technique for V7. All arpeggio fingerings use the position-naming system: \"The scale fingerings are named for the position of lowest root in the fingering\" (Ch. 1, p. 12), and must be practiced on single strings as well as across positions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 53"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Gujarat Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 12"
+            }
+          ],
+          "cross_ref": [
+            "major7/arpeggio-foundation",
+            "minor7/arpeggio-foundation"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "slash-chord-extension",
+          "narrative": "Slash chord notation over major-type chords carries two distinct meanings that must be distinguished: \"'F/G' means that an F chord is to be played, but with the note G added in the bass\" versus quality notation where \"C6/9 means that the 6th and 9th degrees of the scale have been added to a C Major triad. C7/6 shows a C7 chord that also contains a 6th\" (Ch. 2, p. 42). The reader must parse context to determine which meaning applies before voicing the chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 42"
+            }
+          ],
+          "cross_ref": [
+            "major6/tonic-i",
+            "major9/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "neighbor-tone-approach",
+          "narrative": "Neighbor tones are the prescribed approach device into target chord tones across all chord types: \"the most common neighbor tones are the notes one half step below and above the chord tone. Neighbor tones a whole step below and above are common too\" (Ch. 2, p. 31). Over dominant chords, neighbor tones approaching the 3rd or b7 are especially effective since those are the essential tones that define the chord's quality. Both chromatic (half-step) and diatonic (whole-step) approaches are sanctioned.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "minor7/neighbor-tone-approach",
+            "major7/neighbor-tone-approach"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "neighbor-tone-approach",
+          "narrative": "Neighbor tones approaching the ii chord's essential tones (minor 3rd and b7) are prescribed as the core melodic approach device: \"the most common neighbor tones are the notes one half step below and above the chord tone\" (Ch. 2, p. 31). Half-step neighbors are more common; whole-step neighbors are also valid. The neighbor tone precedes the target chord tone at the start of each phrase, refining the basic target-note technique into a more sophisticated approach idiom.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/neighbor-tone-approach",
+            "major7/neighbor-tone-approach"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "neighbor-tone-approach",
+          "narrative": "At the I chord resolution, neighbor tones approaching the major 3rd or major 7th provide smooth melodic entry: \"the most common neighbor tones are the notes one half step below and above the chord tone. Neighbor tones a whole step below and above are common too\" (Ch. 2, p. 31). These approach devices are part of the larger target-note system and combine with the ascending-lines-from-chord-tones technique to create melodically directed improvisation at the resolution point.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 31"
+            }
+          ],
+          "cross_ref": [
+            "minor7/neighbor-tone-approach",
+            "dominant7/neighbor-tone-approach"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "ascending-line-technique",
+          "narrative": "Ascending scale-wise lines starting from chord tones are a prescribed melodic technique over the V7: \"Simply play ascending scale-wise patterns starting from chord tones. Experiment on your own. Most players find this a very easy technique to incorporate\" (Ch. 3, p. 53). Alternating ascending and descending patterns adds contour interest: \"Alternating ascending and descending patterns will give your line a more interesting contour\" (Ch. 3, p. 55). Lines must be initiated on a chord tone to satisfy the target-note requirement.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 53"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 3, p. 55"
+            }
+          ],
+          "cross_ref": [
+            "minor7/ascending-line-technique",
+            "major7/ascending-line-technique"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "swing-eighths",
+          "narrative": "All melodic lines over dominant and every other chord must use swing eighths: \"In jazz it is standard practice to play eighth notes with a swing feel… they will feel and sound like a series of eighth note triplets with a tie between the first two notes. When played in this manner, they are referred to as jazz eighths or swing eighths\" (Ch. 2, p. 26). Straight eighths are the marked, non-standard option — swing eighths are the default rhythmic convention governing all licks and phrases.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 26"
+            }
+          ],
+          "cross_ref": [
+            "minor7/swing-eighths",
+            "major7/swing-eighths"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "swing-eighths",
+          "narrative": "Swing eighths are the universal rhythmic convention and apply at the ii minor chord as at every other position: \"In jazz it is standard practice to play eighth notes with a swing feel\" (Ch. 2, p. 26). Written eighth notes in all lick examples are to be interpreted as swing eighths unless otherwise marked. This convention is established in Chapter 2 and governs every melodic example in Chapters 3–8 without requiring repeated explicit statement.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 26"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/swing-eighths",
+            "major7/swing-eighths"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "swing-eighths",
+          "narrative": "Swing eighths govern all melodic lines over the I major chord: \"While the music may be written as standard eighth notes, they will feel and sound like a series of eighth note triplets with a tie between the first two notes\" (Ch. 2, p. 26). This convention is the rhythmic foundation onto which target-note, neighbor-tone, and ascending-line techniques are layered. The book treats swing eighths as an assumed constant, not an optional stylistic choice.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 26"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/swing-eighths",
+            "minor7/swing-eighths"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "transposition-discipline",
+          "narrative": "Every lick, voicing, and progression in the book must be transposed to all twelve keys without exception: \"Be sure to transpose these progressions to all twelve keys. Have patience, and enjoy the process. It can take some time to get comfortable with these chord connections\" (Ch. 4, p. 62). This discipline is reinforced at every chapter and chord type — \"Transpose them and Start using them immediately\" (Ch. 4, p. 60) — making transposition the foundational fluency-building mechanism of the entire method.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 62"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 60"
+            }
+          ],
+          "cross_ref": [
+            "minor7/transposition-discipline",
+            "dominant7/transposition-discipline"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "minor7",
+          "function_role": "transposition-discipline",
+          "narrative": "Minor chord licks must be transposed and applied immediately: \"learn, transpose and insert these into your solos as soon as possible!\" (Ch. 4, p. 64). The exclamation mark signals that deferred application is an error — isolated study without real-song use does not build vocabulary. Turnaround licks (which frequently include minor chord positions) share the same imperative: \"Memorize and transpose these and keep your ears open to those other players use\" (Ch. 7, p. 86).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 64"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 7, p. 86"
+            }
+          ],
+          "cross_ref": [
+            "major7/transposition-discipline",
+            "dominant7/transposition-discipline"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "transposition-discipline",
+          "narrative": "Dominant licks and voicings demand the same all-twelve-keys transposition discipline: \"Transpose them and apply them to your solos\" (Ch. 4, p. 68). The one-measure ii-V7-I compression also requires transposition: \"Take your time learning each example and then transpose them\" (Ch. 4, p. 71). Knowing the V7 chord in many fingerings directly enables greater musical variety: \"Knowing lots of fingerings will allow you to play with greater taste and variety\" (Ch. 2, p. 43).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 68"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 2, p. 43"
+            }
+          ],
+          "cross_ref": [
+            "major7/transposition-discipline",
+            "minor7/transposition-discipline"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "min7b5",
+          "function_role": "altered-fifth-rule",
+          "polarity": "proscriptive",
+          "narrative": "The lowered 5th of the min7b5 (half-diminished) chord disqualifies the standard major-scale improvisation rule just as it does for dominant 7b5: \"all chords with a raised or lowered 5th… would make this rule inapplicable, because these altered tones are not diatonic (not in the major scale)\" (Ch. 1, p. 8). At this method level, the book prescribes lick-based ear familiarization rather than a specific replacement scale: \"just a few licks to help you get used to the sound\" (Ch. 4, p. 72).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 1, p. 8"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 4, p. 72"
+            }
+          ],
+          "cross_ref": [
+            "dominant7b5/scale-choice",
+            "dominant7b9/scale-choice"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "dominant7",
+          "function_role": "chord-melody-synthesis",
+          "narrative": "The chord solo based on Misty synthesizes all A-lesson chord-melody concepts including dominant voicings: \"Here is a chord solo loosely based on the changes of the song Misty. This arrangement incorporates many of the concepts that have been covered in the 'A' lessons of this book. Use it to reinforce your understanding\" (Ch. 8, p. 89). The single-note solo synthesizes B-lesson improvisation concepts: \"Use it to solidify what you have learned\" (Ch. 8, p. 91). Both pieces serve as capstone application contexts for all chord qualities studied.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 8, p. 89"
+            },
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 8, p. 91"
+            }
+          ],
+          "cross_ref": [
+            "major7/chord-melody-synthesis",
+            "minor7/chord-melody-synthesis"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-2-intermediate",
+          "chord_quality": "major7",
+          "function_role": "chord-melody-synthesis",
+          "narrative": "The Misty chord solo tests mastery of major chord voicings in a real-song context: \"incorporates many of the concepts that have been covered in the 'A' lessons of this book\" (Ch. 8, p. 89). The student is directed to use this piece to \"reinforce your understanding of what you have learned\" — meaning every A-lesson principle (essential tones, rootless voicings, string-set coverage, substitution-with-ear) must be applied, not merely recognized. It is the culminating chord-quality test of the method.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 2 (Intermediate).pdf",
+              "citation": "Ch. 8, p. 89"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/chord-melody-synthesis",
+            "minor7/chord-melody-synthesis"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "melody-top-voicing",
+          "narrative": "Fisher states the fundamental goal of chord-melody arrangement as: \"find chord voicings that have the melody notes on top\" (p. 9). For major chords, this means selecting from the chord family's available voicings specifically those where the melody pitch sits as the highest sounding note. Octave adjustment of the melody is permitted and expected: \"It is often necessary to raise the melody one octave in order to use larger chord voicings\" (p. 9).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 9"
+            }
+          ],
+          "cross_ref": [
+            "major/chord-family-interchangeability",
+            "major/octave-adjustment-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "chord-family-interchangeability",
+          "narrative": "Fisher defines chord enhancement for major chords as functionally interchangeable within the family: \"a Major 6th chord can be thought of in the same light as a Major 9th chord or a Major 7th chord. Functionally, they are all the same\" (p. 12). Arrangers may freely substitute any major-family extension (maj6, maj7, maj9) for another when voicing permits, since the chord family, not the specific extension, defines function.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 12"
+            }
+          ],
+          "cross_ref": [
+            "major/melody-top-voicing",
+            "major7/chord-family-interchangeability"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "octave-adjustment-voicing",
+          "narrative": "When arranging major chord voicings with melody on top, Fisher prescribes raising the melody one octave when larger voicing shapes are desired: \"It is often necessary to raise the melody one octave in order to use larger chord voicings\" (p. 9). The lead-sheet adaptation rule reinforces this: \"When using a lead-sheet... it is generally helpful to raise the melody an octave. Check the highest and lowest notes in the song to see if an octave change would make the tune easier to harmonize\" (p. 11).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "pp. 9, 11"
+            }
+          ],
+          "cross_ref": [
+            "major/melody-top-voicing",
+            "major/chord-family-interchangeability"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "subdominant-approach-passing-chord",
+          "narrative": "Fisher prescribes a specific passing-chord technique for major I chords: \"When approaching a major I chord you may precede it with a IV chord (a major chord whose root is a perfect 4th higher). You can use this technique to handle non-chord tones or as harmonization of a chord tone\" (p. 39). This IV-to-I move is positioned as a characteristic approach distinct from dominant passing chords, applicable to both melodic and harmonic material simultaneously.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 39"
+            }
+          ],
+          "cross_ref": [
+            "major/same-quality-passing-chord",
+            "dominant7/half-step-dominant-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "same-quality-passing-chord",
+          "narrative": "For major chords, Fisher prescribes using same-quality chords a half step away as passing chords: \"use the same quality as the chord you are approaching from either a half step above or below\" (p. 38). A major chord a half step above or below the target major chord can serve as a chromatic passing harmony, smoothing transitions while preserving chord family color.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 38"
+            }
+          ],
+          "cross_ref": [
+            "major/subdominant-approach-passing-chord",
+            "dominant7/half-step-dominant-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "contextual-enhancement-restraint",
+          "polarity": "proscriptive",
+          "narrative": "Fisher warns against over-enriching major chords without regard to context: \"Context is everything. Taste should be your primary concern. Not everything needs to be enriched\" (p. 12). This proscription applies directly to major chord voicings — the availability of extensions such as maj9 or maj13 does not obligate their use; musical judgment must govern enhancement decisions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 12"
+            }
+          ],
+          "cross_ref": [
+            "major/chord-family-interchangeability",
+            "major7/contextual-enhancement-restraint"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major7",
+          "function_role": "chord-family-interchangeability",
+          "narrative": "Major seventh chords belong to the major family and are explicitly interchangeable with maj6 and maj9 voicings: \"a Major 6th chord can be thought of in the same light as a Major 9th chord or a Major 7th chord. Functionally, they are all the same\" (p. 12). The arranger should select the voicing among these options that best places the melody on top and fits the fingerboard position.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 12"
+            }
+          ],
+          "cross_ref": [
+            "major/chord-family-interchangeability",
+            "major9/chord-family-interchangeability"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major7",
+          "function_role": "third-seventh-voice-leading-anchor",
+          "narrative": "Fisher identifies the 3rd and 7th as the critical tones for defining major seventh chord quality: \"chords are defined by their 3rds and 7ths which differentiate major, minor and dominant chords\" (p. 22). In voice leading major7 chords, these two tones must be preserved and resolved with stepwise motion: \"Good voice-leading often means arranging your chords so that the voices actually travel in whole and half steps\" (p. 21).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "pp. 21-22"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/third-seventh-voice-leading-anchor",
+            "minor7/third-seventh-voice-leading-anchor"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major7",
+          "function_role": "contextual-enhancement-restraint",
+          "polarity": "proscriptive",
+          "narrative": "The proscription against indiscriminate enrichment applies equally to major seventh chords: \"Context is everything. Taste should be your primary concern. Not everything needs to be enriched\" (p. 12). Fisher distinguishes enhancement (adding extensions within the family) from substitution (changing root), cautioning that enhancement must always serve the music rather than demonstrate knowledge.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 12"
+            }
+          ],
+          "cross_ref": [
+            "major/contextual-enhancement-restraint",
+            "major9/contextual-enhancement-restraint"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major9",
+          "function_role": "chord-family-interchangeability",
+          "narrative": "Major ninth chords are functionally interchangeable with other major-family voicings: \"a Major 6th chord can be thought of in the same light as a Major 9th chord or a Major 7th chord. Functionally, they are all the same\" (p. 12). The maj9 voicing is particularly suited when the melody note is the 9th scale degree, allowing natural non-chord-tone integration as an extension.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 12"
+            }
+          ],
+          "cross_ref": [
+            "major7/chord-family-interchangeability",
+            "major/chord-family-interchangeability"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major9",
+          "function_role": "symmetrical-whole-step-transposition",
+          "narrative": "Fisher prescribes symmetrical whole-step transposition specifically for voicings containing 9ths: \"Chords with 9ths and altered 5ths may be moved around in whole steps and still retain their function\" (p. 60). Major9 voicings exploit this property to discover new fingerboard positions while maintaining harmonic function, with Fisher noting \"there are many sounds waiting to be discovered within the shapes you already know\" (p. 60).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 60"
+            }
+          ],
+          "cross_ref": [
+            "dominant9/symmetrical-whole-step-transposition",
+            "dominant7-altered/symmetrical-whole-step-transposition"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major6",
+          "function_role": "chord-family-interchangeability",
+          "narrative": "Major sixth chords are the first named member of the major family interchangeability rule: \"a Major 6th chord can be thought of in the same light as a Major 9th chord or a Major 7th chord. Functionally, they are all the same\" (p. 12). Fisher presents maj6 as freely substitutable for maj7 or maj9 wherever voice leading and melody placement permit, under the guiding principle that \"all the chords are interchangeable with any other chord in the same column\" (p. 12).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 12"
+            }
+          ],
+          "cross_ref": [
+            "major7/chord-family-interchangeability",
+            "major9/chord-family-interchangeability"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor",
+          "function_role": "melody-top-voicing",
+          "narrative": "The universal rule for chord-melody voicing applies to minor chords: Fisher prescribes finding voicings that place the melody note on top, with octave adjustment as needed: \"find chord voicings that have the melody notes on top\" (p. 9). Minor chord voicings must be memorized across fingerboard positions to enable this: \"Memorize chord changes and be able to play them in various areas of the fingerboard\" (p. 11).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "pp. 9, 11"
+            }
+          ],
+          "cross_ref": [
+            "minor7/melody-top-voicing",
+            "minor/third-seventh-voice-leading-anchor"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor",
+          "function_role": "third-seventh-voice-leading-anchor",
+          "narrative": "For minor chords, Fisher singles out the 3rd and 7th as the defining tones that distinguish minor from major and dominant: \"chords are defined by their 3rds and 7ths which differentiate major, minor and dominant chords\" (p. 22). Voice leading between minor chords must prioritize smooth motion in these two voices, since they carry the chord's quality identity.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 22"
+            }
+          ],
+          "cross_ref": [
+            "major7/third-seventh-voice-leading-anchor",
+            "minor7/third-seventh-voice-leading-anchor"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor",
+          "function_role": "same-quality-passing-chord",
+          "narrative": "Fisher extends the same-quality passing chord technique to minor chords: \"use the same quality as the chord you are approaching from either a half step above or below\" (p. 38). A minor chord a half step above or below the target minor chord may be inserted as a chromatic passing harmony, preserving minor quality while creating smooth voice motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 38"
+            }
+          ],
+          "cross_ref": [
+            "major/same-quality-passing-chord",
+            "minor7/same-quality-passing-chord"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "ii-chord-in-ii-v7-i",
+          "narrative": "Fisher positions the minor seventh chord as the ii chord in the foundational ii-V7-I progression: \"ii-V7-I progression defines or establishes a key because of the way the roots, 3rds and 7ths of these chords move\" (p. 40). The minor7 chord as ii provides characteristic stepwise voice motion into the dominant, and backcycling extends this by preceding the iim7 with its own ii-V7: \"Backcycling is a way to extend the ii-V7-I approach\" (p. 44).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "pp. 40, 44"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/v7-in-ii-v7-i",
+            "minor7/third-seventh-voice-leading-anchor"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "third-seventh-voice-leading-anchor",
+          "narrative": "Minor seventh chords carry their quality identity in the 3rd (minor 3rd) and 7th (minor 7th), making these tones the primary voice-leading anchors: \"chords are defined by their 3rds and 7ths which differentiate major, minor and dominant chords\" (p. 22). In moving from iim7 to V7, these tones typically resolve by half step or whole step, embodying Fisher's principle that voices \"travel in whole and half steps\" (p. 21).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "pp. 21-22"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/third-seventh-voice-leading-anchor",
+            "minor7/ii-chord-in-ii-v7-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "melody-top-voicing",
+          "narrative": "Minor seventh voicings for chord-melody must be selected to place the melody on top, with systematic fingerboard knowledge enabling flexibility: \"Memorize chord changes and be able to play them in various areas of the fingerboard\" (p. 11). When the minor7 voicing does not accommodate the melody pitch, Fisher prescribes raising the melody an octave rather than compromising the voicing structure (p. 9).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "pp. 9, 11"
+            }
+          ],
+          "cross_ref": [
+            "minor/melody-top-voicing",
+            "minor7/ii-chord-in-ii-v7-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "same-quality-passing-chord",
+          "narrative": "The same-quality passing-chord approach applies to minor seventh chords: \"use the same quality as the chord you are approaching from either a half step above or below\" (p. 38). A minor7 chord a half step above or below the target can be introduced as a chromatic embellishment that preserves the color of the destination while adding approach motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 38"
+            }
+          ],
+          "cross_ref": [
+            "minor/same-quality-passing-chord",
+            "dominant7/half-step-dominant-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "v7-in-ii-v7-i",
+          "narrative": "The dominant seventh chord is the load-bearing V7 of the ii-V7-I progression, which Fisher calls the foundational key-defining formula: \"ii-V7-I progression defines or establishes a key because of the way the roots, 3rds and 7ths of these chords move\" (p. 40). Secondary dominants extend this rule to any chord: \"you may consider any chord a I chord and precede it by its own V7 chord, which can be enhanced or altered\" (p. 39).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "pp. 39-40"
+            }
+          ],
+          "cross_ref": [
+            "minor7/ii-chord-in-ii-v7-i",
+            "dominant7/tritone-substitution"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "half-step-dominant-passing",
+          "narrative": "Fisher prescribes the dominant seventh as the primary passing chord for chromatic approach: \"One common application of passing chords is the use of a dominant chord (altered or unaltered) with a root that is a half step higher, or lower, than the chord being approached. These chords can end up being non-diatonic, or from outside the key\" (p. 23). Non-diatonic dominant passing chords are explicitly permitted when they create smooth voice motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 23"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/v7-in-ii-v7-i",
+            "diminished7/diminished-as-v7-substitute"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "tritone-substitution",
+          "narrative": "Fisher prescribes tritone substitution as a standard reharmonization technique for dominant seventh chords: \"When a progression travels from V7 to I, we often replace the V7 chord with a dominant chord whose root is a diminished 5th (or augmented 4th) away\" (p. 45). This technique also applies to secondary dominants: \"The technique of substituting a chord a tritone away also works with secondary dominant chords\" (p. 45).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 45"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/v7-in-ii-v7-i",
+            "dominant7/tritone-approach-by-root-distance"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "tritone-approach-by-root-distance",
+          "narrative": "Chapter 5 introduces a variant tritone approach distinct from substitution: \"We can approach any chord from another chord whose root is a tritone away. This is different from the tritone substitution approach where the new chord is deduced from the root of the V7 chord. In this approach, we deduce the new chord from the root of the destination chord\" (p. 48). This dominant chord approach targets the destination root rather than replacing a pre-existing V7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 48"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/tritone-substitution",
+            "dominant7/half-step-dominant-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "third-seventh-voice-leading-anchor",
+          "narrative": "The dominant seventh chord's 3rd and 7th are its most critical voice-leading tones — they form the tritone interval that creates dominant tension: \"chords are defined by their 3rds and 7ths which differentiate major, minor and dominant chords\" (p. 22). Fisher's ii-V7-I voice-leading analysis depends entirely on the motion of these two voices resolving into the tonic chord, generating the key-defining effect.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 22"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/v7-in-ii-v7-i",
+            "major7/third-seventh-voice-leading-anchor"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "same-quality-passing-chord",
+          "narrative": "Dominant seventh chords may be used as same-quality passing chords a half step above or below any target dominant chord: \"use the same quality as the chord you are approaching from either a half step above or below\" (p. 38). This generalizes the chromatic approach principle so that dominant color is maintained as the embellishing chord moves into the destination.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 38"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/half-step-dominant-passing",
+            "dominant7/tritone-substitution"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "secondary-dominant-generalization",
+          "narrative": "Fisher prescribes applying dominant seventh function to any chord in a progression: \"you may consider any chord a I chord and precede it by its own V7 chord, which can be enhanced or altered\" (p. 39). This secondary dominant generalization means every chord in an arrangement can be preceded by its own dominant seventh (or enhanced/altered dominant), multiplying passing-chord options throughout the progression.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 39"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/v7-in-ii-v7-i",
+            "dominant7/half-step-dominant-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "backcycling-extension",
+          "narrative": "Dominant seventh chords participate in backcycling — the systematic extension of the ii-V7-I approach by repeatedly adding ii-V7 pairs: \"Backcycling is a way to extend the ii-V7-I approach covered in Lesson 4\" (p. 44). Each dominant in the backcycle is itself approached by its own ii-V7, creating chains of fourth-movement dominant resolutions that enrich skeletal progressions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 44"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/v7-in-ii-v7-i",
+            "minor7/ii-chord-in-ii-v7-i"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7-altered",
+          "function_role": "half-step-dominant-passing",
+          "narrative": "Fisher explicitly permits altered dominant chords as passing chords: \"the use of a dominant chord (altered or unaltered) with a root that is a half step higher, or lower, than the chord being approached\" (p. 23). The altered dominant passing chord creates non-diatonic color while still functioning as a smooth chromatic approach, with non-diatonic notes justified by the approach motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 23"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/half-step-dominant-passing",
+            "dominant7-altered/symmetrical-whole-step-transposition"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7-altered",
+          "function_role": "symmetrical-whole-step-transposition",
+          "narrative": "Fisher prescribes whole-step symmetrical transposition specifically for altered dominant voicings: \"Chords with 9ths and altered 5ths may be moved around in whole steps and still retain their function\" (p. 60). This allows a player to discover new voicing positions for altered dominant shapes without changing harmonic function: \"there are many sounds waiting to be discovered within the shapes you already know\" (p. 60).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 60"
+            }
+          ],
+          "cross_ref": [
+            "dominant9/symmetrical-whole-step-transposition",
+            "dominant7-altered/half-step-dominant-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7-altered",
+          "function_role": "secondary-dominant-enhancement",
+          "narrative": "Secondary dominants may be enhanced or altered: Fisher states the secondary dominant may be \"enhanced or altered\" before the chord it precedes (p. 39). This means altered dominant voicings are not restricted to the primary V7-I relationship but may enrich any temporary dominant in the progression, extending altered dominant color throughout the arrangement.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 39"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/secondary-dominant-generalization",
+            "dominant7-altered/half-step-dominant-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant9",
+          "function_role": "symmetrical-whole-step-transposition",
+          "narrative": "Dominant ninth voicings are explicitly identified as candidates for whole-step symmetrical transposition: \"Chords with 9ths and altered 5ths may be moved around in whole steps and still retain their function\" (p. 60). Fisher frames this as a discovery method — the player moves a known dom9 shape up or down by whole steps to uncover new voicing positions that preserve the dominant ninth's harmonic function.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 60"
+            }
+          ],
+          "cross_ref": [
+            "dominant7-altered/symmetrical-whole-step-transposition",
+            "major9/symmetrical-whole-step-transposition"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant9",
+          "function_role": "secondary-dominant-enhancement",
+          "narrative": "Dominant ninth voicings are suitable enhancements for secondary dominants: \"you may consider any chord a I chord and precede it by its own V7 chord, which can be enhanced or altered\" (p. 39). The chord enhancement principle from Chapter 2 supports this — dom9 is interchangeable with dom7 within the dominant family, so any secondary dominant may be voiced as a ninth chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 39"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/secondary-dominant-generalization",
+            "dominant7-altered/secondary-dominant-enhancement"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "diminished7",
+          "function_role": "diminished-as-v7-substitute",
+          "narrative": "Fisher prescribes diminished seventh chords as direct substitutes for V7 chords: \"Approaching the I chord with a diminished chord from one half step below the root is a common substitute for the V7. The reason this works is that the two chords have three notes in common and both resolve nicely to I\" (p. 30). This substitution is grounded in shared tones and equivalent resolution, not merely convention.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 30"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/v7-in-ii-v7-i",
+            "diminished7/fingerboard-repetition-property"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "diminished7",
+          "function_role": "fingerboard-repetition-property",
+          "narrative": "Fisher highlights the diminished seventh chord's symmetrical fingerboard property as a practical voicing tool: \"diminished chords repeat themselves every three frets, so you can choose from among many possible locations on the fingerboard\" (p. 28). This geometric property means any diminished7 shape has three additional identical-sounding positions, giving the arranger maximum flexibility for voice leading and melody accommodation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord-Melody).pdf",
+              "citation": "p. 28"
+            }
+          ],
+          "cross_ref": [
+            "diminished7/diminished-as-v7-substitute",
+            "diminished7/half-step-below-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "diminished7",
+          "function_role": "half-step-below-passing",
+          "narrative": "The diminished seventh chord functions as a passing chord positioned a half step below the target: \"Approaching the I chord with a diminished chord from one half step below the root is a common substitute for the V7\" (p. 30). Fisher frames this as a common application of passing-chord technique, where the diminished chord's three shared tones with the V7 enable smooth chromatic approach motion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "pp. 23, 30"
+            }
+          ],
+          "cross_ref": [
+            "diminished7/diminished-as-v7-substitute",
+            "dominant7/half-step-dominant-passing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "quartal",
+          "function_role": "stacked-fourths-construction",
+          "narrative": "Fisher introduces quartal harmony as a distinct construction system: \"In conventional harmony, we use chords that are constructed primarily from stacking 3rds. In quartal harmony, chords are constructed by stacking 4ths\" (p. 33). Quartal voicings provide an alternative harmonic color for non-chord tone harmonization, functioning as an alternative to tertian-stack options when a more open or modern sound is desired.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 33"
+            }
+          ],
+          "cross_ref": [
+            "quartal/non-chord-tone-harmonization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "quartal",
+          "function_role": "non-chord-tone-harmonization",
+          "narrative": "Quartal voicings are presented in Chapter 3 as a technique for harmonizing non-chord tones, offering an alternative to conventional third-stacking diads and chord extensions. Fisher teaches quartal harmony within the context of handling non-chord tones: it complements the diad approach (3rds and 6ths) by providing open-interval color, particularly suited to melodic passages where tertian stacking would create unwanted chromaticism.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 33"
+            }
+          ],
+          "cross_ref": [
+            "quartal/stacked-fourths-construction",
+            "diad/non-chord-tone-harmonization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "diad",
+          "function_role": "non-chord-tone-harmonization",
+          "narrative": "Fisher prescribes diads (two-note harmonizations) as the primary tool for harmonizing both chord tones and non-chord tones: \"Diads, also known as double-stops, are two-note harmonizations. They work very well for chord tones and non-chord tones. Any interval is possible, but 3rds and 6ths are the most common\" (p. 18). The preference for 3rds and 6ths reflects their consonance and alignment with chord-tone relationships in jazz voicing.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 18"
+            }
+          ],
+          "cross_ref": [
+            "diad/thirds-sixths-preferred",
+            "quartal/non-chord-tone-harmonization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "diad",
+          "function_role": "thirds-sixths-preferred",
+          "narrative": "Among all possible diad intervals, Fisher identifies 3rds and 6ths as the preferred intervals for jazz chord-melody harmonization: \"Any interval is possible, but 3rds and 6ths are the most common\" (p. 18). These intervals align with the 3rd-and-7th voice-leading anchors Fisher identifies elsewhere, providing harmonic clarity while blending naturally with jazz voicing conventions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 18"
+            }
+          ],
+          "cross_ref": [
+            "diad/non-chord-tone-harmonization",
+            "major/third-seventh-voice-leading-anchor"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "non-chord-tone-extension-integration",
+          "narrative": "Fisher teaches that non-chord tones in the melody may be added directly to major chord voicings to generate extensions: \"Very often we add a non-chord tone that is in the melody to the chord. This will change the name of the chord, as you will be adding higher extensions and altered tones. This is a common way to come up with enhancements\" (p. 19). For major chords, a melody note that is the 9th or 13th becomes the chord's extension, naturally producing maj9 or maj13 voicings.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 19"
+            }
+          ],
+          "cross_ref": [
+            "major7/chord-family-interchangeability",
+            "major9/chord-family-interchangeability"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "non-chord-tone-extension-integration",
+          "narrative": "Dominant seventh chords naturally absorb non-chord tones as extensions or alterations: \"Very often we add a non-chord tone that is in the melody to the chord. This will change the name of the chord, as you will be adding higher extensions and altered tones. This is a common way to come up with enhancements\" (p. 19). For dominant chords, melody tones such as the 9th, #11, or 13th generate the full range of dominant extension voicings naturally from melodic context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 19"
+            }
+          ],
+          "cross_ref": [
+            "dominant9/secondary-dominant-enhancement",
+            "dominant7-altered/secondary-dominant-enhancement"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "non-chord-tone-extension-integration",
+          "narrative": "Non-chord tones in the melody are added to minor seventh voicings as extensions: \"we add a non-chord tone that is in the melody to the chord. This will change the name of the chord, as you will be adding higher extensions and altered tones\" (p. 19). For minor seventh chords, melody notes such as the 9th or 11th generate min9 or min11 voicings organically from the chord-melody context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 19"
+            }
+          ],
+          "cross_ref": [
+            "minor7/third-seventh-voice-leading-anchor",
+            "minor7/melody-top-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "skeletal-arrangement-framework",
+          "narrative": "Fisher prescribes treating major chord arrangements as skeletal frameworks rather than fixed compositions: \"Don't carve your arrangements or chord changes in stone. Basically, you want skeletal arrangements from which you can improvise melodically, harmonically and rhythmically\" (p. 11). This applies universally but is especially relevant to major chord progressions, which provide the harmonic scaffolding from which passing chords, substitutions, and improvised extensions grow.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 11"
+            }
+          ],
+          "cross_ref": [
+            "major/same-quality-passing-chord",
+            "dominant7/secondary-dominant-generalization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "basic-before-enhanced",
+          "narrative": "Fisher prescribes a strict sequencing rule: arrange major chords in basic form first before adding enrichment: \"Arrange your song with the basic chords first. When you have a handle on the basic arrangement, then dress up the harmonies with passing chords, substitutions and harmonizations\" (p. 11). This procedural principle prevents premature harmonic complexity from obscuring the underlying voice-leading structure.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 11"
+            }
+          ],
+          "cross_ref": [
+            "major/skeletal-arrangement-framework",
+            "major/contextual-enhancement-restraint"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "skeletal-form-for-improvisation",
+          "narrative": "Fisher prescribes learning dominant chord progressions in skeletal form to enable real-time improvised harmonization: \"skeletal form so that you can actually start to improvise harmonies as you play\" (p. 38). This is particularly critical for dominant chords given their multiple substitution options (tritone sub, diminished sub, altered enhancement), which require a skeletal foundation before decoration.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 38"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/tritone-substitution",
+            "dominant7/secondary-dominant-generalization"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "all-keys-systematic-learning",
+          "narrative": "Fisher prescribes systematic learning of major chord voicings in all twelve keys: \"Learn the voicings in all twelve keys first. Then put them through all the bass line approaches\" (p. 50). This applies to all chord qualities but is the foundational requirement for major chords since they anchor tonal centers. Without twelve-key mastery, fingerboard flexibility and real-time arrangement are impossible.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 50"
+            }
+          ],
+          "cross_ref": [
+            "minor7/all-keys-systematic-learning",
+            "dominant7/all-keys-systematic-learning"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "all-keys-systematic-learning",
+          "narrative": "Minor seventh chord voicings must be learned systematically across all twelve keys to enable the two-part arrangement system: \"Learn the voicings in all twelve keys first\" (p. 50), with the goal of minimal-finger forms: \"Finger these chords with as few fingers as possible. Two fingers should be adequate for many of them. This is important because you will eventually want to keep as many fingers free as possible for playing melodies and improvising\" (p. 50).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/all-keys-systematic-learning",
+            "dominant7/all-keys-systematic-learning"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "all-keys-systematic-learning",
+          "narrative": "Dominant seventh voicings must be mastered in all twelve keys before applying bass-line approaches: \"Learn the voicings in all twelve keys first. Then put them through all the bass line approaches you will learn in this book in all twelve keys\" (p. 50). For dominant chords, this is especially critical because tritone substitutions and secondary dominant chains require instantaneous access to dominant shapes in any key.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/all-keys-systematic-learning",
+            "minor7/all-keys-systematic-learning"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "minimal-finger-voicing-for-melody",
+          "narrative": "Major chord voicings in the two-part arrangement system must use minimal finger resources: \"Finger these chords with as few fingers as possible. Two fingers should be adequate for many of them. This is important because you will eventually want to keep as many fingers free as possible for playing melodies and improvising\" (p. 50). This efficiency principle ensures that major chord voicings do not consume the left-hand resources needed for melody.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/all-keys-systematic-learning",
+            "minor7/minimal-finger-voicing-for-melody"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "minimal-finger-voicing-for-melody",
+          "narrative": "Minor seventh chord voicings for bass-line arrangements must minimize left-hand finger usage: \"Finger these chords with as few fingers as possible. Two fingers should be adequate for many of them\" (p. 50). For iim7 chords in the two-part arrangement context, this fingering economy is critical since the thumb must simultaneously handle bass notes and fingers must remain available for melody extensions.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 50"
+            }
+          ],
+          "cross_ref": [
+            "major/minimal-finger-voicing-for-melody",
+            "dominant7/all-keys-systematic-learning"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "bass-chord-rhythmic-delay",
+          "narrative": "When comping major chords in the two-part arrangement system, Fisher prescribes rhythmic separation between bass and chord: \"Try delaying the chord by playing the bass note on the downbeat and the chord slightly after (but within the same beat)\" (p. 54). This timing technique creates the illusion of two separate instruments playing major chord voicings above a walking bass.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 54"
+            }
+          ],
+          "cross_ref": [
+            "major/bass-every-beat-chords-accent",
+            "minor7/bass-chord-rhythmic-delay"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "bass-chord-rhythmic-delay",
+          "narrative": "The bass-chord rhythmic delay technique applies equally to minor seventh chord voicings: \"Try delaying the chord by playing the bass note on the downbeat and the chord slightly after (but within the same beat)\" (p. 54). Fisher's two-instrument illusion depends on this timing for all chord qualities including minor seventh chords, breaking the monotony of simultaneous bass-chord attacks.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 54"
+            }
+          ],
+          "cross_ref": [
+            "major/bass-chord-rhythmic-delay",
+            "dominant7/bass-chord-rhythmic-delay"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "bass-chord-rhythmic-delay",
+          "narrative": "Dominant seventh chords in bass-line arrangements should be delivered with the characteristic bass-chord delay: \"Try delaying the chord by playing the bass note on the downbeat and the chord slightly after (but within the same beat)\" (p. 54). For dominant chords, which often coincide with metric emphases in jazz progressions, this rhythmic technique prevents the heavy-handed feel of simultaneous bass-chord attacks.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 54"
+            }
+          ],
+          "cross_ref": [
+            "minor7/bass-chord-rhythmic-delay",
+            "major/bass-chord-rhythmic-delay"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "sustaining-overlapping-triad-voices",
+          "narrative": "Fisher prescribes allowing two notes of a major triad to ring while the next bass note is struck: \"Whenever possible, let two notes of the triad ring as you hit the next bass note. Practice slowly to learn the mechanics of this idea well\" (p. 55). This overlapping sustain maintains harmonic continuity for major chord voicings within the two-instrument arrangement texture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 55"
+            }
+          ],
+          "cross_ref": [
+            "major/bass-chord-rhythmic-delay",
+            "major/bass-every-beat-chords-accent"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "bass-every-beat-chords-accent",
+          "narrative": "For major chord voicings in the two-part arrangement, Fisher prescribes bass on every beat with chords as accents: \"Put a bass note on every beat and have the chords appear as 'punches' (accents). Keep the volume balance between the bass notes and chords realistic like a guitar (or keyboard) player and a bass player together\" (p. 51). Major chord voicings function as rhythmic accents layered over the continuous bass, not as simultaneous chord-bass attacks.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 51"
+            }
+          ],
+          "cross_ref": [
+            "major/sustaining-overlapping-triad-voices",
+            "major/bass-chord-rhythmic-delay"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "octave-exploration-new-voicings",
+          "narrative": "Fisher prescribes octave exploration as a primary method for discovering new dominant seventh voicings: \"moving the different voices around to higher and lower octaves. Some of these changes will be dramatic, others not so, but there are many sounds waiting to be discovered within the shapes you already know\" (p. 60). This technique multiplies available dominant voicings without requiring new theoretical knowledge.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 60"
+            }
+          ],
+          "cross_ref": [
+            "dominant7-altered/symmetrical-whole-step-transposition",
+            "dominant9/symmetrical-whole-step-transposition"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "octave-exploration-new-voicings",
+          "narrative": "Octave exploration of familiar major chord shapes is prescribed as a voicing discovery technique: \"Many chords shapes retain their function (dominant chords stay dominant, etc.) when moved around in certain symmetrical intervals\" (p. 60), and specifically moving voices to higher and lower octaves reveals new sounds \"within the shapes you already know\" (p. 60). For major chords, this is the primary route to voicing variety within the established family.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 60"
+            }
+          ],
+          "cross_ref": [
+            "major/chord-family-interchangeability",
+            "dominant7/octave-exploration-new-voicings"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "reharmonization-via-bassline",
+          "narrative": "Fisher prescribes bassline-driven reharmonization as a method for reimagining major chord sections: \"Reharmonize sections of the tune by composing a new bassline and letting that guide your harmonizations\" (p. 62). Rather than imposing new chord qualities over a fixed major progression, composing a new bass voice first leads organically to new harmonic choices, including substitutions and passing chords above major tonality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 62"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/tritone-substitution",
+            "major/skeletal-arrangement-framework"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "key-change-exploration",
+          "narrative": "Fisher prescribes exploring multiple keys for major chord arrangements to improve fingerboard playability: \"Consider the possibility that the song might lie on the fingerboard better in a different key. Changing the key can often change the basic character of the tune itself. For instance, you may want to try keys that allow the use of open strings. The extra investigation is usually well worth the effort\" (p. 11). Open strings are particularly relevant to major chord voicings in guitar-friendly keys.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 11"
+            }
+          ],
+          "cross_ref": [
+            "major/all-keys-systematic-learning",
+            "major/melody-top-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "octave-doubling-melody-emphasis",
+          "narrative": "Fisher prescribes octave doubling of melody notes over major chord backgrounds for stronger effect: \"Doubling melody notes in octaves will create a stronger effect than single notes, and sometimes you might find this kind of emphasis desirable. Listen to Wes Montgomery and George Benson to hear great examples of this kind of playing\" (p. 36). Major chord contexts particularly suit this technique when a more assertive melodic statement is desired.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 36"
+            }
+          ],
+          "cross_ref": [
+            "major/non-chord-tone-extension-integration",
+            "major/melody-top-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor",
+          "function_role": "octave-doubling-melody-emphasis",
+          "narrative": "The octave doubling technique for melodic emphasis applies over minor chord contexts as well: \"Doubling melody notes in octaves will create a stronger effect than single notes, and sometimes you might find this kind of emphasis desirable\" (p. 36). Fisher cites Wes Montgomery as the authoritative model, whose technique of octave-doubling melody over minor chord contexts became a defining characteristic of jazz guitar.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 36"
+            }
+          ],
+          "cross_ref": [
+            "major/octave-doubling-melody-emphasis",
+            "minor7/melody-top-voicing"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "single-note-minimalist-approach",
+          "narrative": "Fisher presents a minimalist alternative for major chord contexts: \"Some players prefer a chord/melody style with fewer chords. They will play mostly single notes and add chords only when the chord changes. Sometimes this is the best way to deal with chord tones and non-chord tones alike\" (p. 36). This minimalist option is positioned as a legitimate aesthetic choice — not a fallback — appropriate when harmonic density would obscure melodic clarity over major chord backgrounds.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 36"
+            }
+          ],
+          "cross_ref": [
+            "major/contextual-enhancement-restraint",
+            "major/basic-before-enhanced"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "half-step-bass-approach",
+          "narrative": "Dominant seventh chords in walking bass contexts are approached by half-step voice motion from below or above the lowest triad voice: \"Chords can usually be approached from the note a half step above or below the lowest voice in the triad. This is a common feature of walking bass-lines\" (p. 53). For dominant seventh chords particularly, this half-step bass approach reinforces the dominant's tendency toward resolution while maintaining forward momentum.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 53"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/half-step-dominant-passing",
+            "dominant7/bass-chord-rhythmic-delay"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "half-step-bass-approach",
+          "narrative": "Major chord voicings in the two-part arrangement system are approached from a half step above or below the lowest triad voice: \"Chords can usually be approached from the note a half step above or below the lowest voice in the triad. This is a common feature of walking bass-lines\" (p. 53). This walking-bass technique gives major chord arrivals a sense of directed approach motion, reinforcing the two-instrument illusion.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 53"
+            }
+          ],
+          "cross_ref": [
+            "major/sustaining-overlapping-triad-voices",
+            "dominant7/half-step-bass-approach"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "minor7",
+          "function_role": "half-step-bass-approach",
+          "narrative": "Minor seventh chord voicings are approached via half-step bass motion in walking bass arrangements: \"Chords can usually be approached from the note a half step above or below the lowest voice in the triad. This is a common feature of walking bass-lines\" (p. 53). The iim7 chord, as a frequent destination in jazz progressions, particularly benefits from this half-step approach to signal its arrival within the two-part texture.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 53"
+            }
+          ],
+          "cross_ref": [
+            "major/half-step-bass-approach",
+            "dominant7/half-step-bass-approach"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "scale-tone-bass-connection",
+          "narrative": "Fisher prescribes using scale tones of the major chord's parent scale to connect triad voicings in bass-line arrangements: \"In this approach you use the tones of the scale that the chord is built from to connect the various triad voicings of the chord\" (p. 51). This scale-tone connection technique gives bass lines over major chords their melodic coherence while maintaining harmonic fidelity to the major chord quality.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 51"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/scale-tone-bass-connection",
+            "major/half-step-bass-approach"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "scale-tone-bass-connection",
+          "narrative": "Scale tones of the dominant chord's parent scale connect dominant seventh triad voicings in bass-line arrangements: \"you use the tones of the scale that the chord is built from to connect the various triad voicings of the chord\" (p. 51). For dominant chords, this typically means the Mixolydian scale provides the connective tones between dominant triad positions in walking bass contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 51"
+            }
+          ],
+          "cross_ref": [
+            "major/scale-tone-bass-connection",
+            "dominant7/half-step-bass-approach"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "artistic-voice-over-accumulation",
+          "polarity": "proscriptive",
+          "narrative": "Fisher explicitly warns against prioritizing voicing accumulation over artistic application: \"Knowing hundreds of chord voicings and techniques is not as important as finding your artistic voice and then expressing it. Great knowledge brings great flexibility, but it is how you use what you know, rather than how much you know that counts\" (p. 63). For major chord voicings specifically, this proscription discourages collecting voicing shapes at the expense of developing personal expressive use of a smaller, mastered vocabulary.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 63"
+            }
+          ],
+          "cross_ref": [
+            "major/contextual-enhancement-restraint",
+            "major7/contextual-enhancement-restraint"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7-altered",
+          "function_role": "artistic-voice-over-accumulation",
+          "polarity": "proscriptive",
+          "narrative": "The principle that artistic expression outweighs theoretical accumulation applies with particular force to altered dominant voicings: \"Knowing hundreds of chord voicings and techniques is not as important as finding your artistic voice and then expressing it\" (p. 63). The wide vocabulary of altered dominant possibilities (dom7#9, dom7b9, dom7#11, dom7b13) must be subordinated to musical judgment rather than deployed for display.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 63"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/contextual-enhancement-restraint",
+            "dominant7-altered/secondary-dominant-enhancement"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "enhancement-vs-substitution-distinction",
+          "polarity": "proscriptive",
+          "narrative": "Fisher draws a strict distinction that guards against confusing enhancement with substitution for major chords: \"It should be noted that chord enhancement is not the same as chord substitution. Chord substitution implies replacing a chord with another chord that has a different root\" (p. 12). Adding a major ninth to a major chord is enhancement; replacing a major chord with a chord rooted elsewhere is substitution — conflating the two leads to misjudged harmonic choices.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 12"
+            }
+          ],
+          "cross_ref": [
+            "major/chord-family-interchangeability",
+            "major/contextual-enhancement-restraint"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "dominant7",
+          "function_role": "two-instrument-dynamic-balance",
+          "narrative": "Fisher prescribes specific dynamic balance for dominant chord voicings in the two-part arrangement: \"Put a bass note on every beat and have the chords appear as 'punches' (accents). Keep the volume balance between the bass notes and chords realistic like a guitar (or keyboard) player and a bass player together\" (p. 51). Dominant chords as accents over a walking bass must be voiced at a volume level that suggests a separate comping guitarist, not a single player.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 51"
+            }
+          ],
+          "cross_ref": [
+            "dominant7/bass-chord-rhythmic-delay",
+            "major/bass-every-beat-chords-accent"
+          ]
+        },
+        {
+          "source_work_id": "jazz-guitar-method-vol-3-mastering-chord-melody",
+          "chord_quality": "major",
+          "function_role": "right-hand-selective-plucking",
+          "narrative": "For major chord voicings in fingerstyle, Fisher prescribes selective plucking of only the desired chord tones: \"One real advantage of playing chords in this manner is that you don't have to worry about muting strings or barring over a note that is unwanted in the chord. You pluck only the tones you want to hear\" (p. 7). This selective approach is particularly valuable for major chord arrangements where certain extensions or omissions define the voicing's character.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Fisher, Jody - Jazz Guitar Method, Vol 3 (Mastering Chord Melody).pdf",
+              "citation": "p. 7"
+            }
+          ],
+          "cross_ref": [
+            "major/minimal-finger-voicing-for-melody",
+            "major/chord-family-interchangeability"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
Three-volume Stage B cluster for Jody Fisher: Vol 1 Beginning (71/9), Vol 2 Intermediate (77/9), Vol 3 Mastering Chord Melody (72/5). Cluster total: 220 notes, 23 proscriptive. Vol 3 extends the chord-melody comparison axis to 4 masters (Laukens + Van Eps + O'Rourke + Fisher).

Pipeline runs (cyberpower): `2026-05-28T15-05-20-fisher-jazz-guitar-method-vol-{1,2,3}`. Model: sonnet.

Schema 24/24 pass. Refs #457, #459, #471.