### PR TITLE
feat(#527): engine-rules for Goodrick Almanac Vol 3 (30 rules)

### DIFF
--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-3/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-3/derived/engine-rules.json
@@ -1,0 +1,680 @@
+{
+  "master_id": "mick-goodrick",
+  "work_id": "almanac-vol-3",
+  "engine_rules": [
+    {
+      "rule_id": "goodrick-sus4-naming-3part",
+      "name": "Name 3-part stacked-fourth chords as sus4",
+      "when": {
+        "context": "naming_chord",
+        "voicing.family": "3-part-4ths"
+      },
+      "then": {
+        "voicing.naming_convention": "sus4_over_triad_root",
+        "voicing.label_form": "<root> [sus4]"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "clarity",
+        "convention"
+      ],
+      "falsifier": "A 3-part stacked-fourth chord is labelled with cumbersome alterations (e.g., 'B Diminished triad [no b3rd] add b9') or C2 shorthand instead of the sus4 form.",
+      "anchor": "My suggestion for a suitable name for this chord would be: G [sus4]. That means a G Major triad with 4 suspended for 3.",
+      "source_page": 4,
+      "source_chapter": 2
+    },
+    {
+      "rule_id": "goodrick-sus4-naming-4part",
+      "name": "Name 4-part stacked-fourth chords as sus4",
+      "when": {
+        "context": "naming_chord",
+        "voicing.family": "4-part-4ths"
+      },
+      "then": {
+        "voicing.naming_convention": "sus4_over_triad_root"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "clarity",
+        "convention"
+      ],
+      "falsifier": "A 4-part 4ths voicing is labelled as 'C Major 7th [no 5] substitute 4 for the missing 5th' rather than as a sus4 chord.",
+      "anchor": "NAMES FOR 4-PART 4THS This is fairly simple: Sus 4 Chords...[I think it's the best way to go...]",
+      "source_page": 4,
+      "source_chapter": 2
+    },
+    {
+      "rule_id": "goodrick-event-vs-episode",
+      "name": "Classify diatonic passages as event or episode by pitch-class content",
+      "when": {
+        "context": "analyze_passage",
+        "passage.scale_type": "diatonic"
+      },
+      "then": {
+        "passage.category": "event_if_2to6_notes_else_episode",
+        "passage.length_independence": true
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "analytic_precision"
+      ],
+      "falsifier": "A passage is classified as event vs. episode based on its temporal length rather than the count of distinct diatonic notes it contains.",
+      "anchor": "EVENT involves 2-6 diatonic scale notes at least once each. EPISODE involves all 7 diatonic scale notes at least once each.",
+      "source_page": 3,
+      "source_chapter": 2
+    },
+    {
+      "rule_id": "goodrick-event-diatonic-transposition",
+      "name": "Diatonically transposed events may collapse to intervallic identity",
+      "when": {
+        "context": "diatonic_transpose",
+        "passage.category": "event"
+      },
+      "then": {
+        "passage.transposition_yields": "up_to_6_other_events",
+        "passage.intervallic_identity": "possible_collapse"
+      },
+      "preference": "advisory",
+      "quality_binding": [
+        "analytic_precision"
+      ],
+      "falsifier": "Two diatonic transpositions of an event are treated as distinct sonorities when their interval structures are identical.",
+      "anchor": "an event can be diatonically transposed to create 6 other events, but some of them will be intervallically identical.",
+      "source_page": 3,
+      "source_chapter": 2
+    },
+    {
+      "rule_id": "goodrick-episode-diatonic-transposition",
+      "name": "Diatonically transposed episodes correspond to the seven modes",
+      "when": {
+        "context": "diatonic_transpose",
+        "passage.category": "episode"
+      },
+      "then": {
+        "passage.transposition_yields": "6_other_episodes_each_a_mode"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "analytic_precision"
+      ],
+      "falsifier": "An episode's transpositions are claimed to share the same mode rather than mapping one-to-one onto the seven diatonic modes.",
+      "anchor": "an episode can be diatonically transposed to create 6 other episodes, where each corresponds to a different mode.",
+      "source_page": 3,
+      "source_chapter": 2
+    },
+    {
+      "rule_id": "goodrick-spread-cluster-literal-pitch-naming",
+      "name": "Name 3-part spread clusters by literal pitch content",
+      "when": {
+        "context": "naming_chord",
+        "voicing.family": "3-part-spread-clusters"
+      },
+      "then": {
+        "voicing.naming_convention": "literal_pitch_list",
+        "voicing.label_form": "<P1> <P2> <P3>"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "clarity",
+        "convention"
+      ],
+      "falsifier": "A 3-part spread cluster (e.g., the set C D E) is forced into a chord symbol like 'C Major 9 (no 5, no 7)' rather than written as 'C D E'.",
+      "anchor": "Here’s what I think...Just name it like itis! CallitC DE\"! [Daa!!!]",
+      "source_page": 6,
+      "source_chapter": 3
+    },
+    {
+      "rule_id": "goodrick-real-compleat-m-lode-pairing",
+      "name": "M-Lode pairs each 3-part family with exactly one 4-part counterpart",
+      "when": {
+        "context": "navigate_voicing_families",
+        "voicing.density_axis": "3_to_4_or_4_to_3"
+      },
+      "then": {
+        "voicing.family_pair_map": {
+          "triads": "7th-chords",
+          "7th-no-3rd": "TBN-I",
+          "7th-no-5th": "TBN-II",
+          "3-part-4ths": "4-part-4ths",
+          "3-part-spread-clusters": "4-part-spread-clusters"
+        }
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "family_coherence",
+        "completeness"
+      ],
+      "falsifier": "A 3-part family is mapped to a 4-part counterpart outside of the five canonical pairings (e.g., triads paired with TBN I).",
+      "anchor": "So, the REAL, COMPLEAT M-LODE depiction is: 3-Part Structures 4-Part Structures Triads (VolumelI) — 7th Chords 7th (no 3rd) TBNI 7th (no 5th) TBN IE 3-Part 4ths (Volume II) 4-Part 4ths 3-part Spread Clusters| Spread Clusters",
+      "source_page": 7,
+      "source_chapter": 3
+    },
+    {
+      "rule_id": "goodrick-triad-interval-content",
+      "name": "Triad family interval content excludes 2nds and 7ths",
+      "when": {
+        "context": "classify_3part_chord",
+        "voicing.candidate_family": "triad"
+      },
+      "then": {
+        "voicing.family": "triads",
+        "voicing.interval_profile": "mostly_3rds_6ths_some_4ths_5ths_no_2nds_no_7ths"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "family_coherence"
+      ],
+      "falsifier": "A 3-part chord containing a 2nd or a 7th between any voice pair is classified as a triad in the M-Lode sense.",
+      "anchor": "The triads primarily consist of 3rds and 6ths with some 4ths and 5ths, but contain no 2nds or 7ths.",
+      "source_page": 8,
+      "source_chapter": 4
+    },
+    {
+      "rule_id": "goodrick-3part-4ths-interval-content",
+      "name": "3-part 4ths family interval content excludes 3rds and 6ths",
+      "when": {
+        "context": "classify_3part_chord",
+        "voicing.candidate_family": "3-part-4ths"
+      },
+      "then": {
+        "voicing.family": "3-part-4ths",
+        "voicing.interval_profile": "mostly_4ths_5ths_some_2nds_7ths_no_3rds_no_6ths"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "family_coherence"
+      ],
+      "falsifier": "A 3-part chord containing a 3rd or a 6th between any voice pair is classified as a 3-part 4ths voicing.",
+      "anchor": "While the 3-part 4ths primar- ily consist of 4ths and 5ths with some 2nds and 7ths, but contain no 3rds or 6ths.",
+      "source_page": 8,
+      "source_chapter": 4
+    },
+    {
+      "rule_id": "goodrick-omission-allowed-families",
+      "name": "Interval omission is restricted to triads, 3-part 4ths, and spread clusters",
+      "when": {
+        "context": "derive_voicing",
+        "voicing.candidate_family": "any"
+      },
+      "then": {
+        "voicing.omission_allowed_in": [
+          "triads",
+          "3-part-4ths",
+          "3-part-spread-clusters"
+        ]
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "family_coherence"
+      ],
+      "falsifier": "Interval omission is treated as defining a member of the 7th-no-3rd, 7th-no-5th, TBN I, or TBN II family rather than as a structural property of triads / 3-part 4ths / spread clusters.",
+      "anchor": "the omission of interval types only occurs within particular 3-part chord families (triad; 3-part 4th; spread cluster).",
+      "source_page": 8,
+      "source_chapter": 4
+    },
+    {
+      "rule_id": "goodrick-four-family-even-distribution",
+      "name": "Prefer even-distribution families when crossing 3-part / 4-part density",
+      "when": {
+        "context": "select_family",
+        "voicing.density_axis": "crossing_3_and_4"
+      },
+      "then": {
+        "voicing.preferred_families": [
+          "7th-no-3rd",
+          "7th-no-5th",
+          "TBN-I",
+          "TBN-II"
+        ],
+        "voicing.symmetry_basis": "even_interval_distribution"
+      },
+      "preference": "moderate",
+      "quality_binding": [
+        "symmetry"
+      ],
+      "falsifier": "When the goal is consistent interval distribution across 3- and 4-part voicings, a non-even-distribution family (triad, 3-part 4ths, or spread cluster) is selected over the four even-distribution families.",
+      "anchor": "the four chord families with the most even distribution are found both in 3- and 4-part chords (7th, no3rd; 7th, no5th; TBN I; TBN ID).",
+      "source_page": 8,
+      "source_chapter": 4
+    },
+    {
+      "rule_id": "goodrick-derive-3part-from-4part-voice-omission",
+      "name": "Derive 3-part voicings by omitting exactly one voice from a 4-part parent",
+      "when": {
+        "context": "derive_voicing",
+        "voicing.parent_4part": "any",
+        "voicing.target_density": "3-part"
+      },
+      "then": {
+        "voicing.derivation_path": "omit_one_voice_from_4part_parent",
+        "voicing.family": "determined_by_omitted_voice"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "derivation"
+      ],
+      "falsifier": "A 3-part voicing in the M-Lode framework is generated by omitting two voices, by adding a voice to a 2-part structure, or by any method other than single-voice omission from a 4-part parent.",
+      "anchor": "What follows is a brief, introductory study of how to arrive at different 3-part chords by leaving out one voice of a 4-part chord.",
+      "source_page": 9,
+      "source_chapter": 5
+    },
+    {
+      "rule_id": "goodrick-7th-chord-generates-two-triads",
+      "name": "A 4-part 7th chord generates the 7th-no-3rd and 7th-no-5th 3-part triads",
+      "when": {
+        "context": "derive_voicing",
+        "voicing.parent_4part": "7th-chord"
+      },
+      "then": {
+        "voicing.derivation_products": [
+          "7th-no-3rd",
+          "7th-no-5th"
+        ],
+        "voicing.family": "one_of_the_two_products"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "derivation"
+      ],
+      "falsifier": "A 4-part 7th chord is claimed to derive a 3-part voicing other than 7th-no-3rd or 7th-no-5th by single-voice omission.",
+      "anchor": "7th chord generates _ two different triads, 7th (no 3rd), 7th (no 5th)",
+      "source_page": 9,
+      "source_chapter": 5
+    },
+    {
+      "rule_id": "goodrick-each-3part-in-four-4part-families",
+      "name": "Each 3-part chord appears inside exactly four different 4-part families",
+      "when": {
+        "context": "reharmonize",
+        "voicing.target_density": "3-part"
+      },
+      "then": {
+        "voicing.parent_4part_candidates_count": 4,
+        "voicing.reharmonization_lattice": "four_family_substitution"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "symmetry",
+        "reharmonization"
+      ],
+      "falsifier": "A 3-part chord is treated as embeddable in only one 4-part parent family, or in a number of parents other than four.",
+      "anchor": "[Each 3-part chord appears four times...]",
+      "source_page": 9,
+      "source_chapter": 5
+    },
+    {
+      "rule_id": "goodrick-35-structure-roadmap",
+      "name": "The chapter's five worked structures sit at positions 1, 8, 15, 22, 29 of the 35-structure taxonomy",
+      "when": {
+        "context": "extend_method",
+        "voicing.parent_4part": "any",
+        "voicing.taxonomy_position": "indexed"
+      },
+      "then": {
+        "voicing.taxonomy_size": 35,
+        "voicing.worked_examples_at": [
+          1,
+          8,
+          15,
+          22,
+          29
+        ],
+        "voicing.remaining_to_explore": 30
+      },
+      "preference": "advisory",
+      "quality_binding": [
+        "completeness"
+      ],
+      "falsifier": "The five worked CMaj7 examples are claimed to exhaust the derivation taxonomy rather than to sample positions 1, 8, 15, 22, 29 of 35.",
+      "anchor": "the five examples used in the present chapter (CMaj7, C, C, C, C ) correspond to numbers 1, 8, 15, 22 and 29. That means that there are only thirty more 4-part structures to explore in the present fashion!",
+      "source_page": 9,
+      "source_chapter": 5
+    },
+    {
+      "rule_id": "goodrick-drop-toolkit-tbn",
+      "name": "Apply Drop 2 / Drop 3 / Drop 2&3 / Drop 2&4 / Double Drop 2 Drop 3 across TBN parents and inversions",
+      "when": {
+        "context": "derive_voicing",
+        "voicing.parent_4part": "TBN-I_or_TBN-II"
+      },
+      "then": {
+        "voicing.derivation_path": "drop_procedures_across_root_and_inversions",
+        "voicing.drop_toolkit": [
+          "Drop 2",
+          "Drop 3",
+          "Drop 2&3",
+          "Drop 2&4",
+          "Double Drop 2 Drop 3"
+        ]
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "derivation"
+      ],
+      "falsifier": "A TBN I or TBN II parent is derived to 3-part children using a procedure outside the named drop toolkit (e.g., random voice transposition) without justification.",
+      "anchor": "3-Part Chords Derived From a TBN I",
+      "source_page": 10,
+      "source_chapter": 6
+    },
+    {
+      "rule_id": "goodrick-c-major-default-with-transposition-expectation",
+      "name": "Present material in C Major, expect transposition to melodic and harmonic minor",
+      "when": {
+        "context": "voice_lead_in_scale",
+        "scale.presentation_default": "C_Major"
+      },
+      "then": {
+        "voicing.transposition_targets": [
+          "C melodic minor",
+          "C harmonic minor"
+        ],
+        "voicing.student_obligation": "adjust_to_other_7_note_scales"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "coverage"
+      ],
+      "falsifier": "Material is treated as valid only in C Major, with no expectation that the student extend it to melodic or harmonic minor.",
+      "anchor": "All of the material that follows in this next section will be presented in C Major (no accidentals). The assumption is that our readers will have (by now) developed the necessary skills to make the needed adjustments to change the material to other 7-note scales.",
+      "source_page": 14,
+      "source_chapter": 10
+    },
+    {
+      "rule_id": "goodrick-generic-vl-six-pattern-space",
+      "name": "Six generic A-B-C voice-leading patterns exist; explore the three alternates",
+      "when": {
+        "context": "select_voice_leading",
+        "voicing.target_density": "3-part_or_4-part",
+        "scale.notes": 7
+      },
+      "then": {
+        "voicing.generic_vl_pattern_space": 6,
+        "voicing.previously_used_in_vols_1_2": 3,
+        "voicing.alternates_to_explore": 3
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "coverage",
+        "innovation"
+      ],
+      "falsifier": "Voice-leading exploration is restricted to the three patterns used in Volumes I and II without ever considering the three new alternates.",
+      "anchor": "Note: Only 3 different generic voice-leadings were used out of 6!",
+      "source_page": 56,
+      "source_chapter": 10
+    },
+    {
+      "rule_id": "goodrick-abc-label-key",
+      "name": "Use abstract A-B-C labels for chord-tone strands in generic VL formulas",
+      "when": {
+        "context": "analyze_voice_leading",
+        "voicing.analysis_mode": "generic"
+      },
+      "then": {
+        "voicing.strand_labels": {
+          "A": "1st_note",
+          "B": "2nd_note",
+          "C": "3rd_note"
+        },
+        "voicing.analysis_mode": "cycle_independent"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "analytic_precision"
+      ],
+      "falsifier": "Generic voice-leading formulas are analyzed using scale-degree numbers rather than the abstract A/B/C strand labels, collapsing cycle independence.",
+      "anchor": "Key: A= Ist note B = 2nd note C = 3rd note",
+      "source_page": 55,
+      "source_chapter": 10
+    },
+    {
+      "rule_id": "goodrick-intervallic-vs-functional-msrp",
+      "name": "Distinguish intervallic voice-leading from functional voice-leading via M.S.R.P.",
+      "when": {
+        "context": "analyze_voice_leading"
+      },
+      "then": {
+        "voicing.analysis_axes": [
+          "intervallic_motion",
+          "functional_strand"
+        ],
+        "voicing.functional_anchor": "M.S.R.P.",
+        "voicing.cycle_voices_count": 2
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "analytic_precision"
+      ],
+      "falsifier": "Voice-leading is described only by interval distance per voice, without identifying which voices form the M.S.R.P. cycle and which carry the chord-tone strands.",
+      "anchor": "Functional Voice-Leading 1 7 3 5 Ascends 2 different voicing alternate (drop 3; drop 2 & 4) 2 voices are the cycle M.S.R.P.",
+      "source_page": 32,
+      "source_chapter": 10
+    },
+    {
+      "rule_id": "goodrick-duet-texture-passing-tones",
+      "name": "Split 4-part voicings into top-2 / bottom-2 duets and add passing tones",
+      "when": {
+        "context": "elaborate_texture",
+        "voicing.target_density": "4-part"
+      },
+      "then": {
+        "voicing.texture_split": [
+          "top_2",
+          "bottom_2"
+        ],
+        "voicing.embellishment": "add_passing_tones",
+        "voicing.stylistic_preference": "harmonic_minor"
+      },
+      "preference": "moderate",
+      "quality_binding": [
+        "voice_leading",
+        "texture"
+      ],
+      "falsifier": "A 4-part voicing is elaborated by adding passing tones across all four voices simultaneously rather than via the top-2 / bottom-2 duet split.",
+      "anchor": "4-part; no passing tones Duet (top 2, bottom 2); add p.t.. ¢ NICE in Harmonic minor!",
+      "source_page": 43,
+      "source_chapter": 10
+    },
+    {
+      "rule_id": "goodrick-twenty-3part-from-three-scales",
+      "name": "Twenty foundational 3-part chord types derive from Major, Melodic Minor, Harmonic Minor transposed to C",
+      "when": {
+        "context": "build_chord_vocabulary",
+        "voicing.target_density": "3-part"
+      },
+      "then": {
+        "voicing.foundation_types": 20,
+        "voicing.source_scales": [
+          "C major",
+          "C melodic minor",
+          "C harmonic minor"
+        ],
+        "voicing.distinct_voicings_with_inversions": 120
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "completeness"
+      ],
+      "falsifier": "The twenty foundational 3-part chord types are sourced from any scale outside Major / Melodic Minor / Harmonic Minor, or the close+spread inversion expansion is reported as a count other than 120.",
+      "anchor": "All of the following 3-part chords are derived from the Major scale, the Melodic Minor and the Harmonic Minor scales, but they are transposed to the root of C. (Twenty 3-part chords is perhaps misleading...3 close inversions plus 3 spread inversions for each gives us one hundred twenty 3-part chords you should know...)",
+      "source_page": 71,
+      "source_chapter": 11
+    },
+    {
+      "rule_id": "goodrick-prefer-3part-on-guitar",
+      "name": "Prefer 3-part chords on guitar for playability and embellishment space",
+      "when": {
+        "context": "choose_voicing_density",
+        "instrument": "guitar"
+      },
+      "then": {
+        "voicing.preferred_density": "3-part",
+        "voicing.rationale": [
+          "playability",
+          "melodic_embellishment_space"
+        ]
+      },
+      "preference": "moderate",
+      "quality_binding": [
+        "playability",
+        "voice_leading"
+      ],
+      "falsifier": "On guitar, 4-part voicings are recommended over 3-part voicings without acknowledging the reduced embellishment space and increased fingering difficulty.",
+      "anchor": "As guitarists, we can see that 3-part chords are easier to play than 4-part chords. Also, they often afford more space between the voices for melodic embellishment.",
+      "source_page": 71,
+      "source_chapter": 11
+    },
+    {
+      "rule_id": "goodrick-grip-slipping-inversion-cycle",
+      "name": "Use Grip-Slipping (Drop 3 in a six-tonic whole-tone system) to learn all inversions",
+      "when": {
+        "context": "learn_inversions",
+        "voicing.target_density": "4-part"
+      },
+      "then": {
+        "voicing.derivation_path": "grip_slipping_whole_tone_cycle",
+        "voicing.primary_voicing": "Drop 3",
+        "voicing.alternate_voicings": [
+          "Drop 2",
+          "Drop 2&4"
+        ]
+      },
+      "preference": "moderate",
+      "quality_binding": [
+        "coverage",
+        "fluency"
+      ],
+      "falsifier": "Grip-Slipping is presented as using a voicing type other than Drop 3 by default, or it omits the six-tonic / whole-tone organizing system.",
+      "anchor": "\"Grip-Slipping\" is a term I use to describe a series of exercises that I sometimes give to my guitar students to help them learn all the inversions of different chords. Without giving away too many \"secrets,\" I've included six examples incorporating seventh chords in a six tonic system (whole tone scale). The voicing type is Drop 3. (You might try Drop 2 and Drop 2 & 4 as well...)",
+      "source_page": 161,
+      "source_chapter": 12
+    },
+    {
+      "rule_id": "goodrick-gdvl-vs-scvl-mode-switch",
+      "name": "Volumes I and II use GDVL; Grip-Slipping IVL/FVL examples are SCVL",
+      "when": {
+        "context": "classify_voice_leading_mode"
+      },
+      "then": {
+        "voicing.vl_mode_for_vols_1_2": "GDVL",
+        "voicing.vl_mode_for_grip_slipping": "SCVL",
+        "voicing.scvl_includes": [
+          "IVL",
+          "FVL"
+        ]
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "analytic_precision"
+      ],
+      "falsifier": "Volumes I and II are described as using SCVL, or Grip-Slipping IVL/FVL exercises are classified as GDVL.",
+      "anchor": "P.S. The IVLs and the FVLs are all examples of SCVL (specific chromatic voice-leading), as opposed to GDVL (generic diatonic voice-leading), which is all of Volumes 1 & 2.",
+      "source_page": 161,
+      "source_chapter": 12
+    },
+    {
+      "rule_id": "goodrick-harmonic-major-b6-substitution",
+      "name": "Convert C Major material to Harmonic Major by substituting Ab for A (b6)",
+      "when": {
+        "context": "scale_substitution",
+        "scale.source": "C_major"
+      },
+      "then": {
+        "voicing.scale_target": "C_harmonic_major_Ionian_b6",
+        "voicing.pitch_substitution": "Ab_for_A"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "coverage"
+      ],
+      "falsifier": "Conversion from C Major to Harmonic Major is performed by altering a degree other than the 6th (e.g., flatting the 3rd).",
+      "anchor": "Harmonic Major...a major scale with b6...(sometimes named Ionian b6.) Ail of the “red pages” in Volumes 1 & 2 can be used with this very interesting variation: just play Ab (b6) instead of A (6).",
+      "source_page": 145,
+      "source_chapter": 12
+    },
+    {
+      "rule_id": "goodrick-hungarian-minor-sharp4-substitution",
+      "name": "Convert C Harmonic Minor material to Hungarian Minor by raising the 4th",
+      "when": {
+        "context": "scale_substitution",
+        "scale.source": "C_harmonic_minor"
+      },
+      "then": {
+        "voicing.scale_target": "C_hungarian_minor",
+        "voicing.pitch_substitution": "F#_for_F"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "coverage"
+      ],
+      "falsifier": "Conversion from Harmonic Minor to Hungarian Minor is performed without raising the 4th, or by altering a different degree.",
+      "anchor": "Hungarian Minor...a harmonic minor scale with #4..|C D E}FEG AbBC |.",
+      "source_page": 145,
+      "source_chapter": 12
+    },
+    {
+      "rule_id": "goodrick-five-scale-framework",
+      "name": "Present advanced M-Lode material across five parent scales",
+      "when": {
+        "context": "voice_lead_in_scale",
+        "scale.framework": "five_scale"
+      },
+      "then": {
+        "voicing.scale_set": [
+          "C major",
+          "C melodic minor",
+          "C harmonic minor",
+          "C harmonic major (Ionian b6)",
+          "C hungarian minor (harmonic minor #4)"
+        ]
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "coverage"
+      ],
+      "falsifier": "Advanced M-Lode material is restricted to three scales (Major, Melodic Minor, Harmonic Minor) and never extended to Harmonic Major or Hungarian Minor.",
+      "anchor": "We present it in 5 scales: 1. C Major 2. C Melodic Minor 3. C Harmonic Minor 4. C Harmonic Major (C Ionian b6) 5. C Hungarian Minor (C Harmonic Minor #4)",
+      "source_page": 145,
+      "source_chapter": 12
+    },
+    {
+      "rule_id": "goodrick-melody-harmony-equality",
+      "name": "Voice-leading must treat melody and harmony as structural equals",
+      "when": {
+        "context": "voice_lead_any"
+      },
+      "then": {
+        "voicing.aesthetic_principle": "melody_and_harmony_equal",
+        "voicing.subordination": "neither"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "aesthetic",
+        "voice_leading"
+      ],
+      "falsifier": null,
+      "anchor": "I feel that excellent voice-leading treats both melody and harmony as equals.",
+      "source_page": 188,
+      "source_chapter": 12
+    },
+    {
+      "rule_id": "goodrick-spread-clusters-close-the-taxonomy",
+      "name": "Spread Clusters are the missing link that makes the M-Lode finite",
+      "when": {
+        "context": "taxonomy_closure",
+        "voicing.target_density": "4-part"
+      },
+      "then": {
+        "voicing.closing_family": "4-part-spread-clusters",
+        "voicing.taxonomy_status": "finite_and_complete"
+      },
+      "preference": "strong",
+      "quality_binding": [
+        "completeness"
+      ],
+      "falsifier": "The 4-part chord taxonomy is treated as open-ended without recognizing 4-Part Spread Clusters as the closing family.",
+      "anchor": "I had completely overlooked SPREAD CLUSTERS! I did some more musical math and real- ized that this was the missing link! It not only completed the set of 4-part chords, but it helped me to realize that this WORK was not only finite, but do-able!",
+      "source_page": 189,
+      "source_chapter": 12
+    }
+  ]
+}


### PR DESCRIPTION
Engine-rules artifact for #527 (quantitative model of master harmonization).

- Adds plugin/data/masters-corpus/<master>/<work>/derived/engine-rules.json
- Schema: {master_id, work_id, engine_rules: [{rule_id, name, when, then, preference, quality_binding, falsifier, anchor, source_page}]}
- Distilled from systems-draft + PRESCRIPTIVE + prescriptive-lessons-draft
- Each rule has a verbatim anchor quote from source

Closes part of #527 (Goodrick Almanac Vol 3).