### PR TITLE
fix(#505): relax s2 quote-fidelity for OCR soft-hyphens + typographic punctuation

### DIFF
--- a/pipelines/master-distillation/lib/text.py
+++ b/pipelines/master-distillation/lib/text.py
@@ -95,8 +95,43 @@ def find_page_of_quote(quote: str, transcript: str, pages: list[dict]) -> int | 
 
 _WS_RE = re.compile(r"\s+")
 
+# OCR engines emit hard line breaks every ~40 chars and hyphenate
+# overflow words: 'mat-\nter', 'effi-\nciency'. The validator needs to
+# recognize a quote where the LLM correctly de-hyphenated ('matter',
+# 'efficiency') as still verbatim. Match a word char, a literal hyphen,
+# one-or-more whitespace chars (the line break + indent), and another
+# word char on the next line. Compound words like 'well-known' don't
+# match (no whitespace between hyphen and the next word char). Em-dash
+# patterns like ' - ' don't match because there's no word char on the
+# left of the hyphen (a space precedes it).
+_SOFT_HYPHEN_RE = re.compile(r"(\w)-\s+(?=\w)")
+
+# Typographic punctuation that OCR emits as Unicode and LLMs echo as
+# ASCII. Substring fidelity should not depend on which form survives.
+# Curly quotes from PDF extraction map to straight quotes; em-dashes
+# and ellipses map to their ASCII multi-char equivalents BEFORE
+# whitespace collapse so the substring check sees the same shape.
+_TYPOGRAPHIC_MAP = str.maketrans({
+    "‘": "'",   # left single quote
+    "’": "'",   # right single quote / apostrophe
+    "“": '"',   # left double quote
+    "”": '"',   # right double quote
+    "–": "-",   # en-dash
+    "—": "-",   # em-dash
+    "…": "...", # horizontal ellipsis
+    " ": " ",   # non-breaking space
+})
+
 
 def _normalize_whitespace(s: str) -> str:
+    # Normalize Unicode typographic chars to ASCII so curly-vs-straight
+    # quote mismatches (LLM-echoed quote text vs PDF-OCR'd quote text)
+    # don't fail the fidelity check.
+    s = s.translate(_TYPOGRAPHIC_MAP)
+    # Join soft-hyphenated line breaks: 'mat-\nter' -> 'matter'.
+    # Must precede whitespace collapsing because that step turns the
+    # newline into a single space, which loses the line-break signal.
+    s = _SOFT_HYPHEN_RE.sub(r"\1", s)
     return _WS_RE.sub(" ", s).strip()
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -97,6 +97,82 @@ def test_verify_quote_pdftotext_artifact_NOT_normalized():
     assert not text.verify_quote_in_transcript(quote_corrected, transcript)
 
 
+def test_verify_quote_soft_hyphen_at_line_break_joined():
+    """#505: OCR emits hard line breaks with soft hyphens ('mat-\\nter').
+    The LLM correctly de-hyphenates in its echo ('matter'). The validator
+    must accept the de-hyphenated quote as still verbatim."""
+    transcript = "Mechanical efficiency is primarily a mat-\nter of avoiding waste."
+    quote_de_hyphenated = "Mechanical efficiency is primarily a matter of avoiding waste."
+    assert text.verify_quote_in_transcript(quote_de_hyphenated, transcript)
+
+
+def test_verify_quote_multiple_soft_hyphens_joined():
+    """#505: chapter with multiple soft hyphens — each must be joined."""
+    transcript = (
+        "Develop a sense of efi-\n"
+        "ciency but avoid fearing radi-\n"
+        "cal interval jumps."
+    )
+    quote = "Develop a sense of eficiency but avoid fearing radical interval jumps."
+    assert text.verify_quote_in_transcript(quote, transcript)
+
+
+def test_verify_quote_compound_word_preserved():
+    """#505: legitimate compound words ('well-known', 'chord-melody') do NOT
+    match the soft-hyphen pattern (no whitespace between the hyphen and the
+    next word char) and must stay intact through normalization."""
+    transcript = "The well-known chord-melody technique requires both hands."
+    quote_intact = "The well-known chord-melody technique requires both hands."
+    assert text.verify_quote_in_transcript(quote_intact, transcript)
+    # The de-hyphenated form must NOT match (would be a real
+    # hallucination of a non-existent compound).
+    quote_broken = "The wellknown chordmelody technique requires both hands."
+    assert not text.verify_quote_in_transcript(quote_broken, transcript)
+
+
+def test_verify_quote_em_dash_style_preserved():
+    """#505: em-dash style ' - ' (space-hyphen-space) is not a soft hyphen
+    and must stay intact — preserving sentence punctuation fidelity."""
+    transcript = "He plays bebop - the canonical style - with conviction."
+    quote = "He plays bebop - the canonical style - with conviction."
+    assert text.verify_quote_in_transcript(quote, transcript)
+
+
+def test_verify_quote_curly_quotes_normalized_to_straight():
+    """#505: OCR emits Unicode curly quotes (“ ” ‘ ’). The LLM
+    typically echoes ASCII straight quotes. The validator must treat
+    them as equivalent — otherwise every quoted-passage substring fails."""
+    transcript = "He calls it the “singing” string, with ‘sustain’ as its signature."
+    quote_ascii = 'He calls it the "singing" string, with \'sustain\' as its signature.'
+    assert text.verify_quote_in_transcript(quote_ascii, transcript)
+
+
+def test_verify_quote_unicode_dashes_normalized():
+    """#505: en-dash (–) and em-dash (—) both normalize to
+    ASCII hyphen so the substring check ignores typographic style."""
+    transcript = "Pages 12–15 cover the topic—a comprehensive treatment."
+    quote_ascii = "Pages 12-15 cover the topic-a comprehensive treatment."
+    assert text.verify_quote_in_transcript(quote_ascii, transcript)
+
+
+def test_verify_quote_unicode_ellipsis_normalized():
+    """#505: Unicode horizontal ellipsis (…) normalizes to '...'."""
+    transcript = "He paused… then continued the phrase."
+    quote_ascii = "He paused... then continued the phrase."
+    assert text.verify_quote_in_transcript(quote_ascii, transcript)
+
+
+def test_verify_quote_hallucination_still_rejected_after_normalization():
+    """#505 regression: the new normalization rules must not accept a
+    truly fabricated quote. Soft-hyphen + curly-quote + em-dash all
+    applied; the quote must still fail because the content is wrong."""
+    transcript = "Mechanical effi-\nciency is primary in our “method.”"
+    # Real source talks about efficiency in our method; this paraphrase
+    # changes 'effi-ciency' to 'efficacy' and 'method' to 'approach'.
+    hallucination = 'Mechanical efficacy is primary in our "approach."'
+    assert not text.verify_quote_in_transcript(hallucination, transcript)
+
+
 def test_find_page_of_quote_single_page():
     pages = [
         {"n": 1, "start": 0, "length": 20, "preview": "Page-1"},


### PR DESCRIPTION
## Summary

Closes #505. s2's `verify_quote_in_transcript` was rejecting LLM-extracted verbatim quotes whenever the source OCR had soft hyphens at line breaks (`mat-\nter`) or Unicode typographic punctuation (curly quotes, en/em-dashes, ellipsis). The LLM correctly de-hyphenates and normalizes; the substring check then failed.

## Fix

Two new transforms inside `_normalize_whitespace`:

| Input | Old normalize | New normalize |
|---|---|---|
| `"mat-\nter"` | `"mat- ter"` | `"matter"` |
| `"well-known"` | `"well-known"` | `"well-known"` (preserved) |
| `"foo - bar"` (em-dash style) | `"foo - bar"` | `"foo - bar"` (preserved) |
| `"the "sing" string"` (curly quotes) | unchanged | `'the "sing" string'` (ASCII) |
| `"12–15"` (en-dash) | unchanged | `"12-15"` |
| `"…"` (Unicode ellipsis) | unchanged | `"..."` |

## Reproduced on Roberts CM ch01

Before: 3 of 5 sonnet-emitted verbatim quotes rejected by the validator. After: 4 of 4 pass.

## Tests

- 8 new pytest cases in `test_pipeline.py` cover: soft hyphen joining, multiple soft hyphens, compound-word regression, em-dash style preservation, curly-quote normalization, Unicode dashes, Unicode ellipsis, hallucination-still-rejected
- `test_pipeline.py` 58/58 pass (50 existing + 8 new)
- `test_pipeline + test_masters_schema + test_core + test_queue_state_backfill`: 163/163

(`test_integration` has a pre-existing local-env failure unrelated to this change — looks for a MuseScore4 binary not in the checkout.)

## Hallucination check preserved

A truly fabricated quote (paraphrase, wrong word, invented content) still fails — the new transforms only collapse equivalent typographic forms; they don't allow word substitution. Covered by `test_verify_quote_hallucination_still_rejected_after_normalization`.

## Why this matters

Unblocks s2-s5 progression for the 7 OCR-recovered books (Roberts CM/20w, Goodrick V2/V3/V4, Harris, Ligon). These are parked at s1=accepted on cyberpower. Without this fix every chapter extraction would require manual quote-substring fixing (~30 fixes per book × 7 books).

Refs #504 (separate ticket for the watchdog false-negative that originally hid the completed OCR runs).