### PR TITLE
feat(#527): engine rules — Mick Goodrick Almanac Vol 1

### DIFF
--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-1/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-1/derived/engine-rules.json
@@ -1,0 +1,612 @@
+{
+  "master_id": "mick-goodrick",
+  "work_id": "almanac-vol-1",
+  "engine_rules": [
+    {
+      "rule_id": "goodrick-cycle-scale-grid-lookup",
+      "name": "Locate Voicing Entry at Cycle × Scale Intersection",
+      "when": {
+        "cycle.id": [
+          "cycle-2",
+          "cycle-3",
+          "cycle-4",
+          "cycle-5",
+          "cycle-6",
+          "cycle-7"
+        ],
+        "scale.context": [
+          "C Major",
+          "C Melodic Minor",
+          "C Harmonic Minor"
+        ],
+        "voicing.family": [
+          "triad",
+          "seventh",
+          "tbn-i",
+          "tbn-ii"
+        ]
+      },
+      "then": {
+        "voicing.cycle_index": "read entry at (cycle.id × scale.context) cell",
+        "voicing.scale_context": "constrain all voice-leading analysis to the parent scale of the cell"
+      },
+      "preference": "mandatory",
+      "quality_binding": [
+        "triad",
+        "seventh",
+        "tbn-i",
+        "tbn-ii"
+      ],
+      "falsifier": "A voicing entry that produces valid output when cycle.id or scale.context is unspecified",
+      "anchor": "six cycles (2-7) within three parent scales: C Major, C Melodic Minor, and C Harmonic Minor",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Cycle × Scale Grid — 18 Environments",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-cycle-defines-root-motion",
+      "name": "Cycle Number Is Root-Motion Interval",
+      "when": {
+        "cycle.id": [
+          "cycle-2",
+          "cycle-3",
+          "cycle-4",
+          "cycle-5",
+          "cycle-6",
+          "cycle-7"
+        ]
+      },
+      "then": {
+        "voicing.cycle_index": "root moves by interval N where N equals cycle number"
+      },
+      "preference": "required",
+      "quality_binding": [],
+      "falsifier": "A cycle labeled cycle-4 that produces root motion by an interval other than a fourth",
+      "anchor": "cycles (cycles 2 through 7, representing the interval of motion between successive diatonic chords)",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Cycle × Scale Grid — 18 Environments",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-18-env-orthogonal-axes",
+      "name": "Cycle and Scale Are Orthogonal Traversal Axes",
+      "when": {
+        "cycle.id": "any",
+        "scale.context": "any"
+      },
+      "then": {
+        "voicing.cycle_index": "cycle axis may be varied independently of scale axis",
+        "voicing.scale_context": "scale axis may be varied independently of cycle axis"
+      },
+      "preference": "design invariant",
+      "quality_binding": [],
+      "falsifier": "Any (cycle, scale) cell found to be empty",
+      "anchor": "six cycles × 3 parent scales produces 18 distinct voice-leading environments",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Cycle × Scale Grid — 18 Environments",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-close-spread-independent-objects",
+      "name": "Close and Spread Are Independent Voice-Leading Objects",
+      "when": {
+        "voicing.family": "any",
+        "voicing.position": [
+          "close",
+          "spread"
+        ]
+      },
+      "then": {
+        "voicing.shape": "select the voice-leading table specific to voicing.position"
+      },
+      "preference": "mandatory",
+      "quality_binding": [],
+      "falsifier": "A case where Close and Spread entries produce identical intervallic voice-leading profiles",
+      "anchor": "Each voicing is displayed in both close and spread positions",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Close and Spread Position Parameterization",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-register-reshapes-contrapuntal-texture",
+      "name": "Position Choice Reshapes Contrapuntal Texture Without Changing Harmonic Content",
+      "when": {
+        "voicing.position": [
+          "close",
+          "spread"
+        ]
+      },
+      "then": {
+        "voicing.shape": "toggle between close and spread to modify contrapuntal texture; harmonic content preserved",
+        "voicing.functional_class": "unchanged by position toggle"
+      },
+      "preference": "preferred",
+      "quality_binding": [],
+      "falsifier": "A position toggle that changes the pitch-class set",
+      "anchor": "the guitarist can trace how register choice reshapes the contrapuntal texture without changing the harmonic content",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Close and Spread Position Parameterization",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-intervallic-layer-motion-budget",
+      "name": "Read Intervallic Layer First to Establish Motion Budget",
+      "when": {
+        "voicing.family": "any"
+      },
+      "then": {
+        "voicing.cycle_index": "identify common tone, step voices, leap voices"
+      },
+      "preference": "required first step",
+      "quality_binding": [],
+      "falsifier": "A voicing selection that contradicts the intervallic profile listed",
+      "anchor": "intervallic voice-leading relationships",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Three-Layer Analytical Method",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-functional-layer-scale-degree-tracking",
+      "name": "Functional Layer Tracks Scale-Degree Role Across Cycle Steps",
+      "when": {
+        "voicing.family": "any"
+      },
+      "then": {
+        "voicing.functional_class": "assign each voice a scale-degree function and track which function moves to which"
+      },
+      "preference": "required second step",
+      "quality_binding": [],
+      "falsifier": "An entry where two voices carry the same scale-degree function within the same chord",
+      "anchor": "functional voice-leading information",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Three-Layer Analytical Method",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-msrp-top-voice-minimization",
+      "name": "M.S.R.P. Selects Most Stepwise Top-Voice Path Through Cycle",
+      "when": {
+        "voicing.family": "any"
+      },
+      "then": {
+        "voicing.msrp": "prefer voicing sequence whose top voice matches M.S.R.P. encoding"
+      },
+      "preference": "tie-breaker",
+      "quality_binding": [],
+      "falsifier": "A voicing path preferred over M.S.R.P. despite producing less stepwise top-voice",
+      "anchor": "Most Stepwise Resolution Pattern (M.S.R.P.) strings",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Three-Layer Analytical Method",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-common-tone-retention-preference",
+      "name": "Prefer the Voice That Carries the Common Tone to Sustain or Minimally Move",
+      "when": {
+        "voicing.family": "any"
+      },
+      "then": {
+        "voicing.cycle_index": "hold or minimally displace common-tone voice across cycle step"
+      },
+      "preference": "strong preference",
+      "quality_binding": [],
+      "falsifier": "A cycle environment where no voice carries interval 0",
+      "anchor": "intervallic voice-leading relationships, functional voice-leading information",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Three-Layer Analytical Method",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-functional-substitution-equivalence",
+      "name": "Identical Functional Voice-Leading Profiles Signal Substitution Equivalence",
+      "when": {
+        "voicing.functional_class": "same profile across two cells"
+      },
+      "then": {
+        "voicing.functional_class": "treat entries as interchangeable substitutes"
+      },
+      "preference": "available",
+      "quality_binding": [],
+      "falsifier": "Two entries with identical functional profiles that produce non-substitutable results",
+      "anchor": "functional voice-leading information",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Three-Layer Analytical Method",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-triad-3voice-close-spread",
+      "name": "Triad Entries Are 3-Voice Objects in Both Close and Spread",
+      "when": {
+        "voicing.family": "triad",
+        "voicing.position": [
+          "close",
+          "spread"
+        ]
+      },
+      "then": {
+        "voicing.shape": "apply 3-voice intervallic/functional tables",
+        "voicing.functional_class": "assign root, 3rd, 5th"
+      },
+      "preference": "mandatory",
+      "quality_binding": [
+        "triad"
+      ],
+      "falsifier": "A triad entry with fewer than 3 or more than 3 distinct voices",
+      "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs — in both Close and Spread voicings",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Tertian Voicing Families — Triads and Seventh Chords",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-seventh-4voice-close-spread",
+      "name": "Seventh Chord Entries Are 4-Voice Objects in Both Close and Spread",
+      "when": {
+        "voicing.family": "seventh",
+        "voicing.position": [
+          "close",
+          "spread"
+        ]
+      },
+      "then": {
+        "voicing.shape": "apply 4-voice intervallic/functional tables",
+        "voicing.functional_class": "assign root, 3rd, 5th, 7th"
+      },
+      "preference": "mandatory",
+      "quality_binding": [
+        "seventh"
+      ],
+      "falsifier": "A seventh-chord entry with fewer than 4 or more than 4 distinct voices",
+      "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs — in both Close and Spread voicings",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Tertian Voicing Families — Triads and Seventh Chords",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-cycle-rich-common-tones",
+      "name": "Common-Tone-Rich Cycles Yield Smoother Voice-Leading Automatically",
+      "when": {
+        "voicing.family": [
+          "triad",
+          "seventh"
+        ],
+        "cycle.id": [
+          "cycle-4",
+          "cycle-5"
+        ]
+      },
+      "then": {
+        "voicing.cycle_index": "expect one or more common tones per cycle step",
+        "voicing.msrp": "M.S.R.P. reflects predominantly stepwise or common-tone top-voice motion"
+      },
+      "preference": "descriptive",
+      "quality_binding": [
+        "triad",
+        "seventh"
+      ],
+      "falsifier": "A cycle-4 or cycle-5 cell where no voice carries interval 0",
+      "anchor": "some cycles (particularly cycles producing common-tone-rich motion) yield smooth voice-leading almost automatically",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "Tertian Voicing Families — Triads and Seventh Chords",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-tbn-same-analytical-layers",
+      "name": "TBN Constructs Receive All Three Analytical Layers Identically",
+      "when": {
+        "voicing.family": [
+          "tbn-i",
+          "tbn-ii"
+        ],
+        "voicing.position": [
+          "close",
+          "spread"
+        ]
+      },
+      "then": {
+        "voicing.cycle_index": "apply intervallic layer to TBN base and upper structure",
+        "voicing.functional_class": "assign functional labels to TBN voices",
+        "voicing.msrp": "read M.S.R.P. string identically to tertian procedure"
+      },
+      "preference": "mandatory",
+      "quality_binding": [
+        "tbn-i",
+        "tbn-ii"
+      ],
+      "falsifier": "A TBN entry that omits one of the three analytical layers",
+      "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs",
+      "source_page": 12,
+      "_provenance": {
+        "chapter_n": 1,
+        "section_title": "TBN (Two-Note Base) Constructs",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-quartal-same-18-env-grid",
+      "name": "Quartal and Cluster Voicings Use the Same 18-Environment Grid as Tertian",
+      "when": {
+        "voicing.family": [
+          "3part-quartal",
+          "4part-quartal",
+          "spread-cluster"
+        ],
+        "cycle.id": [
+          "cycle-2",
+          "cycle-3",
+          "cycle-4",
+          "cycle-5",
+          "cycle-6",
+          "cycle-7"
+        ],
+        "scale.context": [
+          "C Major",
+          "C Melodic Minor",
+          "C Harmonic Minor"
+        ]
+      },
+      "then": {
+        "voicing.cycle_index": "locate entry at (cycle.id × scale.context) cell",
+        "voicing.scale_context": "constrain analysis to parent scale"
+      },
+      "preference": "mandatory",
+      "quality_binding": [
+        "3part-quartal",
+        "4part-quartal",
+        "spread-cluster"
+      ],
+      "falsifier": "A quartal or cluster entry outside the 18-environment grid",
+      "anchor": "six cycles (cycles 2-7) and three parent scales (C Major, C Melodic Minor, and C Harmonic Minor)",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-quartal-three-analytical-layers",
+      "name": "Quartal and Cluster Entries Receive All Three Analytical Layers",
+      "when": {
+        "voicing.family": [
+          "3part-quartal",
+          "4part-quartal",
+          "spread-cluster"
+        ]
+      },
+      "then": {
+        "voicing.cycle_index": "apply intervallic layer",
+        "voicing.functional_class": "apply functional layer",
+        "voicing.msrp": "read M.S.R.P. string"
+      },
+      "preference": "mandatory",
+      "quality_binding": [
+        "3part-quartal",
+        "4part-quartal",
+        "spread-cluster"
+      ],
+      "falsifier": "A quartal or cluster entry that lacks one of the three layers",
+      "anchor": "Intervallic Voice-Leading (pitch relationships), Functional Voice-Leading (harmonic context)",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-quartal-nct-resist-naming",
+      "name": "Quartal and Cluster Voicings Are Applied Without Requiring a Chord Name",
+      "when": {
+        "voicing.family": [
+          "3part-quartal",
+          "4part-quartal",
+          "spread-cluster"
+        ],
+        "chord_quality": "ambiguous or unnameable by tertian convention"
+      },
+      "then": {
+        "voicing.functional_class": "do not force a tertian chord-quality label",
+        "voicing.shape": "select using (cycle, scale, position) tuple"
+      },
+      "preference": "required when chord_quality cannot be resolved",
+      "quality_binding": [],
+      "falsifier": "A quartal or cluster entry defined only in relation to an underlying tertian chord name",
+      "anchor": "the volume's strategic shift away from tertian harmony toward quartal and cluster sonorities that resist conventional chord naming",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-4part-quartal-six-voicing-types",
+      "name": "4-Part Quartal Has Six Distinct Voicing Types",
+      "when": {
+        "voicing.family": "4part-quartal"
+      },
+      "then": {
+        "voicing.shape": "select one of six 4-part quartal voicing types"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "4part-quartal"
+      ],
+      "falsifier": "Fewer than or more than six distinct 4-part quartal voicing types",
+      "anchor": "4-part quartal voicings across six distinct voicing types",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-spread-cluster-six-types",
+      "name": "Spread Cluster Has Six Distinct Voicing Types",
+      "when": {
+        "voicing.family": "spread-cluster"
+      },
+      "then": {
+        "voicing.shape": "select one of six Spread Cluster voicing types"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "spread-cluster"
+      ],
+      "falsifier": "Fewer than or more than six distinct Spread Cluster voicing types",
+      "anchor": "Spread Cluster voicings across six further types",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-family-agnostic-vl-discipline",
+      "name": "Voice-Leading Discipline Is Invariant Across Sonority Families",
+      "when": {
+        "voicing.family": [
+          "triad",
+          "seventh",
+          "tbn-i",
+          "tbn-ii",
+          "3part-quartal",
+          "4part-quartal",
+          "spread-cluster"
+        ]
+      },
+      "then": {
+        "voicing.cycle_index": "apply same motion-budget analysis regardless of family",
+        "voicing.functional_class": "track scale-degree or quartal-equivalent function using same logic"
+      },
+      "preference": "invariant",
+      "quality_binding": [],
+      "falsifier": "A voicing family requiring a fourth analytical layer or different grid",
+      "anchor": "quartal and cluster harmony is not a special case requiring special treatment. It obeys the same voice-leading discipline as tertian harmony",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Unity of Voice-Leading Across Families",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-family-switch-preserves-motion-budget-method",
+      "name": "Switching Voicing Family Does Not Change Motion-Budget Reading Procedure",
+      "when": {
+        "voicing.family": "any"
+      },
+      "then": {
+        "voicing.cycle_index": "read intervallic layer using same procedure regardless of family"
+      },
+      "preference": "required",
+      "quality_binding": [],
+      "falsifier": "A quartal or cluster entry where interval 0 cannot be identified using the same procedure",
+      "anchor": "By running 4-part fourths and spread cluster voicings through the same 18-environment grid, with the same three analytical layers, Goodrick enforces the insight that the guitarist's contrapuntal obligation does not change when the harmonic language does",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Unity of Voice-Leading Across Families",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-leap-budget-increases-with-leaner-common-tone-coverage",
+      "name": "Families With Fewer Common Tones Per Cycle Force Larger Leap Budgets",
+      "when": {
+        "voicing.family": [
+          "3part-quartal",
+          "4part-quartal",
+          "spread-cluster"
+        ]
+      },
+      "then": {
+        "voicing.cycle_index": "expect larger or more frequent intervallic leaps",
+        "voicing.msrp": "M.S.R.P. reflects wider top-voice range"
+      },
+      "preference": "descriptive",
+      "quality_binding": [
+        "3part-quartal",
+        "4part-quartal",
+        "spread-cluster"
+      ],
+      "falsifier": null,
+      "anchor": "What changes across families is which voice carries the common tone, which voice steps by a second or third, and how large the remaining leaps must be",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Unity of Voice-Leading Across Families",
+        "level": "section"
+      }
+    },
+    {
+      "rule_id": "goodrick-msrp-quartal-top-voice-benchmark",
+      "name": "M.S.R.P. Is the Top-Voice Efficiency Benchmark for Quartal and Cluster Cycles",
+      "when": {
+        "voicing.family": [
+          "3part-quartal",
+          "4part-quartal",
+          "spread-cluster"
+        ]
+      },
+      "then": {
+        "voicing.msrp": "use M.S.R.P. string as compact melodic handle on multi-voice contrapuntal event"
+      },
+      "preference": "tie-breaker",
+      "quality_binding": [
+        "3part-quartal",
+        "4part-quartal",
+        "spread-cluster"
+      ],
+      "falsifier": "A quartal or cluster entry where M.S.R.P. string is absent while equivalent tertian entry at same address has valid M.S.R.P.",
+      "anchor": "M.S.R.P. string indicating the Most Stepwise Resolution Pattern",
+      "source_page": 190,
+      "_provenance": {
+        "chapter_n": 2,
+        "section_title": "Unity of Voice-Leading Across Families",
+        "level": "section"
+      }
+    }
+  ]
+}

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-1/derived/structured-distillation.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-1/derived/structured-distillation.json
@@ -1,0 +1,659 @@
+{
+  "chapters": [
+    {
+      "chapter": {
+        "n": 1,
+        "title": "VOLUME ONE: NAME THAT CHORD",
+        "summary": "A systematic catalog of tertian sonorities — triads, seventh chords, and TBN (Two-Note Base) constructs — in both Close and Spread voicings, organized across six cycles (2–7) and three parent scales (C Major, C Melodic Minor, C Harmonic Minor). The book's teaching is encoded entirely in tabular mappings across three analytical layers: Intervallic Voice-Leading, Functional Voice-Leading, and M.S.R.P. No instructional prose is present; the catalog itself is the argument.",
+        "key_phrases": [
+          "cycle-indexed voice-leading",
+          "Close and Spread voicings",
+          "M.S.R.P.",
+          "Intervallic Voice-Leading",
+          "Functional Voice-Leading",
+          "TBN (Two-Note Base)",
+          "18 environments",
+          "diatonic voicing inventory",
+          "tertian sonority catalog"
+        ]
+      },
+      "sections": [
+        {
+          "title": "Cycle × Scale Grid — 18 Environments",
+          "page_range": [
+            12,
+            189
+          ],
+          "summary": "The master organizational axis of Volume One: every voicing entry is located at the intersection of one of six cycles (2–7, representing the interval of root motion) and one of three parent scales (C Major, C Melodic Minor, C Harmonic Minor), producing 18 distinct voice-leading environments per voicing family.",
+          "key_phrases": [
+            "six cycles (2-7)",
+            "three parent scales",
+            "18 environments",
+            "Close position",
+            "Spread position",
+            "cycle × scale grid"
+          ],
+          "engine_rules": [
+            {
+              "rule_id": "goodrick-cycle-scale-grid-lookup",
+              "name": "Locate Voicing Entry at Cycle × Scale Intersection",
+              "when": {
+                "cycle.id": [
+                  "cycle-2",
+                  "cycle-3",
+                  "cycle-4",
+                  "cycle-5",
+                  "cycle-6",
+                  "cycle-7"
+                ],
+                "scale.context": [
+                  "C Major",
+                  "C Melodic Minor",
+                  "C Harmonic Minor"
+                ],
+                "voicing.family": [
+                  "triad",
+                  "seventh",
+                  "tbn-i",
+                  "tbn-ii"
+                ]
+              },
+              "then": {
+                "voicing.cycle_index": "read entry at (cycle.id × scale.context) cell",
+                "voicing.scale_context": "constrain all voice-leading analysis to the parent scale of the cell"
+              },
+              "preference": "mandatory",
+              "quality_binding": [
+                "triad",
+                "seventh",
+                "tbn-i",
+                "tbn-ii"
+              ],
+              "falsifier": "A voicing entry that produces valid output when cycle.id or scale.context is unspecified",
+              "anchor": "six cycles (2-7) within three parent scales: C Major, C Melodic Minor, and C Harmonic Minor",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-cycle-defines-root-motion",
+              "name": "Cycle Number Is Root-Motion Interval",
+              "when": {
+                "cycle.id": [
+                  "cycle-2",
+                  "cycle-3",
+                  "cycle-4",
+                  "cycle-5",
+                  "cycle-6",
+                  "cycle-7"
+                ]
+              },
+              "then": {
+                "voicing.cycle_index": "root moves by interval N where N equals cycle number"
+              },
+              "preference": "required",
+              "quality_binding": [],
+              "falsifier": "A cycle labeled cycle-4 that produces root motion by an interval other than a fourth",
+              "anchor": "cycles (cycles 2 through 7, representing the interval of motion between successive diatonic chords)",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-18-env-orthogonal-axes",
+              "name": "Cycle and Scale Are Orthogonal Traversal Axes",
+              "when": {
+                "cycle.id": "any",
+                "scale.context": "any"
+              },
+              "then": {
+                "voicing.cycle_index": "cycle axis may be varied independently of scale axis",
+                "voicing.scale_context": "scale axis may be varied independently of cycle axis"
+              },
+              "preference": "design invariant",
+              "quality_binding": [],
+              "falsifier": "Any (cycle, scale) cell found to be empty",
+              "anchor": "six cycles × 3 parent scales produces 18 distinct voice-leading environments",
+              "source_page": 12
+            }
+          ],
+          "paragraphs": []
+        },
+        {
+          "title": "Close and Spread Position Parameterization",
+          "page_range": [
+            12,
+            189
+          ],
+          "summary": "Every voicing family is cataloged in both Close and Spread positions, treated as independent objects with separate voice-leading tables. This parameterizes voicing density as an axis orthogonal to cycle and scale.",
+          "key_phrases": [
+            "Close position",
+            "Spread position",
+            "voicing density",
+            "register choice",
+            "parallel voice-leading tables"
+          ],
+          "engine_rules": [
+            {
+              "rule_id": "goodrick-close-spread-independent-objects",
+              "name": "Close and Spread Are Independent Voice-Leading Objects",
+              "when": {
+                "voicing.family": "any",
+                "voicing.position": [
+                  "close",
+                  "spread"
+                ]
+              },
+              "then": {
+                "voicing.shape": "select the voice-leading table specific to voicing.position"
+              },
+              "preference": "mandatory",
+              "quality_binding": [],
+              "falsifier": "A case where Close and Spread entries produce identical intervallic voice-leading profiles",
+              "anchor": "Each voicing is displayed in both close and spread positions",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-register-reshapes-contrapuntal-texture",
+              "name": "Position Choice Reshapes Contrapuntal Texture Without Changing Harmonic Content",
+              "when": {
+                "voicing.position": [
+                  "close",
+                  "spread"
+                ]
+              },
+              "then": {
+                "voicing.shape": "toggle between close and spread to modify contrapuntal texture; harmonic content preserved",
+                "voicing.functional_class": "unchanged by position toggle"
+              },
+              "preference": "preferred",
+              "quality_binding": [],
+              "falsifier": "A position toggle that changes the pitch-class set",
+              "anchor": "the guitarist can trace how register choice reshapes the contrapuntal texture without changing the harmonic content",
+              "source_page": 12
+            }
+          ],
+          "paragraphs": []
+        },
+        {
+          "title": "Three-Layer Analytical Method",
+          "page_range": [
+            12,
+            189
+          ],
+          "summary": "Every voicing entry is analyzed through three mandatory lenses: Intervallic Voice-Leading, Functional Voice-Leading, M.S.R.P.",
+          "key_phrases": [
+            "Intervallic Voice-Leading",
+            "Functional Voice-Leading",
+            "M.S.R.P.",
+            "three analytical layers"
+          ],
+          "engine_rules": [
+            {
+              "rule_id": "goodrick-intervallic-layer-motion-budget",
+              "name": "Read Intervallic Layer First to Establish Motion Budget",
+              "when": {
+                "voicing.family": "any"
+              },
+              "then": {
+                "voicing.cycle_index": "identify common tone, step voices, leap voices"
+              },
+              "preference": "required first step",
+              "quality_binding": [],
+              "falsifier": "A voicing selection that contradicts the intervallic profile listed",
+              "anchor": "intervallic voice-leading relationships",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-functional-layer-scale-degree-tracking",
+              "name": "Functional Layer Tracks Scale-Degree Role Across Cycle Steps",
+              "when": {
+                "voicing.family": "any"
+              },
+              "then": {
+                "voicing.functional_class": "assign each voice a scale-degree function and track which function moves to which"
+              },
+              "preference": "required second step",
+              "quality_binding": [],
+              "falsifier": "An entry where two voices carry the same scale-degree function within the same chord",
+              "anchor": "functional voice-leading information",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-msrp-top-voice-minimization",
+              "name": "M.S.R.P. Selects Most Stepwise Top-Voice Path Through Cycle",
+              "when": {
+                "voicing.family": "any"
+              },
+              "then": {
+                "voicing.msrp": "prefer voicing sequence whose top voice matches M.S.R.P. encoding"
+              },
+              "preference": "tie-breaker",
+              "quality_binding": [],
+              "falsifier": "A voicing path preferred over M.S.R.P. despite producing less stepwise top-voice",
+              "anchor": "Most Stepwise Resolution Pattern (M.S.R.P.) strings",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-common-tone-retention-preference",
+              "name": "Prefer the Voice That Carries the Common Tone to Sustain or Minimally Move",
+              "when": {
+                "voicing.family": "any"
+              },
+              "then": {
+                "voicing.cycle_index": "hold or minimally displace common-tone voice across cycle step"
+              },
+              "preference": "strong preference",
+              "quality_binding": [],
+              "falsifier": "A cycle environment where no voice carries interval 0",
+              "anchor": "intervallic voice-leading relationships, functional voice-leading information",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-functional-substitution-equivalence",
+              "name": "Identical Functional Voice-Leading Profiles Signal Substitution Equivalence",
+              "when": {
+                "voicing.functional_class": "same profile across two cells"
+              },
+              "then": {
+                "voicing.functional_class": "treat entries as interchangeable substitutes"
+              },
+              "preference": "available",
+              "quality_binding": [],
+              "falsifier": "Two entries with identical functional profiles that produce non-substitutable results",
+              "anchor": "functional voice-leading information",
+              "source_page": 12
+            }
+          ],
+          "paragraphs": []
+        },
+        {
+          "title": "Tertian Voicing Families — Triads and Seventh Chords",
+          "page_range": [
+            12,
+            189
+          ],
+          "summary": "Triads (3-voice) and seventh chords (4-voice), each cataloged across all 18 environments in both Close and Spread positions.",
+          "key_phrases": [
+            "triad",
+            "seventh chord",
+            "three-voice",
+            "four-voice",
+            "diatonic voicing inventory"
+          ],
+          "engine_rules": [
+            {
+              "rule_id": "goodrick-triad-3voice-close-spread",
+              "name": "Triad Entries Are 3-Voice Objects in Both Close and Spread",
+              "when": {
+                "voicing.family": "triad",
+                "voicing.position": [
+                  "close",
+                  "spread"
+                ]
+              },
+              "then": {
+                "voicing.shape": "apply 3-voice intervallic/functional tables",
+                "voicing.functional_class": "assign root, 3rd, 5th"
+              },
+              "preference": "mandatory",
+              "quality_binding": [
+                "triad"
+              ],
+              "falsifier": "A triad entry with fewer than 3 or more than 3 distinct voices",
+              "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs — in both Close and Spread voicings",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-seventh-4voice-close-spread",
+              "name": "Seventh Chord Entries Are 4-Voice Objects in Both Close and Spread",
+              "when": {
+                "voicing.family": "seventh",
+                "voicing.position": [
+                  "close",
+                  "spread"
+                ]
+              },
+              "then": {
+                "voicing.shape": "apply 4-voice intervallic/functional tables",
+                "voicing.functional_class": "assign root, 3rd, 5th, 7th"
+              },
+              "preference": "mandatory",
+              "quality_binding": [
+                "seventh"
+              ],
+              "falsifier": "A seventh-chord entry with fewer than 4 or more than 4 distinct voices",
+              "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs — in both Close and Spread voicings",
+              "source_page": 12
+            },
+            {
+              "rule_id": "goodrick-cycle-rich-common-tones",
+              "name": "Common-Tone-Rich Cycles Yield Smoother Voice-Leading Automatically",
+              "when": {
+                "voicing.family": [
+                  "triad",
+                  "seventh"
+                ],
+                "cycle.id": [
+                  "cycle-4",
+                  "cycle-5"
+                ]
+              },
+              "then": {
+                "voicing.cycle_index": "expect one or more common tones per cycle step",
+                "voicing.msrp": "M.S.R.P. reflects predominantly stepwise or common-tone top-voice motion"
+              },
+              "preference": "descriptive",
+              "quality_binding": [
+                "triad",
+                "seventh"
+              ],
+              "falsifier": "A cycle-4 or cycle-5 cell where no voice carries interval 0",
+              "anchor": "some cycles (particularly cycles producing common-tone-rich motion) yield smooth voice-leading almost automatically",
+              "source_page": 12
+            }
+          ],
+          "paragraphs": []
+        },
+        {
+          "title": "TBN (Two-Note Base) Constructs",
+          "page_range": [
+            12,
+            189
+          ],
+          "summary": "Goodrick's TBN constructs — Two-Note Base Type I and Type II — extend the tertian catalog by pairing a two-note interval base with upper structure voices.",
+          "key_phrases": [
+            "TBN",
+            "Two-Note Base",
+            "TBN I",
+            "TBN II",
+            "upper structure"
+          ],
+          "engine_rules": [
+            {
+              "rule_id": "goodrick-tbn-same-analytical-layers",
+              "name": "TBN Constructs Receive All Three Analytical Layers Identically",
+              "when": {
+                "voicing.family": [
+                  "tbn-i",
+                  "tbn-ii"
+                ],
+                "voicing.position": [
+                  "close",
+                  "spread"
+                ]
+              },
+              "then": {
+                "voicing.cycle_index": "apply intervallic layer to TBN base and upper structure",
+                "voicing.functional_class": "assign functional labels to TBN voices",
+                "voicing.msrp": "read M.S.R.P. string identically to tertian procedure"
+              },
+              "preference": "mandatory",
+              "quality_binding": [
+                "tbn-i",
+                "tbn-ii"
+              ],
+              "falsifier": "A TBN entry that omits one of the three analytical layers",
+              "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs",
+              "source_page": 12
+            }
+          ],
+          "paragraphs": []
+        }
+      ]
+    },
+    {
+      "chapter": {
+        "n": 2,
+        "title": "VOLUME TWO: DO NOT NAME THAT CHORD",
+        "summary": "Applies the identical analytical framework of Volume One to quartal and cluster sonorities — 3-part quartal, 4-part quartal (six voicing types), and Spread Cluster (six voicing types) — across the same 18-environment grid.",
+        "key_phrases": [
+          "quartal voicing",
+          "cluster voicing",
+          "Spread Cluster",
+          "resist conventional chord naming",
+          "NCT harmonization",
+          "4-part fourths",
+          "3-part quartal",
+          "voicing type"
+        ]
+      },
+      "sections": [
+        {
+          "title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
+          "page_range": [
+            190,
+            378
+          ],
+          "summary": "Volume Two applies the 18-environment grid to quartal and cluster sonorities.",
+          "key_phrases": [
+            "3-part quartal",
+            "4-part quartal",
+            "six voicing types",
+            "Spread Cluster",
+            "18 environments"
+          ],
+          "engine_rules": [
+            {
+              "rule_id": "goodrick-quartal-same-18-env-grid",
+              "name": "Quartal and Cluster Voicings Use the Same 18-Environment Grid as Tertian",
+              "when": {
+                "voicing.family": [
+                  "3part-quartal",
+                  "4part-quartal",
+                  "spread-cluster"
+                ],
+                "cycle.id": [
+                  "cycle-2",
+                  "cycle-3",
+                  "cycle-4",
+                  "cycle-5",
+                  "cycle-6",
+                  "cycle-7"
+                ],
+                "scale.context": [
+                  "C Major",
+                  "C Melodic Minor",
+                  "C Harmonic Minor"
+                ]
+              },
+              "then": {
+                "voicing.cycle_index": "locate entry at (cycle.id × scale.context) cell",
+                "voicing.scale_context": "constrain analysis to parent scale"
+              },
+              "preference": "mandatory",
+              "quality_binding": [
+                "3part-quartal",
+                "4part-quartal",
+                "spread-cluster"
+              ],
+              "falsifier": "A quartal or cluster entry outside the 18-environment grid",
+              "anchor": "six cycles (cycles 2-7) and three parent scales (C Major, C Melodic Minor, and C Harmonic Minor)",
+              "source_page": 190
+            },
+            {
+              "rule_id": "goodrick-quartal-three-analytical-layers",
+              "name": "Quartal and Cluster Entries Receive All Three Analytical Layers",
+              "when": {
+                "voicing.family": [
+                  "3part-quartal",
+                  "4part-quartal",
+                  "spread-cluster"
+                ]
+              },
+              "then": {
+                "voicing.cycle_index": "apply intervallic layer",
+                "voicing.functional_class": "apply functional layer",
+                "voicing.msrp": "read M.S.R.P. string"
+              },
+              "preference": "mandatory",
+              "quality_binding": [
+                "3part-quartal",
+                "4part-quartal",
+                "spread-cluster"
+              ],
+              "falsifier": "A quartal or cluster entry that lacks one of the three layers",
+              "anchor": "Intervallic Voice-Leading (pitch relationships), Functional Voice-Leading (harmonic context)",
+              "source_page": 190
+            },
+            {
+              "rule_id": "goodrick-quartal-nct-resist-naming",
+              "name": "Quartal and Cluster Voicings Are Applied Without Requiring a Chord Name",
+              "when": {
+                "voicing.family": [
+                  "3part-quartal",
+                  "4part-quartal",
+                  "spread-cluster"
+                ],
+                "chord_quality": "ambiguous or unnameable by tertian convention"
+              },
+              "then": {
+                "voicing.functional_class": "do not force a tertian chord-quality label",
+                "voicing.shape": "select using (cycle, scale, position) tuple"
+              },
+              "preference": "required when chord_quality cannot be resolved",
+              "quality_binding": [],
+              "falsifier": "A quartal or cluster entry defined only in relation to an underlying tertian chord name",
+              "anchor": "the volume's strategic shift away from tertian harmony toward quartal and cluster sonorities that resist conventional chord naming",
+              "source_page": 190
+            },
+            {
+              "rule_id": "goodrick-4part-quartal-six-voicing-types",
+              "name": "4-Part Quartal Has Six Distinct Voicing Types",
+              "when": {
+                "voicing.family": "4part-quartal"
+              },
+              "then": {
+                "voicing.shape": "select one of six 4-part quartal voicing types"
+              },
+              "preference": "required",
+              "quality_binding": [
+                "4part-quartal"
+              ],
+              "falsifier": "Fewer than or more than six distinct 4-part quartal voicing types",
+              "anchor": "4-part quartal voicings across six distinct voicing types",
+              "source_page": 190
+            },
+            {
+              "rule_id": "goodrick-spread-cluster-six-types",
+              "name": "Spread Cluster Has Six Distinct Voicing Types",
+              "when": {
+                "voicing.family": "spread-cluster"
+              },
+              "then": {
+                "voicing.shape": "select one of six Spread Cluster voicing types"
+              },
+              "preference": "required",
+              "quality_binding": [
+                "spread-cluster"
+              ],
+              "falsifier": "Fewer than or more than six distinct Spread Cluster voicing types",
+              "anchor": "Spread Cluster voicings across six further types",
+              "source_page": 190
+            }
+          ],
+          "paragraphs": []
+        },
+        {
+          "title": "Unity of Voice-Leading Across Families",
+          "page_range": [
+            190,
+            378
+          ],
+          "summary": "By running every non-tertian voicing family through the same 18-environment grid, the Almanac proves voice-leading discipline is invariant across families.",
+          "key_phrases": [
+            "unity of voice-leading",
+            "proof by exhaustion",
+            "structural parallelism",
+            "contrapuntal obligation"
+          ],
+          "engine_rules": [
+            {
+              "rule_id": "goodrick-family-agnostic-vl-discipline",
+              "name": "Voice-Leading Discipline Is Invariant Across Sonority Families",
+              "when": {
+                "voicing.family": [
+                  "triad",
+                  "seventh",
+                  "tbn-i",
+                  "tbn-ii",
+                  "3part-quartal",
+                  "4part-quartal",
+                  "spread-cluster"
+                ]
+              },
+              "then": {
+                "voicing.cycle_index": "apply same motion-budget analysis regardless of family",
+                "voicing.functional_class": "track scale-degree or quartal-equivalent function using same logic"
+              },
+              "preference": "invariant",
+              "quality_binding": [],
+              "falsifier": "A voicing family requiring a fourth analytical layer or different grid",
+              "anchor": "quartal and cluster harmony is not a special case requiring special treatment. It obeys the same voice-leading discipline as tertian harmony",
+              "source_page": 190
+            },
+            {
+              "rule_id": "goodrick-family-switch-preserves-motion-budget-method",
+              "name": "Switching Voicing Family Does Not Change Motion-Budget Reading Procedure",
+              "when": {
+                "voicing.family": "any"
+              },
+              "then": {
+                "voicing.cycle_index": "read intervallic layer using same procedure regardless of family"
+              },
+              "preference": "required",
+              "quality_binding": [],
+              "falsifier": "A quartal or cluster entry where interval 0 cannot be identified using the same procedure",
+              "anchor": "By running 4-part fourths and spread cluster voicings through the same 18-environment grid, with the same three analytical layers, Goodrick enforces the insight that the guitarist's contrapuntal obligation does not change when the harmonic language does",
+              "source_page": 190
+            },
+            {
+              "rule_id": "goodrick-leap-budget-increases-with-leaner-common-tone-coverage",
+              "name": "Families With Fewer Common Tones Per Cycle Force Larger Leap Budgets",
+              "when": {
+                "voicing.family": [
+                  "3part-quartal",
+                  "4part-quartal",
+                  "spread-cluster"
+                ]
+              },
+              "then": {
+                "voicing.cycle_index": "expect larger or more frequent intervallic leaps",
+                "voicing.msrp": "M.S.R.P. reflects wider top-voice range"
+              },
+              "preference": "descriptive",
+              "quality_binding": [
+                "3part-quartal",
+                "4part-quartal",
+                "spread-cluster"
+              ],
+              "falsifier": null,
+              "anchor": "What changes across families is which voice carries the common tone, which voice steps by a second or third, and how large the remaining leaps must be",
+              "source_page": 190
+            },
+            {
+              "rule_id": "goodrick-msrp-quartal-top-voice-benchmark",
+              "name": "M.S.R.P. Is the Top-Voice Efficiency Benchmark for Quartal and Cluster Cycles",
+              "when": {
+                "voicing.family": [
+                  "3part-quartal",
+                  "4part-quartal",
+                  "spread-cluster"
+                ]
+              },
+              "then": {
+                "voicing.msrp": "use M.S.R.P. string as compact melodic handle on multi-voice contrapuntal event"
+              },
+              "preference": "tie-breaker",
+              "quality_binding": [
+                "3part-quartal",
+                "4part-quartal",
+                "spread-cluster"
+              ],
+              "falsifier": "A quartal or cluster entry where M.S.R.P. string is absent while equivalent tertian entry at same address has valid M.S.R.P.",
+              "anchor": "M.S.R.P. string indicating the Most Stepwise Resolution Pattern",
+              "source_page": 190
+            }
+          ],
+          "paragraphs": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
2 chapters, 7 sections, 23 engine_rules. Cycle-indexed 18-environment grid (6 cycles x 3 parent scales), close/spread parameterization, 3-layer analytical method (Intervallic / Functional / M.S.R.P.), TBN constructs, unity of voice-leading across families. Per #527.