### PR TITLE
feat(#457): onboard 4 masters + 3 configs (Roberts/Goodrick/Harris/Ligon)

### DIFF
--- a/pipelines/master-distillation/configs/goodrick-almanac-vol-4.toml
+++ b/pipelines/master-distillation/configs/goodrick-almanac-vol-4.toml
@@ -1,0 +1,45 @@
+# Queued via #457 (umbrella #428). Voice-leading axis Vol 4. Existing master mick-goodrick.
+
+[master]
+id = "mick-goodrick"
+name = "Mick Goodrick"
+
+[work]
+id = "almanac-vol-4"
+title = "Almanac of Guitar Voice Leading, Volume 4"
+year = 2005
+instrument_scope = "6-string"
+
+[source]
+pdf = "~/jazz_docs/Guitar/Methods/Jazz/Mick Goodrick/Goodrick, Mick - Almanac of Guitar Voice Leading, Vol 4.pdf"
+host = "cyberpower"
+user = "dheerajchand"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Goodrick Vol 4 — completes the Almanac voice-leading series. Same axis as Vol 1/2/3. Granular-levels (#434)."

--- a/pipelines/master-distillation/configs/harris-jazz-workshop.toml
+++ b/pipelines/master-distillation/configs/harris-jazz-workshop.toml
@@ -1,0 +1,46 @@
+# Queued via #457 (umbrella #428). Bebop sixth-diminished system / Barry Harris harmonic
+# method. Substitution-theory axis. New master barry-harris.
+
+[master]
+id = "barry-harris"
+name = "Barry Harris"
+
+[work]
+id = "jazz-workshop"
+title = "Jazz Workshop"
+year = 1986
+instrument_scope = "piano-translatable-to-guitar"
+
+[source]
+pdf = "~/jazz_docs/Guitar/Methods/Jazz/Barry Harris/Harris, Barry - Jazz Workshop.pdf"
+host = "cyberpower"
+user = "dheerajchand"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Barry Harris — sixth-diminished bebop system. Substitution-theory axis (complements Baker / Greene / Pass / Martino / Felts / Dunbar). Source is piano-pedagogy but the harmonic system translates directly to guitar voicings. Granular-levels (#434)."

--- a/pipelines/master-distillation/configs/ligon-connecting-chords.toml
+++ b/pipelines/master-distillation/configs/ligon-connecting-chords.toml
@@ -1,0 +1,46 @@
+# Queued via #457 (umbrella #428). Linear-harmony approach / Bert Ligon's voice-leading
+# system. Substitution-theory axis. New master bert-ligon.
+
+[master]
+id = "bert-ligon"
+name = "Bert Ligon"
+
+[work]
+id = "connecting-chords-with-linear-harmony"
+title = "Connecting Chords with Linear Harmony"
+year = 1996
+instrument_scope = "concert-pitch-translatable-to-guitar"
+
+[source]
+pdf = "~/jazz_docs/Guitar/Methods/Jazz/Bert Ligon/Ligon, Bert - Connecting Chords with Linear Harmony.pdf"
+host = "cyberpower"
+user = "dheerajchand"
+needs_ocr = true
+
+[ocr]
+host = "cyberpower"
+user = "dheerajchand"
+vision_model = "qwen2.5vl:7b"
+confidence_threshold = 0.70
+min_chars_per_page = 40
+render_dpi = 200
+
+[stages.s1]
+ocr_lang = "en"
+
+[stages.s2]
+chapter_strategy = "toc-or-heading"
+min_chapter_chars = 500
+model = "claude-sonnet"
+
+[stages.s3]
+per_chapter_model = "claude-haiku"
+book_level_model = "claude-sonnet"
+
+[stages.s4]
+model = "claude-sonnet"
+engine_kind_policy = "pending-when-unsure"
+
+[stages.s5]
+model = "claude-sonnet"
+notes = "Bert Ligon — linear-harmony / voice-leading framework. Substitution + voice-leading axis (complements Van Eps voice-leading and Felts reharmonization). Source is concert-pitch pedagogy translatable to guitar. Granular-levels (#434)."

--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -67644,6 +67644,112 @@
           "provenance": "extracted"
         }
       ]
+    },
+    {
+      "id": "howard-roberts",
+      "name": "Howard Roberts",
+      "lived": "1929-1992",
+      "traditions": [
+        "jazz",
+        "studio"
+      ],
+      "instrument": "6-string electric",
+      "biography": "American studio guitarist and educator, Wrecking Crew session veteran. Known for terse pragmatic teaching emphasizing chord-melody arrangements and bebop vocabulary. Author of Chord Melody and Jazz Guitar Technique in 20 Weeks.",
+      "principles": [],
+      "works": [
+        {
+          "id": "chord-melody",
+          "title": "Chord Melody",
+          "year": 1971,
+          "instrument_scope": "6-string"
+        },
+        {
+          "id": "jazz-guitar-technique-20-weeks",
+          "title": "Jazz Guitar Technique in 20 Weeks",
+          "year": 1971,
+          "instrument_scope": "6-string"
+        }
+      ],
+      "status": "pending-extraction"
+    },
+    {
+      "id": "mick-goodrick",
+      "name": "Mick Goodrick",
+      "lived": "1945-2022",
+      "traditions": [
+        "jazz"
+      ],
+      "instrument": "6-string electric",
+      "biography": "American jazz guitarist and Berklee educator. The Advancing Guitarist (1987) and the Almanac of Guitar Voice Leading (4 vols) are the canonical voice-leading texts in jazz guitar pedagogy.",
+      "principles": [],
+      "works": [
+        {
+          "id": "almanac-vol-1",
+          "title": "Almanac of Guitar Voice Leading, Vol 1",
+          "year": 2001,
+          "instrument_scope": "6-string"
+        },
+        {
+          "id": "almanac-vol-2",
+          "title": "Almanac of Guitar Voice Leading, Vol 2",
+          "year": 2002,
+          "instrument_scope": "6-string"
+        },
+        {
+          "id": "almanac-vol-3",
+          "title": "Almanac of Guitar Voice Leading, Vol 3",
+          "year": 2003,
+          "instrument_scope": "6-string"
+        },
+        {
+          "id": "almanac-vol-4",
+          "title": "Almanac of Guitar Voice Leading, Vol 4",
+          "year": 2005,
+          "instrument_scope": "6-string"
+        }
+      ],
+      "status": "pending-extraction"
+    },
+    {
+      "id": "barry-harris",
+      "name": "Barry Harris",
+      "lived": "1929-2021",
+      "traditions": [
+        "jazz",
+        "bebop"
+      ],
+      "instrument": "piano",
+      "biography": "American bebop pianist and educator. The sixth-diminished system documented in the Jazz Workshop is the seminal bebop harmonic method, widely adapted by guitarists for chord-melody and substitution work. Note: piano-pedagogy source, translatable directly to guitar voicings.",
+      "principles": [],
+      "works": [
+        {
+          "id": "jazz-workshop",
+          "title": "Jazz Workshop",
+          "year": 1986,
+          "instrument_scope": "piano-translatable-to-guitar"
+        }
+      ],
+      "status": "pending-extraction"
+    },
+    {
+      "id": "bert-ligon",
+      "name": "Bert Ligon",
+      "lived": "1955-",
+      "traditions": [
+        "jazz"
+      ],
+      "instrument": "concert-pitch",
+      "biography": "American jazz educator and author. Connecting Chords with Linear Harmony (1996) is a canonical text on linear voice-leading and chord-progression generation. Concert-pitch pedagogy translatable to guitar.",
+      "principles": [],
+      "works": [
+        {
+          "id": "connecting-chords-with-linear-harmony",
+          "title": "Connecting Chords with Linear Harmony",
+          "year": 1996,
+          "instrument_scope": "concert-pitch-translatable-to-guitar"
+        }
+      ],
+      "status": "pending-extraction"
     }
   ]
 }


### PR DESCRIPTION
PDFs were on cyberpower the whole time. Added 4 master entries (Roberts, Goodrick, Harris, Ligon) and 3 new configs (Goodrick V4, Harris, Ligon). 4 s1 pipelines (Roberts×2 + Goodrick V2/V3) running in background on cyberpower; will fire the remaining 3 once this merges. Reinhardt missing-data filed as #502. Schema 24/24. Refs #457.