### PR TITLE
feat(#457): Stage B — Coker + Aebersold (199 entries)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -36935,7 +36935,2391 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "tonic-i",
+          "narrative": "Coker establishes that the Major Seventh chord is formed by \"extracting tones #1-3-5-7\" from the major scale of the chord root, uniting it with the triad, M6, and M9 under a single parent scale: \"the major triad, M6, M7, and M9 chords all use the same basic scale: the major scale of the chord root\" (Ch. 4, p. 16). The pedagogical implication is that the improviser need not switch scales between these four chord symbols — one major scale covers all of them.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 1, p. 2: 'Tones #1-3-5-7 form the C Major Seventh Chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 4, p. 16: 'the major triad, M6, M7, and M9 chords all use the same basic scale: the major scale of the chord root.'"
+            }
+          ],
+          "cross_ref": [
+            "maj6/tonic-i",
+            "maj9/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "tonic-im7-default-reading",
+          "narrative": "Coker prescribes that in real-time chord-group reading, M7 should be assumed to function as IM7 by default: \"in most instances, the M7 chord is likely to function as IM7 rather than IVM7\" (Ch. 16, p. 82). This heuristic reduces decision burden in improvisation by giving the player a probabilistic default before more contextual evidence is available.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 82: 'in most instances, the M7 chord is likely to function as IM7 rather than IVM7.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/iim7-default-reading"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "turnaround-start-quality",
+          "narrative": "In the turnaround/turnback system, Coker positions the Major Seventh chord as the starting quality, held \"for about two beats,\" before permuting the chord type on the same root to create motion: \"most will begin with a tonic chord (but only for about two beats) and will end with either a V7 chord (dominant) or a flat-II7 or flat-IIM7\" (Ch. 25, p. 118). The IM7 is thus the anchor from which chord-type permutation departs.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 118: 'most will begin with a tonic chord (but only for about two beats) and will end with either a V7 chord (dominant) or a flat-II7 or flat-IIM7 (dominant substitute).'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 23, p. 115: 'the root will remain stationary through two or more chords, while the chord type on that same root will change.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/turnaround-endpoint",
+            "min7/turnaround-intermediate"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "resolution-target-im7",
+          "narrative": "Within the IIm7–V7–IM7 progression — the book's \"foundational harmonic unit for jazz improvisation\" — the IM7 is the resolution target and shares the same parent key signature as the IIm7 and V7: \"the scales of these three chords will share exactly the same key signature\" (Ch. 16, p. 83). Coker's instruction is to extend mastered two-measure IIm7–V7 patterns to the IM7 rather than learn new vocabulary, recycling existing fragments to reach the resolution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 83: 'The IIm7-V7-IM7 progression is important, therefore, because it establishes a specific key. Also, the scales of these three chords will share exactly the same key signature.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 17, p. 90: 'Rather than introducing new patterns, we will use four of the patterns previously discussed with the IIm7-V7 progression and extend them to the IM7.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/iim7-progression-function",
+            "dom7/v7-progression-function"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "augmented-scale-secondary-target",
+          "narrative": "Coker notes that the augmented scale can be applied \"with slightly less effect\" to the major seventh chord (M7) as a secondary option beyond its primary M7+5 context: \"With slightly less effect, the scale can be applied to the major seventh chord (M7)\" (Ch. 28, p. 134). This secondary application extends the augmented scale's harmonic utility to diatonic tonic chords.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 28, p. 134: 'With slightly less effect, the scale can be applied to the major seventh chord (M7).'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/augmented-scale-primary-target"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj6",
+          "function_role": "tonic-i",
+          "narrative": "The Major Sixth chord shares the major scale of its chord root with the triad, M7, and M9: \"a C, CM6, CM7, and CM9 will all share the C major scale\" (Ch. 4, p. 16). Coker treats M6 as interchangeable with its sibling major chord qualities at the scale level, using the triad symbol for convenience when the scale is common to all. The chord's formula is 1-3-5-6, derived from the C Major scale.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 1, p. 1: 'Tones No. 1-3-5-6 of the C Major scale form the C Major Sixth Chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 4, p. 16: 'a C, CM6, CM7, and CM9 will all share the C major scale.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i",
+            "maj9/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj6",
+          "function_role": "two-fragment-coverage-member",
+          "narrative": "The two-fragment rule in Chapter 7 demonstrates that fragments 5-8-6-4 and 2-5-3-1 together \"will sound any of the major forms of the chords expressed (Triad, M6, M7 and M9)\" (Ch. 7, p. 27). M6 is thus one of four chord qualities covered by a single two-fragment pattern, reinforcing the scale-centric rather than chord-centric approach.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 7, p. 27: 'This pattern utilizes two fragments (5-8-6-4 and 2-5-3-1) from the chord scale, which when played simultaneously will sound any of the major forms of the chords expressed (Triad, M6, M7 and M9).'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/two-fragment-coverage-member",
+            "maj9/two-fragment-coverage-member"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj9",
+          "function_role": "tonic-i",
+          "narrative": "The Major Ninth chord is derived from the major scale by extracting tones 1-3-5-7-9, completing the four-quality major family. Because all four major chord types share the same parent scale, the chord symbol used in patterns is \"merely for convenience\" (Ch. 4, p. 16) — the improviser applies the same major scale regardless of whether the symbol reads C, CM6, CM7, or CM9.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 1, p. 2: 'Tones #1-3-5-7-9 form the C Major Ninth Chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 5, p. 25: 'Note: To be used for C, CM6, CM7 or CM9.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-i",
+            "maj6/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "v7-mixolydian-source",
+          "narrative": "Coker derives the dominant seventh chord from the Mixolydian mode by extracting scale degrees 1-3-5-7: \"By extracting tones No. 1-3-5-7 from the B-Flat Mixolydian mode, we arrive at the notes forming the B-Flat Dominant Seventh Chord\" (Ch. 9, p. 50). The Mixolydian mode is the mandatory scale for improvisation over dominant seventh chords, established as the parent-key relationship rather than an interval formula.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 9, p. 50: 'By extracting tones No. 1-3-5-7 from the B-Flat Mixolydian mode, we arrive at the notes forming the B-Flat Dominant Seventh Chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 9, p. 51: 'The student must remember to relate each mixolydian mode to its parent key before attempting to apply the numerical formulas for the formation of dominant seventh and ninth chords.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v7-progression-function",
+            "dom7/mixolydian-shared-with-dom9"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "mixolydian-shared-with-dom9",
+          "narrative": "A critical economy principle: dominant seventh and dominant ninth chords on the same root share a single Mixolydian scale for improvisation — \"Note that the same scale is used for dominant seventh and dominant ninth chords having the same root\" (Ch. 9, p. 51). The player need not shift scales when the chord symbol changes from C7 to C9; the Mixolydian mode covers both.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 9, p. 51: 'Note that the same scale is used for dominant seventh and dominant ninth chords having the same root.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v7-mixolydian-source"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "v7-progression-function",
+          "narrative": "Within the IIm7–V7–IM7 progression, the V7 chord shares the same parent key signature as the IIm7 and IM7: \"the scales of these three chords will share exactly the same key signature\" (Ch. 16, p. 83). Coker assigns ascending scale motion to the IIm7 and descending scale motion to the V7 in his two-measure patterns: \"ascending the scale of the minor seventh chord and descending the scale of the dominant seventh chord\" (Ch. 17, p. 94).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 17, p. 94: 'ascending the scale of the minor seventh chord and descending the scale of the dominant seventh chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 83: 'the scales of these three chords will share exactly the same key signature.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/iim7-progression-function",
+            "maj7/resolution-target-im7"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "fragment-3-4-5-1-assignment",
+          "narrative": "In the two-fragment substitution rule for IIm7–V7 patterns, the dominant seventh chord is assigned the fragment 3-4-5-1 from its own scale: \"The fragment 3-4-5-7 is to be extracted from the scale of the minor 7th chord, and the fragment 3-4-5-1 is to be extracted from the scale of the dominant seventh chord\" (Ch. 17, p. 88). This asymmetric fragment assignment is the book's primary melodic cell for navigating the V7 chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 17, p. 88: 'the fragment 3-4-5-1 is to be extracted from the scale of the dominant seventh chord.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/fragment-3-4-5-7-assignment",
+            "dom7/fragment-1-2-6-5-assignment"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "fragment-1-2-6-5-assignment",
+          "narrative": "An alternative fragment assignment for the V7 in the two-measure IIm7–V7 context is 1-2-6-5, with a specific ear-training caution: \"This pattern uses the fragments 3-4-5-7 9-10-9-8 from the scale of the minor seventh chord, and fragment 1-2-6-5 (note the interval between the tones 2 and 6) from the scale of the dominant seventh chord\" (Ch. 20, p. 97). The unusual leap from scale degree 2 to 6 is explicitly flagged as a feature the student must consciously hear.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 20, p. 97: 'fragment 1-2-6-5 (note the interval between the tones 2 and 6) from the scale of the dominant seventh chord.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/fragment-3-4-5-1-assignment"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "dominant-function-retention-rule",
+          "narrative": "Coker establishes the invariant condition for dominant function: \"the chord retains its dominant function as long as the third is major and the seventh is minor, regardless of the type of ninth used\" (Ch. 25, p. 119). This means the fifth, ninth, eleventh, and thirteenth may be freely altered — perfect, diminished, or augmented — without disrupting the chord's harmonic direction toward resolution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 119: 'the chord retains its dominant function as long as the third is major and the seventh is minor, regardless of the type of ninth used.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 121: 'the fifth of a dominant seventh may be unaltered (perfect), lowered (diminished), or raised (augmented), without changing the chord\\'s function.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/dominant-function-retention-rule",
+            "dom7b9/dominant-function-retention-rule"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "turnaround-endpoint",
+          "narrative": "In the turnaround device, the dominant seventh is one of two permissible ending qualities: the progression \"will end with either a V7 chord (dominant) or a flat-II7 or flat-IIM7 (dominant substitute)\" (Ch. 25, p. 118). This positions dom7 as the terminal functional quality in stationary-root chord-type permutation, providing the harmonic impetus to return to the section's beginning.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 118: 'most will begin with a tonic chord (but only for about two beats) and will end with either a V7 chord (dominant) or a flat-II7 or flat-IIM7 (dominant substitute).'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/turnaround-start-quality",
+            "dom7/stationary-root-permutation"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "stationary-root-permutation",
+          "narrative": "In turnaround writing, Coker demonstrates that the dominant seventh quality may appear on the same root as a preceding IM7, creating functional and key-center shift through quality alone: \"CM7 Cm7 F7 BbM7 / Bbm7 Eb7 AbM7\" and \"DM7 D7 GM7 G7 CM7\" — stationary-root permutation sequences where the dom7 changes both chord function and key center without root motion (Ch. 23, p. 115).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 23, p. 115: 'the root will remain stationary through two or more chords, while the chord type on that same root will change... Such a permutation in chord type will usually cause a change in chord function as well.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/turnaround-start-quality",
+            "dom7/turnaround-endpoint"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "diminished-half-step-color-tone-rule",
+          "narrative": "Coker's most-cited application rule for the diminished scale over dominant chords: \"the most common use of the diminished scale in the jazz idiom is with the dominant seventh chord where the scale adds the color tones of flat-9, +9, +11, and 13, and where the root of the scale is a half-step above the root of the seventh chord (i.e, a C-sharp diminished scale is used with a C7)\" (Ch. 27, p. 130). One diminished scale simultaneously supplies all four essential color tones.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 130: 'the root of the scale is a half-step above the root of the seventh chord (i.e, a C-sharp diminished scale is used with a C7).'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 131: 'the pattern also yields the color tones of flat-9, +9, +11, and 13... all four color tones are common to one another and can be used together to good effect.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7b9/diminished-scale-source",
+            "dom7/diminished-fifth-substitution"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "diminished-fifth-substitution",
+          "narrative": "Dominant seventh chords whose roots lie a tritone apart are interchangeable substitutes: \"chords whose roots are within the same diminished seventh chord are likely substitutes for each other... chords located a diminished fifth apart, especially when they are dominant sevenths, will substitute for each other (i.e., C7 and F-sharp7)\" (Ch. 27, p. 131). Additionally, chords a minor third apart within the same diminished-seventh-chord root set also function as substitutes.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 131: 'chords whose roots are within the same diminished seventh chord are likely substitutes for each other... chords located a diminished fifth apart, especially when they are dominant sevenths, will substitute for each other (i.e., C7 and F-sharp7).'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/diminished-half-step-color-tone-rule",
+            "dim7/substitution-for-dominant"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "four-dominants-one-diminished-scale",
+          "narrative": "One diminished scale serves four different dominant seventh chords simultaneously due to the scale's four-root symmetry: \"a diminished scale on C-sharp, E, G, or A will fit and enhance (because of the color tones provided) a C7, E-flat7, F-sharp7, or A7 chord\" (Ch. 27, p. 131). This efficiency principle — four dominant functions from one scale — is central to the book's symmetrical-scale system.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 131: 'a diminished scale on C-sharp, E, G, or A will fit and enhance (because of the color tones provided) a C7, E-flat7, F-sharp7, or A7 chord.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/diminished-half-step-color-tone-rule",
+            "dim7/four-root-symmetry"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "polychord-upper-structure-source",
+          "narrative": "For dominant seventh chords, polychord upper structures are selected either from the chord's substitution set or from its upper extensions: \"either by using both the given chord and one of its substitutions; or by locating a second chord whose tones are made up of ninths, elevenths, or thirteenths of the given chord\" (Ch. 25, p. 121). The function of the bottom dom7 must not be displaced by the added triad.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 121: 'proper choice of the added triad is achieved in one of two ways: either by using both the given chord and one of its substitutions; or by locating a second chord whose tones are made up of ninths, elevenths, or thirteenths of the given chord plus, perhaps, a tone or two from the given chord itself.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-function-retention-rule",
+            "dom7alt/polychord-upper-structure"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7b5",
+          "function_role": "lydian-augmented-position-one",
+          "narrative": "The Lydian Augmented Scale's first application aligns its root with the seventh of the dom7b5 chord: \"In the case of the dominant 7th, flat 5th (b5), the root of the scale is the seventh of the chord\" (Ch. 33, p. 146). This root-alignment position yields a flatted fifth (augmented eleventh) coloration over the dominant seventh, providing an altered-fifth sound without departing from the Lydian Augmented scale system.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 33, p. 145–146: 'one resulting in the addition of a flatted fifth (or augmented eleventh)... In the case of the dominant 7th, flat 5th (b5), the root of the scale is the seventh of the chord.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/lydian-augmented-position-two",
+            "dom7#11/lydian-augmented-application"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7alt",
+          "function_role": "lydian-augmented-position-two",
+          "narrative": "The Lydian Augmented Scale's second application, targeting a dominant seventh with raised fifth, raised ninth, lowered ninth, and augmented eleventh, aligns the scale root with the third of the chord: \"In the case of the dominant 7th, raised 5th, raised 9th, lowered 9th, and augmented 11th, the root of the scale is the third of the chord\" (Ch. 33, p. 146). This single root-alignment position simultaneously generates four distinct alterations.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 33, p. 146: 'In the case of the dominant 7th, raised 5th, raised 9th, lowered 9th, and augmented 11th, the root of the scale is the third of the chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 33, p. 145: 'the other application supplying an augmented fifth, a flatted ninth, an augmented ninth, and an augmented eleventh.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7b5/lydian-augmented-position-one",
+            "dom7#9/lydian-augmented-source"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7b9",
+          "function_role": "diminished-scale-source",
+          "narrative": "The flat-9 color tone on a dominant seventh is one of four color tones supplied by the diminished scale positioned a half-step above the chord root: the pattern \"yields the color tones of flat-9, +9, +11, and 13\" (Ch. 27, p. 131). Flat-9 is listed first among the four tones and is the most characteristic altered tension Coker associates with diminished-scale-over-dominant usage in jazz.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 131: 'the pattern also yields the color tones of flat-9, +9, +11, and 13... all four color tones are common to one another and can be used together to good effect.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 119: 'when the ninth is added to the dominant seventh chord (1-3-5-7), it can also be augmented (+9) or minor (flat-9 —sometimes referred to as a diminished ninth).'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#9/diminished-scale-color-tone",
+            "dom7/diminished-half-step-color-tone-rule"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7b9",
+          "function_role": "altered-ninth-dominant-function-retained",
+          "narrative": "Coker explicitly prescribes that adding a flat-9 to a dominant seventh chord does not alter its dominant function: \"the chord retains its dominant function as long as the third is major and the seventh is minor, regardless of the type of ninth used\" (Ch. 25, p. 119). The flat-9 is presented as an available tension that enriches dominant color while the chord retains its syntactic role.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 119: 'it can also be augmented (+9) or minor (flat-9—sometimes referred to as a diminished ninth)... the chord retains its dominant function as long as the third is major and the seventh is minor.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7#9/altered-ninth-dominant-function-retained",
+            "dom7/dominant-function-retention-rule"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7#9",
+          "function_role": "altered-ninth-dominant-function-retained",
+          "narrative": "The augmented ninth (+9) is one of three available ninth qualities on a dominant seventh chord — major, minor (flat-9), and augmented (+9) — all of which preserve dominant function provided the third remains major and the seventh minor: \"the chord retains its dominant function as long as the third is major and the seventh is minor, regardless of the type of ninth used\" (Ch. 25, p. 119).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 119: 'it can also be augmented (+9) or minor (flat-9)... the chord retains its dominant function as long as the third is major and the seventh is minor, regardless of the type of ninth used.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7b9/altered-ninth-dominant-function-retained",
+            "dom7/dominant-function-retention-rule"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7#9",
+          "function_role": "diminished-scale-color-tone",
+          "narrative": "The raised ninth (+9) is the second color tone supplied by the diminished scale positioned a half-step above the dominant seventh root, appearing in the set \"flat-9, +9, +11, and 13\" (Ch. 27, p. 131). Because all four color tones come from a single diminished scale positioning, the improviser generates +9 automatically when applying the half-step diminished-scale rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 131: 'the pattern also yields the color tones of flat-9, +9, +11, and 13... all four color tones are common to one another and can be used together to good effect.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7b9/diminished-scale-source",
+            "dom7/diminished-half-step-color-tone-rule"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7#11",
+          "function_role": "lydian-augmented-position-two",
+          "narrative": "The augmented eleventh (+11) is one of four simultaneous alterations available when the Lydian Augmented Scale is applied with its root on the chord's third: the second position \"supplying an augmented fifth, a flatted ninth, an augmented ninth, and an augmented eleventh\" (Ch. 33, p. 145). It also appears as the primary result of the first Lydian Augmented position (root = chord's seventh), which \"result[s] in the addition of a flatted fifth (or augmented eleventh)\" (Ch. 33, p. 145).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 33, p. 145: 'one resulting in the addition of a flatted fifth (or augmented eleventh) and the other application supplying an augmented fifth, a flatted ninth, an augmented ninth, and an augmented eleventh.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 131: 'the pattern also yields the color tones of flat-9, +9, +11, and 13.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7alt/lydian-augmented-position-two",
+            "dom7b5/lydian-augmented-position-one"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom13",
+          "function_role": "diminished-scale-color-tone-13",
+          "narrative": "The 13th (major thirteenth) is the fourth color tone supplied when the diminished scale is applied a half-step above the dominant seventh root: \"the pattern also yields the color tones of flat-9, +9, +11, and 13\" (Ch. 27, p. 131). Coker notes that the thirteenth is normally major and only rarely appears as a lowered (minor) thirteenth: \"the thirteenth is usually major, though in rare cases it can be lowered (minor thirteenth)\" (Ch. 25, p. 121).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 131: 'the pattern also yields the color tones of flat-9, +9, +11, and 13.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 121: 'the thirteenth is usually major, though in rare cases it can be lowered (minor thirteenth).'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/diminished-half-step-color-tone-rule",
+            "dom7b9/diminished-scale-source"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "iim7-progression-function",
+          "narrative": "The minor seventh chord most commonly functions as IIm7 in jazz progressions: \"the m7 chord functions more commonly as a IIm7 than as a IIIm7 or VIm7\" (Ch. 16, p. 82). Within the IIm7–V7–IM7 progression, the IIm7 uses the Dorian mode on its root, which shares the same parent key signature as the V7 and IM7 — enabling a single scalar approach to cover all three chords.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 82: 'the m7 chord functions more commonly as a IIm7 than as a IIIm7 or VIm7.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 83: 'the Gm7 uses a Dorian Mode on the note G (which has the parent key of F Major).'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-im7-default-reading",
+            "dom7/v7-progression-function"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "dorian-mode-source",
+          "narrative": "The minor seventh chord is derived from the Dorian mode by extracting tones 1-3-5-7, and its Dorian mode is the single scale required for improvising over it: \"The student must remember to relate each Dorian Mode to its parent key before attempting to apply the numerical formulas for the formation of the four types of minor chords and before attempting to play the scale (dorian mode) of these chords\" (Ch. 12, p. 63). The parent-key relationship — not interval counting — is the method's governing tool.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 12, p. 67: 'Tones No. 1-3-5-7 of the B Dorian Mode form the B Minor Seventh Chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 12, p. 63: 'The student must remember to relate each Dorian Mode to its parent key before attempting to apply the numerical formulas.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/iim7-progression-function",
+            "min9/dorian-mode-source"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "dorian-mode-covers-all-minor-qualities",
+          "narrative": "Because all four minor chord qualities — minor triad, m6, m7, and m9 — share the same Dorian mode, a single digital pattern labeled with the minor seventh symbol covers them all: \"the minor triad, m6, m7 and m9 chords all use the same basic scale: a dorian mode on the chord root... The use of the minor seventh chord symbol is merely for convenience\" (Ch. 15, p. 79). This scale-centric unification is the chapter's foundational lesson.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 15, p. 79: 'the minor triad, m6, m7 and m9 chords all use the same basic scale: a dorian mode on the chord root. For example, a Cm, Cm6, Cm7 and Cm9 will all share the C dorian mode. The use of the minor seventh chord symbol is merely for convenience.'"
+            }
+          ],
+          "cross_ref": [
+            "min6/dorian-mode-shared",
+            "min9/dorian-mode-source"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "fragment-3-4-5-7-assignment",
+          "narrative": "In the IIm7–V7 two-fragment substitution rule, the minor seventh chord is assigned fragment 3-4-5-7 from its scale: \"The fragment 3-4-5-7 is to be extracted from the scale of the minor 7th chord\" (Ch. 17, p. 88). This fragment is the characteristic melodic cell for the IIm7 position across Patterns 127–134 and is the primary cell in the extended four-measure version as well.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 17, p. 88: 'The fragment 3-4-5-7 is to be extracted from the scale of the minor 7th chord, and the fragment 3-4-5-1 is to be extracted from the scale of the dominant seventh chord.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/fragment-3-4-5-1-assignment",
+            "min7/fragment-1-2-3-5-rule"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "fragment-1-2-3-5-rule",
+          "narrative": "The foundational ascending scalar fragment for the IIm7 is 1-2-3-5, extracted from each chord's scale: \"This pattern is based on the fragments 1-2-3-5 of EACH chord scale\" (Ch. 17, p. 87). This is the opening pattern for the IIm7–V7 two-measure sequence and is described as covering \"one complete octave, in the ascending form\" of the m7 scale (Ch. 16, p. 85).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 17, p. 87: 'This pattern is based on the fragments 1-2-3-5 of EACH chord scale.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 85: 'This pattern uses the scale of the m7 chord in one complete octave, in the ascending form.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/fragment-3-4-5-7-assignment",
+            "dom7/fragment-3-4-5-1-assignment"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "shared-parent-key-with-v7",
+          "narrative": "Because IIm7 and V7 share the same parent key, a single scalar pattern begun on the IIm7 chord may continue through the V7 without scale change: \"The pattern fits both chords because they both have the same parent key. Consequently, the accidentals in their respective scales are the same\" (Ch. 17, p. 95). Coker calls this the defining rationale for running continuous scalar lines across both chords of the IIm7–V7 complex.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 17, p. 95: 'The pattern fits both chords because they both have the same parent key. Consequently, the accidentals in their respective scales are the same.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 20, p. 97: 'these tones also fit the dominant seventh chord because both chords use the same \"parent\" scale.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v7-progression-function",
+            "min7/iim7-progression-function"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "directional-ascending-assignment",
+          "narrative": "In the systematic directional-alternation rules for two-measure IIm7–V7 patterns, the ascending scale direction is assigned to the IIm7 while descending is assigned to the V7: \"ascending the scale of the minor seventh chord and descending the scale of the dominant seventh chord\" (Ch. 17, p. 94). This directional assignment creates a melodic arc (rise then fall) that mirrors the harmonic tension–resolution shape of the progression.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 17, p. 94: 'This pattern uses the scales of the illustrated chords, ascending the scale of the minor seventh chord and descending the scale of the dominant seventh chord.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v7-progression-function",
+            "min7/shared-parent-key-with-v7"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min6",
+          "function_role": "dorian-mode-shared",
+          "narrative": "The Minor Sixth chord is derived from the Dorian mode by extracting tones 1-3-5-6: \"Tones No. 1-3-5-6 of the B Dorian Mode form the B Minor Sixth Chord\" (Ch. 11, p. 62). It shares the same Dorian mode parent scale with the minor triad, m7, and m9, and thus all four minor chord qualities are interchangeable at the scale level: \"all four chords contain the same triad... and all four chords use the same basic scale, the B Dorian Mode\" (Ch. 12, p. 67).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 11, p. 62: 'Tones No. 1-3-5-6 of the B Dorian Mode form the B Minor Sixth Chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 12, p. 67: 'all four chords contain the same triad, B, D, F-Sharp; and all four chords use the same basic scale, the B Dorian Mode, to establish their sound.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/dorian-mode-covers-all-minor-qualities",
+            "min9/dorian-mode-source"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min9",
+          "function_role": "dorian-mode-source",
+          "narrative": "The Minor Ninth chord is derived from the Dorian mode by extracting tones 1-3-5-7-9: \"Tones No. 1-3-5-7-9 of the B Dorian Mode form the B Minor Ninth Chord\" (Ch. 12, p. 67). Because all four minor chord qualities (triad, m6, m7, m9) share the same Dorian parent scale, a pattern labeled m7 covers m9 contexts as well — the student need not internalize a separate scale for the added ninth.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 12, p. 67: 'Tones No. 1-3-5-7-9 of the B Dorian Mode form the B Minor Ninth Chord.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 15, p. 79: 'the minor triad, m6, m7 and m9 chords all use the same basic scale: a dorian mode on the chord root.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/dorian-mode-covers-all-minor-qualities",
+            "min6/dorian-mode-shared"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7b5",
+          "function_role": "viim7-diatonic-function",
+          "narrative": "Coker identifies the half-diminished chord (minor seventh flat five) as the chord built on the seventh scale degree in any major key: \"Seventh chords formed on tones V and VII are Dominant and Half-Diminished, respectively\" (Ch. 16, p. 81). While this chord type is named but not developed as an improvisation target in the same depth as IIm7, V7, and IM7, its diatonic position at VII establishes its theoretical place in the method's Roman-numeral framework.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 81: 'Seventh chords formed on tones V and VII are Dominant and Half-Diminished, respectively.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v7-progression-function",
+            "min7/iim7-progression-function"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dim7",
+          "function_role": "diminished-scale-formula",
+          "narrative": "The Diminished Seventh Chord is derived from the diminished scale by extracting tones 1-3-5-7: \"By extracting tones No. 1-3-5-7 from any diminished scale, we arrive at the Diminished Seventh Chord on that particular root\" (Ch. 21, p. 110). Because four roots share the same diminished scale, this formula yields four Diminished Seventh chords from a single scale — a key efficiency principle in the method.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 21, p. 110: 'By extracting tones No. 1-3-5-7 from any diminished scale, we arrive at the Diminished Seventh Chord on that particular root.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 21, p. 109: 'when using the tones E-flat, G-flat and A as starting points, the student is actually playing the same tones as he did when starting on C.'"
+            }
+          ],
+          "cross_ref": [
+            "dim7/four-root-symmetry",
+            "dim7/shared-scale-with-diminished-triad"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dim7",
+          "function_role": "four-root-symmetry",
+          "narrative": "The Diminished Seventh chord's four-root symmetry means that the same scale — and therefore the same patterns — applies when starting from any of four roots: C, E-flat, G-flat, or A all yield identical tones (Ch. 21, p. 109). The practical consequence is that mastering three chromatically adjacent diminished scales covers all twelve possible Diminished Seventh chord roots.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 21, p. 109: 'Thus the C diminished scale will yield three other diminished scales: the E-flat diminished scale, the G-flat diminished scale and the A diminished scale.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 130: 'there are (in sound) only three different diminished scales, chromatically adjacent (i.e., scales on C, C-sharp, and D).'"
+            }
+          ],
+          "cross_ref": [
+            "dim7/diminished-scale-formula",
+            "dom7/four-dominants-one-diminished-scale"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dim7",
+          "function_role": "shared-scale-with-diminished-triad",
+          "narrative": "The Diminished Seventh Chord and Diminished Triad share the same diminished scale on the chord root, making chord symbol choice a notational convenience: \"the Diminished Triad and the Diminished Seventh Chord use the same scale: a diminished scale on the chord root. The use of the Diminished Triad symbol in the following patterns is merely for convenience\" (Ch. 22, p. 116). Players can freely interchange the two chord symbols within a given pattern context.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 22, p. 116: 'the Diminished Triad and the Diminished Seventh Chord use the same scale: a diminished scale on the chord root. The use of the Diminished Triad symbol in the following patterns is merely for convenience, since it would be impossible to determine exactly which chord is being used when the scale is common to both of the chords mentioned.'"
+            }
+          ],
+          "cross_ref": [
+            "dim7/diminished-scale-formula",
+            "dim7/four-root-symmetry"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dim7",
+          "function_role": "substitution-for-dominant",
+          "narrative": "Diminished seventh chords whose roots lie within the same symmetrical root-set as a dominant seventh are interchangeable substitutes for that dominant: \"chords whose roots are within the same diminished seventh chord are likely substitutes for each other\" (Ch. 27, p. 131). This extends the tritone substitution principle to include minor-third relationships, linking dim7 harmony directly to dominant-function substitution.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 131: 'chords whose roots are within the same diminished seventh chord are likely substitutes for each other... halfway to each of the diminished fifth intervals... are two more substitute possibilities.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/diminished-fifth-substitution",
+            "dim7/four-root-symmetry"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dim7",
+          "function_role": "chromatic-nct-passing-tone-context",
+          "narrative": "Chromatic non-harmonic tones may be inserted between whole-step pairs within a diminished scale pattern to produce chromatic density while preserving the diminished character: \"a non-harmonic (non-chord) tone is added chromatically between pairs of tones from the scale — pairs which are normally a whole-step apart. The result is a chromatic scale, though the scale continues to sound like a diminished scale because of the placement of the non-harmonic tones\" (Ch. 27, p. 130). The diminished seventh chord is the harmonic context for this technique.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 130: 'Beginning with Pattern No. 216, a non-harmonic (non-chord) tone is added chromatically between pairs of tones from the scale—pairs which are normally a whole-step apart. The result is a chromatic scale, though the scale continues to sound like a diminished scale because of the placement of the non-harmonic tones.'"
+            }
+          ],
+          "cross_ref": [
+            "dim7/diminished-scale-formula",
+            "dim7/shared-scale-with-diminished-triad"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "aug7",
+          "function_role": "whole-tone-scale-formula",
+          "narrative": "The Augmented Seventh Chord (aug7, tones 1-3-5-6) is derived from the whole-tone scale by extracting tones 1-3-5-6: \"By extracting tones No. 1-3-5-6 from a whole tone scale, we arrive at the Augmented Seventh chord on that particular root\" (Ch. 19, p. 107). It shares the same parent augmented triad and whole-tone scale as the augmented triad built on the same root: \"both chords contain the same triad... and both chords use the same scale, the E whole tone scale\" (Ch. 19, p. 107).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 19, p. 107: 'By extracting tones No. 1-3-5-6 from a whole tone scale, we arrive at the Augmented Seventh chord on that particular root.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 19, p. 107: 'both chords contain the same triad, E-G-sharp-C, and both chords use the same scale, the E whole tone scale, to establish their sound.'"
+            }
+          ],
+          "cross_ref": [
+            "aug7/whole-tone-two-collections",
+            "aug7/shared-parent-with-augmented-triad"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "aug7",
+          "function_role": "whole-tone-two-collections",
+          "narrative": "The whole-tone scale underlying the Augmented Seventh chord exists in only two distinct pitch collections across all twelve roots: \"Thus the C whole tone scale is used to form five other whole tone scales. all having the same tones but with different starting pitches\" (Ch. 18, p. 104). This two-collection economy means the improviser need only master two whole-tone scale fingerings to cover all possible Augmented Seventh roots.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 18, p. 104: 'Thus the C whole tone scale is used to form five other whole tone scales. all having the same tones but with different starting pitches.'"
+            }
+          ],
+          "cross_ref": [
+            "aug7/whole-tone-scale-formula",
+            "aug7/enharmonic-spelling-required"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "aug7",
+          "function_role": "enharmonic-spelling-required",
+          "narrative": "When extracting Augmented Seventh chords from the whole-tone scale chart, enharmonic respelling is required to maintain proper chord spelling: \"The use of enharmonic tones is justifiable whenever the student desires... The enharmonic tone does not change the sound of the tone but rather the spelling\" (Ch. 19, p. 106). Students are warned not to miscount chord tones when enharmonic substitution causes an apparent span larger than the expected five letter-names.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 19, p. 106: 'The use of enharmonic tones is justifiable whenever the student desires. The enharmonic tone does not change the sound of the tone but rather the spelling, which may allow the student to use the material related to whole tone scales.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 19, p. 107: 'The student is cautioned not to be misled into thinking the augmented triad has six tones.'"
+            }
+          ],
+          "cross_ref": [
+            "aug7/whole-tone-scale-formula",
+            "aug7/whole-tone-two-collections"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "aug7",
+          "function_role": "shared-parent-with-augmented-triad",
+          "narrative": "The Augmented Seventh Chord and the augmented triad on the same root share both their parent triad and their parent whole-tone scale, establishing a structural unity useful for voice-leading and substitution: \"Note that both chords contain the same triad, E-G-sharp-C, and both chords use the same scale, the E whole tone scale, to establish their sound\" (Ch. 19, p. 107). An improviser can freely move between augmented triad and Augmented Seventh Chord contexts using the same whole-tone scale material.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 19, p. 107: 'Note that both chords contain the same triad, E-G-sharp-C, and both chords use the same scale, the E whole tone scale, to establish their sound.'"
+            }
+          ],
+          "cross_ref": [
+            "aug7/whole-tone-scale-formula",
+            "aug7/whole-tone-two-collections"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7#11",
+          "function_role": "augmented-scale-m7plus5-primary",
+          "narrative": "The major seventh chord with augmented fifth (M7+5, which maps to maj7#11 / maj7 with #5 and #11 coloring) is the primary chord target for the augmented scale: \"the augmented scale fits a rarely-used chord, the major seventh chord with an augmented fifth (M7+5)\" (Ch. 28, p. 134). The augmented scale is presented as the defining scale source for this chord quality, giving the improviser an unusual sound with \"interesting\" qualities. Coker acknowledges it is \"relatively new\" and predicts it may \"enjoy wider use in the future.\"",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 28, p. 134: 'the augmented scale fits a rarely-used chord, the major seventh chord with an augmented fifth (M7+5)... both the chord and the scale present interesting sounds that might prove attractive to the jazz improviser.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/augmented-scale-secondary-target",
+            "aug7/whole-tone-scale-formula"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7#11",
+          "function_role": "augmented-scale-free-form-potential",
+          "narrative": "Beyond specific chord contexts, the augmented scale's primary chord (M7+5) participates in free-form, atonal applications due to the scale's \"mystical, keyless sound\": \"It also carries much potential for becoming a 'free form' device, because of its mystical, keyless sound and its symmetry in construction\" (Ch. 28, p. 134). This proscribes treating the augmented scale over M7+5 as strictly functional — it is equally suited to non-functional contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 28, p. 134: 'It also carries much potential for becoming a \"free form\" device, because of its mystical, keyless sound and its symmetry in construction.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7#11/augmented-scale-m7plus5-primary"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "scale-degree-functions-by-roman-numeral",
+          "narrative": "Coker establishes exactly which chord quality is produced at each major-scale degree for seventh chords: \"seventh chords formed on tones I and IV are Major Seventh chords... on tones II, III and VI are Minor Seventh chords... on tones V and VII are Dominant and Half-Diminished, respectively\" (Ch. 16, p. 81). The dom7 quality uniquely belongs to scale degree V, making the V7 designation an intrinsic property of the major-scale system rather than an externally applied label.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 81: 'In the key of B-Flat Major. seventh chords formed on tones I and IV are Major Seventh chords... seventh chords formed on tones V and VII are Dominant and Half-Diminished, respectively.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-im7-default-reading",
+            "min7/iim7-progression-function"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "chord-group-reading-unit",
+          "narrative": "Coker argues that the key improvisational skill is reading chords in related harmonic groups rather than individually: \"an improviser who can read groups of chords that are related to each other, rather than improvising on one chord at a time, will also be developing good reading habits which consequently allow for more spontaneity in playing\" (Ch. 16, p. 84). The IIm7 is always read as part of the IIm7–V7 unit, never in isolation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 84: 'an improviser who can read groups of chords that are related to each other, rather than improvising on one chord at a time, will also be developing good reading habits which consequently allow for more spontaneity in playing.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v7-progression-function",
+            "maj7/resolution-target-im7"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "chord-group-reading-unit",
+          "narrative": "Just as the IIm7 is always read as part of the IIm7–V7 harmonic unit, the V7 chord must be understood in the context of the group. Coker's IIm7–V7 chart (Figure 27) is prescribed for memorization: \"Figure 27 is a chart which will help the student recognize the IIm7-V7 and IIm7-V7-IM7 progressions as they are used in standard tunes. It is advisable to MEMORIZE the chart\" (Ch. 16, p. 83). The V7 is never parsed as an isolated chord in the method.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 83: 'Figure 27 is a chart which will help the student recognize the IIm7-V7 and IIm7-V7-IM7 progressions as they are used in standard tunes. It is advisable to MEMORIZE the chart.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/chord-group-reading-unit",
+            "maj7/resolution-target-im7"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "elevated-ninth-alteration-option",
+          "narrative": "The eleventh may be perfect or augmented on a dominant seventh chord without altering its function: \"The eleventh can be perfect or augmented\" (Ch. 25, p. 121). Coker lists this alongside the freely alterable ninth and fifth, cataloging the full range of tensions available to the dominant seventh chord as raw material for polychord construction and free improvisation.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 121: 'It is also true that the fifth of a dominant seventh may be unaltered (perfect), lowered (diminished), or raised (augmented), without changing the chord\\'s function. The eleventh can be perfect or augmented, and the thirteenth is usually major, though in rare cases it can be lowered (minor thirteenth).'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/dominant-function-retention-rule",
+            "dom7alt/lydian-augmented-position-two"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "scale-degree-i-and-iv-quality",
+          "narrative": "In any major key, both scale degree I and scale degree IV produce Major Seventh chords: \"seventh chords formed on tones I and IV are Major Seventh chords\" (Ch. 16, p. 81). Coker uses this diatonic relationship to explain why the M7 symbol alone is insufficient to determine chord function — the improviser must determine from context whether it is IM7 or IVM7, with the default heuristic strongly favoring IM7.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 81: 'seventh chords formed on tones I and IV are Major Seventh chords.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 82: 'the M7 chord is likely to function as IM7 rather than IVM7.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/tonic-im7-default-reading"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "scale-degrees-ii-iii-vi-quality",
+          "narrative": "Minor Seventh chords occur naturally on scale degrees II, III, and VI in any major key: \"seventh chords formed on tones II, III and VI are Minor Seventh chords\" (Ch. 16, p. 81). The method's heuristic collapses these three possibilities into one default: \"the m7 chord functions more commonly as a IIm7 than as a IIIm7 or VIm7\" (Ch. 16, p. 82), simplifying real-time harmonic reading.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 81: 'seventh chords formed on tones II, III and VI are Minor Seventh chords.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 16, p. 82: 'the m7 chord functions more commonly as a IIm7 than as a IIIm7 or VIm7.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/iim7-progression-function",
+            "min7/chord-group-reading-unit"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "polychord-non-keyboard-alternation",
+          "narrative": "For non-keyboard players, polychords over dominant seventh chords are realized through rhythmic alternation rather than simultaneous voicing: \"Beginning with Pattern No. 180, a large number of polychordal possibilities are investigated as well as methods for putting polychords together in patterns that will permit a non-keyboard instrument to sound two chords together by alternation\" (Ch. 25, p. 121). This technique-specific instruction is prescriptive for instrumentalists who cannot play full polychords at once.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 121: 'methods for putting polychords together in patterns that will permit a non-keyboard instrument to sound two chords together by alternation.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/polychord-upper-structure-source"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "turnaround-harmonic-purpose",
+          "narrative": "The turnaround device is prescribed specifically to solve the problem of excessive tonic repetition in the final measures of a section: \"a device is needed which would remove the excessive use of the tonic and at the same time give the phrase-endings a sense of direction, namely to return gracefully to the beginning of a repeated section\" (Ch. 25, p. 118). The dominant seventh chord (V7 or flat-II7) serves as the vehicle for this directional harmonic momentum.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 25, p. 118: 'a device is needed which would remove the excessive use of the tonic and at the same time give the phrase-endings a sense of direction, namely to return gracefully to the beginning of a repeated section.'"
+            }
+          ],
+          "cross_ref": [
+            "maj7/turnaround-start-quality",
+            "dom7/turnaround-endpoint"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "diminished-scale-eight-tone-structure",
+          "narrative": "The diminished scale governing dom7 color-tone application contains eight tones rather than the standard seven, with alternating whole and half steps: \"It is a symmetrical scale of alternating whole steps and half steps. It contains eight letters in its spelling, instead of the usual seven found in major and minor scales\" (Ch. 27, p. 130). This structural property is what enables the four-root symmetry and the simultaneous supply of four altered color tones over a single dominant seventh chord.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 27, p. 130: 'It is a symmetrical scale of alternating whole steps and half steps. It contains eight letters in its spelling, instead of the usual seven found in major and minor scales. Since there are only seven letters to work with, one letter (arbitrarily chosen) will occur twice.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/diminished-half-step-color-tone-rule",
+            "dom7/four-dominants-one-diminished-scale"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "dorian-parent-key-prerequisite",
+          "narrative": "Before applying any numerical formula to a minor seventh chord context, the student must first relate the Dorian mode to its parent major key: \"The student must remember to relate each Dorian Mode to its parent key before attempting to apply the numerical formulas for the formation of the four types of minor chords and before attempting to play the scale (dorian mode) of these chords\" (Ch. 12, p. 63). This parent-key derivation — not interval counting — is the sole method sanctioned by Coker.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 12, p. 63: 'The student must remember to relate each Dorian Mode to its parent key before attempting to apply the numerical formulas for the formation of the four types of minor chords and before attempting to play the scale (dorian mode) of these chords.'"
+            },
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 9, p. 44: 'the term parent key has been used for the purpose of establishing the accidentals belonging to the particular mode relating the mode to a specific key signature, rather than defining the construction of each mode by measuring the distances between each tone.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/dorian-mode-source",
+            "dom7/v7-mixolydian-source"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "mixolydian-parent-key-prerequisite",
+          "narrative": "For dominant seventh chords, the Mixolydian mode must be derived from its parent key before any formula is applied: \"The student must remember to relate each mixolydian mode to its parent key before attempting to apply the numerical formulas for the formation of dominant seventh and ninth chords\" (Ch. 9, p. 51). This is the exact same parent-key procedural prerequisite required for Dorian in minor contexts, establishing the method's universal parent-key-first rule.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 9, p. 51: 'The student must remember to relate each mixolydian mode to its parent key before attempting to apply the numerical formulas for the formation of dominant seventh and ninth chords and before attempting to play the \"scale\" (mixolydian mode) of the two chords just mentioned.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v7-mixolydian-source",
+            "min7/dorian-parent-key-prerequisite"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "prerequisite-fluency-all-keys",
+          "narrative": "Before beginning any pattern work, Coker requires complete fluency in all four major chord types across every key: \"In preparation for the following exercises, be able to recite, write and play the following chords in every key: Major Triads, Major Sixth Chords, Major Seventh Chords and Major Ninth Chords\" (Ch. 1, p. 3). This is a gating prerequisite — pattern work does not begin until this chord fluency is established across the full chromatic spectrum.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 1, p. 3: 'In preparation for the following exercises, be able to recite, write and play the following chords in every key: Major Triads, Major Sixth Chords, Major Seventh Chords and Major Ninth Chords.'"
+            }
+          ],
+          "cross_ref": [
+            "maj6/tonic-i",
+            "maj9/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "prerequisite-all-minor-chord-types",
+          "narrative": "Parallel to the major chord prerequisite, Coker requires the student to be able to recite, write, and play all four minor chord types across every Dorian mode root before beginning pattern work: \"be able to recite, write and play the following chords as they are extracted from every Dorian Mode: Minor Triads, Minor Sixth Chords, Minor Seventh Chords and Minor Ninth Chords\" (Ch. 13, p. 65). The instruction specifies that execution is rhythm-free — pure chord-tone drill.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 13, p. 65: 'be able to recite, write and play the following chords as they are extracted from every Dorian Mode: Minor Triads, Minor Sixth Chords, Minor Seventh Chords and Minor Ninth Chords. Use the illustrated routine form for playing the chord tones. It does not require any specific rhythm or tempo.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/dorian-mode-source",
+            "min6/dorian-mode-shared"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "rhythmic-liberation-in-improvisation",
+          "narrative": "Patterns are notated in eighth notes but must be rhythmically freed when applied to improvisation: \"When the practiced patterns are applied to an improvisation, it is expected that the rhythms would be loosened, so that the idea takes on a more lyrical, natural, and less mechanical feeling\" (Ch. 1, p. 3). This is a universal rule governing all dominant chord patterns as much as any other — mechanical application of learned V7 lines is explicitly proscribed.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 1, p. 3: 'When the practiced patterns are applied to an improvisation, it is expected that the rhythms would be loosened, so that the idea takes on a more lyrical, natural, and less mechanical feeling.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/rhythmic-liberation-in-improvisation",
+            "maj7/rhythmic-liberation-in-improvisation"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "chord-symbol-context-required",
+          "narrative": "All dominant seventh pattern practice must be conducted with awareness of the governing chord symbol: \"The observation of that symbol while practicing, then, becomes crucial to an understanding of how the pattern is used... Used in the wrong place or the wrong key, the best patterns will fail, even in free-form jazz\" (Ch. 1, p. 3). Playing V7 patterns without harmonic context awareness is explicitly proscribed.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 1, p. 3: 'Used in the wrong place or the wrong key, the best patterns will fail, even in free-form jazz. We have therefore placed accompanying chord or scale symbols above each pattern. The observation of that symbol while practicing, then, becomes crucial to an understanding of how the pattern is used.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/chord-symbol-context-required",
+            "maj7/chord-symbol-context-required"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "chord-symbol-context-required",
+          "narrative": "The proscription against context-free pattern practice applies equally to minor seventh chord patterns: \"the practice of patterns has little value unless the student understands what musical situations befit the pattern. Used in the wrong place or the wrong key, the best patterns will fail\" (Ch. 1, p. 3). The student must observe the m7 chord symbol above each exercise during practice to build the harmonic association.",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 1, p. 3: 'the practice of patterns has little value unless the student understands what musical situations befit the pattern. Used in the wrong place or the wrong key, the best patterns will fail, even in free-form jazz.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/chord-symbol-context-required",
+            "maj7/chord-symbol-context-required"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "chord-symbol-context-required",
+          "narrative": "The universal proscription against decontextualized pattern practice applies to major seventh patterns: \"the practice of patterns has little value unless the student understands what musical situations befit the pattern\" (Ch. 1, p. 3). Every major seventh pattern in the book is accompanied by a chord symbol above it precisely to enforce this principle — pattern practice divorced from harmonic context is explicitly condemned as producing \"little value.\"",
+          "polarity": "proscriptive",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 1, p. 3: 'the practice of patterns has little value unless the student understands what musical situations befit the pattern. Used in the wrong place or the wrong key, the best patterns will fail, even in free-form jazz.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/chord-symbol-context-required",
+            "min7/chord-symbol-context-required"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "maj7",
+          "function_role": "two-fragment-5-8-6-4-and-2-5-3-1",
+          "narrative": "Two complementary scale-degree fragments — 5-8-6-4 and 2-5-3-1 — together cover all major chord qualities simultaneously: \"This pattern utilizes two fragments (5-8-6-4 and 2-5-3-1) from the chord scale, which when played simultaneously will sound any of the major forms of the chords expressed (Triad, M6, M7 and M9)\" (Ch. 7, p. 27). The M7 quality is implicitly covered by fragment 2-5-3-1 which reaches scale degree 7 (=major seventh above root).",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 7, p. 27: 'This pattern utilizes two fragments (5-8-6-4 and 2-5-3-1) from the chord scale, which when played simultaneously will sound any of the major forms of the chords expressed (Triad, M6, M7 and M9).'"
+            }
+          ],
+          "cross_ref": [
+            "maj6/two-fragment-coverage-member",
+            "maj9/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dom7",
+          "function_role": "scale-tone-seventh-positional-definition",
+          "narrative": "Coker's foundational definition of the dominant seventh as a chord type is positional rather than qualitative: \"we are not using the term seventh chord to mean a specific type of seventh chord, but rather as a general term referring to a four-note chord which measures seven tones from bottom to top\" (Ch. 9, p. 38). The dominant seventh emerges specifically when this positional construction is applied to scale degree V of a major scale using the Mixolydian mode.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 9, p. 38: 'we are not using the term seventh chord to mean a specific type of seventh chord, but rather as a general term referring to a four-note chord which measures seven tones from bottom to top (counting the first tone as No. 1) and having the same line to line or space to space relationship previously explained for scale tone triads.'"
+            }
+          ],
+          "cross_ref": [
+            "dom7/v7-mixolydian-source",
+            "maj7/tonic-i"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "dim7",
+          "function_role": "transposition-all-chart-roots-required",
+          "narrative": "Diminished seventh chord patterns must be practiced starting from every root illustrated in the diminished scale reference chart — partial coverage is not acceptable: \"Be sure to practice it using EVERY starting note illustrated on the chart in fig. 32\" (Ch. 22, p. 116). This mandatory exhaustive transposition is the method's strongest practice directive for diminished seventh contexts.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 22, p. 116: 'This pattern is based on the tones of the C Diminished Scale. Be sure to practice it using EVERY starting note illustrated on the chart in fig. 32.'"
+            }
+          ],
+          "cross_ref": [
+            "dim7/four-root-symmetry",
+            "dim7/shared-scale-with-diminished-triad"
+          ]
+        },
+        {
+          "source_work_id": "patterns-for-jazz",
+          "chord_quality": "min7",
+          "function_role": "two-beat-duration-arpeggio-drill",
+          "narrative": "In the Dorian mode arpeggio exercises of Chapter 14, each minor seventh chord lasts exactly two beats: \"Note: Each chord lasts two beats\" (Ch. 14, p. 71). This explicit rhythmic rule governs the metrical framework for all directional arpeggio exercises over m7 chords and is the method's way of building harmonic rhythm awareness alongside chord-tone facility.",
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "patterns-for-jazz",
+              "citation": "Ch. 14, p. 71: 'Note: Each chord lasts two beats.'"
+            }
+          ],
+          "cross_ref": [
+            "min7/dorian-mode-source",
+            "min7/fragment-3-4-5-7-assignment"
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-7-3-source",
+          "narrative": "Coker establishes that the 7-3 resolution is \"most often a harmonic progression of II-7 to V7,\" naming the min7 chord the canonical source of the b7 that resolves down a half-step to the 3rd of the following dominant. He argues the device compresses change-running efficiency: \"In the 7-3 resolution, we can use only 2 notes, yet imply two chords (1 note per chord)!\" Parker used fifteen 7-3 resolutions across two choruses of \"Confirmation,\" establishing the min7 as the most fertile launch-point for the device.",
+          "cross_ref": [
+            "dom7/v-chord-7-3-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 4, p. 20 — '7-3 resolution is most often a harmonic progression of II-7 to V7'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-cesh-deployment",
+          "narrative": "Chapter 12 extends CESH beyond its canonical long-duration minor chord home into II-7 contexts: \"improvisers will also use CESH on II-7 chords.\" Coker frames this as an observed performance practice rather than a theoretical extension, grounding the rule in transcribed solos. The minor/root-in-motion CESH variety — the most common of the four — is the recommended starting point for II-7 application.",
+          "cross_ref": [
+            "dom7/v-chord-cesh-on-fifth",
+            "min7/static-harmony-cesh-primary"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 12, p. 74 — 'improvisers will also use CESH on II-7 chords'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "3rd-and-7th-as-color-tones",
+          "narrative": "Coker notes that in 7-3 embellishment on minor seventh chords, \"Often the 3rd of the minor seventh chord will be pulled into the embellishment (along with the 7th, of course), since both the 3rd and 7th are crucial notes for determining or establishing chord-types.\" This singles out the minor 3rd and b7 as the two defining scale-degrees the improviser must emphasize on a min7 chord to clarify the chord quality to the listener.",
+          "cross_ref": [
+            "dom7/3rd-and-7th-as-color-tones"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 5, p. 22 — 'both the 3rd and 7th are crucial notes for determining or establishing chord-types'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "bebop-lick-primary-home",
+          "narrative": "Coker defines the bebop lick as \"a specific melodic phrase, generally taking place on dominant seventh and minor seventh chords,\" placing the min7 chord as a co-primary harmonic home alongside the dom7. The pedagogical directive is to first learn the lick \"against exercise tracks and tunes which have a preponderance of minor seventh chords and dominant seventh chords,\" making the min7 the initial training context before integration into mixed progressions.",
+          "cross_ref": [
+            "dom7/bebop-lick-primary-home"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 8, p. 40 & 44 — 'generally taking place on dominant seventh and minor seventh chords'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "dorian-bebop-scale-anachronism",
+          "narrative": "When applying the bebop scale to a min7 (dorian) chord, Coker flags a deliberate anachronism: the added chromatic note between scale degrees 3 and 4 produces a major 3rd against the minor chord quality — \"precisely the notes we generally consider to be contrary to the chord quality.\" Despite this contradiction, the note appears with \"99+% consistency\" in transcribed solos, making it a non-negotiable element of the bebop-scale vocabulary on min7 chords.",
+          "cross_ref": [
+            "dom7/mixolydian-bebop-scale-anachronism"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 6, p. 33 — 'a major third against a minor seventh chord... precisely the notes we generally consider to be contrary to the chord quality'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "pentatonic-generalization-target",
+          "narrative": "Coker's pentatonic harmonic generalization list includes A-7, D-7, and G-7 as three of the ten chords accommodated by a single C pentatonic scale \"with not one colliding\" pitch. This makes the min7 chord one of the safest targets for pentatonic generalization, allowing the improviser to sustain a single pentatonic over multiple successive min7 roots without any wrong notes.",
+          "cross_ref": [
+            "maj7/pentatonic-generalization-target",
+            "dom7/pentatonic-generalization-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 45 — 'C pentatonic scale (C, D, E, G, A) will fit... A-7, D-7, G-7'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "cry-me-a-river-lick-ninth-entry",
+          "narrative": "The Cry Me A River lick's first chord-type application is the min7 chord, where the lick starts on the ninth of the chord. Coker frames the lick's versatility as its key virtue: \"capable of accommodating five different chord-types without being altered!\" On a min7, the 9th entry point is the prescribed launch-note, requiring no alteration of the melodic fragment itself.",
+          "cross_ref": [
+            "dom7/cry-me-a-river-lick-thirteenth-entry",
+            "dom7alt/cry-me-a-river-lick-sharp-nine-entry"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 73 — 'Lick starts on the: ninth of the -7 chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "gone-but-not-forgotten-lick-deployment",
+          "narrative": "The Gone But Not Forgotten lick shares the same five-chord-type versatility as the Cry Me A River lick: \"it too can be played with any of the five chord-types given for the 'Cry Me A River' lick, without being altered.\" The min7 chord is therefore also a primary home for the GBNF lick, with the same ninth-based entry point implied by structural parallel to CMAR.",
+          "cross_ref": [
+            "dom7/gone-but-not-forgotten-lick-deployment",
+            "min7/cry-me-a-river-lick-ninth-entry"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 78 — 'it too can be played with any of the five chord-types given for the Cry Me A River lick, without being altered'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-7-3-target",
+          "narrative": "The V7 chord is the resolution target of the 7-3 device: \"the seventh (b7) of the first chord resolves to the third (3) of the second chord\" in the II-7 to V7 progression. Coker documents Monk's \"Round Midnight\" using six 7-3 resolutions in the first eight bars, and Rollins deploying thirty-one across five choruses of \"Eternal Triangle,\" establishing the dom7 as the harmonic destination that validates the device's efficiency.",
+          "cross_ref": [
+            "min7/ii-chord-7-3-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 4, p. 20 — 'the seventh (b7) of the first chord resolves to the third (3) of the second chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "3-b9-primary-home",
+          "narrative": "Coker defines the 3-b9 device exclusively on the dom7 chord: \"3-b9 refers to melodic motion from the 3rd of a dominant seventh chord to the flatted 9th of the same chord, an extremely common occurrence in improvised solos.\" The device is bidirectional (3 up to b9 or 3 down to b9) and may be realized by leap or scalar fill. Prescribed practice contexts are \"dominant seventh chords, dominant seventh chords moving around the cycle of fifths, II-7 to V7 cells.\"",
+          "cross_ref": [
+            "min7/ii-chord-7-3-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 5, p. 26 — '3-b9 refers to melodic motion from the 3rd of a dominant seventh chord to the flatted 9th of the same chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "mixolydian-bebop-scale-anachronism",
+          "narrative": "On the dom7 (mixolydian) chord, the bebop scale adds a chromatic note between scale degrees 7 and 8, yielding a major 7th — \"a major seventh against a dominant seventh,\" which Coker acknowledges is \"precisely the notes we generally consider to be contrary to the chord quality.\" Despite this, the note appears with 99+% consistency in transcribed solos, and Coltrane plays the resulting pattern 21 times in one 8-chorus solo on a 16-bar tune.",
+          "cross_ref": [
+            "min7/dorian-bebop-scale-anachronism"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 6, p. 33 — 'a major seventh against a dominant seventh are precisely the notes we generally consider to be contrary to the chord quality'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "bebop-lick-primary-home",
+          "narrative": "The bebop lick is defined as occurring \"generally\" on dom7 and min7 chords, making the dominant seventh chord a co-primary home. Coker extends the lick's dom7 application further: \"Another interesting way to apply the bebop lick against dominant seventh chords is to use it as a means of playing tri-tone substitutions (or altered dominants),\" making the dom7 the gateway to both standard and substitution lick uses.",
+          "cross_ref": [
+            "min7/bebop-lick-primary-home",
+            "dom7alt/bebop-lick-tritone-application"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 8, p. 40 & 44 — 'generally taking place on dominant seventh and minor seventh chords'; 'use it as a means of playing tri-tone substitutions'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "v-chord-cesh-on-fifth",
+          "narrative": "CESH may be applied on V7 chords by a specific positional rule: \"the minor CESH will actually be built on the fifth of the V7, as in G- on a C7.\" This transposition rule allows the minor/root-in-motion CESH — the most common variety — to function on dominant chords without changing the melodic template, relocating its root to the fifth scale-degree of the dom7.",
+          "cross_ref": [
+            "min7/ii-chord-cesh-deployment"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 12, p. 74 — 'the minor CESH will actually be built on the fifth of the V7, as in G- on a C7'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "tritone-substitution-source",
+          "narrative": "Coker defines tritone substitution specifically for dominant seventh chords: \"Tri-tone substitution is the substituting, especially of dominant seventh chords, with a chord of the same type whose root is a tri-tone... away from the given chord, as in substituting an F#7 for a C7.\" The dom7 is both the source chord being replaced and the type of chord that replaces it, making this a dom7-to-dom7 substitution lattice.",
+          "cross_ref": [
+            "dom7/back-door-v7-substitute",
+            "dim7/sharp-ii-v7-substitute"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 82 — 'substituting, especially of dominant seventh chords, with a chord of the same type whose root is a tri-tone away'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "cry-me-a-river-lick-thirteenth-entry",
+          "narrative": "On an unaltered dominant seventh chord, the Cry Me A River lick starts on the thirteenth — the 6th scale degree above the root. Coker lists this as one of five unaltered deployments of the lick across chord qualities, prescribing practice with the lick in all twelve keys against tracks containing \"dominant seventh chord\" harmonic settings.",
+          "cross_ref": [
+            "min7/cry-me-a-river-lick-ninth-entry",
+            "dom7alt/cry-me-a-river-lick-sharp-nine-entry"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 73 — 'Lick starts on the: thirteenth of the 7 chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "pentatonic-generalization-target",
+          "narrative": "C7 and G7(sus. 4) appear on Coker's ten-chord pentatonic generalization list — a single C pentatonic covers both without any colliding pitches. The dom7 chord is thus an approved target for pentatonic generalization, allowing the improviser to sustain the same pentatonic across unaltered dominant chords in a progression.",
+          "cross_ref": [
+            "min7/pentatonic-generalization-target",
+            "maj7/pentatonic-generalization-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 45 — 'C pentatonic scale (C, D, E, G, A) will fit... C7, G7(sus. 4)'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "back-door-v7-substitute",
+          "narrative": "Coker identifies the back door progression as a V7 substitute: \"The I chord, in a given progression, is often preceded by IV-7 to bVII7, instead of the usual V7 chord,\" leading improvisers to use that progression even \"when the given chord is V7.\" He explains the perceptual rationale: notes that seem wrong against V7 (such as the fourth and the major seventh) sound consonant because the listener's ear hears the familiar precedents of the substitute chords.",
+          "cross_ref": [
+            "min7/back-door-iv-minor-chord",
+            "dom7/tritone-substitution-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 82 — 'The I chord, in a given progression, is often preceded by IV-7 to bVII7, instead of the usual V7 chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "blues-scale-generalization-target",
+          "narrative": "Coker cites Parker's use of the blues scale over the last four measures of the Rhythm Changes A section — a passage containing multiple dominant and other chord types — as evidence that the blues scale generalizes across dom7-heavy progressions. This is framed as a deliberate artistic option: \"harmonic generalization may become, rather than a cop-out... a deliberate compositional tool.\"",
+          "cross_ref": [
+            "dom7/pentatonic-generalization-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 45 — 'Charles Parker favored using the blues scale over the last four measures of the [A section]'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7alt",
+          "function_role": "altered-dominant-definition",
+          "narrative": "Coker defines the altered dominant chord's full realization: \"a dominant seventh chord which contains, in its complete realization, an augmented fifth (+5), a flatted ninth (b9), an augmented ninth (+9), and an augmented eleventh (+11, or +4).\" He further states that \"Tri-tone substitutions and altered dominants are nearly identical,\" making the dom7alt structurally interchangeable with the tritone substitute in improvisation practice.",
+          "cross_ref": [
+            "dom7/tritone-substitution-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 82 — 'altered dominant is a dominant seventh chord which contains... an augmented fifth (+5), a flatted ninth (b9), an augmented ninth (+9), and an augmented eleventh (+11)'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7alt",
+          "function_role": "cry-me-a-river-lick-sharp-nine-entry",
+          "narrative": "On an altered dominant chord, the Cry Me A River lick starts on the augmented ninth (+9), one of the five unaltered deployments of the lick across chord qualities. Coker's prescription treats the dom7alt as structurally near-identical to the tritone substitute, making the lick's +9 entry point consistent with tritone-substitution practice on dominants.",
+          "cross_ref": [
+            "dom7/cry-me-a-river-lick-thirteenth-entry",
+            "min7/cry-me-a-river-lick-ninth-entry"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 73 — 'Lick starts on the: augmented ninth of the 7 (+5, +9) chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7alt",
+          "function_role": "bebop-lick-tritone-application",
+          "narrative": "Coker extends the bebop lick's application to altered dominants: \"Another interesting way to apply the bebop lick against dominant seventh chords is to use it as a means of playing tri-tone substitutions (or altered dominants).\" This forward-pointing concept allows the lick — defined on unaltered dom7 and min7 — to imply the more chromatic altered-dominant sound when deployed against a V7 context.",
+          "cross_ref": [
+            "dom7/bebop-lick-primary-home"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 8, p. 44 — 'apply the bebop lick against dominant seventh chords is to use it as a means of playing tri-tone substitutions (or altered dominants)'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7alt",
+          "function_role": "track-aa-substitution-context",
+          "narrative": "Chapter 6 specifies that Track AA uses \"altered\" dominants in place of unaltered dominants from Track Y, with the root sequence remaining identical (C, F, Bb, Eb, Ab…). This creates a prescribed practice environment where the improviser trains the 3-b9 device against altered-dominant chord sounds, integrating the alteration into ear-to-harmony association rather than treating it as a later add-on.",
+          "cross_ref": [
+            "dom7/3-b9-primary-home"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 6, p. 32 — 'Track AA... the letters of the root sequence for Track AA is the same as that for Track Y... [using] altered for unaltered dominants'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7b9",
+          "function_role": "3-b9-target-tone",
+          "narrative": "The flatted ninth is the explicit target of the 3-b9 device, which Coker defines as \"melodic motion from the 3rd of a dominant seventh chord to the flatted 9th of the same chord.\" The b9 may be reached by leap from the 3rd or by scalar fill; it may be approached from above (3 up to b9) or below (3 down to b9). The device chains with the 7-3 resolution because \"the 3 that ends a 7-3 resolution can launch a 3-b9.\"",
+          "cross_ref": [
+            "dom7/3-b9-primary-home",
+            "dom7/v-chord-7-3-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 5, p. 26 — '3-b9 refers to melodic motion from the 3rd of a dominant seventh chord to the flatted 9th of the same chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7b9",
+          "function_role": "v-chord-cesh-built-on-fifth",
+          "narrative": "The minor CESH built on the fifth of a dom7 chord effectively creates a dom7b9 context: G-minor CESH over C7 produces G-Ab-G-F motion, where Ab is the b9 of C7. Coker's rule that \"the minor CESH will actually be built on the fifth of the V7\" applies directly to any dominant chord where the b9 is the minor-third step above the chord's fifth.",
+          "cross_ref": [
+            "dom7/v-chord-cesh-on-fifth",
+            "min7/static-harmony-cesh-primary"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 12, p. 74 — 'the minor CESH will actually be built on the fifth of the V7, as in G- on a C7'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "maj7",
+          "function_role": "cry-me-a-river-lick-fourth-entry",
+          "narrative": "On a major (maj7 / major) chord, the Cry Me A River lick starts on the fourth scale degree. Coker lists this as one of five unaltered deployments of the lick, and his Table 293 maps each of the five chord-types to a specific entry point without any alteration of the melodic fragment itself. Practice is prescribed against tracks G, H, I, J, K, L, W, X, and BB.",
+          "cross_ref": [
+            "min7/cry-me-a-river-lick-ninth-entry",
+            "dom7/cry-me-a-river-lick-thirteenth-entry"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 73 — 'Lick starts on the: fourth of the Δ chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "maj7",
+          "function_role": "pentatonic-generalization-target",
+          "narrative": "C major and F major appear on the ten-chord pentatonic generalization list: a single C pentatonic \"will fit C4, F4, Bb4(+4)... with not one colliding\" pitch. Coker prescribes the pentatonic as the safest generalization tool — \"reduces the risk of colliding pitches\" — making the maj7 chord a primary collision-free pentatonic target.",
+          "cross_ref": [
+            "min7/pentatonic-generalization-target",
+            "dom7/pentatonic-generalization-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 45 — 'C pentatonic scale (C, D, E, G, A) will fit C4, F4'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "maj7",
+          "function_role": "tonic-major-generalization-anchor",
+          "narrative": "The maj7 tonic chord is the harmonic anchor of Coker's simplest generalization strategy: the tonic major scale over a II-V-I in major produces no wrong notes because \"D dorian and G mixolydian are both C major scale reindexed.\" Coker warns the strategy may yield \"weak chord-tone emphasis\" but is the safest entry point into harmonic generalization.",
+          "cross_ref": [
+            "min7/ii-chord-tonic-major-generalization",
+            "dom7/v-chord-tonic-major-generalization"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 45 — 'a progression of D-7, G7, C4 could be realized by simply playing a C major scale'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "maj7",
+          "function_role": "major-bebop-scale-chromatic-between-5-6",
+          "narrative": "On major-quality chords the bebop scale adds the chromatic note \"between the fifth and sixth degrees of the scale\" — producing a passing tone between scale degrees 5 and 6 (e.g., G and G# in C major). This is the most structurally consonant of the three bebop-scale variants because the added note does not contradict the chord quality, unlike the dorian and mixolydian versions.",
+          "cross_ref": [
+            "min7/dorian-bebop-scale-anachronism",
+            "dom7/mixolydian-bebop-scale-anachronism"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 6, p. 33 — 'The added chromatic note in the major scale is the half-step between the fifth and sixth degrees of the scale'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "maj9",
+          "function_role": "pentatonic-fourth-scale-entry",
+          "narrative": "Coker includes Bb major with an added fourth (Bb4, i.e. Bb maj with an added 9 and #11 / lydian color) on the pentatonic generalization list. While the label is Bb4(+4), this functions as a Bbmaj9#11 context. A single C pentatonic fits this chord without collision, establishing it as a safe generalization target alongside plain major and minor seventh chords.",
+          "cross_ref": [
+            "maj7/pentatonic-generalization-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 45 — 'C pentatonic scale (C, D, E, G, A) will fit... Bb4(+4)'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7b5",
+          "function_role": "minor-ii-chord-diminished-scale-generalization",
+          "narrative": "Coker prescribes diminished-scale harmonic generalization specifically over the minor II-V pairing (min7b5 + dom7alt), as a more advanced extension of the harmonic-minor generalization: \"another variation comes about when an improviser combines the II and V chords in a minor key (but not the I chord) under a single diminished scale.\" He acknowledges collision tones but states it \"can and does work, especially in the hands of the more capable improviser.\"",
+          "cross_ref": [
+            "dom7/minor-ii-v-diminished-scale-generalization"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 46 — 'combines the II and V chords in a minor key (but not the I chord) under a single diminished scale'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7b5",
+          "function_role": "minor-ii-harmonic-minor-generalization",
+          "narrative": "The min7b5 chord serves as the II chord in minor II-V-I progressions where Coker prescribes harmonic minor generalization. Three justifications make the collision tones acceptable: the progression transpires \"about twice as quickly\" as major II-V-I; the aggregate effect on the hearer is minor; and \"most players instinctively avoid the collision tones, perhaps because their ears warn them in advance of the potential danger.\"",
+          "cross_ref": [
+            "dom7/minor-ii-v-harmonic-minor",
+            "min-maj7/minor-i-harmonic-minor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 46 — 'most II-V-I progressions in minor transpire about twice as quickly (shorter chord durations)'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min-maj7",
+          "function_role": "minor-i-harmonic-minor-generalization-target",
+          "narrative": "The minor-major 7 chord functions as the I chord in the minor II-V-I progression over which Coker prescribes harmonic minor generalization. The min-maj7 tonic is the harmonic justification for applying harmonic minor across all three chords of the minor II-V-I: \"the aggregate effect on the hearer is a minor key.\" The chord's natural scale (harmonic minor) is the source of the generalization.",
+          "cross_ref": [
+            "min7b5/minor-ii-harmonic-minor-generalization",
+            "dom7/minor-ii-v-harmonic-minor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 46 — 'the sum total of the effect on the hearer is a minor key'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dim7",
+          "function_role": "sharp-ii-v7-substitute",
+          "narrative": "Coker identifies #II°7 as a standard V7 substitute: \"the #II°7 is often used to precede the I chord (or III-7, a substitute for I) in a given progression, leading to the improvised use of #II°7 in place of a given V7 chord.\" Like the back door progression, the #II°7 introduces notes anachronistic to V7 (fourth, major seventh) that sound consonant because the listener's ear hears the familiar precedent.",
+          "cross_ref": [
+            "dom7/back-door-v7-substitute",
+            "dom7/tritone-substitution-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 82 — '#II°7 is often used to precede the I chord... leading to the improvised use of #II°7 in place of a given V7 chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dim7",
+          "function_role": "diminished-scale-over-minor-ii-v",
+          "narrative": "Coker prescribes the diminished scale over the combined minor II (min7b5) and V (dom7) as an advanced harmonic generalization: the improviser treats both chords under a single diminished scale. Collision tones are present but the approach \"can and does work.\" The dim7 chord's symmetrical structure (minor 3rd stacking) provides the scale-tone set that covers both chords partially.",
+          "cross_ref": [
+            "min7b5/minor-ii-chord-diminished-scale-generalization"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 46 — 'combines the II and V chords in a minor key (but not the I chord) under a single diminished scale'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "ii-v-single-scale-harmonic-generalization",
+          "narrative": "Appendix B codifies the rule that whenever a II-V progression occurs in one measure, \"only one scale is given for the whole measure, since both chords are accommodated by the same pitches.\" The notes of a Bb dorian scale (for Bb-7) are identical to those of Eb mixolydian (for Eb7). Coker explicitly frames this as \"a form of harmonic generalization\" and notates the scales non-root-starting to avoid over-emphasizing the root — \"the root is generally the weakest note of a chord.\"",
+          "cross_ref": [
+            "min7/ii-chord-7-3-source",
+            "dom7/v-chord-7-3-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 17, p. 117 — 'only one scale is given for the whole measure, since both chords are accommodated by the same pitches'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "root-as-weakest-tone-proscription",
+          "polarity": "proscriptive",
+          "narrative": "Coker explicitly warns against over-using the root of a chord as the starting point for scales: \"when all scales are thought of as beginning on the roots of the chords, the player is more subject to over-using the root, which is a questionable practice, since the root is generally the weakest note of a chord, sounding simplistic and redundant.\" This proscription applies across all chord types but is stated in the context of dominant chord scale assignment.",
+          "cross_ref": [
+            "maj7/root-as-weakest-tone-proscription",
+            "min7/root-as-weakest-tone-proscription"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 17, p. 116 — 'the root is generally the weakest note of a chord, sounding simplistic and redundant'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "static-harmony-cesh-primary",
+          "narrative": "The canonical harmonic setting for CESH is \"a minor chord of long duration\" — a sustained min7 chord creates the static harmony that the contrapuntal elaboration decorates. Of CESH's four varieties, the minor/root-in-motion variant (where the root steps down a half-step and back) is identified as \"the most common one by far\" and the focus for initial study. Coker anchors learning to standard repertoire melodies rather than improvised solos.",
+          "cross_ref": [
+            "dom7/v-chord-cesh-on-fifth",
+            "min7/ii-chord-cesh-deployment"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 12, p. 74 — 'The supposed harmonic setting for a CESH to take place is a minor chord of long duration'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "harmonic-minor-generalization-ii-chord",
+          "narrative": "In minor II-V-I progressions, Coker prescribes a single harmonic minor scale across the min7b5 (II), dom7 (V), and min-maj7 (I) chords. Three justifications apply: brevity of the progression, aggregate minor identity, and players' instinctive avoidance of collision tones. The min7 (or min7b5) II chord is the starting point of this generalization, and the strategy is ranked above the diminished-scale approach on the safety ladder.",
+          "cross_ref": [
+            "min7b5/minor-ii-harmonic-minor-generalization",
+            "min-maj7/minor-i-harmonic-minor-generalization-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 46 — 'most II-V-I progressions in minor transpire about twice as quickly'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "3-b9-harmonic-context-practice-order",
+          "narrative": "Coker prescribes a specific ordering of harmonic contexts for 3-b9 practice: \"dominant seventh chords\" alone first, then \"dominant seventh chords moving around the cycle of fifths,\" then \"II-7 to V7 cells moving downward in whole steps,\" and finally \"II-7 to V7 (alt.) moving downward in whole steps.\" This hierarchy moves from isolated dom7 contexts to progressively more complex harmonic motion.",
+          "cross_ref": [
+            "dom7/3-b9-primary-home",
+            "dom7alt/track-aa-substitution-context"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 6, p. 31 — 'dominant seventh chords, dominant seventh chords moving around the cycle of fifths, II-7 to V7 cells moving downward in whole steps'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "maj7",
+          "function_role": "gone-but-not-forgotten-lick-major-seventh-entry",
+          "narrative": "The major seventh of a #5 major chord is the entry point for the Cry Me A River and Gone But Not Forgotten licks on their fifth and most chromatic chord-type application. Coker lists this as \"major seventh of the 4 (+5) chord\" — a major chord with an augmented fifth — pointing to the maj7 tone as the entry despite the augmented quality. Both licks share this application \"without being altered.\"",
+          "cross_ref": [
+            "maj7/cry-me-a-river-lick-fourth-entry"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 73 — 'Lick starts on the: major seventh of the 4 (+5) chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "bar-line-shift-generalization-cause",
+          "narrative": "Bar-line shifts on dominant chords are caused by harmonic generalization: Coker cites \"playing a II-7 to V7 (+5, b9) progression as only a V7 (+4, b9)\" as a paradigmatic cause of arriving at the V7 a beat early or late. The analyst rule is to check chords before and after a suspected error before judging — shifts are \"not errors\" and may be legitimate generalization artifacts.",
+          "cross_ref": [
+            "dom7alt/bar-line-shift-deliberate-tension"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 16, p. 85 — 'playing a II-7 to V7 (+5, +9) progression as only a V7 (+4, +9)'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "bar-line-shift-deliberate-tension",
+          "narrative": "Cannonball Adderley's \"So What\" example — where he \"deliberately enters and exits the bridge early, causing considerable tension, since the chord of the A section (D-) is one-half step lower than the chord of the bridge (Eb-)\" — is Coker's canonical illustration of deliberate bar-line shift as tension device on minor seventh chords. The half-step relationship between the two min7 chords amplifies the tension of the temporal displacement.",
+          "cross_ref": [
+            "dom7/bar-line-shift-generalization-cause"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 16, p. 85 — 'Cannonball Adderley... deliberately enters and exits the bridge early, causing considerable tension'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "outside-playing-five-wrong-notes",
+          "narrative": "Coker's outside-playing arithmetic applies universally but is framed around the dom7 chord context: \"most chords are accommodated by a seven-note scale\" leaving five wrong notes from the chromatic set of twelve. The improviser \"needs to know what notes are 'wrong' with any given chord, using those notes in convincing groups of 'wrong' notes, as well as learning to use them singly in a mildly dissonant, but smooth manner.\"",
+          "cross_ref": [
+            "min7/outside-playing-five-wrong-notes"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 16, p. 85 — 'there are five wrong notes possible with the average chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "cry-me-a-river-lick-error-test",
+          "polarity": "proscriptive",
+          "narrative": "Coker uses the Cry Me A River lick as a test for errors on dominant chords: if the lick's application \"doesn't agree with any of the five applications, and the harmonic setting causes several of the notes of the lick to be in conflict with the chord, it is reasonable to assume that the lick was placed in the wrong 'key'.\" This is an explicit proscription — wrong harmonic placement of a known stock lick on a dom7 is classifiable as error, not chromaticism.",
+          "cross_ref": [
+            "dom7/cry-me-a-river-lick-thirteenth-entry"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 16, p. 85 — 'if the application analyzed doesn't agree with any of the five applications... it is reasonable to assume that the lick was placed in the wrong key'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "back-door-melody-prescription",
+          "narrative": "Appendix B's footnote provides a melodic rule for back-door substitution on dominant chords: \"Whenever a BD is chosen, CMAR or GBNF may be played, starting on 9th of BD substitute, or a BBL on the 4th.\" This makes the bVII7 chord (the back-door dominant) a prescribed launch context for both named stock licks, with entry on the ninth, and for the bebop lick starting on the fourth.",
+          "cross_ref": [
+            "dom7/back-door-v7-substitute",
+            "min7/back-door-iv-minor-chord"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 17, p. 119 — 'Whenever a BD is chosen, CMAR or GBNF may be played, starting on 9th of BD substitute, or a BBL on the 4th'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "back-door-iv-minor-chord",
+          "narrative": "The back door progression begins on IV-7 (a min7 chord a fourth above tonic) proceeding to bVII7. Coker's back-door footnote prescribes entry on the 9th of the IV-7 for CMAR or GBNF. The IV-7 min7 chord is thus a prescribed lick-entry point in back-door contexts, and the player must recognize the IV-7 as the harmonic start of the substitution gesture rather than a standalone chord.",
+          "cross_ref": [
+            "dom7/back-door-v7-substitute",
+            "dom7/back-door-melody-prescription"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 82 — 'The I chord, in a given progression, is often preceded by IV-7 to bVII7'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom11",
+          "function_role": "suspended-dominant-pentatonic-target",
+          "narrative": "Coker's pentatonic generalization list explicitly includes G7(sus. 4) and D7(sus. 4) as two of the ten chords that a single C pentatonic covers without collision. The suspended dominant (dom11 / dom7sus4) is therefore one of the safest pentatonic generalization targets, and its inclusion alongside plain min7 and dom7 chords confirms the pentatonic strategy spans sus-chord contexts without modification.",
+          "cross_ref": [
+            "dom7/pentatonic-generalization-target",
+            "min7/pentatonic-generalization-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 45 — 'C pentatonic scale (C, D, E, G, A) will fit... G7(sus. 4), D7(sus. 4)'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7#11",
+          "function_role": "pentatonic-generalization-altered-target",
+          "narrative": "Coker includes Gb7 (+5, b9) — an altered dominant with the characteristic #11 (tritone) relationship to C — on the ten-chord pentatonic generalization list. A single C pentatonic fits this chord without collision, which Coker explains is because the listener's ear hears the familiar substitute precedent rather than the conflict. This makes the dom7#11 / altered dominant a safe pentatonic target.",
+          "cross_ref": [
+            "dom7alt/altered-dominant-definition",
+            "dom7/pentatonic-generalization-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 45 — 'C pentatonic scale (C, D, E, G, A) will fit... Gb7 (+5, b9)'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "sequence-prerequisite-any-chord-type",
+          "narrative": "Coker names the non-negotiable prerequisite for sequence deployment: \"the acquired ability to play any motive or short melody in any key and with any chord-type.\" The min7 chord — as the most frequently occurring II and VI chord in standard progressions — is the chord-type most commonly requiring motive adaptation. The directive to \"learn to slightly alter them to fit different chord-types\" directly addresses min7 quality adjustment.",
+          "cross_ref": [
+            "dom7/sequence-prerequisite-any-chord-type",
+            "maj7/sequence-prerequisite-any-chord-type"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 11, p. 61 — 'acquired ability to play any motive or short melody in any key and with any chord-type'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "v7-to-i-7-3-secondary-setting",
+          "narrative": "Beyond the II-7 to V7 setting, Coker notes the 7-3 resolution also operates in \"V7 to I\" — where the b7 of the dominant resolves to the 3rd of the tonic chord. He states that \"in our study we will be focusing more on the II-7 to V7 melodic realizations than on the V7-I possibilities,\" establishing II-V as the primary training context while acknowledging the V7-I form as a secondary legitimate use.",
+          "cross_ref": [
+            "min7/ii-chord-7-3-source",
+            "maj7/tonic-major-generalization-anchor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 4, p. 20 — '7-3 resolution is most often a harmonic progression of II-7 to V7, though the setting is sometimes V7 to I'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "mulligan-pianoless-7-3-harmonic-fill",
+          "narrative": "Coker uses Gerry Mulligan's \"Line For Lyons\" bridge as a performance-practice lesson for single-line instruments: \"Mulligan made exclusive use of 7-3 resolutions\" in six bars to fill the harmonic gap between melody and bass on a pianoless instrument. On min7 chords, the b7 (the source note of the 7-3) is particularly critical for a single-line player because without it the chord quality is ambiguous to listeners without piano accompaniment.",
+          "cross_ref": [
+            "dom7/v-chord-7-3-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 4, p. 20 — 'Mulligan made exclusive use of 7-3 resolutions' [in Line For Lyons bridge]"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "linear-chromaticism-metric-fill",
+          "narrative": "Coker defines linear chromaticism as a metric-fill device on dominant chords: \"chromatic notes are often the result of a metric problem that results in adding one or more notes to cause the phrase to agree with the number of beats in a measure.\" He explicitly parallels this to \"the principle of the bebop scale,\" tying chromaticism on dom7 chords to the same rhythmic rationale that motivates the added note in the mixolydian bebop scale.",
+          "cross_ref": [
+            "dom7/mixolydian-bebop-scale-anachronism"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 81 — 'Similar to the principle of the bebop scale, chromatic notes are often the result of a metric problem'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "tritone-sub-perceptual-consonance",
+          "narrative": "Coker provides a perceptual rationale for why tritone substitutions and back-door progressions sound consonant over a V7 chord: \"when an improviser uses them against the V7, the listener's ear hears the given precedents for the event, instead of the conflict with the V7.\" This explains why notes that are theoretically anachronistic to the dom7 (such as the major seventh and perfect fourth introduced by the back door) are heard as correct.",
+          "cross_ref": [
+            "dom7/back-door-v7-substitute",
+            "dim7/sharp-ii-v7-substitute"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 82 — 'the listener's ear hears the given precedents for the event, instead of the conflict with the V7'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "change-running-pickup-function",
+          "narrative": "Change-running on min7 chords serves a specific pickup function: Coker identifies one of its five functions as \"pick-up notes into a melodic phrase,\" allowing the improviser to establish the chord quality before launching a more melodic statement. The structural freedom rules apply: the arpeggiation \"does not necessarily begin on the root,\" may omit chord members, and may move in any direction.",
+          "cross_ref": [
+            "dom7/change-running-pickup-function",
+            "maj7/change-running-pickup-function"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 2, p. 8 — '(3) as pick-up notes into a melodic phrase; (4) as a means to make the sound of a chord clear to an audience'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "change-running-pickup-function",
+          "narrative": "Change-running on dom7 chords is described as \"somewhat superfluous\" in a solo context because the chord is already being sounded by the rhythm section — yet it remains prescribed for five functional purposes including ensemble communication. Coker insists practice must span \"triads, seventh chords, ninth chords, elevenths, and thirteenths\" on dominant chord-types, building arpeggiation facility across all extension levels.",
+          "cross_ref": [
+            "min7/change-running-pickup-function"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 2, p. 8 — 'change-running is somewhat superfluous when it occurs in an improvised solo, since the chord is already being sounded'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "digital-pattern-minor-quality-alteration",
+          "narrative": "Coker prescribes a direct alteration rule for adapting digital patterns to minor seventh chords: \"a 1-3-5-3 pattern can be adjusted to 1-b3-5-b3 to accommodate a minor chord.\" This makes the minor-quality chord a mandatory modification target — any digital pattern learned on a major chord type must be transposed in quality as well as pitch to be functionally available on min7 chords.",
+          "cross_ref": [
+            "dom7/digital-pattern-quality-alteration"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 3, p. 19 — '1-3-5-3 pattern can be adjusted to 1-b3-5-b3 to accommodate a minor chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "7-3-resolution-without-bass",
+          "narrative": "Coker prescribes that the 7-3 resolution functions even without bass accompaniment: \"Even without the bass notes, which provide chord roots, the principle continues to work, because we are so accustomed to hearing the device with the bass notes that our ear memory supplies the root sounds.\" This is a prescriptive practice technique: remove the piano channel, then improvise unaccompanied, using 7-3 resolutions to imply the progression.",
+          "cross_ref": [
+            "min7/ii-chord-7-3-source"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 5, p. 24 — 'try turning off the piano channel... Try improvising with no accompaniment, also, using the 7-3 resolutions'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "gone-but-not-forgotten-lick-voice-leading-flexibility",
+          "narrative": "Appendix B's footnote explicitly authorizes flexible use of the GBNF lick beyond its canonical context when voice-leading justifies: \"A different use of GBNF than what was recommended in Chapter 13, but because of the resolution to the next chord, it works.\" This is a prescriptive flexibility rule specific to dominant chord contexts where the following resolution validates otherwise non-canonical lick placement.",
+          "cross_ref": [
+            "dom7/cry-me-a-river-lick-thirteenth-entry"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 17, p. 119 — 'A different use of GBNF than what was recommended in Chapter 13, but because of the resolution to the next chord, it works'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "maj7",
+          "function_role": "sequence-motive-common-tone-stasis",
+          "narrative": "Coker describes a sequence transformation type where \"the motive remained the same (same notes) but against a different chord that had those notes in common with the first chord.\" This common-tone stasis sequence is particularly applicable to maj7 chords in diatonic progressions where the same notes serve both the II-7 and I major 7 chord, creating sequence without transposition.",
+          "cross_ref": [
+            "min7/sequence-prerequisite-any-chord-type"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 11, p. 61 — 'the motive remained the same (same notes) but against a different chord that had those notes in common with the first chord'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "diatonic-generalization-recognition",
+          "narrative": "Coker prescribes pattern recognition for diatonic chord successions as a generalization technique: \"Learn to recognize particular chord successions in which a change of scale is unnecessary. Chords which simply move diatonically (i.e., C, D-7, E-7, F, etc.), are easy to spot and are prime targets for harmonic generalization.\" Dominant chords appearing in diatonic sequences within a key — such as V before I — can share the tonic scale without collision.",
+          "cross_ref": [
+            "maj7/tonic-major-generalization-anchor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 9, p. 49 — 'Chords which simply move diatonically... are easy to spot and are prime targets for harmonic generalization'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "coltrane-pattern-density-target",
+          "narrative": "Coker's Coltrane analysis of \"Giant Steps\" establishes a prescriptive density target for digital patterns: 35-40% of non-rest measures contain digital patterns at the steady eighth-note level. Over dom7 chords, the most frequent patterns are 1-2-3-5 (fifteen occurrences) and 5-6-7-9 (two occurrences). \"Either figure should be enough to convince the reader\" that pattern study is non-optional even on complex dominant progressions.",
+          "cross_ref": [
+            "maj7/coltrane-pattern-density-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 3, p. 22 — 'the figure becomes nearly 40%... much of the remaining 60-65% is taken up with change-running substance'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "enclosure-density-target",
+          "narrative": "Coker establishes normative enclosure density targets through transcription counts: Clifford Brown used thirty-five enclosures in four choruses of \"Confirmation\" and Clark Terry seventeen in seven blues choruses. Since enclosures target object notes on all chord types, the min7 chord is implicitly a primary enclosure site given its frequency in standard progressions. The recommended study source is Baker's HOW TO PLAY BEBOP.",
+          "cross_ref": [
+            "dom7/enclosure-density-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 10, p. 54 — 'Clifford Brown used thirty-five enclosures in his four-chorus solo on Confirmation'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "enclosure-density-target",
+          "narrative": "Rollins used five enclosures in his solo on \"Airegin\" and Terry seventeen across seven blues choruses — both dom7-heavy contexts. Coker uses these counts to establish density targets for enclosure use, framing the device as a high-frequency structural element rather than an ornament. Enclosures are location-independent and therefore absent from Appendix B annotations, but equally important to practice.",
+          "cross_ref": [
+            "min7/enclosure-density-target"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 10, p. 54 — 'Rollins used the example shown here a total of five times in his solo on Airegin'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "maj7",
+          "function_role": "element-combination-density-within-two-bars",
+          "narrative": "Coker illustrates that \"sometimes elements of the jazz language carry the potential for being quickly successive, overlapping, and/or interlocking\" with an example that \"combines six elements in one 2-measure phrase.\" While not chord-quality specific, this is illustrated over major-key contexts and establishes that the maj7 (tonic) chord is no excuse for sparse element usage — maximum density across two bars is demonstrated and implicitly prescribed.",
+          "cross_ref": [
+            "dom7/element-combination-density-within-two-bars"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 10, p. 50 — 'The following example combines six elements in one 2-measure phrase!'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "min7",
+          "function_role": "quote-harmonic-match-ii-v-i",
+          "narrative": "Coker grounds quote deployment in harmonic setting matching: \"It can take place at any moment when the chord or progression cell of the tune being improvised agrees with the harmonic setting in which the phrase originally occurred.\" The II-V-I progression is his paradigm example — the opening phrase of \"Laura\" fits any tune containing a II-V-I in major — making the min7 II chord a primary trigger for quote recognition and deployment.",
+          "cross_ref": [
+            "dom7/quote-harmonic-match-ii-v-i",
+            "maj7/quote-harmonic-match-ii-v-i"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 73 — 'any time a II-V-I progression occurs... the opening phrase of Laura becomes one of many possibilities for a quote'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "elements-of-the-jazz-language",
+          "chord_quality": "dom7",
+          "function_role": "quote-harmonic-match-ii-v-i",
+          "narrative": "The V7 chord is the harmonic pivot that validates many quote insertions: Coker's \"Laura\" example shows that whenever a II-V-I occurs, a quote from a source tune with the same II-V-I setting becomes available. The dom7 V chord is the moment of maximum harmonic tension where the quote's source and destination progressions align, and the quick-witted improviser must recognize the opening interval and \"decide to complete the allusion.\"",
+          "cross_ref": [
+            "min7/quote-harmonic-match-ii-v-i"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Elements of the Jazz Language",
+              "citation": "Ch. 15, p. 73 — 'the opening phrase of Laura utilized the harmonic setting of II-V-I (in major)'"
+            }
+          ]
+        }
+      ]
     },
     {
       "id": "jamey-aebersold",
@@ -37875,7 +40259,1225 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "usage_notes": [
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "tonic-avoidance-of-fourth",
+          "polarity": "proscriptive",
+          "narrative": "Aebersold explicitly warns that the 4th scale degree of a dominant 7th chord carries too much tension to be emphasized: \"The 4th tone of major and dominant 7th chord/scales contains much tension and thus usually isn't emphasized. The 4th is usually treated as a passing tone between the 3rd and 5th scale tones. When in major or dominant keys don't end a phrase on the 4th.\" (Ch. 2, p. 6). This proscription is reinforced in Chapter 19: \"Be careful when playing the 4th note of major or dominant scales. Treat it as a passing tone.\" The rule distinguishes dominant from minor treatment, where the 4th is acceptable to emphasize.",
+          "cross_ref": [
+            "maj7/tonic-avoidance-of-fourth"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 6 — 'The 4th tone of major and dominant 7th chord/scales contains much tension and thus usually isn't emphasized.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 19",
+              "citation": "p. 65 — 'Be careful when playing the 4th note of major or dominant scales. Treat it as a passing tone.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "guide-tone-emphasis",
+          "narrative": "The 3rd and 7th are identified as the two structurally primary tones of the dominant 7th chord: \"The two most important notes in any scale are the 3rd and 7th. They tell the listener what the quality is and indicate the harmonic motion. The 3rd tells us if it's major or minor. The 7th tells whether the sound is stable or if it wants to move on to a chord of resolution.\" (Ch. 16, p. 54). Chapter 19 reinforces: \"Emphasize 3rds and 7ths. They are the important notes in the dominant 7th scale/chord.\" Placing these tones on beats 1 and 3 is described as \"vital\" for communicating harmonic intent to the listener.",
+          "cross_ref": [
+            "min7/guide-tone-emphasis",
+            "min7b5/guide-tone-emphasis"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'The two most important notes in any scale are the 3rd and 7th.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 19",
+              "citation": "p. 65 — 'Emphasize 3rds and 7ths. They are the important notes in the dominant 7th scale/chord.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "resolution-up-perfect-fourth",
+          "narrative": "Dominant 7th chords carry a directional imperative encoded into the method's core vocabulary: \"Dominants typically want to resolve to a chord up a perfect 4th (C7 wants to resolve to F, F-, F7 etc.).\" (Ch. 16, p. 54). Altered tones intensify this pull because \"those tones usually resolve by half-step to a scale or chord tone. This amounts to tension then release. It's a natural occurrence in music.\" Chapter 8 elaborates that beats 1 and 3 should receive \"b9's on dom.7th chords that resolve up a perfect fourth,\" anchoring resolution awareness into the physical act of melodic target selection.",
+          "cross_ref": [
+            "dom7alt/resolution-up-perfect-fourth",
+            "dom7b9/resolution-up-perfect-fourth"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'Dominants typically want to resolve to a chord up a perfect 4th.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'b9's on dom.7th chords that resolve up a perfect fourth.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "bebop-scale-chromatic-insertion",
+          "narrative": "The bebop scale is the method's central modification to the plain dominant 7th scale: \"The bebop scale contains one added tone to each of the four most used scales. Dominant 7th, C7 = C D E F G A Bb B C (The underlined tone is the added tone.)\" (Ch. 8, p. 28). The added natural 7th creates an 8-tone scale that mechanically aligns chord tones to strong beats in 4/4. Aebersold calls this the \"'glue' of the jazz language. Don't leave home without it!\" The scale is characteristically played descending and its added tone must never land on a downbeat.",
+          "cross_ref": [
+            "maj7/bebop-scale-chromatic-insertion",
+            "min7/bebop-scale-chromatic-insertion"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'The bebop scale contains one added tone to each of the four most used scales.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'BEBOP = C7 = CDEFGABbBC Play B natural as a passing tone. It should always appear on an upbeat, never on the downbeat.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "added-tone-upbeat-placement",
+          "polarity": "proscriptive",
+          "narrative": "Aebersold issues an explicit rhythmic constraint governing where the bebop scale's chromatic addition may fall: \"Don't allow the B natural (added tone) to fall on a downbeat. The added tone must always come on the upbeat in order to give it the jazz sound we are used to hearing.\" (Ch. 8, p. 28). This rule is not merely stylistic but structural: the 8-tone alignment depends on it. When a phrase begins on the 2nd, 4th, or 6th scale degree, \"you must use additional chromaticism somewhere in the phrase in order to make the B natural fall on the upbeat.\"",
+          "cross_ref": [
+            "maj7/added-tone-upbeat-placement",
+            "min7/added-tone-upbeat-placement"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'Don't allow the B natural (added tone) to fall on a downbeat. The added tone must always come on the upbeat.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "color-tone-selection",
+          "narrative": "Aebersold identifies four specific color tones available over major and dominant 7th chord-scale members: \"The pretty notes for major and dominant 7th chords/scales are the 6, 7, 9, and #4.\" (Ch. 7, p. 25). These tones \"create tension and should be used in the over-all tension-release process,\" functioning as expressive embellishments above the bare chord tones. The #4 (raised fourth, also called b5) is described in Chapter 16 as a \"favorite note\" in the Lydian Dominant context, providing a characteristic altered color without full superlocrian density.",
+          "cross_ref": [
+            "maj7/color-tone-selection",
+            "dom7#11/color-tone-selection"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 25 — 'The pretty notes for major and dominant 7th chords/scales are the 6, 7, 9, and #4.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'LYDIAN DOM. = C7#4 = CDEF#GABbC The #4 was/is a favorite note.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "scale-palette-expansion",
+          "narrative": "Chapter 16 catalogues seven distinct scale options available over any dominant 7th chord, ordered from least to most tense: DOM.7th, Bebop, Lydian Dominant, Whole-tone, Diminished, Diminished Whole-tone, and Spanish/Jewish. Aebersold instructs: \"Experiment with these scales over the Cycle of Dominant 7th Chords track on the recording. The proper use of these various scales is part of what makes jazz so appealing.\" (Ch. 16, p. 54). This palette expansion embodies the Scale Syllabus principle that \"scales near the top of each category will sound mild or consonant and scale choices further down the list will become increasingly tense or dissonant.\"",
+          "cross_ref": [
+            "dom7alt/scale-palette-expansion",
+            "dom7b9/scale-palette-expansion"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — seven dominant scales listed: DOM.7th, Bebop, Lydian Dominant, Whole-tone, Diminished, Dim. Whole-tone, Spanish/Jewish."
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 52 — 'scales near the top of each category will sound mild or consonant and scale choices further down the list will become increasingly tense or dissonant.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "chord-tone-strong-beat-targeting",
+          "narrative": "Over dominant 7th chords, Aebersold mandates that beats 1 and 3 receive chord tones: \"Beats 1 and 3 seem to want roots, 3rd's, 5th's, 7th's and 9th's (b9's on dom.7th chords that resolve up a perfect fourth)... in so doing, the listener can plainly hear the intended harmony. They can also anticipate where your melodic line is going, the contour, the shape of it.\" (Ch. 8, p. 28). These target notes are called \"Guide-Tones or Goal-Notes,\" and Chapter 6 declares it \"extremely important to place (play) chord tones on the downbeat, especially beats one and three.\"",
+          "cross_ref": [
+            "min7/chord-tone-strong-beat-targeting",
+            "maj7/chord-tone-strong-beat-targeting"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'Beats 1 and 3 seem to want roots, 3rd's, 5th's, 7th's and 9th's.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 6",
+              "citation": "p. 22 — 'It is extremely important to place (play) chord tones on the downbeat, especially beats one and three!'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "chromatic-guide-tone-approach",
+          "narrative": "Approaching the 3rd and 7th of dominant chords by half step is presented as a foundational technique for strengthening harmonic definition: \"Lead into the 3rd or 7th by half step. This strengthens the harmony.\" (Ch. 11, p. 39). Chapter 10 systematizes this into three chromatic approach types: from a half step below each chord tone; from enclosure using the scale tone above combined with the chromatic tone below; and descending through half steps from a whole step above. This technique applies across all chord qualities but is especially emphasized over dominant-function chords in the blues context.",
+          "cross_ref": [
+            "min7/chromatic-guide-tone-approach",
+            "min7b5/chromatic-guide-tone-approach"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 39 — 'Lead into the 3rd or 7th by half step. This strengthens the harmony.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 10",
+              "citation": "p. 33 — 'A good beginning exercise is to approach each chord tone (root, 3rd, 5th, and 7th) from a half step below.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "blues-lick-extraction",
+          "narrative": "The blues scale is positioned as an overlay for dominant 7th contexts in the 12-bar blues, but Aebersold restricts its deployment mode explicitly: \"This scale sounds strange when played straight up or down. Jazz players usually play bits and pieces of the scale or make up licks utilizing certain notes of the scale.\" (Ch. 12, p. 41). The blues scale's intentional friction with dominant harmony is embraced as its defining feature — \"the notes of the blues scale often clash with the given harmony, but that is what makes it sound like the blues!\" (Ch. 11, p. 39) — but running it as a scalar passage is proscribed.",
+          "polarity": "proscriptive",
+          "cross_ref": [
+            "min7/blues-lick-extraction"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 12",
+              "citation": "p. 41 — 'Jazz players usually play bits and pieces of the scale or make up licks utilizing certain notes of the scale.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 39 — 'the notes of the blues scale often clash with the given harmony, but that is what makes it sound like the blues!'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "overuse-warning",
+          "polarity": "proscriptive",
+          "narrative": "While the blues scale is authorized over dominant harmonies, Aebersold cautions against over-reliance: \"Don't run it in the ground by overuse! Rhythm and blues players use this scale extensively.\" (Ch. 12, p. 41). Chapter 11 similarly warns: \"Be careful not to confine your soloing to just the sound of the blues scale, and in so doing, overlook possibilities of variety by employing the other scales such as minor and dominant.\" The antidote is alternation between the blues scale and the regular dominant or Dorian scales for textural variety.",
+          "cross_ref": [
+            "min7/overuse-warning"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 12",
+              "citation": "p. 41 — 'Don't run it in the ground by overuse!'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 39 — 'Be careful not to confine your soloing to just the sound of the blues scale.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "pentatonic-superimposition",
+          "narrative": "Blues melodies characteristically employ minor pentatonic material over dominant harmony: \"Blues heads (melodies) are often made up of a single pentatonic scale, usually a minor pentatonic scale superimposed over a dominant 7th chord/scale.\" (Ch. 10, p. 32). The pentatonic is described as applicable over \"major, minor, dom.7th, half-diminished, dim., whole tone and almost any other scale\" (Ch. 9, p. 30), but should be used as a colorant rather than as primary vocabulary: \"sprinkle it in amongst other scale sounds\" rather than 'running it in the ground.'",
+          "cross_ref": [
+            "min7/pentatonic-superimposition",
+            "maj7/pentatonic-superimposition"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 10",
+              "citation": "p. 32 — 'Blues heads are often made up of a single pentatonic scale, usually a minor pentatonic scale superimposed over a dominant 7th chord/scale.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 9",
+              "citation": "p. 30 — 'The pentatonic scale can be used over major, minor, dom.7th, half-diminished, dim., whole tone and almost any other scale.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7alt",
+          "function_role": "altered-tone-half-step-resolution",
+          "narrative": "Altered dominant tones are characterized by their strong half-step resolution tendencies: \"The altered tones are in bold type. Those tones usually resolve by half-step to a scale or chord tone. This amounts to tension then release. It's a natural occurrence in music.\" (Ch. 16, p. 54). The Diminished Whole-tone (C7+9) scale contains four such tones — b9, +9, +4, +5 — and is explicitly described as generating maximum tension. The resolution target is always the chord a perfect 4th above, and each altered tone has a specific half-step destination in that target harmony.",
+          "cross_ref": [
+            "dom7b9/altered-tone-half-step-resolution",
+            "dom7#9/altered-tone-half-step-resolution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'Those tones usually resolve by half-step to a scale or chord tone. This amounts to tension then release.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 53 — C7+9 scale: 'Root, b9, +9, 3rd, +4, +5, b7 & root — Diminished Whole Tone sometimes called Super Locrian or Altered Scale.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7alt",
+          "function_role": "maximum-tension-dominant-option",
+          "narrative": "The Diminished Whole-tone (Altered) scale is positioned as the highest-tension option in the dominant palette: \"DIM. WHOLE-TONE = C7+9 = CDbEbEF#G#BbC. This scale has four altered tones which help create tension.\" (Ch. 16, p. 54). Its abbreviated symbol C7+9 conceals that it contains not just a raised 9th but also a b9, #4, and #5 — the full complement of altered tones. Players must understand this hidden tone content: \"Even though a C7+9 would appear to have only a raised 9th, it also has a b9, +4 & +5.\" (Ch. 15, p. 53).",
+          "cross_ref": [
+            "dom7b9/maximum-tension-dominant-option",
+            "dom7#9/maximum-tension-dominant-option"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'DIM. WHOLE-TONE = C7+9... This scale has four altered tones which help create tension.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 53 — 'Even though a C7+9 would appear to have only a raised 9th, it also has a b9, +4 & +5.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7b9",
+          "function_role": "diminished-scale-deployment",
+          "narrative": "The C7b9 symbol encodes a diminished (octatonic) scale with three altered tones, not just one: \"C7b9 appears to have only one altered tone (b9) but actually has three: b9, +9 and +4. The entire scale looks like this: Root, b9, +9, 3rd, +4, 5th, 6th, b7 & root (C, Db, D#, E, F#, G, A, Bb, C). This is called a Diminished scale.\" (Ch. 15, p. 53). Chapter 18 notes that \"there are only three Diminished Scales,\" meaning the same scale serves multiple C7b9 roots. Michael Brecker is cited as a master of this sound.",
+          "cross_ref": [
+            "dim7/diminished-scale-deployment",
+            "dom7alt/diminished-scale-deployment"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 53 — 'C7b9 appears to have only one altered tone (b9) but actually has three: b9, +9 and +4.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'DIMINISHED = C7b9... Michael Brecker is a master of this scale sound.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7b9",
+          "function_role": "symmetry-economy",
+          "narrative": "Aebersold reveals a structural economy underlying the diminished scale: \"There are only three Diminished Scales.\" (Ch. 18, p. 61). Because the scale is symmetrical (built in alternating whole and half steps), each of the three scales covers four dominant-flat-9 roots, reducing the apparent complexity of the chord-scale system. This principle parallels the book's broader reduction claim that \"the 36 scales on page 60/61 can be reduced to 12 scales or twelve finger patterns\" (Ch. 14, p. 46), emphasizing that theoretical variety collapses to manageable physical patterns under analysis.",
+          "cross_ref": [
+            "dim7/symmetry-economy"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 18",
+              "citation": "p. 61 — 'There are only three Diminished Scales.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 14",
+              "citation": "p. 46 — 'The 36 scales on page 60/61 can be reduced to 12 scales or twelve finger patterns on your instrument.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7#9",
+          "function_role": "hidden-altered-tone-content",
+          "narrative": "The C7+9 chord symbol appears to specify only a raised 9th, but Aebersold insists the player understand its full altered content: \"Even though a C7+9 would appear to have only a raised 9th, it also has a b9, +4 & +5. The entire C7+9 scale would look like: Root, b9, +9, 3rd, +4, +5, b7 & root.\" (Ch. 15, p. 53). The scale is also known as Diminished Whole Tone, Super Locrian, or the Altered Scale. This naming transparency is part of Aebersold's broader \"reduced chord symbol notation\" pedagogy, which abbreviates for reading convenience while demanding full tonal awareness.",
+          "cross_ref": [
+            "dom7alt/hidden-altered-tone-content"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 53 — 'Even though a C7+9 would appear to have only a raised 9th, it also has a b9, +4 & +5.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7#11",
+          "function_role": "lydian-dominant-color",
+          "narrative": "The Lydian Dominant scale (C7#4) is presented as one of the seven available dominant palette options with a distinctive color: \"LYDIAN DOM. = C7#4 = CDEF#GABbC. The #4 was/is a favorite note. It used to be called a b5.\" (Ch. 16, p. 54). It occupies the consonant-to-moderate-tension range within the dominant category — more colorful than plain DOM.7th but less dissonant than the whole-tone or diminished options. The raised 4th (#11) is specifically identified in the color-tone list as a \"pretty note\" for dominant chords (Ch. 7, p. 25).",
+          "cross_ref": [
+            "dom7/color-tone-selection",
+            "maj7#11/lydian-dominant-color"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'LYDIAN DOM. = C7#4 = CDEF#GABbC. The #4 was/is a favorite note.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 25 — 'The pretty notes for major and dominant 7th chords/scales are the 6, 7, 9, and #4.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom13",
+          "function_role": "whole-tone-symmetrical-option",
+          "narrative": "The whole-tone scale is catalogued as a dominant-quality color option with a distinctive symmetrical property: \"WHOLE-TONE = C7+ = CDE F# G# BbC. This scale only has 6 tones. It is a symmetrical scale used often in cartoon music and by DeBussy and Ravel.\" (Ch. 16, p. 54). Chapter 18 notes \"there are two Whole Tone Scales\" governing C7, E7, F7, G7, A7, and B7. The augmented fifth implied in the C7+ symbol places this in tension with dom13 constructions, but Aebersold's broader Scale Syllabus lists it as a moderate-to-high tension option within the dominant 7th category.",
+          "cross_ref": [
+            "aug7/whole-tone-symmetrical-option",
+            "dom7/scale-palette-expansion"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'WHOLE-TONE = C7+ = CDE F# G# BbC. This scale only has 6 tones. It is a symmetrical scale.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 18",
+              "citation": "p. 61 — 'There are two Whole Tone Scales: WHWHWHWH — C7, E7, F7, G7, A7, B7.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "dorian-as-universal-minor",
+          "narrative": "Aebersold designates Dorian mode as the universal minor scale throughout the method: \"Every minor scale employed on the record and in the musical examples is in the Dorian mode. I chose this scale because it is used extensively in jazz and popular music.\" (Ch. 2, p. 7). The preference order for minor scale substitutes formally places Dorian first: \"the order of preference to be Dorian, Bebop, Melodic, Blues, Pentatonic, and then any of the remaining Minor scale choices.\" (Ch. 15, p. 53). Pure minor is listed as the last resort in the Scale Syllabus hierarchy.",
+          "cross_ref": [
+            "min9/dorian-as-universal-minor",
+            "min-maj7/dorian-as-universal-minor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 7 — 'Every minor scale employed on the record and in the musical examples is in the Dorian mode.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 53 — 'the order of preference to be Dorian, Bebop, Melodic, Blues, Pentatonic.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "fourth-degree-availability",
+          "narrative": "Unlike major and dominant contexts where the 4th degree is proscribed, Aebersold explicitly authorizes emphasis on the 4th in minor harmony: \"It's okay to emphasize the 4th when in minor or half-dim.\" (Ch. 2, p. 6). Chapter 7 confirms this by naming the 4th among the color tones for minor: \"The pretty notes for minor chords/scales are 4, 6, 7, and 9th. These notes create tension and should be used in the over-all tension-release process.\" This distinction — 4th forbidden on dominant/major, permitted on minor — is one of the method's most specific voice-leading rules.",
+          "cross_ref": [
+            "min7b5/fourth-degree-availability",
+            "dom7/tonic-avoidance-of-fourth"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 6 — 'It's okay to emphasize the 4th when in minor or half-dim.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 25 — 'The pretty notes for minor chords/scales are 4, 6, 7, and 9th.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "blues-scale-static-duration-rule",
+          "narrative": "The blues scale is authorized over minor chords only when the chord persists for a sufficient duration: \"The blues scale can also be used over minor chords when the minor chord is sounded for 2, 4, 8, or 16 measures or longer. EXAMPLE: If D minor is sounded for eight measures, you may use the D blues scale: D, F, G, Ab, A, C, D.\" (Ch. 12, p. 41). This durational prerequisite reflects the blues scale's intentional harmonic clash — brief minor chords do not allow sufficient time for the friction to read as stylistic rather than erroneous.",
+          "cross_ref": [
+            "dom7/blues-lick-extraction"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 12",
+              "citation": "p. 41 — 'The blues scale can also be used over minor chords when the minor chord is sounded for 2, 4, 8, or 16 measures or longer.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "dorian-blues-alternation",
+          "narrative": "When improvising over sustained minor chords, Aebersold recommends toggling between the Dorian minor and the blues scale rather than committing to one: \"When playing in minor tonalities you may choose to alternate between the dorian minor and the blues scale, both having the same root tone. EXAMPLE: D minor is sounded for eight measures — play D minor (dorian) or play D blues scale or alternate between the two scale sounds.\" (Ch. 12, p. 41). This toggling strategy prevents the monotony of either pure diatonic or pure blues playing.",
+          "cross_ref": [
+            "min9/dorian-blues-alternation"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 12",
+              "citation": "p. 41 — 'you may choose to alternate between the dorian minor and the blues scale, both having the same root tone.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "bebop-scale-minor-variant",
+          "narrative": "The minor bebop scale is presented as a direct parallel to the dominant bebop scale, with a chromatic passing tone inserted to create an 8-tone alignment of chord tones to strong beats: \"MINOR = C D Eb D E F G A Bb C\" (Ch. 8, p. 28). The same constraint applies as with all bebop variants — the added tone must fall on an upbeat. Minor bebop also ranks second in the minor scale preference order after Dorian (Ch. 15, p. 53), making it the first available substitution when Dorian alone sounds insufficient.",
+          "cross_ref": [
+            "min9/bebop-scale-minor-variant",
+            "dom7/bebop-scale-chromatic-insertion"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'MINOR = C D Eb D E F G A Bb C' (bebop scale for minor chord quality)."
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 53 — 'the order of preference to be Dorian, Bebop, Melodic, Blues, Pentatonic.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "ii-chord-bebop-substitution",
+          "narrative": "A key harmonic substitution allows the dominant 7th bebop scale to cover the minor ii chord in a ii-V progression: \"The dom.7th bebop scale can act as a substitute for the minor ii chord. Example: C7 bebop scale (C D E F G A Bb B C) could also be played over the G- chord and vice versa. The chords are interchangeable over the scale.\" (Ch. 8, p. 28). This means a single 8-tone scale serves both the ii and V7 simultaneously, simplifying the improvisational decision at the most common chord change in jazz.",
+          "cross_ref": [
+            "dom7/ii-chord-bebop-substitution",
+            "min7b5/ii-chord-bebop-substitution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'The dom.7th bebop scale can act as a substitute for the minor ii chord.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "diatonic-seventh-chord-pool",
+          "narrative": "All seven diatonic seventh chords built on the dorian minor scale share tones with the parent scale and are therefore usable as both melodic and harmonic material over a sustained tonic minor: \"Since all of the seventh chords found inside a minor scale contain tones of the basic scale, any of these seventh chords can be used in improvisation when the tonic minor chord is being sounded. Thus, every chord listed can be played horizontally or vertically over the F minor scale.\" (Ch. 12, p. 41). The quality sequence is minor, minor, major, dominant, minor, half-diminished, major.",
+          "cross_ref": [
+            "maj7/diatonic-seventh-chord-pool",
+            "min7b5/diatonic-seventh-chord-pool"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 12",
+              "citation": "p. 41 — 'any of these seventh chords can be used in improvisation when the tonic minor chord is being sounded.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "pentatonic-root-matching",
+          "narrative": "Minor pentatonic scale selection should match the root of the minor chord: \"Use the pentatonic scale (minor pentatonic) that corresponds to the root of the minor scale/chord. The first choice pentatonic scale for eight measures of F minor would be the F minor pentatonic scale.\" (Ch. 10, p. 32). However, multiple pentatonic subsets exist within any minor scale — \"there are usually several pentatonic scales inside every regular scale\" — and all scale degrees of the Dorian minor are usable as pentatonic subsets, unlike the major scale where the 4th is typically excluded.",
+          "cross_ref": [
+            "dom7/pentatonic-superimposition",
+            "maj7/pentatonic-superimposition"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 10",
+              "citation": "p. 32 — 'Use the pentatonic scale (minor pentatonic) that corresponds to the root of the minor scale/chord.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 9",
+              "citation": "p. 30 — 'All of the notes of the minor (dorian) scale are useable [as pentatonic subsets].'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "guide-tone-voice-leading",
+          "narrative": "For minor harmony in the blues context, the 3rd and 7th remain the primary guide tones: \"Improvise on the 3rd or 7th of each chord in order to get the sound and feel of the harmony in your mind. Using just the 3rd and 7th will sound like this: Notice the half-step melodic motion from the first chord to the second.\" (Ch. 11, p. 38). Chapter 11 summarizes: \"Remember leading tones are the 3rd and 7th usually. These tones should be emphasized in order to bring out the harmonic movement from chord to chord.\" The half-step voice motion between chord changes is the defining characteristic of this technique.",
+          "cross_ref": [
+            "dom7/guide-tone-emphasis",
+            "maj7/guide-tone-voice-leading"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 38 — 'Improvise on the 3rd or 7th of each chord in order to get the sound and feel of the harmony in your mind.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 39 — 'Remember leading tones are the 3rd and 7th usually.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min9",
+          "function_role": "ninth-as-color-extension",
+          "narrative": "The 9th is explicitly named among the color tones available over minor chords: \"The pretty notes for minor chords/scales are 4, 6, 7, and 9th. These notes create tension and should be used in the over-all tension-release process.\" (Ch. 7, p. 25). Chapter 4 establishes the structural basis: \"You may be thinking of roots as 'home-base', 3rd's and 5th's as 'family' and 7th and 9th's as more exciting tones you might meet on a week-end.\" The ninth chord (1, 3, 5, 7, 9) is practiced as a complete harmonic entity in the 12-step memorization procedure, reinforcing the 9th as a routine chord tone rather than an exotic extension.",
+          "cross_ref": [
+            "maj9/ninth-as-color-extension",
+            "dom7/color-tone-selection"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 25 — 'The pretty notes for minor chords/scales are 4, 6, 7, and 9th.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 4",
+              "citation": "p. 15 — '7th and 9th's as more exciting tones you might meet on a week-end.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj7",
+          "function_role": "tonic-avoidance-of-fourth",
+          "polarity": "proscriptive",
+          "narrative": "The 4th degree of the major scale carries the same proscription as in dominant contexts: \"The 4th tone of major and dominant 7th chord/scales contains much tension and thus usually isn't emphasized. The 4th is usually treated as a passing tone between the 3rd and 5th scale tones. When in major or dominant keys don't end a phrase on the 4th.\" (Ch. 2, p. 6). This rule appears again in Chapter 9 regarding pentatonic construction: \"We usually avoid using the 4th note of the major scale as part of a pentatonic scale.\" The 4th is structurally demoted to a passing tone in both melodic and pentatonic contexts.",
+          "cross_ref": [
+            "dom7/tonic-avoidance-of-fourth"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 6 — 'When in major or dominant keys don't end a phrase on the 4th.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 9",
+              "citation": "p. 30 — 'We usually avoid using the 4th note of the major scale as part of a pentatonic scale.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj7",
+          "function_role": "color-tone-selection",
+          "narrative": "Major chords share the same color-tone designation as dominant 7th chords: \"The pretty notes for major and dominant 7th chords/scales are the 6, 7, 9, and #4.\" (Ch. 7, p. 25). The raised fourth (#4, or #11) gives access to the Lydian sound within major harmony, and the 6th and 9th provide diatonic warmth. These tones are framed as expressive tools within the tension-release system — adding a degree of color above the baseline 1-3-5-7 without producing the friction of altered tones.",
+          "cross_ref": [
+            "dom7/color-tone-selection",
+            "maj7#11/color-tone-selection"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 25 — 'The pretty notes for major and dominant 7th chords/scales are the 6, 7, 9, and #4.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj7",
+          "function_role": "bebop-scale-major-variant",
+          "narrative": "A bebop scale variant exists for major chords: \"MAJOR = C D E F G G# A B C\" (Ch. 8, p. 28). Like all bebop scales, the added chromatic tone (G#, the raised 5th acting as a chromatic passing tone between G and A) must land on an upbeat: \"Since the scale has 8 tones, it helps to naturally place the chord tones ON the beat rather than have them scattered all around.\" (Ch. 8, p. 28). Chapter 14 shows the efficiency of this: major, Dorian minor, and dominant 7th built on related roots share key signatures, meaning one bebop fingering pattern covers three chord qualities.",
+          "cross_ref": [
+            "dom7/bebop-scale-chromatic-insertion",
+            "min7/bebop-scale-minor-variant"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'MAJOR = C D E F G G# A B C' (bebop scale major variant)."
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'Since the scale has 8 tones, it helps to naturally place the chord tones ON the beat.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj7",
+          "function_role": "stability-quality-definition",
+          "narrative": "The 7th scale degree is described as the indicator of harmonic stability or motion: \"The 7th tells whether the sound is stable (doesn't want to move to another chord) or if it wants to move on to a chord of resolution.\" (Ch. 16, p. 54). A major 7th (natural 7th in a major chord) conveys stability and does not create resolution pressure, while a lowered 7th (dominant quality) generates the motion impulse. This quality distinction is why the book's reduced notation uses a triangle (Δ) for major 7th and a plain 7 for dominant — the symbols encode the harmonic behavior, not just the interval.",
+          "cross_ref": [
+            "dom7/guide-tone-emphasis",
+            "min7/guide-tone-voice-leading"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'The 7th tells whether the sound is stable (doesn't want to move to another chord) or if it wants to move on to a chord of resolution.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj7",
+          "function_role": "pentatonic-fourth-avoidance",
+          "narrative": "When extracting pentatonic subsets from a major scale, the 4th degree is specifically excluded: \"We usually avoid using the 4th note of the major scale as part of a pentatonic scale. All of the notes of the minor (dorian) scale are useable.\" (Ch. 9, p. 30). This mirrors the broader 4th-avoidance rule for major harmony and creates a practical constraint on which of the multiple nested pentatonics within a major scale are stylistically valid. The contrast with minor/Dorian — where all degrees are usable — is explicit and deliberate.",
+          "cross_ref": [
+            "min7/pentatonic-root-matching",
+            "dom7/tonic-avoidance-of-fourth"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 9",
+              "citation": "p. 30 — 'We usually avoid using the 4th note of the major scale as part of a pentatonic scale.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj9",
+          "function_role": "ninth-chord-as-practice-target",
+          "narrative": "The ninth chord (root, 3rd, 5th, 7th, 9th) is established as the primary arpeggio practice target representing the full harmonic vocabulary of a chord/scale: \"You can even extend the chord to include the 9th tone of the scale. This is called the ninth chord (9th chord). It uses the root, 3rd, 5th, 7th, and 9th tones of the scale. Remember, the 9th is also referred to as the 2nd... the tones are the same, just an octave apart.\" (Ch. 4, p. 15). The seven-step practice method culminates in ninth-chord arpeggios (steps 5–7), and the 12-step memorization procedure includes playing up the ninth chord and back down the scale as a standalone exercise.",
+          "cross_ref": [
+            "dom7/chord-tone-strong-beat-targeting",
+            "min9/ninth-as-color-extension"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 4",
+              "citation": "p. 15 — 'You can even extend the chord to include the 9th tone of the scale. This is called the ninth chord.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 7 — Seven-step scale practice culminating in ninth-chord exercises (steps 5-7)."
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj7#11",
+          "function_role": "lydian-sound-characterization",
+          "narrative": "The Lydian mode, characterized by its raised fourth, is described with warmth as \"the first cousin to a major scale\" and a distinctive color: \"The scale on the third line contains a raised 4th (#4 = F#). This scale is the first cousin to a major scale and is called lydian; C D E F# G A B C. It's a beautiful sound and much used.\" (Ch. 10, p. 32). The raised 4th is simultaneously listed as a \"pretty note\" for major and dominant 7th chords (Ch. 7, p. 25), making Lydian sound a recognized expressive color available when the static tension of an avoid note is desired.",
+          "cross_ref": [
+            "dom7#11/lydian-dominant-color",
+            "maj7/color-tone-selection"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 10",
+              "citation": "p. 32 — 'This scale is the first cousin to a major scale and is called lydian; C D E F# G A B C. It's a beautiful sound and much used.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7b5",
+          "function_role": "fourth-degree-availability",
+          "narrative": "Half-diminished chords share the minor chord's permissiveness toward the 4th degree: \"It's okay to emphasize the 4th when in minor or half-dim.\" (Ch. 2, p. 6). This authorization distinguishes min7b5 from major and dominant contexts and reflects the scale structure — the Locrian mode underlying half-diminished chords includes a natural 4th that does not carry the same avoidance weight as it would over a dominant or major chord. Chapter 8 confirms that a bebop scale variant exists for half-diminished: \"HALF-DIMINISHED = C Db Eb F Gb G Ab Bb C.\"",
+          "cross_ref": [
+            "min7/fourth-degree-availability"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 6 — 'It's okay to emphasize the 4th when in minor or half-dim.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'HALF-DIMINISHED = C Db Eb F Gb G Ab Bb C' (bebop scale for half-diminished)."
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7b5",
+          "function_role": "bebop-scale-half-diminished-variant",
+          "narrative": "The bebop scale concept extends specifically to half-diminished chords: \"There are also BEBOP scales to be used over major, minor and half-diminished as well as the dominant 7th... HALF-DIMINISHED = C Db Eb F Gb G Ab Bb C.\" (Ch. 8, p. 28). This 8-tone bebop variant applies the same alignment principle as the dominant bebop scale — placing chord tones on strong beats by ensuring the added chromatic tone falls on the upbeat. Aebersold's extension of the bebop principle to all four main chord qualities signals its importance as a universal melodic grammar device.",
+          "cross_ref": [
+            "dom7/bebop-scale-chromatic-insertion",
+            "min7/bebop-scale-minor-variant"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'HALF-DIMINISHED = C Db Eb F Gb G Ab Bb C' (bebop variant)."
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7b5",
+          "function_role": "ii-chord-role-in-minor-ii-v",
+          "narrative": "The half-diminished chord functions as the ii chord in minor ii-V progressions and is covered by the dominant bebop scale via substitution: \"The dom.7th bebop scale can act as a substitute for the minor ii chord.\" (Ch. 8, p. 28). This makes min7b5 a passing waypoint rather than a distinct harmonic destination requiring its own scale choice — the soloist can deploy the resolving V7's bebop scale across the entire ii-V boundary. The half-diminished chord's role as a tension-generating pre-dominant chord is consistent with the book's treatment of it as a member of the dominant-function complex.",
+          "cross_ref": [
+            "dom7/ii-chord-bebop-substitution",
+            "min7/ii-chord-bebop-substitution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'The dom.7th bebop scale can act as a substitute for the minor ii chord.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dim7",
+          "function_role": "symmetry-economy",
+          "narrative": "Like the half-step-whole-step diminished scale used for dom7b9 chords, the fully diminished seventh chord is governed by the same structural economy: \"There are only three Diminished Scales.\" (Ch. 18, p. 61). The diminished scale's perfect symmetry (repeating minor 3rd intervals) means each of three root forms covers four diminished chord roots, dramatically reducing the memorization burden. This principle connects to Aebersold's broader reduction strategy: apparent variety in the scale system collapses to a small number of physical patterns that recur across multiple chord symbols.",
+          "cross_ref": [
+            "dom7b9/symmetry-economy"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 18",
+              "citation": "p. 61 — 'There are only three Diminished Scales. The Diminished scale fits these chord symbols: G7b5, A7b5, B7b5, also D7b5, F7b5, G7b5.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dim7",
+          "function_role": "cartoon-music-stylistic-context",
+          "narrative": "The diminished scale is contextualized with a specific stylistic association that both validates and subtly delimits its use: \"DIMINISHED = C7b9 = CDbEbEF#GABbC. This scale has 8 different tones. It is symmetrical and is also used in cartoon music.\" (Ch. 16, p. 54). The cartoon music reference appears for both the diminished and whole-tone scales, suggesting that deliberate overuse risks a dated or caricatured sound. Michael Brecker is cited as a contemporary master who uses this scale well, providing a corrective model of sophisticated modern application.",
+          "cross_ref": [
+            "dom7b9/diminished-scale-deployment",
+            "dom13/whole-tone-symmetrical-option"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'DIMINISHED = C7b9... It is symmetrical and is also used in cartoon music. Michael Brecker is a master of this scale sound.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "aug7",
+          "function_role": "whole-tone-augmented-equivalence",
+          "narrative": "The whole-tone scale (C7+) implies an augmented quality through its raised fifth, making aug7 and whole-tone constructions functionally equivalent in Aebersold's system: \"WHOLE-TONE = C7+ = CDE F# G# BbC. This scale only has 6 tones. It is a symmetrical scale used often in cartoon music and by DeBussy and Ravel.\" (Ch. 16, p. 54). Chapter 18 confirms only two whole-tone scales exist, each covering six dominant-augmented chord roots. The augmented sound occupies the moderate-to-high tension range in the dominant palette — more dissonant than Lydian Dominant but less dense than the diminished options.",
+          "cross_ref": [
+            "dom13/whole-tone-symmetrical-option",
+            "dom7alt/maximum-tension-dominant-option"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'WHOLE-TONE = C7+ = CDE F# G# BbC. This scale only has 6 tones. It is a symmetrical scale.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 18",
+              "citation": "p. 61 — 'There are two Whole Tone Scales.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min6",
+          "function_role": "sixth-chord-as-practice-step",
+          "narrative": "The minor sixth chord (1, 3, 5, 6) appears as a distinct step in the 12-step memorization procedure: \"Play 6th chords (1, 3, 5 and 6th tones of the scale).\" (Ch. 7, p. 26, Step 9). The 6th is also named among the color tones for minor chords — \"The pretty notes for minor chords/scales are 4, 6, 7, and 9th\" (Ch. 7, p. 25) — confirming its status as a standard harmonic extension rather than an alteration. In the Dorian mode context, the natural 6th is the defining tone that distinguishes Dorian from pure minor (Aeolian), giving the min6 sound a bright, characteristic color.",
+          "cross_ref": [
+            "min7/dorian-as-universal-minor",
+            "maj6/sixth-chord-as-practice-step"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 26 — 'Play 6th chords (1, 3, 5 and 6th tones of the scale).' (Step 9 of 12-step procedure)"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 25 — 'The pretty notes for minor chords/scales are 4, 6, 7, and 9th.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj6",
+          "function_role": "sixth-chord-as-practice-step",
+          "narrative": "The major sixth chord appears as Step 9 of the 12-step memorization procedure for any scale: \"Play 6th chords (1, 3, 5 and 6th tones of the scale).\" (Ch. 7, p. 26). The 6th is listed among the color tones for major and dominant chords — \"The pretty notes for major and dominant 7th chords/scales are the 6, 7, 9, and #4\" (Ch. 7, p. 25) — positioning it as a warm, consonant extension. The scale-tone hierarchy treats roots and thirds as \"family\" while 6ths and 7ths are \"more exciting tones\" (Ch. 4, p. 15), suggesting the 6th adds flavor without the resolution imperative of dominant 7th dissonance.",
+          "cross_ref": [
+            "min6/sixth-chord-as-practice-step",
+            "maj7/color-tone-selection"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 26 — 'Play 6th chords (1, 3, 5 and 6th tones of the scale).' (Step 9 of 12-step procedure)"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 25 — 'The pretty notes for major and dominant 7th chords/scales are the 6, 7, 9, and #4.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min-maj7",
+          "function_role": "notation-system-inclusion",
+          "narrative": "The minor-major 7th chord (C-Δ) is explicitly included in Aebersold's reduced chord symbol system: \"C—Δ means a minor scale/chord with a major 7th.\" (Ch. 15, p. 51). Its inclusion in the reduced notation list — alongside C, C7, C-, C∅, C7+9, and C7b9 — signals that it is treated as a distinct harmonic quality requiring its own chord-scale assignment in the Scale Syllabus, not a passing curiosity. The symbol combines the dash for minor (lowered 3rd) with the triangle for major 7th, encoding both the quality and the characteristic raised 7th in a single symbol.",
+          "cross_ref": [
+            "min7/dorian-as-universal-minor",
+            "maj7/stability-quality-definition"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 51 — 'C—Δ means a minor scale/chord with a major 7th.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "sus4",
+          "function_role": "fourth-as-structural-tension-source",
+          "narrative": "While the sus4 chord quality is not explicitly named as a chord symbol in the reduced notation system, the 4th degree's role as a structural tension agent is thoroughly theorized. Over dominant chords, \"the 4th tone... contains much tension and thus usually isn't emphasized\" (Ch. 2, p. 6), while over minor chords the 4th is listed as a \"pretty note\" worth emphasizing. The tension/release framework codified in Chapter 13 includes \"NON-CHORD TONES (4ths, 6ths, 7ths, & 9ths)\" explicitly in the tension-producing elements list (Ch. 13, p. 45), framing the 4th as a suspension requiring resolution down to the 3rd.",
+          "cross_ref": [
+            "dom7/tonic-avoidance-of-fourth",
+            "min7/fourth-degree-availability"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 13",
+              "citation": "p. 45 — 'NON-CHORD TONES (4ths, 6ths, 7ths, & 9ths)' listed under 'ELEMENTS WHICH PRODUCE TENSION.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 6 — 'The 4th tone of major and dominant 7th chord/scales contains much tension and thus usually isn't emphasized.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "phrase-start-tone-selection",
+          "narrative": "Good phrase-starting notes over dominant 7th chords are the chord tones 1, 3, 5, and b7: \"Good notes to begin/start a phrase with are the chord tones: 1, 3, 5, and b7. When you begin a phrase with the 2nd, 4th, or 6th notes of the scale on a downbeat, you must use additional chromaticism somewhere in the phrase in order to make the B natural fall on the upbeat.\" (Ch. 8, p. 28). Starting on a non-chord tone triggers a corrective obligation — the improviser must compensate with added chromaticism, making chord-tone starts the path of least resistance and greatest harmonic clarity.",
+          "cross_ref": [
+            "maj7/chord-tone-strong-beat-targeting",
+            "min7/chord-tone-strong-beat-targeting"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'Good notes to begin/start a phrase with are the chord tones: 1, 3, 5, and b7.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "spanish-jewish-minor-key-application",
+          "narrative": "The Spanish/Jewish scale is prescribed specifically for minor key contexts over dominant chords: \"SPANISH or JEWISH SCALE = C7(b9) = CDbEFGAbBbC. This scale is used often when playing in a minor key. It's the same as F harmonic minor.\" (Ch. 16, p. 54). This scale provides a darker, modal minor color over dominant 7th chords resolving to minor tonic chords, as opposed to the major-resolving altered scale options. Its equivalence to harmonic minor (starting on the 5th degree) connects it to the broader tradition of harmonic minor over V7 in minor keys.",
+          "cross_ref": [
+            "dom7b9/diminished-scale-deployment",
+            "min7/dorian-as-universal-minor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 16",
+              "citation": "p. 54 — 'SPANISH or JEWISH SCALE = C7(b9) = CDbEFGAbBbC. This scale is used often when playing in a minor key. It's the same as F harmonic minor.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "three-key-fingering-reduction",
+          "narrative": "The dominant 7th chord participates in a three-way key signature equivalence that reduces the memorization burden: \"C major = D minor (dorian) = G7 (dominant 7th or mixolydian). These three scales share the same key signature... no sharps and no flats and have identical fingerings.\" (Ch. 14, p. 47). This means a player who knows C major physically also knows D Dorian and G Mixolydian/dom7. Aebersold codifies the reduction: \"When thinking of scales in this related manner there are really only twelve scales to learn or twelve key signatures to memorize. The 36 scales on page 60/61 can be reduced to 12 scales.\"",
+          "cross_ref": [
+            "maj7/three-key-fingering-reduction",
+            "min7/three-key-fingering-reduction"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 14",
+              "citation": "p. 47 — 'C major = D minor (dorian) = G7 (dominant 7th or mixolydian). These three scales share the same key signature and have identical fingerings.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 14",
+              "citation": "p. 46 — 'The 36 scales on page 60/61 can be reduced to 12 scales or twelve finger patterns.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "three-key-fingering-reduction",
+          "narrative": "The Dorian minor shares key signatures and fingerings with its relative major and the dominant 7th built a whole step below: \"The minor scale (dorian) is really the same as a major scale whose root lies a whole step below the root of the dorian minor. Example: F- is the same as Eb major (3 flats), D- is the same as C major (no sharps or flats).\" (Ch. 2, p. 7). This reduces minor scale learning to a recontextualization of known major fingerings, directly serving the book's practice efficiency goal. The same reduction appears in Chapter 14's formal statement of the 36-to-12 compression.",
+          "cross_ref": [
+            "maj7/three-key-fingering-reduction",
+            "dom7/three-key-fingering-reduction"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 7 — 'The minor scale (dorian) is really the same as a major scale whose root lies a whole step below the root of the dorian minor.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 14",
+              "citation": "p. 47 — 'C major = D minor (dorian) = G7. These three scales share the same key signature and have identical fingerings.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj7",
+          "function_role": "three-key-fingering-reduction",
+          "narrative": "The major scale forms the anchor of the three-way fingering equivalence: \"C major = D minor (dorian) = G7 (dominant 7th or mixolydian). These three scales share the same key signature... no sharps and no flats and have identical fingerings.\" (Ch. 14, p. 47). Aebersold frames this as a cognitive and technical shortcut, encouraging students to \"Look on the scales page and see if you can find the ones that are similar. Example: C, D- & G7 are all alike. A, B- & E7 are all alike.\" The same fingering fluency developed for major chord-scale contexts transfers directly to Dorian minor and dominant 7th without additional physical learning.",
+          "cross_ref": [
+            "min7/three-key-fingering-reduction",
+            "dom7/three-key-fingering-reduction"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 14",
+              "citation": "p. 47 — 'C major = D minor (dorian) = G7 (dominant 7th or mixolydian). These three scales share the same key signature and have identical fingerings.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "ii-v-progression-harmonic-foundation",
+          "narrative": "The II-V7 pattern is named as the primary vehicle for 12-key memorization practice: \"You should transpose them through the other 11 keys. You may want to begin by playing the exercises on page 26 or the TEN BASIC PATTERNS.\" (Ch. 20, p. 68). The Circle of Fourths, which generates the ii-V root motion, is called \"the harmonic foundation found everywhere in jazz\" (Ch. 19, p. 65), and the entire book's transposition discipline is organized around fluency with this two-chord progression. Chapter 8's bebop-scale substitution treating one scale as covering both ii and V is the dominant 7th's central technical contribution to this framework.",
+          "cross_ref": [
+            "min7/ii-chord-bebop-substitution",
+            "min7b5/ii-chord-role-in-minor-ii-v"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 19",
+              "citation": "p. 65 — 'the harmonic movement of a perfect fourth is found everywhere in jazz.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 20",
+              "citation": "p. 68 — II/V7 patterns as starting point for 12-key transposition practice."
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "eight-note-density-priority",
+          "narrative": "Eighth notes are identified as the rhythmic foundation of the dominant-chord jazz language: \"8th notes are used in jazz more than any other note value.\" (Ch. 2, p. 8). For swing feel over dominant-function chords, eighth notes must be swung rather than played evenly: \"In order to make eighth-notes 'swing' or imply swing, they must be played like an eighth-note [triplet feel].\" (Ch. 4, p. 15). Even eighths are reserved for non-swing styles: \"When playing a bossa nova or rock tune you will want to straighten out the eighth-notes and play them more evenly. This is called even eighths.\" (Ch. 4, p. 15).",
+          "cross_ref": [
+            "min7/eight-note-density-priority",
+            "maj7/eight-note-density-priority"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 2",
+              "citation": "p. 8 — '8th notes are used in jazz more than any other note value.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 4",
+              "citation": "p. 15 — 'In order to make eighth-notes swing or imply swing, they must be played like an eighth-note [triplet feel].'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "blues-singing-as-improvisational-origin",
+          "narrative": "Singing over the blues progression is prescribed as the direct path to authentic musical voice before any note selection: \"Begin by singing (with your voice) several choruses of blues along with the recording... Then, with your instrument in hand, try playing the phrases that you just sang! What you sing is often closer to the REAL YOU than what comes out of your instrument.\" (Ch. 11, p. 36). This principle elevates voice over instrument as the primary improvisational tool across all chord qualities, but is introduced specifically in the minor blues context where the blues scale's clash with underlying minor harmony produces the most immediate expressive material.",
+          "cross_ref": [
+            "dom7/blues-lick-extraction"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 36 — 'What you sing is often closer to the REAL YOU than what comes out of your instrument.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "consonant-tone-tension-release-anchor",
+          "narrative": "Root, 3rd, and 5th are designated as the release anchors of any phrase over all chord qualities including dominant 7th: \"the most consonant tones of scales are the root, 3rd and 5th. These three tones are excellent notes to begin and end phrases with.\" (Ch. 13, p. 43). Non-chord tones create tension that \"should eventually resolve naturally - melodically (to one of the consonant tones), or by artificial means such as change of key, abrupt change in dynamics, change of tempo, use of rests.\" The paired tension/release reference lists in Chapter 13 explicitly categorize \"EMPHASIS ON CHORD TONES (root, 3rd, or 5th)\" as a release element.",
+          "cross_ref": [
+            "maj7/consonant-tone-tension-release-anchor",
+            "min7/consonant-tone-tension-release-anchor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 13",
+              "citation": "p. 43 — 'the most consonant tones of scales are the root, 3rd and 5th. These three tones are excellent notes to begin and end phrases with.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 13",
+              "citation": "p. 45 — 'EMPHASIS ON CHORD TONES (root, 3rd, or 5th)' listed as a release element."
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "maj7",
+          "function_role": "consonant-tone-tension-release-anchor",
+          "narrative": "Over major 7th harmony, root, 3rd, and 5th function as the stable phrase anchors: \"the most consonant tones of scales are the root, 3rd and 5th. These three tones are excellent notes to begin and end phrases with.\" (Ch. 13, p. 43). The tension-release architecture treats chord tones as release destinations and non-chord tones as tension sources requiring resolution. Chapter 6 reinforces this as a physical prescription: \"Always know the chord tones 1, 3, 5 and 7 of each scale. Use them as anchors when building a solo.\" The 7th is added to the physical-knowledge requirement even though it creates mild tension in major contexts.",
+          "cross_ref": [
+            "dom7/consonant-tone-tension-release-anchor",
+            "min7/consonant-tone-tension-release-anchor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 13",
+              "citation": "p. 43 — 'the most consonant tones of scales are the root, 3rd and 5th. These three tones are excellent notes to begin and end phrases with.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 6",
+              "citation": "p. 22 — 'Always know the chord tones 1, 3, 5 and 7 of each scale. Use them as anchors when building a solo.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "consonant-tone-tension-release-anchor",
+          "narrative": "Minor chord tones function as release anchors just as they do in major and dominant contexts: \"the most consonant tones of scales are the root, 3rd and 5th. These three tones are excellent notes to begin and end phrases with.\" (Ch. 13, p. 43). However, the additional color tones for minor — the 4th, 6th, 7th, and 9th — are described as tension-producing elements that \"should be used in the over-all tension-release process\" (Ch. 7, p. 25), meaning the tension arc is richer over minor than over major. The root-3rd-5th anchor remains the return destination regardless of how far the chromatic or color-tone material ventures.",
+          "cross_ref": [
+            "dom7/consonant-tone-tension-release-anchor",
+            "maj7/consonant-tone-tension-release-anchor"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 13",
+              "citation": "p. 43 — 'the most consonant tones of scales are the root, 3rd and 5th. These three tones are excellent notes to begin and end phrases with.'"
+            },
+            {
+              "source": "Aebersold Vol 1 Ch. 7",
+              "citation": "p. 25 — 'The pretty notes for minor chords/scales are 4, 6, 7, and 9th. These notes create tension and should be used in the over-all tension-release process.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "pentatonic-fourth-avoidance-over-major-scale",
+          "polarity": "proscriptive",
+          "narrative": "When constructing pentatonic subsets for use over dominant or major chord-scale contexts, the 4th degree is excluded from the usable pool: \"There are usually several pentatonic scales inside every regular scale... We usually avoid using the 4th note of the major scale as part of a pentatonic scale.\" (Ch. 9, p. 30). This exclusion is consistent with the broader 4th-avoidance rule but restricts the available pentatonic choices from the parent scale. All Dorian minor scale degrees remain usable for minor pentatonic construction, creating an asymmetry between major/dominant and minor contexts.",
+          "cross_ref": [
+            "maj7/pentatonic-fourth-avoidance",
+            "min7/pentatonic-root-matching"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 9",
+              "citation": "p. 30 — 'We usually avoid using the 4th note of the major scale as part of a pentatonic scale. All of the notes of the minor (dorian) scale are useable.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "b9-on-resolving-dominant",
+          "narrative": "A specific alteration is authorized for dominant 7th chords that resolve up a perfect 4th — the flat 9 may land on beats 1 and 3 in this resolution context: \"Beats 1 and 3 seem to want roots, 3rd's, 5th's, 7th's and 9th's (b9's on dom.7th chords that resolve up a perfect fourth).\" (Ch. 8, p. 28). This parenthetical exception to the standard chord-tone list reflects the b9's function as a leading tone toward the resolution target's root. The b9 is also revealed as a hidden component of the C7b9 diminished scale (Ch. 15, p. 53), confirming its status as a standard member of the resolving dominant sound.",
+          "cross_ref": [
+            "dom7b9/diminished-scale-deployment",
+            "dom7alt/altered-tone-half-step-resolution"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 8",
+              "citation": "p. 28 — 'Beats 1 and 3 seem to want roots, 3rd's, 5th's, 7th's and 9th's (b9's on dom.7th chords that resolve up a perfect fourth).'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "two-note-rhythmic-foundation",
+          "narrative": "A foundational improvisation entry point over minor blues harmony involves restricting pitch to just two notes while maximizing rhythmic invention: \"To get the 'feel' of playing the blues progression spend time just soloing on 2 or 3 notes. For instance, play the root and the lowered 3rd. Use rhythmic imagination and see if you can make just those two notes swing. Then, gradually add a note or two such as the 2nd or the 6th.\" (Ch. 11, p. 37). This technique prioritizes rhythmic feel — the essential blues ingredient — over harmonic completeness, and establishes that compelling improvisation can emerge from minimal pitch material when rhythm is mastered.",
+          "cross_ref": [
+            "dom7/guide-tone-emphasis"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 37 — 'spend time just soloing on 2 or 3 notes. For instance, play the root and the lowered 3rd. Use rhythmic imagination and see if you can make just those two notes swing.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "basic-blues-dominant-structure",
+          "narrative": "The foundational 12-bar blues chord structure is built exclusively from three dominant 7th chords: \"The basic 12 bar blues originally used three chords. They are: a dominant 7th built on the root, a dominant 7th built on the fourth, and a dominant 7th built on the fifth of the key you are in. Example: Blues in the key of F uses these three chords F7, Bb7 and C7.\" (Ch. 11, p. 37). This establishes dominant 7th as the exclusive harmonic quality of basic blues, making it both the tonic and subdominant sound — an unusual role that accounts for the blues scale's intentional clash with the tonic-functioning dominant.",
+          "cross_ref": [
+            "min7/blues-singing-as-improvisational-origin"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 37 — 'The basic 12 bar blues originally used three chords. They are: a dominant 7th built on the root, a dominant 7th built on the fourth, and a dominant 7th built on the fifth.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "dom7",
+          "function_role": "dissonance-ordering-practice-sequence",
+          "narrative": "Aebersold prescribes a specific scale-type practice order for chaining exercises that moves from most consonant to more colorful: \"A good order for practicing would look like this: major, dom.7th, minor (dorian), lydian dom, lydian, whole tone, diminished, dim. whole tone.\" (Ch. 15, p. 50). Dominant 7th occupies the second position — immediately after plain major and before minor — positioning it as a lightly tense, foundational sound from which progressively more altered scale options extend. This ordering embodies the Scale Syllabus principle of building dissonance tolerance gradually through systematic experimentation.",
+          "cross_ref": [
+            "maj7/dissonance-ordering-practice-sequence",
+            "dom7alt/maximum-tension-dominant-option"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 15",
+              "citation": "p. 50 — 'A good order for practicing would look like this: major, dom.7th, minor (dorian), lydian dom, lydian, whole tone, diminished, dim. whole tone.'"
+            }
+          ]
+        },
+        {
+          "source_work_id": "vol-1-how-to-play-jazz-and-improvise",
+          "chord_quality": "min7",
+          "function_role": "progressive-scale-learning-four-stages",
+          "narrative": "Learning a new minor chord-scale follows a prescribed four-stage progression from simplest to complete: \"When beginning to practice the blues, it's necessary to: 1. Get the feel of the roots; 2. Then the first five notes of each scale; 3. Then the triad (root, 3rd, and 5th); 4. And finally the entire scale.\" (Ch. 11, p. 37). This graduated entry method prevents overwhelm and ensures each sub-component is internalized before the complete scale is attempted. The same principle governs the broader 12-step memorization procedure, but this four-stage version provides a more accessible on-ramp specifically for minor blues contexts.",
+          "cross_ref": [
+            "dom7/progressive-scale-learning-four-stages",
+            "maj7/progressive-scale-learning-four-stages"
+          ],
+          "provenance": "extracted",
+          "references": [
+            {
+              "source": "Aebersold Vol 1 Ch. 11",
+              "citation": "p. 37 — 'When beginning to practice the blues, it's necessary to: 1. Get the feel of the roots; 2. Then the first five notes of each scale; 3. Then the triad; 4. And finally the entire scale.'"
+            }
+          ]
+        }
+      ]
     },
     {
       "id": "dirk-laukens",


### PR DESCRIPTION
Lines-content cluster. Coker Patterns 70/4, Coker Elements 66/2, Aebersold Vol 1 63/6. Cluster total: 199 notes, 12 proscriptive. Extraction filtered to chord_quality-specific lessons only.

Forward-classification note: when ellington-web#59 (s5_lines payload_kind discriminator) lands, some entries may be re-tagged as payload_kind='line'. Mechanical, non-breaking — schema default is 'voicing'.

Schema 24/24 pass. Refs #457, #471, #493.