### PR TITLE
fix(#527): rename rules→engine_rules in 4 engine-rules.json files

### DIFF
--- a/plugin/data/masters-corpus/barry-harris/jazz-workshop/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/barry-harris/jazz-workshop/derived/engine-rules.json
@@ -3,7 +3,7 @@
   "work": "jazz-workshop",
   "schema_version": "0.1",
   "count": 38,
-  "rules": [
+  "engine_rules": [
     {
       "rule_id": "harris-technique-musical-context",
       "name": "Technique requires musical context",

--- a/plugin/data/masters-corpus/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
@@ -5,14 +5,23 @@
   "source_pdf": "Ligon, Bert - Connecting Chords with Linear Harmony.pdf",
   "run_id": "2026-06-12T09-48-05-ligon-connecting-chords",
   "rule_id_prefix": "ligon-",
-  "rules": [
+  "engine_rules": [
     {
       "rule_id": "ligon-prefer-harmonic-specificity",
       "name": "Prefer harmonically specific tones over generalization",
-      "when": {"context": "improvising_single_line", "over_progression": "any_functional"},
-      "then": {"line.preference": "harmonic_specificity", "line.target_tone": "chord_third_or_seventh"},
+      "when": {
+        "context": "improvising_single_line",
+        "over_progression": "any_functional"
+      },
+      "then": {
+        "line.preference": "harmonic_specificity",
+        "line.target_tone": "chord_third_or_seventh"
+      },
       "preference": "strong",
-      "quality_binding": ["specificity", "clarity"],
+      "quality_binding": [
+        "specificity",
+        "clarity"
+      ],
       "falsifier": "Line outlines the chord with non-chord-tones on strong beats while skipping 3rd/7th entirely.",
       "anchor": "Harmonic Specificity: Careful attention to the implications of harmony. Reliance on proper thirds, sevenths resolving appropriately.",
       "source_page": 1,
@@ -21,10 +30,18 @@
     {
       "rule_id": "ligon-vagueness-is-informed-choice",
       "name": "Deliberate harmonic vagueness requires knowing what to avoid",
-      "when": {"context": "improvising_single_line", "stance": "harmonic_generalization_or_avoidance"},
-      "then": {"line.preference": "informed_avoidance", "line.target_tone": "non_harmonic_chosen_with_awareness"},
+      "when": {
+        "context": "improvising_single_line",
+        "stance": "harmonic_generalization_or_avoidance"
+      },
+      "then": {
+        "line.preference": "informed_avoidance",
+        "line.target_tone": "non_harmonic_chosen_with_awareness"
+      },
       "preference": "advisory",
-      "quality_binding": ["intentionality"],
+      "quality_binding": [
+        "intentionality"
+      ],
       "falsifier": "Player avoids chord tones without being able to name the 3rd/7th they are avoiding.",
       "anchor": "When an experienced jazz improviser plays deliberately vague, he does so knowing the harmonic implications, and therefore knowing just what tones to avoid.",
       "source_page": 2,
@@ -33,10 +50,18 @@
     {
       "rule_id": "ligon-linear-not-vertical",
       "name": "Analyze and construct lines linearly, not vertically",
-      "when": {"context": "constructing_or_analyzing_line", "across": "barlines"},
-      "then": {"line.analysis_mode": "linear_across_time", "line.metric_placement": "honor_anticipation_and_suspension"},
+      "when": {
+        "context": "constructing_or_analyzing_line",
+        "across": "barlines"
+      },
+      "then": {
+        "line.analysis_mode": "linear_across_time",
+        "line.metric_placement": "honor_anticipation_and_suspension"
+      },
       "preference": "strong",
-      "quality_binding": ["voice_leading"],
+      "quality_binding": [
+        "voice_leading"
+      ],
       "falsifier": "Note over barline is judged dissonant by vertical snapshot without considering anticipation or suspension.",
       "anchor": "Do not fall into the trap of labeling everything by its vertical arrangement. Music is heard and conceived in a linear manner and should be studied in the same way.",
       "source_page": 4,
@@ -45,10 +70,19 @@
     {
       "rule_id": "ligon-bass-as-counterpoint-reference",
       "name": "Choose melodic notes against the bass line, not piano voicings",
-      "when": {"context": "improvising_single_line", "rhythm_section": "any"},
-      "then": {"line.reference": "bass_line", "line.target_tone": "counterpoint_against_bass"},
+      "when": {
+        "context": "improvising_single_line",
+        "rhythm_section": "any"
+      },
+      "then": {
+        "line.reference": "bass_line",
+        "line.target_tone": "counterpoint_against_bass"
+      },
       "preference": "strong",
-      "quality_binding": ["independence", "voice_leading"],
+      "quality_binding": [
+        "independence",
+        "voice_leading"
+      ],
       "falsifier": "Note selection assumes a particular piano voicing rather than the bass pitch.",
       "anchor": "The experienced jazz improviser does not depend on a piano playing chords for his lines to make sense. The lines make sense because of well chosen and well placed notes in relation to the bass line.",
       "source_page": 5,
@@ -57,10 +91,19 @@
     {
       "rule_id": "ligon-omit-root-from-line",
       "name": "Omit the root from the improvised line because the bass covers it",
-      "when": {"context": "improvising_single_line", "bass_plays": "root"},
-      "then": {"line.exclude_pitch_class": "chord_root", "line.candidate_pool": "remaining_11_pitches"},
+      "when": {
+        "context": "improvising_single_line",
+        "bass_plays": "root"
+      },
+      "then": {
+        "line.exclude_pitch_class": "chord_root",
+        "line.candidate_pool": "remaining_11_pitches"
+      },
       "preference": "moderate",
-      "quality_binding": ["counterpoint", "specificity"],
+      "quality_binding": [
+        "counterpoint",
+        "specificity"
+      ],
       "falsifier": "Root is played in the line on a strong beat solely because it is the chord root.",
       "anchor": "if the roots are sounding in the bass and the melody there is no counter point, just parallel octaves, Eliminating the root leaves eleven other notes to choose from",
       "source_page": 5,
@@ -69,10 +112,19 @@
     {
       "rule_id": "ligon-third-as-primary-target",
       "name": "Target the 3rd as the most harmonically specific tone",
-      "when": {"context": "improvising_single_line", "metric_position": "strong_beat"},
-      "then": {"line.target_tone": "chord_third", "line.metric_placement": "downbeat"},
+      "when": {
+        "context": "improvising_single_line",
+        "metric_position": "strong_beat"
+      },
+      "then": {
+        "line.target_tone": "chord_third",
+        "line.metric_placement": "downbeat"
+      },
       "preference": "strong",
-      "quality_binding": ["specificity", "clarity"],
+      "quality_binding": [
+        "specificity",
+        "clarity"
+      ],
       "falsifier": "Strong beat over a chord lands on a non-3rd/7th and no other guide tone is voice-led in.",
       "anchor": "F reveals the minor quality of the chord and is the best choice for harmonically specific counterpoint over the D in the bass.",
       "source_page": 5,
@@ -81,10 +133,21 @@
     {
       "rule_id": "ligon-seventh-resolves-to-third",
       "name": "Resolve the 7th of one chord down to the 3rd of the next",
-      "when": {"context": "voice_leading", "progression": "root_motion_down_a_fifth", "current_chord_tone": "seventh"},
-      "then": {"line.target_tone": "third_of_next_chord", "line.approach_method": "stepwise_down", "line.metric_placement": "next_downbeat"},
+      "when": {
+        "context": "voice_leading",
+        "progression": "root_motion_down_a_fifth",
+        "current_chord_tone": "seventh"
+      },
+      "then": {
+        "line.target_tone": "third_of_next_chord",
+        "line.approach_method": "stepwise_down",
+        "line.metric_placement": "next_downbeat"
+      },
       "preference": "strong",
-      "quality_binding": ["voice_leading", "specificity"],
+      "quality_binding": [
+        "voice_leading",
+        "specificity"
+      ],
       "falsifier": "7th leaps up or jumps to a non-3rd on the next chord while a stepwise resolution to the 3rd was available.",
       "anchor": "the 7th of chords in these progressions resolve downward to the third of the following chord. The seventh is the pointer.",
       "source_page": 5,
@@ -93,10 +156,18 @@
     {
       "rule_id": "ligon-ninth-resolves-to-fifth",
       "name": "Resolve the 9th down to the 5th",
-      "when": {"context": "voice_leading", "current_chord_tone": "ninth"},
-      "then": {"line.target_tone": "fifth_of_same_or_next_chord", "line.approach_method": "stepwise_down"},
+      "when": {
+        "context": "voice_leading",
+        "current_chord_tone": "ninth"
+      },
+      "then": {
+        "line.target_tone": "fifth_of_same_or_next_chord",
+        "line.approach_method": "stepwise_down"
+      },
       "preference": "moderate",
-      "quality_binding": ["voice_leading"],
+      "quality_binding": [
+        "voice_leading"
+      ],
       "falsifier": "9th leaps away with no resolution to the 5th anywhere in the phrase.",
       "anchor": "Good voice leading is observed; sevenths resolve to thirds, ninths to fifths.",
       "source_page": 6,
@@ -105,10 +176,17 @@
     {
       "rule_id": "ligon-third-before-seventh",
       "name": "Place the 3rd earlier in the line, the 7th later",
-      "when": {"context": "constructing_outline_phrase"},
-      "then": {"line.metric_placement": "third_on_beat_one_seventh_on_beat_four", "line.approach_method": "stepwise"},
+      "when": {
+        "context": "constructing_outline_phrase"
+      },
+      "then": {
+        "line.metric_placement": "third_on_beat_one_seventh_on_beat_four",
+        "line.approach_method": "stepwise"
+      },
       "preference": "moderate",
-      "quality_binding": ["voice_leading"],
+      "quality_binding": [
+        "voice_leading"
+      ],
       "falsifier": "Phrase opens on the 7th with the 3rd appearing only after the chord changes.",
       "anchor": "Thirds are more consonant and usually occur earlier in a melody line before the more dissonant sevenths.",
       "source_page": 6,
@@ -117,10 +195,22 @@
     {
       "rule_id": "ligon-outline-1-stepwise-descent",
       "name": "Outline No.1 — stepwise descent from 3rd of ii through V7 to 3rd of I",
-      "when": {"context": "improvising_single_line", "progression": "ii_V_I", "outline_choice": "stepwise_descending"},
-      "then": {"line.outline_id": "ligon_outline_1", "line.target_tone": "third_of_ii_then_third_of_I", "line.approach_method": "stepwise_descending_scale", "line.metric_placement": "third_on_beat_one_seventh_on_beat_four"},
+      "when": {
+        "context": "improvising_single_line",
+        "progression": "ii_V_I",
+        "outline_choice": "stepwise_descending"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_1",
+        "line.target_tone": "third_of_ii_then_third_of_I",
+        "line.approach_method": "stepwise_descending_scale",
+        "line.metric_placement": "third_on_beat_one_seventh_on_beat_four"
+      },
       "preference": "strong",
-      "quality_binding": ["voice_leading", "outline_integrity"],
+      "quality_binding": [
+        "voice_leading",
+        "outline_integrity"
+      ],
       "falsifier": "Line claims Outline No.1 but ascends or skips the stepwise connective scale.",
       "anchor": "By moving down the scale, a stepwise line is created from the third of the ii chord through the V7 chord and down to the third of the I chord.",
       "source_page": 6,
@@ -129,10 +219,20 @@
     {
       "rule_id": "ligon-outline-2-ascending-arpeggio",
       "name": "Outline No.2 — ascending 1-3-5-7 arpeggio of ii resolving to 3rd of V7",
-      "when": {"context": "improvising_single_line", "progression": "ii_V", "outline_choice": "ascending_arpeggio"},
-      "then": {"line.outline_id": "ligon_outline_2", "line.approach_method": "arpeggio_ascending_1_3_5_7", "line.target_tone": "third_of_V7"},
+      "when": {
+        "context": "improvising_single_line",
+        "progression": "ii_V",
+        "outline_choice": "ascending_arpeggio"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_2",
+        "line.approach_method": "arpeggio_ascending_1_3_5_7",
+        "line.target_tone": "third_of_V7"
+      },
       "preference": "strong",
-      "quality_binding": ["outline_integrity"],
+      "quality_binding": [
+        "outline_integrity"
+      ],
       "falsifier": "Ascending arpeggio omits the 7th before resolving, or starts on the 5th rather than the root.",
       "anchor": "Outline no.2 is an ascending arpeggio of the ii chord (1-3-5) with the added restless tone (7) above the chord, which resolves to the third of the V7 chord.",
       "source_page": 8,
@@ -141,10 +241,22 @@
     {
       "rule_id": "ligon-outline-3-descending-arpeggio",
       "name": "Outline No.3 — descending 5-3-1 arpeggio of ii with 7th below resolving to 3rd of V7",
-      "when": {"context": "improvising_single_line", "progression": "ii_V", "outline_choice": "descending_arpeggio"},
-      "then": {"line.outline_id": "ligon_outline_3", "line.approach_method": "arpeggio_descending_5_3_1_then_7_below", "line.target_tone": "third_of_V7", "line.metric_placement": "seventh_on_upbeat_third_on_downbeat"},
+      "when": {
+        "context": "improvising_single_line",
+        "progression": "ii_V",
+        "outline_choice": "descending_arpeggio"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_3",
+        "line.approach_method": "arpeggio_descending_5_3_1_then_7_below",
+        "line.target_tone": "third_of_V7",
+        "line.metric_placement": "seventh_on_upbeat_third_on_downbeat"
+      },
       "preference": "strong",
-      "quality_binding": ["outline_integrity", "metric_alignment"],
+      "quality_binding": [
+        "outline_integrity",
+        "metric_alignment"
+      ],
       "falsifier": "Target 3rd of V7 lands on an upbeat or the 7th lands on a strong downbeat.",
       "anchor": "outline no.3 begins with the descending arpeggio of the ii chord (5-3-1), adds the restless tone (7) below the chord, which resolves to the third of the V7 chord. The seventh usually occurs on the upbeat; the target third on the strong downbeat.",
       "source_page": 9,
@@ -153,10 +265,18 @@
     {
       "rule_id": "ligon-outlines-not-constraints",
       "name": "Treat outlines as enabling skeletons, not constraints",
-      "when": {"context": "improvising_single_line", "outline_choice": "any"},
-      "then": {"line.outline_id": "selected_outline", "line.preference": "skeleton_then_personalize"},
+      "when": {
+        "context": "improvising_single_line",
+        "outline_choice": "any"
+      },
+      "then": {
+        "line.outline_id": "selected_outline",
+        "line.preference": "skeleton_then_personalize"
+      },
       "preference": "advisory",
-      "quality_binding": ["creativity"],
+      "quality_binding": [
+        "creativity"
+      ],
       "falsifier": null,
       "anchor": "The outlines are skeletons. Our bodies all have similar skeletons yet we all look unique.",
       "source_page": 6,
@@ -165,10 +285,18 @@
     {
       "rule_id": "ligon-chromatic-direction-continues",
       "name": "Chromatic alterations continue in their altered direction",
-      "when": {"context": "chromatic_elaboration", "altered_tone": "any"},
-      "then": {"line.chromatic_insertion": "continue_in_altered_direction", "line.approach_method": "flat_descends_sharp_ascends"},
+      "when": {
+        "context": "chromatic_elaboration",
+        "altered_tone": "any"
+      },
+      "then": {
+        "line.chromatic_insertion": "continue_in_altered_direction",
+        "line.approach_method": "flat_descends_sharp_ascends"
+      },
       "preference": "strong",
-      "quality_binding": ["voice_leading"],
+      "quality_binding": [
+        "voice_leading"
+      ],
       "falsifier": "Flatted note ascends or sharped note descends without an intervening enclosure.",
       "anchor": "Chromatically altered tones tend to continue in the direction in which they have been altered. Flatted notes are lowered and therefore have downward tendencies, sharped notes are raised and have upward tendencies.",
       "source_page": 11,
@@ -177,10 +305,18 @@
     {
       "rule_id": "ligon-unt-diatonic-lnt-chromatic",
       "name": "Use diatonic UNT and chromatic LNT",
-      "when": {"context": "neighbor_tone_embellishment"},
-      "then": {"line.chromatic_insertion": "lnt_chromatic_unt_diatonic", "line.approach_method": "neighbor_tone"},
+      "when": {
+        "context": "neighbor_tone_embellishment"
+      },
+      "then": {
+        "line.chromatic_insertion": "lnt_chromatic_unt_diatonic",
+        "line.approach_method": "neighbor_tone"
+      },
       "preference": "strong",
-      "quality_binding": ["idiom", "voice_leading"],
+      "quality_binding": [
+        "idiom",
+        "voice_leading"
+      ],
       "falsifier": "Chromatic upper neighbor used without functional pull, or diatonic lower neighbor used where chromatic LNT is idiomatic.",
       "anchor": "The common practice (from Mozart to Charlie Parker) is to use the diatonic (from the key) upper neighbor tone (UNT) and the chromatic lower neighbor tone (LNT).",
       "source_page": 11,
@@ -189,10 +325,19 @@
     {
       "rule_id": "ligon-octave-displacement-placement",
       "name": "Place octave-displacement leaps after the guide tone, downbeat-to-upbeat",
-      "when": {"context": "octave_displacement", "current_position": "after_guide_tone"},
-      "then": {"line.approach_method": "leap_after_guide_tone", "line.metric_placement": "downbeat_to_upbeat_never_over_barline"},
+      "when": {
+        "context": "octave_displacement",
+        "current_position": "after_guide_tone"
+      },
+      "then": {
+        "line.approach_method": "leap_after_guide_tone",
+        "line.metric_placement": "downbeat_to_upbeat_never_over_barline"
+      },
       "preference": "strong",
-      "quality_binding": ["metric_alignment", "phrasing"],
+      "quality_binding": [
+        "metric_alignment",
+        "phrasing"
+      ],
       "falsifier": "Octave-displacement leap occurs across the barline or from a weak beat to a strong beat.",
       "anchor": "Leaps most often occur after the main guide-tone, leap from down beat to upbeat; never over the barline and rarely from a weak beat to a strong beat.",
       "source_page": 14,
@@ -201,10 +346,20 @@
     {
       "rule_id": "ligon-3-up-to-9-displacement",
       "name": "3-to-9 octave-displacement signature move",
-      "when": {"context": "improvising_single_line", "current_chord_tone": "third", "next_intended_step": "down_a_second"},
-      "then": {"line.approach_method": "leap_up_seventh_to_ninth_or_flat_ninth", "line.chromatic_insertion": "flat_nine_optional"},
+      "when": {
+        "context": "improvising_single_line",
+        "current_chord_tone": "third",
+        "next_intended_step": "down_a_second"
+      },
+      "then": {
+        "line.approach_method": "leap_up_seventh_to_ninth_or_flat_ninth",
+        "line.chromatic_insertion": "flat_nine_optional"
+      },
       "preference": "advisory",
-      "quality_binding": ["idiom", "drama"],
+      "quality_binding": [
+        "idiom",
+        "drama"
+      ],
       "falsifier": null,
       "anchor": "3rd up to the 9th or flat 9th: A simple descending scale step (3-2) becomes dramatic when a descending second is replaced with a leap of a seventh.",
       "source_page": 14,
@@ -213,10 +368,19 @@
     {
       "rule_id": "ligon-cesh-descending-chromatic",
       "name": "C.E.S.H. — chromatic descent from root of ii to 3rd of V7",
-      "when": {"context": "ii_V_progression", "outline_choice": "any"},
-      "then": {"line.chromatic_insertion": "cesh_descent_root_to_third_of_V7", "line.approach_method": "stepwise_chromatic_descent"},
+      "when": {
+        "context": "ii_V_progression",
+        "outline_choice": "any"
+      },
+      "then": {
+        "line.chromatic_insertion": "cesh_descent_root_to_third_of_V7",
+        "line.approach_method": "stepwise_chromatic_descent"
+      },
       "preference": "moderate",
-      "quality_binding": ["idiom", "voice_leading"],
+      "quality_binding": [
+        "idiom",
+        "voice_leading"
+      ],
       "falsifier": "Chromatic descent skips the chromatic passing tone or fails to land the target 3rd of V7.",
       "anchor": "Jerry Coker's acronym for Chromatic Elaboration of Static Harmony. The most common example in a ii - V progression is the descending movement from the root of the ii chord to the third of the V7 chord, In the key of C (D minor - G7), the movement of D-C#-C-B.",
       "source_page": 15,
@@ -225,10 +389,19 @@
     {
       "rule_id": "ligon-borrowed-parallel-minor",
       "name": "Borrow b9 / #9 / b13 from parallel minor on the V7",
-      "when": {"context": "improvising_over_dominant", "chord_quality": "V7"},
-      "then": {"line.chromatic_insertion": "borrowed_b9_sharp9_b13_from_parallel_minor", "line.target_tone": "altered_extension"},
+      "when": {
+        "context": "improvising_over_dominant",
+        "chord_quality": "V7"
+      },
+      "then": {
+        "line.chromatic_insertion": "borrowed_b9_sharp9_b13_from_parallel_minor",
+        "line.target_tone": "altered_extension"
+      },
       "preference": "moderate",
-      "quality_binding": ["color", "voice_leading"],
+      "quality_binding": [
+        "color",
+        "voice_leading"
+      ],
       "falsifier": "Altered extensions are used over a non-dominant chord with no functional justification.",
       "anchor": "Over G7, the dominant of C major, jazz musicians often use A-flat (flat 9) , B-flat (sharp 9) and E-flat (flat 13) from the parallel key of C minor.",
       "source_page": 16,
@@ -237,10 +410,18 @@
     {
       "rule_id": "ligon-iteration-for-eighth-motion",
       "name": "Use iteration (repeated notes) to convert quarter outlines to eighth-note motion",
-      "when": {"context": "rhythmic_elaboration", "outline_state": "quarter_note_skeleton"},
-      "then": {"line.approach_method": "repeat_target_tones_as_iteration", "line.metric_placement": "eighth_note_grid"},
+      "when": {
+        "context": "rhythmic_elaboration",
+        "outline_state": "quarter_note_skeleton"
+      },
+      "then": {
+        "line.approach_method": "repeat_target_tones_as_iteration",
+        "line.metric_placement": "eighth_note_grid"
+      },
       "preference": "advisory",
-      "quality_binding": ["rhythm"],
+      "quality_binding": [
+        "rhythm"
+      ],
       "falsifier": null,
       "anchor": "With the outline in quarter note values, an easy way to get eighth note motion is to repeat notes, sometimes called iteration.",
       "source_page": 21,
@@ -249,10 +430,18 @@
     {
       "rule_id": "ligon-outlines-generalize-to-fifths",
       "name": "Outlines apply to any progression with root motion down a fifth",
-      "when": {"context": "improvising_single_line", "progression": "root_motion_down_a_fifth"},
-      "then": {"line.outline_id": "any_of_three", "line.preference": "outline_application_generalizes"},
+      "when": {
+        "context": "improvising_single_line",
+        "progression": "root_motion_down_a_fifth"
+      },
+      "then": {
+        "line.outline_id": "any_of_three",
+        "line.preference": "outline_application_generalizes"
+      },
       "preference": "moderate",
-      "quality_binding": ["generalization"],
+      "quality_binding": [
+        "generalization"
+      ],
       "falsifier": "Outline assumed to work despite root motion not being down a fifth.",
       "anchor": "These outlines will work with many other progressions. Anytime the root movement is down in fifths any of theses outlines will work, regardless of the quality of the chord.",
       "source_page": 29,
@@ -261,10 +450,18 @@
     {
       "rule_id": "ligon-cesh-applies-all-outlines",
       "name": "C.E.S.H. applies across all three outlines",
-      "when": {"context": "outline_elaboration", "outline_choice": "1_or_2_or_3"},
-      "then": {"line.chromatic_insertion": "cesh_layer", "line.outline_id": "selected_outline"},
+      "when": {
+        "context": "outline_elaboration",
+        "outline_choice": "1_or_2_or_3"
+      },
+      "then": {
+        "line.chromatic_insertion": "cesh_layer",
+        "line.outline_id": "selected_outline"
+      },
       "preference": "advisory",
-      "quality_binding": ["idiom"],
+      "quality_binding": [
+        "idiom"
+      ],
       "falsifier": null,
       "anchor": "This type of chromatic elaboration is found with all three outlines.",
       "source_page": 39,
@@ -273,10 +470,19 @@
     {
       "rule_id": "ligon-cesh-encircles-ii-root",
       "name": "C.E.S.H. chromatic tone reverses direction and encircles the ii root",
-      "when": {"context": "cesh_elaboration", "chromatic_position": "leading_tone_to_ii"},
-      "then": {"line.approach_method": "encircle_root_of_ii_before_descent", "line.target_tone": "third_of_V7"},
+      "when": {
+        "context": "cesh_elaboration",
+        "chromatic_position": "leading_tone_to_ii"
+      },
+      "then": {
+        "line.approach_method": "encircle_root_of_ii_before_descent",
+        "line.target_tone": "third_of_V7"
+      },
       "preference": "moderate",
-      "quality_binding": ["voice_leading", "idiom"],
+      "quality_binding": [
+        "voice_leading",
+        "idiom"
+      ],
       "falsifier": "C.E.S.H. line treats the chromatic note as a passing tone with no upward pull or encirclement.",
       "anchor": "The chromatic altered tone stops the descent of the line; since it is a leading tone to the ii chord it pulls upwards. Often this momentarily changes the direction of the line, encircling the root of the ii chord before descending through the diatonic tones and finally resolving to the third of the V chord.",
       "source_page": 39,
@@ -285,10 +491,18 @@
     {
       "rule_id": "ligon-chromatic-justified-linearly",
       "name": "Chromatic tones are justified linearly, not vertically",
-      "when": {"context": "chromatic_evaluation", "chord_quality": "any"},
-      "then": {"line.analysis_mode": "linear_targeting", "line.chromatic_insertion": "point_to_target_tone"},
+      "when": {
+        "context": "chromatic_evaluation",
+        "chord_quality": "any"
+      },
+      "then": {
+        "line.analysis_mode": "linear_targeting",
+        "line.chromatic_insertion": "point_to_target_tone"
+      },
       "preference": "strong",
-      "quality_binding": ["voice_leading"],
+      "quality_binding": [
+        "voice_leading"
+      ],
       "falsifier": "Chromatic tone is rejected solely because it is dissonant against the vertical chord, without considering its linear target.",
       "anchor": "Viewing harmony as strictly vertical, these notes would not sound good; but when viewing them in a linear context we see and hear how these notes point to the target notes and make the line more interesting by creating and releasing tension.",
       "source_page": 38,
@@ -297,10 +511,20 @@
     {
       "rule_id": "ligon-all-twelve-pitches-target-anchored",
       "name": "All 12 chromatic pitches are usable if targets land on rhythmically significant spots",
-      "when": {"context": "chromatic_elaboration", "scope": "phrase"},
-      "then": {"line.chromatic_insertion": "any_of_twelve", "line.metric_placement": "target_tones_on_strong_beats", "line.target_tone": "resolved_chord_tone"},
+      "when": {
+        "context": "chromatic_elaboration",
+        "scope": "phrase"
+      },
+      "then": {
+        "line.chromatic_insertion": "any_of_twelve",
+        "line.metric_placement": "target_tones_on_strong_beats",
+        "line.target_tone": "resolved_chord_tone"
+      },
       "preference": "moderate",
-      "quality_binding": ["clarity", "voice_leading"],
+      "quality_binding": [
+        "clarity",
+        "voice_leading"
+      ],
       "falsifier": "Chromatic notes land on strong beats while chord tones land on weak beats with no resolution.",
       "anchor": "All twelve chromatic pitches are used in this example, yet it remains harmonically clear; it is not random chromaticism. Target notes occur in rhythmically significant spots, non-harmonic chromatic notes resolve when and where we expect them.",
       "source_page": 43,
@@ -309,10 +533,18 @@
     {
       "rule_id": "ligon-break-scale-to-avoid-target",
       "name": "Break an ascending scale to avoid hitting the next target note early",
-      "when": {"context": "scalar_elaboration", "approaching": "target_note_of_next_chord"},
-      "then": {"line.approach_method": "skip_target_note_in_scale_run", "line.metric_placement": "reserve_target_for_target_chord"},
+      "when": {
+        "context": "scalar_elaboration",
+        "approaching": "target_note_of_next_chord"
+      },
+      "then": {
+        "line.approach_method": "skip_target_note_in_scale_run",
+        "line.metric_placement": "reserve_target_for_target_chord"
+      },
       "preference": "moderate",
-      "quality_binding": ["punch_line_integrity"],
+      "quality_binding": [
+        "punch_line_integrity"
+      ],
       "falsifier": "Ascending scale runs through the next chord's target note before that chord arrives.",
       "anchor": "Notice that the ascending scale breaks to avoid the upcoming target note. In ex.57, the scale that starts on beat three from C, goes to G, skips the A natural because it is the target note for the F7 chord.",
       "source_page": 32,
@@ -321,10 +553,18 @@
     {
       "rule_id": "ligon-strip-embellishments-as-reduction",
       "name": "Stripping embellishments reveals the underlying outline",
-      "when": {"context": "analysis_or_practice", "phrase_state": "embellished"},
-      "then": {"line.analysis_mode": "reduce_to_outline", "line.outline_id": "underlying_outline"},
+      "when": {
+        "context": "analysis_or_practice",
+        "phrase_state": "embellished"
+      },
+      "then": {
+        "line.analysis_mode": "reduce_to_outline",
+        "line.outline_id": "underlying_outline"
+      },
       "preference": "advisory",
-      "quality_binding": ["analytical_clarity"],
+      "quality_binding": [
+        "analytical_clarity"
+      ],
       "falsifier": null,
       "anchor": "taking away the insertions, ornaments, and embellishments also reveals interesting lines by the realignment of the original notes of the outline.",
       "source_page": 45,
@@ -333,10 +573,18 @@
     {
       "rule_id": "ligon-compound-melody-from-lower-tones",
       "name": "Compound melody — a counterline emerges from selected lower tones",
-      "when": {"context": "improvising_single_line", "register_usage": "wide"},
-      "then": {"line.approach_method": "imply_counterline_via_lower_tones", "line.outline_id": "any_of_three"},
+      "when": {
+        "context": "improvising_single_line",
+        "register_usage": "wide"
+      },
+      "then": {
+        "line.approach_method": "imply_counterline_via_lower_tones",
+        "line.outline_id": "any_of_three"
+      },
       "preference": "advisory",
-      "quality_binding": ["texture"],
+      "quality_binding": [
+        "texture"
+      ],
       "falsifier": null,
       "anchor": "There is a counterline (indicated by the arrows below the staff) implied by some of the lower tones making this a compound melody.",
       "source_page": 45,
@@ -345,10 +593,17 @@
     {
       "rule_id": "ligon-outline-2-diatonic-passing",
       "name": "Outline No.2 takes diatonic passing tones between chord tones",
-      "when": {"context": "outline_2_elaboration"},
-      "then": {"line.outline_id": "ligon_outline_2", "line.chromatic_insertion": "diatonic_passing_only_between_chord_tones"},
+      "when": {
+        "context": "outline_2_elaboration"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_2",
+        "line.chromatic_insertion": "diatonic_passing_only_between_chord_tones"
+      },
       "preference": "moderate",
-      "quality_binding": ["outline_integrity"],
+      "quality_binding": [
+        "outline_integrity"
+      ],
       "falsifier": "Chromatic passing tones are used between chord tones of Outline No.2 without functional purpose.",
       "anchor": "Passing tones: Since outline no.2 is an arpeggiated outline, it lends itself to diatonic passing tones between the chord tones.",
       "source_page": 54,
@@ -357,10 +612,20 @@
     {
       "rule_id": "ligon-punch-line-rule",
       "name": "Punch line rule — withhold the V7 target until the V7 chord arrives",
-      "when": {"context": "outline_2_elaboration", "current_chord": "ii", "tone_between_5_and_7": "available"},
-      "then": {"line.metric_placement": "delay_target_to_V7_arrival", "line.target_tone": "third_of_V7_on_V7_downbeat"},
+      "when": {
+        "context": "outline_2_elaboration",
+        "current_chord": "ii",
+        "tone_between_5_and_7": "available"
+      },
+      "then": {
+        "line.metric_placement": "delay_target_to_V7_arrival",
+        "line.target_tone": "third_of_V7_on_V7_downbeat"
+      },
       "preference": "strong",
-      "quality_binding": ["punch_line_integrity", "narrative"],
+      "quality_binding": [
+        "punch_line_integrity",
+        "narrative"
+      ],
       "falsifier": "Tone between 5th and 7th of ii is played as a passing tone before V7 arrives, giving away the punch line.",
       "anchor": "The tone between the 5th and 7th of the ii chord is the target note of the V7 chord. This tone is usually saved for the V7 chord. It is the punch line, the denouement of the story, that is not given away by using it ahead of time as a passing tone.",
       "source_page": 54,
@@ -369,10 +634,18 @@
     {
       "rule_id": "ligon-minor-ii-V-applicability",
       "name": "All three outlines apply to ii(half-dim)-V7 in minor",
-      "when": {"context": "improvising_single_line", "progression": "ii_half_dim_V7_minor"},
-      "then": {"line.outline_id": "any_of_three", "line.preference": "outlines_generalize_to_minor"},
+      "when": {
+        "context": "improvising_single_line",
+        "progression": "ii_half_dim_V7_minor"
+      },
+      "then": {
+        "line.outline_id": "any_of_three",
+        "line.preference": "outlines_generalize_to_minor"
+      },
       "preference": "moderate",
-      "quality_binding": ["generalization"],
+      "quality_binding": [
+        "generalization"
+      ],
       "falsifier": "Outline avoided in minor ii-V context despite root motion down a fifth.",
       "anchor": "All the outlines work as well for ii@ - V7 in minor as they do in major.",
       "source_page": 52,
@@ -381,10 +654,17 @@
     {
       "rule_id": "ligon-add-notes-before-within-after",
       "name": "Embellish by adding notes before, within, or after the motive",
-      "when": {"context": "motive_elaboration"},
-      "then": {"line.approach_method": "insert_before_within_or_after", "line.outline_id": "selected_outline"},
+      "when": {
+        "context": "motive_elaboration"
+      },
+      "then": {
+        "line.approach_method": "insert_before_within_or_after",
+        "line.outline_id": "selected_outline"
+      },
       "preference": "advisory",
-      "quality_binding": ["elaboration_taxonomy"],
+      "quality_binding": [
+        "elaboration_taxonomy"
+      ],
       "falsifier": null,
       "anchor": "Any musical motive can be embellished by adding notes. Notes can be added before, within, and after the motive.",
       "source_page": 52,
@@ -393,10 +673,18 @@
     {
       "rule_id": "ligon-encircle-target",
       "name": "Encircle the target tone for tension and ambiguity",
-      "when": {"context": "target_approach"},
-      "then": {"line.approach_method": "encircle_target_from_above_and_below", "line.target_tone": "delayed_chord_tone"},
+      "when": {
+        "context": "target_approach"
+      },
+      "then": {
+        "line.approach_method": "encircle_target_from_above_and_below",
+        "line.target_tone": "delayed_chord_tone"
+      },
       "preference": "moderate",
-      "quality_binding": ["voice_leading", "tension"],
+      "quality_binding": [
+        "voice_leading",
+        "tension"
+      ],
       "falsifier": "Target tone is approached only from one side and labeled as encirclement.",
       "anchor": "He chooses to encircle the target note, creating a slight tension and ambiguity.",
       "source_page": 52,
@@ -405,10 +693,17 @@
     {
       "rule_id": "ligon-outline-2-standard-direction",
       "name": "Outline No.2 canonical form starts on root and ascends 1-3-5-7",
-      "when": {"context": "outline_2_application"},
-      "then": {"line.outline_id": "ligon_outline_2", "line.approach_method": "ascend_root_third_fifth_seventh"},
+      "when": {
+        "context": "outline_2_application"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_2",
+        "line.approach_method": "ascend_root_third_fifth_seventh"
+      },
       "preference": "moderate",
-      "quality_binding": ["outline_integrity"],
+      "quality_binding": [
+        "outline_integrity"
+      ],
       "falsifier": "Outline No.2 invoked but starts on a non-root chord tone without explicit inversion.",
       "anchor": "Outline no.2 usually begins on the root of the ii chord and spells the arpeggio to the seventh: 1-3-5-7.",
       "source_page": 60,
@@ -417,10 +712,17 @@
     {
       "rule_id": "ligon-outline-2-inverted",
       "name": "Outline No.2 may invert direction (descend the arpeggio)",
-      "when": {"context": "outline_2_variation"},
-      "then": {"line.outline_id": "ligon_outline_2", "line.approach_method": "arpeggio_descending_inverted"},
+      "when": {
+        "context": "outline_2_variation"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_2",
+        "line.approach_method": "arpeggio_descending_inverted"
+      },
       "preference": "advisory",
-      "quality_binding": ["variation"],
+      "quality_binding": [
+        "variation"
+      ],
       "falsifier": null,
       "anchor": "Instead of ascending the arpeggio of the ii chord, the arpeggio is turned upside down and descends in some way.",
       "source_page": 61,
@@ -429,10 +731,18 @@
     {
       "rule_id": "ligon-punch-line-break-with-extension",
       "name": "Breaking the punch line is mitigated by extending the line to the 9th of ii",
-      "when": {"context": "outline_2_elaboration", "target_note_used_early": true},
-      "then": {"line.approach_method": "extend_line_to_ninth_of_ii", "line.preference": "mitigate_negative_effect"},
+      "when": {
+        "context": "outline_2_elaboration",
+        "target_note_used_early": true
+      },
+      "then": {
+        "line.approach_method": "extend_line_to_ninth_of_ii",
+        "line.preference": "mitigate_negative_effect"
+      },
       "preference": "advisory",
-      "quality_binding": ["punch_line_integrity"],
+      "quality_binding": [
+        "punch_line_integrity"
+      ],
       "falsifier": null,
       "anchor": "The F sharp appears as a passing tone before the D7 chord, but the negative effect is diminished by the extension of the line to the ninth of the ii chord.",
       "source_page": 58,
@@ -441,10 +751,18 @@
     {
       "rule_id": "ligon-combine-outlines-2-then-1",
       "name": "Outlines may be combined within a single phrase (e.g., No.2 into No.1)",
-      "when": {"context": "phrase_construction", "phrase_length": "long_enough_for_combination"},
-      "then": {"line.outline_id": "combination_outline_2_then_1", "line.approach_method": "join_outlines_at_target_tone"},
+      "when": {
+        "context": "phrase_construction",
+        "phrase_length": "long_enough_for_combination"
+      },
+      "then": {
+        "line.outline_id": "combination_outline_2_then_1",
+        "line.approach_method": "join_outlines_at_target_tone"
+      },
       "preference": "advisory",
-      "quality_binding": ["vocabulary"],
+      "quality_binding": [
+        "vocabulary"
+      ],
       "falsifier": null,
       "anchor": "Parker begins with outline no.2 and ends with outline no.1. There are many occurrences of this line in different guises throughout Parker solos.",
       "source_page": 59,
@@ -453,10 +771,18 @@
     {
       "rule_id": "ligon-fragment-preserves-clarity",
       "name": "Outline fragments preserve clarity when target tones remain emphasized",
-      "when": {"context": "outline_application", "completeness": "fragment_omits_root_or_first_note"},
-      "then": {"line.outline_id": "outline_fragment", "line.target_tone": "third_of_ii_emphasized"},
+      "when": {
+        "context": "outline_application",
+        "completeness": "fragment_omits_root_or_first_note"
+      },
+      "then": {
+        "line.outline_id": "outline_fragment",
+        "line.target_tone": "third_of_ii_emphasized"
+      },
       "preference": "moderate",
-      "quality_binding": ["clarity"],
+      "quality_binding": [
+        "clarity"
+      ],
       "falsifier": "Fragment omits both the root and the target third, leaving no anchor.",
       "anchor": "These omissions take none of the clarity away from the lines. They all emphasize the target note (third of ii) even more, and the root of the chord is covered by the bass.",
       "source_page": 63,
@@ -465,10 +791,18 @@
     {
       "rule_id": "ligon-sus-equals-ii-V-for-outlines",
       "name": "Sus-dominant voicings are interchangeable with ii-V7 for outline selection",
-      "when": {"context": "improvising_single_line", "chord_quality": "dominant_sus"},
-      "then": {"line.outline_id": "any_of_three", "line.preference": "treat_sus_as_ii_V"},
+      "when": {
+        "context": "improvising_single_line",
+        "chord_quality": "dominant_sus"
+      },
+      "then": {
+        "line.outline_id": "any_of_three",
+        "line.preference": "treat_sus_as_ii_V"
+      },
       "preference": "moderate",
-      "quality_binding": ["generalization"],
+      "quality_binding": [
+        "generalization"
+      ],
       "falsifier": "Player avoids outlines over sus chord despite the chord functioning as ii-V composite.",
       "anchor": "Since this sound is essentially the ii and V7 chord together, any of the outlines will work for this harmony.",
       "source_page": 65,
@@ -477,10 +811,17 @@
     {
       "rule_id": "ligon-outline-3-octave-displacement-variation",
       "name": "Outline No.3 with octave-displacement scale continuation is idiomatic",
-      "when": {"context": "outline_3_variation"},
-      "then": {"line.outline_id": "ligon_outline_3", "line.approach_method": "continue_down_scale_with_octave_displacement"},
+      "when": {
+        "context": "outline_3_variation"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_3",
+        "line.approach_method": "continue_down_scale_with_octave_displacement"
+      },
       "preference": "advisory",
-      "quality_binding": ["idiom"],
+      "quality_binding": [
+        "idiom"
+      ],
       "falsifier": null,
       "anchor": "The second variation of outline no.3 that continues down the scale with octave displacement is very common.",
       "source_page": 66,
@@ -489,10 +830,21 @@
     {
       "rule_id": "ligon-third-to-flat-nine-leap",
       "name": "Leap from 3rd to b9 on the dominant creates compound melody",
-      "when": {"context": "outline_3_application", "current_chord": "V7", "current_chord_tone": "third"},
-      "then": {"line.outline_id": "ligon_outline_3", "line.approach_method": "leap_third_to_flat_nine", "line.chromatic_insertion": "flat_nine_over_V7"},
+      "when": {
+        "context": "outline_3_application",
+        "current_chord": "V7",
+        "current_chord_tone": "third"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_3",
+        "line.approach_method": "leap_third_to_flat_nine",
+        "line.chromatic_insertion": "flat_nine_over_V7"
+      },
       "preference": "moderate",
-      "quality_binding": ["compound_melody", "idiom"],
+      "quality_binding": [
+        "compound_melody",
+        "idiom"
+      ],
       "falsifier": "Leap from 3rd lands on natural 9 without functional justification.",
       "anchor": "The leap from the third to the flat nine on the dominant is one of its attractive elements; giving it characteristics of a compound melody.",
       "source_page": 66,
@@ -501,10 +853,17 @@
     {
       "rule_id": "ligon-outline-3-cesh-affinity",
       "name": "Outline No.3 has special affinity for C.E.S.H.",
-      "when": {"context": "outline_choice_with_cesh"},
-      "then": {"line.outline_id": "ligon_outline_3", "line.chromatic_insertion": "cesh_preferred"},
+      "when": {
+        "context": "outline_choice_with_cesh"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_3",
+        "line.chromatic_insertion": "cesh_preferred"
+      },
       "preference": "advisory",
-      "quality_binding": ["idiom"],
+      "quality_binding": [
+        "idiom"
+      ],
       "falsifier": null,
       "anchor": "Outline no.3 seems to lend itself to the C.E.S.H. more than the other outlines, the chromatic motion often suggesting a compound melody.",
       "source_page": 68,
@@ -513,10 +872,17 @@
     {
       "rule_id": "ligon-lower-pivot-note",
       "name": "One note added below the outline adds angularity",
-      "when": {"context": "outline_elaboration"},
-      "then": {"line.approach_method": "add_single_lower_pivot_note", "line.outline_id": "selected_outline"},
+      "when": {
+        "context": "outline_elaboration"
+      },
+      "then": {
+        "line.approach_method": "add_single_lower_pivot_note",
+        "line.outline_id": "selected_outline"
+      },
       "preference": "advisory",
-      "quality_binding": ["contour"],
+      "quality_binding": [
+        "contour"
+      ],
       "falsifier": null,
       "anchor": "One note added below adds angularity and rhythmic interest to this outline.",
       "source_page": 71,
@@ -525,10 +891,18 @@
     {
       "rule_id": "ligon-chromatic-passing-on-weak-beats",
       "name": "Chromatic passing tones go on weak beats; diatonic tones on strong beats",
-      "when": {"context": "chromatic_elaboration"},
-      "then": {"line.chromatic_insertion": "chromatic_on_weak_beats", "line.metric_placement": "diatonic_on_strong_beats"},
+      "when": {
+        "context": "chromatic_elaboration"
+      },
+      "then": {
+        "line.chromatic_insertion": "chromatic_on_weak_beats",
+        "line.metric_placement": "diatonic_on_strong_beats"
+      },
       "preference": "strong",
-      "quality_binding": ["clarity", "metric_alignment"],
+      "quality_binding": [
+        "clarity",
+        "metric_alignment"
+      ],
       "falsifier": "Chromatic passing tone lands on a strong beat while a diatonic chord tone lands on a weak beat without resolution.",
       "anchor": "These chromatic passing tones do not blur the distinct harmonic clarity as the diatonic notes fall on strong beats.",
       "source_page": 74,
@@ -537,10 +911,18 @@
     {
       "rule_id": "ligon-function-over-taxonomy",
       "name": "Prioritize harmonic clarity over outline-category labeling",
-      "when": {"context": "phrase_analysis", "ambiguous_outline_category": true},
-      "then": {"line.analysis_mode": "judge_by_target_tone_clarity", "line.outline_id": "any_or_hybrid"},
+      "when": {
+        "context": "phrase_analysis",
+        "ambiguous_outline_category": true
+      },
+      "then": {
+        "line.analysis_mode": "judge_by_target_tone_clarity",
+        "line.outline_id": "any_or_hybrid"
+      },
       "preference": "advisory",
-      "quality_binding": ["clarity"],
+      "quality_binding": [
+        "clarity"
+      ],
       "falsifier": null,
       "anchor": "The central point is their harmonic clarity; thirds and seventh delineate the harmony.",
       "source_page": 73,
@@ -549,10 +931,17 @@
     {
       "rule_id": "ligon-fragment-minimal-kernel",
       "name": "Minimal fragment kernel — 7 of ii resolving to 3 of V7 is sufficient",
-      "when": {"context": "outline_fragmentation"},
-      "then": {"line.outline_id": "fragment_kernel_7ii_to_3V7", "line.target_tone": "third_of_V7"},
+      "when": {
+        "context": "outline_fragmentation"
+      },
+      "then": {
+        "line.outline_id": "fragment_kernel_7ii_to_3V7",
+        "line.target_tone": "third_of_V7"
+      },
       "preference": "moderate",
-      "quality_binding": ["clarity"],
+      "quality_binding": [
+        "clarity"
+      ],
       "falsifier": "Claimed fragment lacks both the 7 of ii and the 3 of V7.",
       "anchor": "Parker's sequence in ex.249 relies on the seventh of ii resolving to the third of V7 for clarity.",
       "source_page": 76,
@@ -561,10 +950,18 @@
     {
       "rule_id": "ligon-fragment-omit-third-of-ii",
       "name": "Fragment may omit the 3rd of ii if V7 is anticipated and arpeggiated",
-      "when": {"context": "outline_fragmentation", "v7_treatment": "anticipated_arpeggio"},
-      "then": {"line.outline_id": "ligon_outline_1_fragment", "line.approach_method": "anticipate_V7_arpeggio"},
+      "when": {
+        "context": "outline_fragmentation",
+        "v7_treatment": "anticipated_arpeggio"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_1_fragment",
+        "line.approach_method": "anticipate_V7_arpeggio"
+      },
       "preference": "advisory",
-      "quality_binding": ["clarity"],
+      "quality_binding": [
+        "clarity"
+      ],
       "falsifier": null,
       "anchor": "The only note missing from Morgan's excerpt is the third of the iig chord. The V7 chord is anticipated and arpeggiated.",
       "source_page": 77,
@@ -573,10 +970,18 @@
     {
       "rule_id": "ligon-target-rhythm-7-upbeat-3-downbeat",
       "name": "Place 7th on upbeat and next target on downbeat across fragments",
-      "when": {"context": "outline_fragmentation_rhythm"},
-      "then": {"line.metric_placement": "seventh_on_upbeat_target_on_downbeat", "line.target_tone": "next_chord_third"},
+      "when": {
+        "context": "outline_fragmentation_rhythm"
+      },
+      "then": {
+        "line.metric_placement": "seventh_on_upbeat_target_on_downbeat",
+        "line.target_tone": "next_chord_third"
+      },
       "preference": "strong",
-      "quality_binding": ["metric_alignment", "voice_leading"],
+      "quality_binding": [
+        "metric_alignment",
+        "voice_leading"
+      ],
       "falsifier": "7th lands on the downbeat with target tone on the upbeat in a fragment context.",
       "anchor": "The seventh on the upbeat is followed by the next target note on the downb",
       "source_page": 77,
@@ -585,10 +990,17 @@
     {
       "rule_id": "ligon-modal-leading-tone-approach",
       "name": "Modal extension — approach modal chord tones by leading tone",
-      "when": {"context": "improvising_over_modal_chord"},
-      "then": {"line.approach_method": "leading_tone_approach_to_modal_third", "line.target_tone": "third_of_modal_chord"},
+      "when": {
+        "context": "improvising_over_modal_chord"
+      },
+      "then": {
+        "line.approach_method": "leading_tone_approach_to_modal_third",
+        "line.target_tone": "third_of_modal_chord"
+      },
       "preference": "moderate",
-      "quality_binding": ["modal_voice_leading"],
+      "quality_binding": [
+        "modal_voice_leading"
+      ],
       "falsifier": "Modal chord third approached only diatonically with no leading-tone color over an entire chorus.",
       "anchor": "the third of the G minor chord is approached by its leading tone. The F# and A encircle the root. E natural implies C7 and is approached from above and below.",
       "source_page": 78,
@@ -597,10 +1009,17 @@
     {
       "rule_id": "ligon-sawtooth-from-leading-tones",
       "name": "Sawtooth contour emerges from adding leading tones to Outline No.1",
-      "when": {"context": "outline_1_elaboration_modal_or_tonal"},
-      "then": {"line.approach_method": "add_leading_tones_below_targets", "line.outline_id": "ligon_outline_1"},
+      "when": {
+        "context": "outline_1_elaboration_modal_or_tonal"
+      },
+      "then": {
+        "line.approach_method": "add_leading_tones_below_targets",
+        "line.outline_id": "ligon_outline_1"
+      },
       "preference": "advisory",
-      "quality_binding": ["contour"],
+      "quality_binding": [
+        "contour"
+      ],
       "falsifier": null,
       "anchor": "outline no.1 can be clearly heard on the downbeats; leading tones have been added giving the line more of a sawtooth shape.",
       "source_page": 78,
@@ -609,10 +1028,19 @@
     {
       "rule_id": "ligon-cesh-outline-3-in-modal-blues",
       "name": "C.E.S.H. Outline No.3 contrasts with modal motivic playing in modal blues",
-      "when": {"context": "improvising_modal_blues", "intent": "contrast_with_motivic_modal"},
-      "then": {"line.outline_id": "ligon_outline_3", "line.chromatic_insertion": "cesh", "line.preference": "deploy_for_contrast"},
+      "when": {
+        "context": "improvising_modal_blues",
+        "intent": "contrast_with_motivic_modal"
+      },
+      "then": {
+        "line.outline_id": "ligon_outline_3",
+        "line.chromatic_insertion": "cesh",
+        "line.preference": "deploy_for_contrast"
+      },
       "preference": "advisory",
-      "quality_binding": ["narrative_contrast"],
+      "quality_binding": [
+        "narrative_contrast"
+      ],
       "falsifier": null,
       "anchor": "Cannonball Adderley uses this C.E.S.H. version of outline no.3 several times in the solo to contrast with his modal, motivic, and down and dirty blues playing on this modal blues tune.",
       "source_page": 78,
@@ -621,10 +1049,18 @@
     {
       "rule_id": "ligon-stop-and-go-delay-resolution",
       "name": "Stop-and-go rhythms delay outline resolution to an off-beat downbeat",
-      "when": {"context": "rhythmic_personalization"},
-      "then": {"line.metric_placement": "delay_resolution_to_beat_three", "line.outline_id": "ligon_outline_1"},
+      "when": {
+        "context": "rhythmic_personalization"
+      },
+      "then": {
+        "line.metric_placement": "delay_resolution_to_beat_three",
+        "line.outline_id": "ligon_outline_1"
+      },
       "preference": "advisory",
-      "quality_binding": ["rhythm", "drama"],
+      "quality_binding": [
+        "rhythm",
+        "drama"
+      ],
       "falsifier": null,
       "anchor": "Outline No.1: Stop and go rhythms delay the resolution of E7 until beat three; arpeggio on E7 (3- 5-7-9) dela",
       "source_page": 145,
@@ -633,10 +1069,18 @@
     {
       "rule_id": "ligon-sawtooth-leap-back-to-chord-tone",
       "name": "Leap back to a chord tone creates sawtooth shape and delays resolution",
-      "when": {"context": "outline_2_elaboration"},
-      "then": {"line.approach_method": "leap_back_to_chord_tone", "line.metric_placement": "delay_resolution", "line.chromatic_insertion": "chromatic_leading_tone_precedes_target"},
+      "when": {
+        "context": "outline_2_elaboration"
+      },
+      "then": {
+        "line.approach_method": "leap_back_to_chord_tone",
+        "line.metric_placement": "delay_resolution",
+        "line.chromatic_insertion": "chromatic_leading_tone_precedes_target"
+      },
       "preference": "advisory",
-      "quality_binding": ["contour"],
+      "quality_binding": [
+        "contour"
+      ],
       "falsifier": null,
       "anchor": "Outline No.2: Leap back to a chord tone creates sawtooth shape, delays resolution of C7; chromatic leading tone (D#) precedes target note (E); leap from third to root of C7,",
       "source_page": 145,
@@ -645,10 +1089,18 @@
     {
       "rule_id": "ligon-neighbor-tone-surrounding",
       "name": "Delay target tone with upper-then-lower neighbor surrounding",
-      "when": {"context": "outline_3_elaboration"},
-      "then": {"line.approach_method": "surround_target_with_upper_then_lower_neighbor", "line.target_tone": "delayed_chord_tone"},
+      "when": {
+        "context": "outline_3_elaboration"
+      },
+      "then": {
+        "line.approach_method": "surround_target_with_upper_then_lower_neighbor",
+        "line.target_tone": "delayed_chord_tone"
+      },
       "preference": "moderate",
-      "quality_binding": ["voice_leading", "tension"],
+      "quality_binding": [
+        "voice_leading",
+        "tension"
+      ],
       "falsifier": "Single neighbor used and labeled as surrounding.",
       "anchor": "Outline No.3: arpeggiated tone is used below; target note (A) is delayed by its upper and lower neighbor tones; target note (A) is approached from above (C — Bb — A) and below (G — G# — A).",
       "source_page": 145,

--- a/plugin/data/masters-corpus/howard-roberts/chord-melody/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/howard-roberts/chord-melody/derived/engine-rules.json
@@ -3,7 +3,7 @@
   "work": "chord-melody",
   "rule_id_prefix": "roberts-",
   "count": 22,
-  "rules": [
+  "engine_rules": [
     {
       "rule_id": "roberts-string-selection-by-sustain",
       "name": "Prefer string set with greatest vibrating length",

--- a/plugin/data/masters-corpus/ted-greene/single-note-soloing-vol-1/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/ted-greene/single-note-soloing-vol-1/derived/engine-rules.json
@@ -10,7 +10,7 @@
   },
   "master_id": "ted-greene",
   "work_id": "single-note-soloing-vol-1",
-  "rules": [
+  "engine_rules": [
     {
       "rule_id": "greene-three-question-framework",
       "name": "Three-question framework for soloing decisions",


### PR DESCRIPTION
Schema canon is `{master_id, work_id, engine_rules}` but four books shipped with `{master_id, work_id, rules}`, reporting 0 rules to the engine. This rename preserves all 160 rule definitions (Greene 46 + Roberts CM 22 + Ligon 54 + Harris 38).

Closes part of #527 (engine-rules normalization).