### PR TITLE
fix(#524): re-status 4 masters to corpus_only — unblock 12 stacked Stage B PRs

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -67670,7 +67670,7 @@
           "instrument_scope": "6-string"
         }
       ],
-      "status": "pending-extraction"
+      "status": "corpus_only"
     },
     {
       "id": "mick-goodrick",
@@ -67708,7 +67708,7 @@
           "instrument_scope": "6-string"
         }
       ],
-      "status": "pending-extraction"
+      "status": "corpus_only"
     },
     {
       "id": "barry-harris",
@@ -67729,7 +67729,7 @@
           "instrument_scope": "piano-translatable-to-guitar"
         }
       ],
-      "status": "pending-extraction"
+      "status": "corpus_only"
     },
     {
       "id": "bert-ligon",
@@ -67749,7 +67749,7 @@
           "instrument_scope": "concert-pitch-translatable-to-guitar"
         }
       ],
-      "status": "pending-extraction"
+      "status": "corpus_only"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The CI test \`test_loads_repo_masters_json\` has been red on develop since commit \`4f49652\` (2026-06-12). All 12 currently-open Stage B PRs (#507-#520) inherit the failure and cannot merge.

Root cause: \`howard-roberts\`, \`mick-goodrick\`, \`barry-harris\`, \`bert-ligon\` were onboarded with \`status: pending-extraction\` and \`principles: []\`. The test invariant requires every non-\`corpus_only\` master to have non-empty principles. This PR re-statuses those 4 to \`corpus_only\`.

## Why this is the right fix

The existing status taxonomy already has the right slot:

- \`corpus_only\` = master has corpus data (usage_notes) but no curated principles yet.
- \`promoted\` = both corpus content AND curated principles.

After the 12 Stage B PRs land, each of these 4 masters will have substantial usage_notes (Roberts 88 across 2 books, Goodrick 79 across 4 vols, Harris 22, Ligon 25). That IS corpus content. Curated principles can be authored later via a separate workflow and the status promoted to \`promoted\` then.

## Validation

Local replication of the test invariant against the patched file:

\`\`\`
PASSES — all non-corpus_only masters have principles
\`\`\`

## Test plan

- [ ] CI green on this PR
- [ ] Rebase #507-#520 against new develop tip; expect them to inherit the green check
- [ ] Merge cascade

Closes #524.