### PR TITLE
fix(#547): backfill _provenance headers in 13 engine-rules.json files

### DIFF
--- a/plugin/data/masters-corpus/barry-harris/jazz-workshop/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/barry-harris/jazz-workshop/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16--",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:28-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master": "barry-harris",
   "work": "jazz-workshop",
   "schema_version": "0.1",

--- a/plugin/data/masters-corpus/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16--",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:34-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "schema_version": "0.1",
   "master": "bert-ligon",
   "work": "connecting-chords-with-linear-harmony",

--- a/plugin/data/masters-corpus/dirk-laukens/complete-chord-melody/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/dirk-laukens/complete-chord-melody/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16-dirk-laukens-complete-chord-melody",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:51-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "dirk-laukens",
   "work_id": "complete-chord-melody",
   "engine_rules": [

--- a/plugin/data/masters-corpus/howard-roberts/chord-melody/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/howard-roberts/chord-melody/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16--",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:31-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master": "howard-roberts",
   "work": "chord-melody",
   "rule_id_prefix": "roberts-",

--- a/plugin/data/masters-corpus/howard-roberts/jazz-guitar-technique-in-20-weeks/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/howard-roberts/jazz-guitar-technique-in-20-weeks/derived/engine-rules.json
@@ -1,52 +1,909 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-17-howard-roberts-jazz-guitar-technique-in-20-weeks",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-17T09:44:51-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "howard-roberts",
   "work_id": "jazz-guitar-technique-in-20-weeks",
   "engine_rules": [
-    {"rule_id":"roberts-20w-alt-pick-equality","name":"Enforce Alternate Picking Stroke Equality","when":{"technique.picking":"alternate","phase":"weeks-1-13"},"then":{"stroke.dynamic_equality":true,"stroke.direction":"strict-alternate"},"preference":"required","quality_binding":["any"],"falsifier":"Upstroke produces measurably weaker dynamic than downstroke","anchor":"strive to make up strokes sound as strong as down strokes","source_page":19},
-    {"rule_id":"roberts-20w-eighth-only-phase1","name":"Restrict to Eighth Notes in Phase 1","when":{"phase":"weeks-1-13","subdivision":"any"},"then":{"subdivision":"eighth","ornamentation":"none","rests":false,"hammer_ons":false,"pull_offs":false},"preference":"required","quality_binding":["any"],"falsifier":"Any non-eighth subdivision, rest, hammer-on, or pull-off appears in weeks 1–13","anchor":"Play only eighth notes, continuous and uninterrupted. No rests. No phrasing. No hammer-on's. No pull-offts. No other ornamentation.","source_page":19},
-    {"rule_id":"roberts-20w-legato-unlock-week15","name":"Unlock Legato Techniques at Week 15","when":{"phase":"weeks-15-17"},"then":{"hammer_ons":true,"pull_offs":true,"glissandi":true,"notes_per_stroke":">=2"},"preference":"recommended","quality_binding":["any"],"falsifier":"Legato devices introduced before week 15","anchor":"via these devices several notes can be produced with one picking stroke","source_page":15},
-    {"rule_id":"roberts-20w-dom7-whole-tone","name":"Apply Whole-Tone Scale Over Dominant 7th","when":{"chord_quality":"dominant7","harmonic.context":"floating"},"then":{"scale.type":"whole-tone","scale.interval_pattern":"W-W-W-W-W-W"},"preference":"preferred","quality_binding":["dom7"],"falsifier":"Scale contains a half step","anchor":"The Whole Tone Scale (symetrical, consecutive whole steps) most commonly used over dominant 7th chords.","source_page":12},
-    {"rule_id":"roberts-20w-dom7-diminished","name":"Apply Diminished Scale Over Dominant 7th for Tension","when":{"chord_quality":"dominant7","harmonic.context":"tension"},"then":{"scale.type":"diminished","scale.interval_pattern":"W-H-W-H-W-H-W-H"},"preference":"preferred","quality_binding":["dom7","dim"],"falsifier":"Scale does not alternate whole and half steps symmetrically","anchor":"The Diminished Scale (symetrical, consecutive whole step and half steps) most commonly used over dominant 7th chords or diminished chords.","source_page":12},
-    {"rule_id":"roberts-20w-maj69-pentatonic","name":"Use Major Pentatonic Over Major 6/9 Context","when":{"chord_quality":"major6/9","harmonic.context":"any"},"then":{"scale.type":"major-pentatonic","scale.omit_degrees":[4,7],"gravitational_pull":"low"},"preference":"preferred","quality_binding":["maj6/9"],"falsifier":"Scale includes the 4th or 7th degree","anchor":"The Major Pentatonic Scale (same as diatonic major with the active tones 3rd and 7th left out). When harmonized creates inversions of a Major 6/9 chord","source_page":13},
-    {"rule_id":"roberts-20w-key-center-nav","name":"Navigate by Key Center Not Chord-by-Chord","when":{"progression.type":"diatonic","harmonic.analysis":"any"},"then":{"navigation.unit":"key-center","pattern.selection":"one-of-five-movable"},"preference":"required","quality_binding":["any"],"falsifier":"Improviser treats each chord as an independent harmonic target rather than a member of a key center","anchor":"for each new one, move your hand to a convenient fingering pattern for that particular scale and do your improvising in that region of the guitar.","source_page":8},
-    {"rule_id":"roberts-20w-dom7-key-id","name":"Use Dominant 7th as Key Center Identifier","when":{"chord_quality":"dominant7","progression.role":"V"},"then":{"harmonic.key_center":"parent-major-of-V","analysis.confidence":"high"},"preference":"required","quality_binding":["dom7"],"falsifier":"Dominant 7th chord resolves ambiguously to more than one key center","anchor":"Eb 7 is a V chord (Dominant 7 type) which only appears once in any given major key, always as the V chord","source_page":7},
-    {"rule_id":"roberts-20w-five-pattern-coverage","name":"Use Five Movable Patterns for Full Neck Coverage","when":{"fingerboard.region":"any","scale.key":"any"},"then":{"pattern.count":5,"pattern.type":"finger-per-fret-movable","fingerboard.coverage":"full"},"preference":"required","quality_binding":["any"],"falsifier":"Fewer than five patterns are learned for a given key, leaving fingerboard regions uncovered","anchor":"There are five such patterns for any given scale. And each of these five are movable up or down the neck to the selected key","source_page":8},
-    {"rule_id":"roberts-20w-three-pattern-moves","name":"Connect Patterns with Exactly Three Move Types","when":{"navigation.transition":"pattern-to-pattern"},"then":{"transition.methods":["position-skip","stretch-to-adjacent","slide-on-half-step"]},"preference":"required","quality_binding":["any"],"falsifier":"A fourth transition method is employed that is not a position skip, stretch, or half-step slide","anchor":"There are essentially three 'moves' involved in moving from one pattern to another.","source_page":10},
-    {"rule_id":"roberts-20w-arpeggio-in-pattern","name":"Play Arpeggios Within Scale Pattern","when":{"melody.device":"arpeggio","harmonic.context":"any"},"then":{"arpeggio.placement":"within-key-center-pattern","arpeggio.isolation":false},"preference":"required","quality_binding":["any"],"falsifier":"Arpeggio is played as an isolated chord shape outside the key-center scale pattern","anchor":"arpeggios will be easier to handle if they are played within a scale pattern that corresponds to the key center from which the chord is derived","source_page":9},
-    {"rule_id":"roberts-20w-scale-run-ceiling","name":"Cap Consecutive Scalar Tones at 3-4","when":{"line.motion":"scalar","line.direction":"unidirectional"},"then":{"line.consecutive_scale_tones.max":4},"preference":"required","quality_binding":["any"],"falsifier":"More than 4 consecutive scale tones appear in the same direction without a skip or direction change","anchor":"don't play more than 3 or 4 scale tones in the same direction","source_page":13},
-    {"rule_id":"roberts-20w-diatonic-intervals","name":"Derive Interval Skips Diatonically","when":{"line.device":"interval-skip","scale.context":"diatonic"},"then":{"interval.derivation":"diatonic","interval.parallel":false,"interval.mixed_major_minor":true},"preference":"required","quality_binding":["any"],"falsifier":"Interval sequence produces parallel (non-diatonic) intervals that ignore the key's half steps","anchor":"playing scale intervals that take into account the half steps of the scale","source_page":13},
-    {"rule_id":"roberts-20w-common-tone-relief","name":"Use Common Tones as Line Relief","when":{"line.motion":"excessive-vertical","harmonic.context":"chord-change"},"then":{"melody.device":"common-tone-sustain","line.flattening":true},"preference":"recommended","quality_binding":["any"],"falsifier":"No note is shared between consecutive chords making common-tone sustain harmonically invalid","anchor":"The line can be flattened out --- a nice relief from excessive vertical movement.","source_page":11},
-    {"rule_id":"roberts-20w-arpeggio-contrast","name":"Use Arpeggios to Contrast Scale Movement","when":{"line.preceding_motion":"scalar","harmonic.context":"bar-harmony"},"then":{"melody.device":"arpeggio","line.angle":"steep","line.texture":"rolling"},"preference":"preferred","quality_binding":["any"],"falsifier":"Arpeggio used consecutively with another arpeggio without any intervening scalar motion","anchor":"Arpeggios are specifically chords, broken up into single notes. They are effective in outlining the bar harmony and offer a nice contrast to scale movement","source_page":13},
-    {"rule_id":"roberts-20w-interval-skip-drama","name":"Use Large Interval Skips for Dramatic Lines","when":{"line.character":"dramatic","line.preceding_motion":"scalar"},"then":{"melody.device":"large-interval-skip","line.scalar_monotony":false},"preference":"preferred","quality_binding":["any"],"falsifier":"Interval skip is a step (2nd) rather than a skip of a 3rd or larger","anchor":"Large interval skips can be a valuable tool for creating interesting lines and can have a dramatic effect","source_page":13},
-    {"rule_id":"roberts-20w-harmonic-minor-derive","name":"Derive Harmonic Minor by Raising 5th Degree of Diatonic Pattern","when":{"scale.type":"harmonic-minor","pattern.base":"diatonic-major"},"then":{"scale.modification":"raise-degree-5","scale.new_type":"harmonic-minor"},"preference":"recommended","quality_binding":["min","minMaj7"],"falsifier":"Harmonic minor is learned as an entirely new fingering independent of diatonic major patterns","anchor":"the relative harmonic minor scales can be quickly learned by simply sharping the fifth scale step of the diatonic scales","source_page":9},
-    {"rule_id":"roberts-20w-melodic-minor-context","name":"Prioritize Bar Harmony Over Melodic Minor Ascending Rule","when":{"scale.type":"melodic-minor","harmonic.context":"bar-harmony-present"},"then":{"scale.ascending_descending_rule":"optional","scale.priority":"bar-harmony"},"preference":"preferred","quality_binding":["min","min7"],"falsifier":"Bar harmony is absent and ascending/descending rules are the only contextual guide","anchor":"The ascending and descending rules here are a technicality, which in the final analysis may be disregarded in favor of the existant bar harmony","source_page":12},
-    {"rule_id":"roberts-20w-ear-final-arbiter","name":"Ear is Final Harmonic Arbiter for Substitutions","when":{"substitution.context":"any","analysis.ambiguous":true},"then":{"substitution.validity":"ear-determined","analysis.override":"allowed"},"preference":"recommended","quality_binding":["any"],"falsifier":"A substitution is accepted on theoretical grounds alone without an aural check","anchor":"If they're right, they will sound right and if they're wrong, you will know it immediately.","source_page":19},
-    {"rule_id":"roberts-20w-key-center-bracket-flexible","name":"Treat Key-Center Brackets as One Valid Analysis","when":{"harmonic.analysis":"key-center-bracket","substitution.available":true},"then":{"analysis.exclusivity":false,"substitution.allowed":true},"preference":"recommended","quality_binding":["any"],"falsifier":"Only a single key-center reading is considered with no alternative interpretations explored","anchor":"The key centers bracketed in the chord progressions represent only one analysis of the progression. Other views may be applied as well","source_page":19},
-    {"rule_id":"roberts-20w-visual-auditory-imprint","name":"Couple Visual Pattern Imprint with Sound","when":{"learning.stage":"pattern-internalization"},"then":{"imprint.modality":["visual","auditory"],"fingering.flexibility":true},"preference":"required","quality_binding":["any"],"falsifier":"Pattern is learned visually only without internalized sound association","anchor":"develop a strong visual imprint of the pattern itself, coupled with the tone sequence it produces (the sound)","source_page":10},
-    {"rule_id":"roberts-20w-speed-accuracy-gate","name":"Never Sacrifice Accuracy for Tempo","when":{"tempo.goal":"any","accuracy.current":"below-threshold"},"then":{"tempo.increase":false,"accuracy.priority":"absolute"},"preference":"required","quality_binding":["any"],"falsifier":"Tempo is increased while note clarity or synchronization errors remain present","anchor":"Care should be taken not to sacrifice accuracy and precision in order to meet the tempo goals.","source_page":19},
-    {"rule_id":"roberts-20w-metronome-tracker","name":"Use Metronome as Progress Tracker Not Target","when":{"practice.tool":"metronome"},"then":{"metronome.mode":"record-only","tempo.preset_target":false},"preference":"required","quality_binding":["any"],"falsifier":"Metronome is set to a desired future tempo and player attempts to match it","anchor":"Do not set your metronome to a desired speed and try to rise to meet it. Rather, use the metronome only to track your progress.","source_page":19},
-    {"rule_id":"roberts-20w-21day-imprint","name":"Maintain Tempo 21 Days for Permanent Imprinting","when":{"tempo.level":"current-max","practice.consecutive_days":">=21"},"then":{"skill.imprint":"permanent","retention.after_layoff":"restorable-2-3-weeks"},"preference":"recommended","quality_binding":["any"],"falsifier":"Fewer than 21 consecutive daily sessions are completed at a given tempo level","anchor":"once you reach a given level of speed, and maintain playing at that level or faster, for approximately 21 days, on a daily basis, -- the ability acquired during that period of time will be permanently imprinted","source_page":18},
-    {"rule_id":"roberts-20w-right-hand-flexibility","name":"Maintain Flexible Right-Hand Technique","when":{"technique.right_hand":"any"},"then":{"right_hand.anchor":"none","right_hand.adaptability":"required"},"preference":"required","quality_binding":["any"],"falsifier":"Right hand is anchored at elbow, wrist, or pick guard in a way that restricts movement","anchor":"flexibility-the ability to adapt the right hand to a variety of moves-is the key to longevity.","source_page":5},
-    {"rule_id":"roberts-20w-no-fixed-anchor","name":"Avoid Fixed Right-Hand Anchor Systems","when":{"technique.right_hand":"anchored"},"then":{"technique.right_hand":"free","speed_ceiling":"removed"},"preference":"avoid","quality_binding":["any"],"falsifier":"Anchor does not restrict picking range at faster tempos","anchor":"avoid is any kind of anchor system that inhibits freedom of movement.","source_page":5},
-    {"rule_id":"roberts-20w-no-flam","name":"Eliminate Flams via Simultaneous Hand Attack","when":{"technique.hands":"both","note.attack":"any"},"then":{"attack.simultaneity":true,"flam.tolerance":0},"preference":"required","quality_binding":["any"],"falsifier":"Left and right hand attacks are not simultaneous, producing two audible events per note","anchor":"the left and right hands must be in perfect synchronization. No Flams!","source_page":5},
-    {"rule_id":"roberts-20w-session-warmup","name":"Begin Every Session with 5-Minute Slow Warm-Up","when":{"session.stage":"start"},"then":{"warmup.duration_minutes":5,"warmup.tempo":"very-slow","warmup.register_coverage":["low","mid","high"]},"preference":"required","quality_binding":["any"],"falsifier":"Session begins without any slow full-fingerboard warm-up","anchor":"At the beginning of each practice session, warm up for 5 minutes by playing notes all over the fingerboard. Play very slowly","source_page":16},
-    {"rule_id":"roberts-20w-left-hand-perpendicular","name":"Fret Strings Perpendicular to Fingerboard","when":{"technique.left_hand":"fretting"},"then":{"finger.angle":"perpendicular","finger.axis":"right-angle-to-board"},"preference":"required","quality_binding":["any"],"falsifier":"Finger contacts string at an oblique angle, shifting string from center","anchor":"The fingers should operate straight up and down on the strings, like hammers in a piano, at a right angle to the fingerboard.","source_page":5},
-    {"rule_id":"roberts-20w-minimal-finger-lift","name":"Minimize Left-Hand Finger Lift","when":{"technique.left_hand":"fretting-movement"},"then":{"finger.lift_height":"minimum-to-avoid-noise"},"preference":"required","quality_binding":["any"],"falsifier":"Fingers lifted conspicuously higher than needed to clear the string","anchor":"The fingers should be lifted only high enough off the string to avoid string noise when moving","source_page":5},
-    {"rule_id":"roberts-20w-flat-left-wrist","name":"Maintain Flat Left-Wrist Posture","when":{"technique.left_hand":"any"},"then":{"wrist.posture":"flat","wrist.arch":"minimal"},"preference":"required","quality_binding":["any"],"falsifier":"Wrist is severely arched, creating strain or limiting finger mobility","anchor":"The wrist should maintain a fairly flat posture. Avoid severe arching of the left wrist","source_page":5},
-    {"rule_id":"roberts-20w-string-gauge-min","name":"Use Minimum .012 First String Gauge","when":{"equipment.strings":"any"},"then":{"string.gauge_first":">=.012","string.set":"medium-heavy"},"preference":"required","quality_binding":["any"],"falsifier":"First string is lighter than .012","anchor":"use a medium-heavy set of strings; nothing smaller than an .012 first string","source_page":3},
-    {"rule_id":"roberts-20w-pick-medium-heavy","name":"Use Medium-Sized Medium-to-Heavy Celluloid Pick","when":{"equipment.pick":"any"},"then":{"pick.size":"medium","pick.thickness":"medium-to-heavy","pick.material":"celluloid","pick.shape":"standard"},"preference":"required","quality_binding":["any"],"falsifier":"Pick is very large, oddly shaped, or thin","anchor":"Your pick should be of medium size, and medium to heavy in thickness. Avoid very large or odd shaped picks. Standard celluloid picks are well suited to this purpose.","source_page":4},
-    {"rule_id":"roberts-20w-three-tools-mandatory","name":"Require Metronome, Recorder, and Timer","when":{"practice.session":"any"},"then":{"tools.metronome":true,"tools.recorder":true,"tools.timer":true},"preference":"required","quality_binding":["any"],"falsifier":"Any one of the three tools is absent from the practice setup","anchor":"Also essential to the studies in this book will be: (1) a metronome, (2) a reel-to-reel or cassette tape recorder, and (3) an alarm clock or timer.","source_page":4},
-    {"rule_id":"roberts-20w-q-and-a-form","name":"Use Question-and-Answer as Primary Structural Form","when":{"improvisation.structure":"any","line.stalled":false},"then":{"line.form":"question-answer","line.repetition_unit":"sequence"},"preference":"preferred","quality_binding":["any"],"falsifier":"Line proceeds without any phrase-response relationship","anchor":"A very common form for building a solo line is: QUESTION AND ANSWER.","source_page":16},
-    {"rule_id":"roberts-20w-sing-before-play","name":"Vocalize Line Before Executing on Instrument","when":{"improvisation.stage":"pre-execution"},"then":{"workflow.step":"sing-first","ear_to_hand.priority":"high"},"preference":"recommended","quality_binding":["any"],"falsifier":"Player executes a line on instrument without any prior internal or vocal conception","anchor":"Listen to the 'pre-recorded changes' and sing the solo the way [you want to play it].","source_page":16},
-    {"rule_id":"roberts-20w-melody-sketch-scaffold","name":"Sketch Structural Melody to Scaffold Improvisation","when":{"improvisation.state":"stalled"},"then":{"scaffold.type":"simple-melody","scaffold.note_values":["half","quarter"],"line.form":"fills-around-melody"},"preference":"recommended","quality_binding":["any"],"falsifier":"No simple structural melody is present to anchor the improvised fills","anchor":"sketch out a very simple melody line over the changes, i.e. half note, quarter notes, halves, etc. Let this line run through your head as a basic melody and play 'fills' around it.","source_page":16},
-    {"rule_id":"roberts-20w-memorize-changes","name":"Memorize Chord Changes Before Improvising","when":{"improvisation.stage":"any","changes.memorized":false},"then":{"practice.priority":"memorize-changes-first","reading.from_page":false},"preference":"required","quality_binding":["any"],"falsifier":"Player improvises while reading chord symbols from notation","anchor":"Get the progression off the paper and into your head as soon as possible.","source_page":17},
-    {"rule_id":"roberts-20w-50min-six-days","name":"Practice 50 Minutes Six Days Per Week","when":{"program.phase":"any","week":"1-20"},"then":{"session.duration_minutes":50,"session.days_per_week":6,"rest.days_per_week":1},"preference":"required","quality_binding":["any"],"falsifier":"Session shorter than 50 minutes or fewer than 6 days practiced in a week without injury","anchor":"The Program is made up of a series of project lessons, each lasting 50 minutes per day, running six consecutive days per week, with one day off.","source_page":14},
-    {"rule_id":"roberts-20w-phase-sequence","name":"Execute Three Phases in Strict Sequence","when":{"program.phase":"any"},"then":{"phase.order":["duple-weeks-1-6","triple-weeks-8-13","legato-weeks-15-17"],"phase.skip":false},"preference":"required","quality_binding":["any"],"falsifier":"A later phase technique (triplets, legato) is introduced before its designated week range","anchor":"The First Six Weeks ... focus on the use of eighth notes ... Weeks Eight Through Thirteen ... focus on triple time via eighth note triplets.","source_page":14},
-    {"rule_id":"roberts-20w-no-skip-days","name":"Never Skip a Practice Day","when":{"practice.schedule":"any"},"then":{"session.skip":false,"regularity":"daily-non-negotiable"},"preference":"required","quality_binding":["any"],"falsifier":"A day is skipped for any reason during the program","anchor":"Avoid skipping a day, for whatever reason. The effect is hazardous to progress. Regularity is essential.","source_page":19},
-    {"rule_id":"roberts-20w-transpose-for-stimulus","name":"Transpose Lessons to New Keys for Creative Stimulus","when":{"practice.mode":"lesson-review","key.repeated":true},"then":{"transposition":"required","fingering.patterns":"new","melodic.ideas":"fresh"},"preference":"recommended","quality_binding":["any"],"falsifier":"Lesson is repeated in the same key without transposition","anchor":"Project Lesson 1-B uses the same chord progression transposed to another key, thus requiring a change of fingering patterns, licks, etc.","source_page":14},
-    {"rule_id":"roberts-20w-group-practice-accelerator","name":"Prioritize Group Practice as Phase Accelerator","when":{"practice.mode":"any","participants.count":">=2"},"then":{"practice.format":"ensemble-exchange","acceleration.factor":"superior-to-solo"},"preference":"preferred","quality_binding":["any"],"falsifier":"Group practice is available but solo practice is chosen instead","anchor":"The group dynamics is superior to private study for a program of this sort.","source_page":18},
-    {"rule_id":"roberts-20w-technique-serves-invention","name":"Treat All Technique as Servant of Spontaneous Invention","when":{"practice.goal":"technique-development"},"then":{"output.goal":"spontaneous-invention","model_solos.status":"reference-only"},"preference":"required","quality_binding":["any"],"falsifier":"Model solo examples are reproduced verbatim rather than used as reference","anchor":"The important consideration is the spontaneous invention of your own solo line.","source_page":27},
-    {"rule_id":"roberts-20w-break-repeated-licks","name":"Break Repeated Licks in Real Time Without Stopping","when":{"improvisation.lick":"repeated","line.flow":"continuous"},"then":{"response.action":"play-different-next-pass","response.stop":false},"preference":"required","quality_binding":["any"],"falsifier":"Player stops playing to reconsider rather than varying in the flow","anchor":"Be aware of this point in the tune and the next time around, do something else, no stops.","source_page":16},
-    {"rule_id":"roberts-20w-play-legato-steady","name":"Play Legato and Hold Steady Time","when":{"execution.context":"project-lesson"},"then":{"note.sustain":"maximum","tempo.stability":"metronomic","rush":false,"drag":false},"preference":"required","quality_binding":["any"],"falsifier":"Notes are clipped short or tempo wavers measurably from the metronome click","anchor":"Play Legato. Hold each note as long as possible. Great attention should be given to holding steady time. Do not rush or drag the tempo.","source_page":19}
+    {
+      "rule_id": "roberts-20w-alt-pick-equality",
+      "name": "Enforce Alternate Picking Stroke Equality",
+      "when": {
+        "technique.picking": "alternate",
+        "phase": "weeks-1-13"
+      },
+      "then": {
+        "stroke.dynamic_equality": true,
+        "stroke.direction": "strict-alternate"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Upstroke produces measurably weaker dynamic than downstroke",
+      "anchor": "strive to make up strokes sound as strong as down strokes",
+      "source_page": 19
+    },
+    {
+      "rule_id": "roberts-20w-eighth-only-phase1",
+      "name": "Restrict to Eighth Notes in Phase 1",
+      "when": {
+        "phase": "weeks-1-13",
+        "subdivision": "any"
+      },
+      "then": {
+        "subdivision": "eighth",
+        "ornamentation": "none",
+        "rests": false,
+        "hammer_ons": false,
+        "pull_offs": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Any non-eighth subdivision, rest, hammer-on, or pull-off appears in weeks 1–13",
+      "anchor": "Play only eighth notes, continuous and uninterrupted. No rests. No phrasing. No hammer-on's. No pull-offts. No other ornamentation.",
+      "source_page": 19
+    },
+    {
+      "rule_id": "roberts-20w-legato-unlock-week15",
+      "name": "Unlock Legato Techniques at Week 15",
+      "when": {
+        "phase": "weeks-15-17"
+      },
+      "then": {
+        "hammer_ons": true,
+        "pull_offs": true,
+        "glissandi": true,
+        "notes_per_stroke": ">=2"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Legato devices introduced before week 15",
+      "anchor": "via these devices several notes can be produced with one picking stroke",
+      "source_page": 15
+    },
+    {
+      "rule_id": "roberts-20w-dom7-whole-tone",
+      "name": "Apply Whole-Tone Scale Over Dominant 7th",
+      "when": {
+        "chord_quality": "dominant7",
+        "harmonic.context": "floating"
+      },
+      "then": {
+        "scale.type": "whole-tone",
+        "scale.interval_pattern": "W-W-W-W-W-W"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "dom7"
+      ],
+      "falsifier": "Scale contains a half step",
+      "anchor": "The Whole Tone Scale (symetrical, consecutive whole steps) most commonly used over dominant 7th chords.",
+      "source_page": 12
+    },
+    {
+      "rule_id": "roberts-20w-dom7-diminished",
+      "name": "Apply Diminished Scale Over Dominant 7th for Tension",
+      "when": {
+        "chord_quality": "dominant7",
+        "harmonic.context": "tension"
+      },
+      "then": {
+        "scale.type": "diminished",
+        "scale.interval_pattern": "W-H-W-H-W-H-W-H"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "dom7",
+        "dim"
+      ],
+      "falsifier": "Scale does not alternate whole and half steps symmetrically",
+      "anchor": "The Diminished Scale (symetrical, consecutive whole step and half steps) most commonly used over dominant 7th chords or diminished chords.",
+      "source_page": 12
+    },
+    {
+      "rule_id": "roberts-20w-maj69-pentatonic",
+      "name": "Use Major Pentatonic Over Major 6/9 Context",
+      "when": {
+        "chord_quality": "major6/9",
+        "harmonic.context": "any"
+      },
+      "then": {
+        "scale.type": "major-pentatonic",
+        "scale.omit_degrees": [
+          4,
+          7
+        ],
+        "gravitational_pull": "low"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "maj6/9"
+      ],
+      "falsifier": "Scale includes the 4th or 7th degree",
+      "anchor": "The Major Pentatonic Scale (same as diatonic major with the active tones 3rd and 7th left out). When harmonized creates inversions of a Major 6/9 chord",
+      "source_page": 13
+    },
+    {
+      "rule_id": "roberts-20w-key-center-nav",
+      "name": "Navigate by Key Center Not Chord-by-Chord",
+      "when": {
+        "progression.type": "diatonic",
+        "harmonic.analysis": "any"
+      },
+      "then": {
+        "navigation.unit": "key-center",
+        "pattern.selection": "one-of-five-movable"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Improviser treats each chord as an independent harmonic target rather than a member of a key center",
+      "anchor": "for each new one, move your hand to a convenient fingering pattern for that particular scale and do your improvising in that region of the guitar.",
+      "source_page": 8
+    },
+    {
+      "rule_id": "roberts-20w-dom7-key-id",
+      "name": "Use Dominant 7th as Key Center Identifier",
+      "when": {
+        "chord_quality": "dominant7",
+        "progression.role": "V"
+      },
+      "then": {
+        "harmonic.key_center": "parent-major-of-V",
+        "analysis.confidence": "high"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "dom7"
+      ],
+      "falsifier": "Dominant 7th chord resolves ambiguously to more than one key center",
+      "anchor": "Eb 7 is a V chord (Dominant 7 type) which only appears once in any given major key, always as the V chord",
+      "source_page": 7
+    },
+    {
+      "rule_id": "roberts-20w-five-pattern-coverage",
+      "name": "Use Five Movable Patterns for Full Neck Coverage",
+      "when": {
+        "fingerboard.region": "any",
+        "scale.key": "any"
+      },
+      "then": {
+        "pattern.count": 5,
+        "pattern.type": "finger-per-fret-movable",
+        "fingerboard.coverage": "full"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Fewer than five patterns are learned for a given key, leaving fingerboard regions uncovered",
+      "anchor": "There are five such patterns for any given scale. And each of these five are movable up or down the neck to the selected key",
+      "source_page": 8
+    },
+    {
+      "rule_id": "roberts-20w-three-pattern-moves",
+      "name": "Connect Patterns with Exactly Three Move Types",
+      "when": {
+        "navigation.transition": "pattern-to-pattern"
+      },
+      "then": {
+        "transition.methods": [
+          "position-skip",
+          "stretch-to-adjacent",
+          "slide-on-half-step"
+        ]
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A fourth transition method is employed that is not a position skip, stretch, or half-step slide",
+      "anchor": "There are essentially three 'moves' involved in moving from one pattern to another.",
+      "source_page": 10
+    },
+    {
+      "rule_id": "roberts-20w-arpeggio-in-pattern",
+      "name": "Play Arpeggios Within Scale Pattern",
+      "when": {
+        "melody.device": "arpeggio",
+        "harmonic.context": "any"
+      },
+      "then": {
+        "arpeggio.placement": "within-key-center-pattern",
+        "arpeggio.isolation": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Arpeggio is played as an isolated chord shape outside the key-center scale pattern",
+      "anchor": "arpeggios will be easier to handle if they are played within a scale pattern that corresponds to the key center from which the chord is derived",
+      "source_page": 9
+    },
+    {
+      "rule_id": "roberts-20w-scale-run-ceiling",
+      "name": "Cap Consecutive Scalar Tones at 3-4",
+      "when": {
+        "line.motion": "scalar",
+        "line.direction": "unidirectional"
+      },
+      "then": {
+        "line.consecutive_scale_tones.max": 4
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "More than 4 consecutive scale tones appear in the same direction without a skip or direction change",
+      "anchor": "don't play more than 3 or 4 scale tones in the same direction",
+      "source_page": 13
+    },
+    {
+      "rule_id": "roberts-20w-diatonic-intervals",
+      "name": "Derive Interval Skips Diatonically",
+      "when": {
+        "line.device": "interval-skip",
+        "scale.context": "diatonic"
+      },
+      "then": {
+        "interval.derivation": "diatonic",
+        "interval.parallel": false,
+        "interval.mixed_major_minor": true
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Interval sequence produces parallel (non-diatonic) intervals that ignore the key's half steps",
+      "anchor": "playing scale intervals that take into account the half steps of the scale",
+      "source_page": 13
+    },
+    {
+      "rule_id": "roberts-20w-common-tone-relief",
+      "name": "Use Common Tones as Line Relief",
+      "when": {
+        "line.motion": "excessive-vertical",
+        "harmonic.context": "chord-change"
+      },
+      "then": {
+        "melody.device": "common-tone-sustain",
+        "line.flattening": true
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "No note is shared between consecutive chords making common-tone sustain harmonically invalid",
+      "anchor": "The line can be flattened out --- a nice relief from excessive vertical movement.",
+      "source_page": 11
+    },
+    {
+      "rule_id": "roberts-20w-arpeggio-contrast",
+      "name": "Use Arpeggios to Contrast Scale Movement",
+      "when": {
+        "line.preceding_motion": "scalar",
+        "harmonic.context": "bar-harmony"
+      },
+      "then": {
+        "melody.device": "arpeggio",
+        "line.angle": "steep",
+        "line.texture": "rolling"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Arpeggio used consecutively with another arpeggio without any intervening scalar motion",
+      "anchor": "Arpeggios are specifically chords, broken up into single notes. They are effective in outlining the bar harmony and offer a nice contrast to scale movement",
+      "source_page": 13
+    },
+    {
+      "rule_id": "roberts-20w-interval-skip-drama",
+      "name": "Use Large Interval Skips for Dramatic Lines",
+      "when": {
+        "line.character": "dramatic",
+        "line.preceding_motion": "scalar"
+      },
+      "then": {
+        "melody.device": "large-interval-skip",
+        "line.scalar_monotony": false
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Interval skip is a step (2nd) rather than a skip of a 3rd or larger",
+      "anchor": "Large interval skips can be a valuable tool for creating interesting lines and can have a dramatic effect",
+      "source_page": 13
+    },
+    {
+      "rule_id": "roberts-20w-harmonic-minor-derive",
+      "name": "Derive Harmonic Minor by Raising 5th Degree of Diatonic Pattern",
+      "when": {
+        "scale.type": "harmonic-minor",
+        "pattern.base": "diatonic-major"
+      },
+      "then": {
+        "scale.modification": "raise-degree-5",
+        "scale.new_type": "harmonic-minor"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "min",
+        "minMaj7"
+      ],
+      "falsifier": "Harmonic minor is learned as an entirely new fingering independent of diatonic major patterns",
+      "anchor": "the relative harmonic minor scales can be quickly learned by simply sharping the fifth scale step of the diatonic scales",
+      "source_page": 9
+    },
+    {
+      "rule_id": "roberts-20w-melodic-minor-context",
+      "name": "Prioritize Bar Harmony Over Melodic Minor Ascending Rule",
+      "when": {
+        "scale.type": "melodic-minor",
+        "harmonic.context": "bar-harmony-present"
+      },
+      "then": {
+        "scale.ascending_descending_rule": "optional",
+        "scale.priority": "bar-harmony"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "min",
+        "min7"
+      ],
+      "falsifier": "Bar harmony is absent and ascending/descending rules are the only contextual guide",
+      "anchor": "The ascending and descending rules here are a technicality, which in the final analysis may be disregarded in favor of the existant bar harmony",
+      "source_page": 12
+    },
+    {
+      "rule_id": "roberts-20w-ear-final-arbiter",
+      "name": "Ear is Final Harmonic Arbiter for Substitutions",
+      "when": {
+        "substitution.context": "any",
+        "analysis.ambiguous": true
+      },
+      "then": {
+        "substitution.validity": "ear-determined",
+        "analysis.override": "allowed"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A substitution is accepted on theoretical grounds alone without an aural check",
+      "anchor": "If they're right, they will sound right and if they're wrong, you will know it immediately.",
+      "source_page": 19
+    },
+    {
+      "rule_id": "roberts-20w-key-center-bracket-flexible",
+      "name": "Treat Key-Center Brackets as One Valid Analysis",
+      "when": {
+        "harmonic.analysis": "key-center-bracket",
+        "substitution.available": true
+      },
+      "then": {
+        "analysis.exclusivity": false,
+        "substitution.allowed": true
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Only a single key-center reading is considered with no alternative interpretations explored",
+      "anchor": "The key centers bracketed in the chord progressions represent only one analysis of the progression. Other views may be applied as well",
+      "source_page": 19
+    },
+    {
+      "rule_id": "roberts-20w-visual-auditory-imprint",
+      "name": "Couple Visual Pattern Imprint with Sound",
+      "when": {
+        "learning.stage": "pattern-internalization"
+      },
+      "then": {
+        "imprint.modality": [
+          "visual",
+          "auditory"
+        ],
+        "fingering.flexibility": true
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Pattern is learned visually only without internalized sound association",
+      "anchor": "develop a strong visual imprint of the pattern itself, coupled with the tone sequence it produces (the sound)",
+      "source_page": 10
+    },
+    {
+      "rule_id": "roberts-20w-speed-accuracy-gate",
+      "name": "Never Sacrifice Accuracy for Tempo",
+      "when": {
+        "tempo.goal": "any",
+        "accuracy.current": "below-threshold"
+      },
+      "then": {
+        "tempo.increase": false,
+        "accuracy.priority": "absolute"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Tempo is increased while note clarity or synchronization errors remain present",
+      "anchor": "Care should be taken not to sacrifice accuracy and precision in order to meet the tempo goals.",
+      "source_page": 19
+    },
+    {
+      "rule_id": "roberts-20w-metronome-tracker",
+      "name": "Use Metronome as Progress Tracker Not Target",
+      "when": {
+        "practice.tool": "metronome"
+      },
+      "then": {
+        "metronome.mode": "record-only",
+        "tempo.preset_target": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Metronome is set to a desired future tempo and player attempts to match it",
+      "anchor": "Do not set your metronome to a desired speed and try to rise to meet it. Rather, use the metronome only to track your progress.",
+      "source_page": 19
+    },
+    {
+      "rule_id": "roberts-20w-21day-imprint",
+      "name": "Maintain Tempo 21 Days for Permanent Imprinting",
+      "when": {
+        "tempo.level": "current-max",
+        "practice.consecutive_days": ">=21"
+      },
+      "then": {
+        "skill.imprint": "permanent",
+        "retention.after_layoff": "restorable-2-3-weeks"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Fewer than 21 consecutive daily sessions are completed at a given tempo level",
+      "anchor": "once you reach a given level of speed, and maintain playing at that level or faster, for approximately 21 days, on a daily basis, -- the ability acquired during that period of time will be permanently imprinted",
+      "source_page": 18
+    },
+    {
+      "rule_id": "roberts-20w-right-hand-flexibility",
+      "name": "Maintain Flexible Right-Hand Technique",
+      "when": {
+        "technique.right_hand": "any"
+      },
+      "then": {
+        "right_hand.anchor": "none",
+        "right_hand.adaptability": "required"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Right hand is anchored at elbow, wrist, or pick guard in a way that restricts movement",
+      "anchor": "flexibility-the ability to adapt the right hand to a variety of moves-is the key to longevity.",
+      "source_page": 5
+    },
+    {
+      "rule_id": "roberts-20w-no-fixed-anchor",
+      "name": "Avoid Fixed Right-Hand Anchor Systems",
+      "when": {
+        "technique.right_hand": "anchored"
+      },
+      "then": {
+        "technique.right_hand": "free",
+        "speed_ceiling": "removed"
+      },
+      "preference": "avoid",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Anchor does not restrict picking range at faster tempos",
+      "anchor": "avoid is any kind of anchor system that inhibits freedom of movement.",
+      "source_page": 5
+    },
+    {
+      "rule_id": "roberts-20w-no-flam",
+      "name": "Eliminate Flams via Simultaneous Hand Attack",
+      "when": {
+        "technique.hands": "both",
+        "note.attack": "any"
+      },
+      "then": {
+        "attack.simultaneity": true,
+        "flam.tolerance": 0
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Left and right hand attacks are not simultaneous, producing two audible events per note",
+      "anchor": "the left and right hands must be in perfect synchronization. No Flams!",
+      "source_page": 5
+    },
+    {
+      "rule_id": "roberts-20w-session-warmup",
+      "name": "Begin Every Session with 5-Minute Slow Warm-Up",
+      "when": {
+        "session.stage": "start"
+      },
+      "then": {
+        "warmup.duration_minutes": 5,
+        "warmup.tempo": "very-slow",
+        "warmup.register_coverage": [
+          "low",
+          "mid",
+          "high"
+        ]
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Session begins without any slow full-fingerboard warm-up",
+      "anchor": "At the beginning of each practice session, warm up for 5 minutes by playing notes all over the fingerboard. Play very slowly",
+      "source_page": 16
+    },
+    {
+      "rule_id": "roberts-20w-left-hand-perpendicular",
+      "name": "Fret Strings Perpendicular to Fingerboard",
+      "when": {
+        "technique.left_hand": "fretting"
+      },
+      "then": {
+        "finger.angle": "perpendicular",
+        "finger.axis": "right-angle-to-board"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Finger contacts string at an oblique angle, shifting string from center",
+      "anchor": "The fingers should operate straight up and down on the strings, like hammers in a piano, at a right angle to the fingerboard.",
+      "source_page": 5
+    },
+    {
+      "rule_id": "roberts-20w-minimal-finger-lift",
+      "name": "Minimize Left-Hand Finger Lift",
+      "when": {
+        "technique.left_hand": "fretting-movement"
+      },
+      "then": {
+        "finger.lift_height": "minimum-to-avoid-noise"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Fingers lifted conspicuously higher than needed to clear the string",
+      "anchor": "The fingers should be lifted only high enough off the string to avoid string noise when moving",
+      "source_page": 5
+    },
+    {
+      "rule_id": "roberts-20w-flat-left-wrist",
+      "name": "Maintain Flat Left-Wrist Posture",
+      "when": {
+        "technique.left_hand": "any"
+      },
+      "then": {
+        "wrist.posture": "flat",
+        "wrist.arch": "minimal"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Wrist is severely arched, creating strain or limiting finger mobility",
+      "anchor": "The wrist should maintain a fairly flat posture. Avoid severe arching of the left wrist",
+      "source_page": 5
+    },
+    {
+      "rule_id": "roberts-20w-string-gauge-min",
+      "name": "Use Minimum .012 First String Gauge",
+      "when": {
+        "equipment.strings": "any"
+      },
+      "then": {
+        "string.gauge_first": ">=.012",
+        "string.set": "medium-heavy"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "First string is lighter than .012",
+      "anchor": "use a medium-heavy set of strings; nothing smaller than an .012 first string",
+      "source_page": 3
+    },
+    {
+      "rule_id": "roberts-20w-pick-medium-heavy",
+      "name": "Use Medium-Sized Medium-to-Heavy Celluloid Pick",
+      "when": {
+        "equipment.pick": "any"
+      },
+      "then": {
+        "pick.size": "medium",
+        "pick.thickness": "medium-to-heavy",
+        "pick.material": "celluloid",
+        "pick.shape": "standard"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Pick is very large, oddly shaped, or thin",
+      "anchor": "Your pick should be of medium size, and medium to heavy in thickness. Avoid very large or odd shaped picks. Standard celluloid picks are well suited to this purpose.",
+      "source_page": 4
+    },
+    {
+      "rule_id": "roberts-20w-three-tools-mandatory",
+      "name": "Require Metronome, Recorder, and Timer",
+      "when": {
+        "practice.session": "any"
+      },
+      "then": {
+        "tools.metronome": true,
+        "tools.recorder": true,
+        "tools.timer": true
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Any one of the three tools is absent from the practice setup",
+      "anchor": "Also essential to the studies in this book will be: (1) a metronome, (2) a reel-to-reel or cassette tape recorder, and (3) an alarm clock or timer.",
+      "source_page": 4
+    },
+    {
+      "rule_id": "roberts-20w-q-and-a-form",
+      "name": "Use Question-and-Answer as Primary Structural Form",
+      "when": {
+        "improvisation.structure": "any",
+        "line.stalled": false
+      },
+      "then": {
+        "line.form": "question-answer",
+        "line.repetition_unit": "sequence"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Line proceeds without any phrase-response relationship",
+      "anchor": "A very common form for building a solo line is: QUESTION AND ANSWER.",
+      "source_page": 16
+    },
+    {
+      "rule_id": "roberts-20w-sing-before-play",
+      "name": "Vocalize Line Before Executing on Instrument",
+      "when": {
+        "improvisation.stage": "pre-execution"
+      },
+      "then": {
+        "workflow.step": "sing-first",
+        "ear_to_hand.priority": "high"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Player executes a line on instrument without any prior internal or vocal conception",
+      "anchor": "Listen to the 'pre-recorded changes' and sing the solo the way [you want to play it].",
+      "source_page": 16
+    },
+    {
+      "rule_id": "roberts-20w-melody-sketch-scaffold",
+      "name": "Sketch Structural Melody to Scaffold Improvisation",
+      "when": {
+        "improvisation.state": "stalled"
+      },
+      "then": {
+        "scaffold.type": "simple-melody",
+        "scaffold.note_values": [
+          "half",
+          "quarter"
+        ],
+        "line.form": "fills-around-melody"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "No simple structural melody is present to anchor the improvised fills",
+      "anchor": "sketch out a very simple melody line over the changes, i.e. half note, quarter notes, halves, etc. Let this line run through your head as a basic melody and play 'fills' around it.",
+      "source_page": 16
+    },
+    {
+      "rule_id": "roberts-20w-memorize-changes",
+      "name": "Memorize Chord Changes Before Improvising",
+      "when": {
+        "improvisation.stage": "any",
+        "changes.memorized": false
+      },
+      "then": {
+        "practice.priority": "memorize-changes-first",
+        "reading.from_page": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Player improvises while reading chord symbols from notation",
+      "anchor": "Get the progression off the paper and into your head as soon as possible.",
+      "source_page": 17
+    },
+    {
+      "rule_id": "roberts-20w-50min-six-days",
+      "name": "Practice 50 Minutes Six Days Per Week",
+      "when": {
+        "program.phase": "any",
+        "week": "1-20"
+      },
+      "then": {
+        "session.duration_minutes": 50,
+        "session.days_per_week": 6,
+        "rest.days_per_week": 1
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Session shorter than 50 minutes or fewer than 6 days practiced in a week without injury",
+      "anchor": "The Program is made up of a series of project lessons, each lasting 50 minutes per day, running six consecutive days per week, with one day off.",
+      "source_page": 14
+    },
+    {
+      "rule_id": "roberts-20w-phase-sequence",
+      "name": "Execute Three Phases in Strict Sequence",
+      "when": {
+        "program.phase": "any"
+      },
+      "then": {
+        "phase.order": [
+          "duple-weeks-1-6",
+          "triple-weeks-8-13",
+          "legato-weeks-15-17"
+        ],
+        "phase.skip": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A later phase technique (triplets, legato) is introduced before its designated week range",
+      "anchor": "The First Six Weeks ... focus on the use of eighth notes ... Weeks Eight Through Thirteen ... focus on triple time via eighth note triplets.",
+      "source_page": 14
+    },
+    {
+      "rule_id": "roberts-20w-no-skip-days",
+      "name": "Never Skip a Practice Day",
+      "when": {
+        "practice.schedule": "any"
+      },
+      "then": {
+        "session.skip": false,
+        "regularity": "daily-non-negotiable"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A day is skipped for any reason during the program",
+      "anchor": "Avoid skipping a day, for whatever reason. The effect is hazardous to progress. Regularity is essential.",
+      "source_page": 19
+    },
+    {
+      "rule_id": "roberts-20w-transpose-for-stimulus",
+      "name": "Transpose Lessons to New Keys for Creative Stimulus",
+      "when": {
+        "practice.mode": "lesson-review",
+        "key.repeated": true
+      },
+      "then": {
+        "transposition": "required",
+        "fingering.patterns": "new",
+        "melodic.ideas": "fresh"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Lesson is repeated in the same key without transposition",
+      "anchor": "Project Lesson 1-B uses the same chord progression transposed to another key, thus requiring a change of fingering patterns, licks, etc.",
+      "source_page": 14
+    },
+    {
+      "rule_id": "roberts-20w-group-practice-accelerator",
+      "name": "Prioritize Group Practice as Phase Accelerator",
+      "when": {
+        "practice.mode": "any",
+        "participants.count": ">=2"
+      },
+      "then": {
+        "practice.format": "ensemble-exchange",
+        "acceleration.factor": "superior-to-solo"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Group practice is available but solo practice is chosen instead",
+      "anchor": "The group dynamics is superior to private study for a program of this sort.",
+      "source_page": 18
+    },
+    {
+      "rule_id": "roberts-20w-technique-serves-invention",
+      "name": "Treat All Technique as Servant of Spontaneous Invention",
+      "when": {
+        "practice.goal": "technique-development"
+      },
+      "then": {
+        "output.goal": "spontaneous-invention",
+        "model_solos.status": "reference-only"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Model solo examples are reproduced verbatim rather than used as reference",
+      "anchor": "The important consideration is the spontaneous invention of your own solo line.",
+      "source_page": 27
+    },
+    {
+      "rule_id": "roberts-20w-break-repeated-licks",
+      "name": "Break Repeated Licks in Real Time Without Stopping",
+      "when": {
+        "improvisation.lick": "repeated",
+        "line.flow": "continuous"
+      },
+      "then": {
+        "response.action": "play-different-next-pass",
+        "response.stop": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Player stops playing to reconsider rather than varying in the flow",
+      "anchor": "Be aware of this point in the tune and the next time around, do something else, no stops.",
+      "source_page": 16
+    },
+    {
+      "rule_id": "roberts-20w-play-legato-steady",
+      "name": "Play Legato and Hold Steady Time",
+      "when": {
+        "execution.context": "project-lesson"
+      },
+      "then": {
+        "note.sustain": "maximum",
+        "tempo.stability": "metronomic",
+        "rush": false,
+        "drag": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Notes are clipped short or tempo wavers measurably from the metronome click",
+      "anchor": "Play Legato. Hold each note as long as possible. Great attention should be given to holding steady time. Do not rush or drag the tempo.",
+      "source_page": 19
+    }
   ]
 }

--- a/plugin/data/masters-corpus/jerry-bergonzi/melodic-rhythms-vol-4/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/jerry-bergonzi/melodic-rhythms-vol-4/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16-jerry-bergonzi-melodic-rhythms-vol-4",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:48-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "jerry-bergonzi",
   "work_id": "melodic-rhythms-vol-4",
   "engine_rules": [

--- a/plugin/data/masters-corpus/jimmy-bruno/the-art-of-picking/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/jimmy-bruno/the-art-of-picking/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16-jimmy-bruno-the-art-of-picking",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:44-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "jimmy-bruno",
   "work_id": "the-art-of-picking",
   "engine_rules": [

--- a/plugin/data/masters-corpus/joe-pass/guitar-chords/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/joe-pass/guitar-chords/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16-joe-pass-guitar-chords",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:41-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "joe-pass",
   "work_id": "guitar-chords",
   "engine_rules": [

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-1/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-1/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16-mick-goodrick-almanac-vol-1",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:58-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "mick-goodrick",
   "work_id": "almanac-vol-1",
   "engine_rules": [

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-2/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-2/derived/engine-rules.json
@@ -1,45 +1,876 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-17-mick-goodrick-almanac-vol-2",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-17T09:44:55-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "mick-goodrick",
   "work_id": "almanac-vol-2",
   "engine_rules": [
-    {"rule_id":"goodrick-v2-quartal-interval-inventory","name":"Restrict quartal voicing to 4ths, 5ths, 2nds, 7ths","when":{"voicing.family":"quartal"},"then":{"voicing.allowed_intervals":["2nd","4th","5th","7th"],"voicing.excluded_intervals":["3rd","6th"]},"preference":"required","quality_binding":["any"],"falsifier":"A quartal voicing containing a 3rd or 6th as primary structural interval","anchor":"Primary intervals: 4ths and 5ths","source_page":10},
-    {"rule_id":"goodrick-v2-quartal-tertial-opposition","name":"Treat quartal and tertial harmony as structural opposites","when":{"voicing.family":"quartal"},"then":{"harmonic.context":"non-tertial","voicing.color_intervals":["3rd","6th"]},"preference":"required","quality_binding":["any"],"falsifier":"Quartal voicing treated as tertial chord with added color tones","anchor":"tertial harmony and quartal harmony are pretty much exact opposites.","source_page":9},
-    {"rule_id":"goodrick-v2-quartal-diminished-fourth-avoid","name":"Avoid B-Eb in quartal voicings","when":{"voicing.family":"quartal","voicing.interval_pair":"B-Eb"},"then":{"voicing.action":"exclude","voicing.reason":"enharmonic-collapse-to-major-3rd"},"preference":"avoid","quality_binding":["any"],"falsifier":"A B-Eb interval in quartal context that does not collapse to triadic sound","anchor":"they don't work very well in a 4th voicings context.","source_page":9},
-    {"rule_id":"goodrick-v2-drop-d-pedal-dorian","name":"Use drop-D pedal for quartal cycle exploration in D Dorian","when":{"voicing.family":"quartal","arrangement.style":"free-exploration"},"then":{"scale.context":"D-Dorian","voicing.technique":"drop-D-pedal","tuning.low_string":"D"},"preference":"recommended","quality_binding":["any"],"falsifier":"D Dorian containing an avoid note that obstructs free pedal exploration","anchor":"tune the low E string down a whole step to D. Use the low D string as a pedal","source_page":10},
-    {"rule_id":"goodrick-v2-dorian-no-avoid-notes","name":"Prefer D Dorian as avoid-note-free quartal context","when":{"voicing.family":"quartal","scale.context":"D-Dorian"},"then":{"voicing.avoid_note_count":0,"arrangement.style":"unrestricted-cycle-traversal"},"preference":"preferred","quality_binding":["any"],"falsifier":"Another Dorian mode that also has zero avoid notes","anchor":"there aren't any \"avoid\" notes in Dorian","source_page":10},
-    {"rule_id":"goodrick-v2-arpeggio-direction-alternation","name":"Alternate arpeggio direction on successive chord positions","when":{"voicing.deployment_mode":"arpeggios","progression.type":"diatonic-cycle"},"then":{"voicing.arpeggio_direction":"alternating-up-down","voice_leading.constraint":"ascend-odd-descend-even"},"preference":"required","quality_binding":["any"],"falsifier":"Two successive chords arpeggiated in the same direction","anchor":"Arpeggiate up the first chord, then down the second chord","source_page":11},
-    {"rule_id":"goodrick-v2-five-application-modes","name":"Apply every voicing through all five M-Lode deployment modes","when":{"voicing.family":["quartal","triads","seventh-chords","tbn-i","tbn-ii","spread-clusters"]},"then":{"voicing.deployment_modes":["melodies","arpeggios","counterpoint","3-part-chords","4-part-chords"]},"preference":"recommended","quality_binding":["any"],"falsifier":"A voicing family for which fewer than five deployment modes are applicable","anchor":"1. melodies 2. arpeggios 3. counterpoint (2 simultaneous voices) 4. 3-part chords 5. 4-part chords","source_page":11},
-    {"rule_id":"goodrick-v2-stepwise-voice-motion","name":"Move each voice by 2nd, 3rd, or common tone across diatonic cycle positions","when":{"progression.type":"diatonic-cycle","voicing.family":["quartal","seventh-chords","spread-clusters"]},"then":{"voice_leading.constraint":"stepwise-or-common-tone","voice_leading.max_motion":"3rd"},"preference":"required","quality_binding":["any"],"falsifier":"A voice moving by a 4th or larger between adjacent cycle positions without common-tone annotation","anchor":"All of the M-Lode is based on voice-leading.","source_page":22},
-    {"rule_id":"goodrick-v2-common-tone-annotation","name":"Mark non-moving voices as c.t. in voice-leading analysis","when":{"voice_leading.constraint":"stepwise-or-common-tone"},"then":{"voice_leading.static_voice_label":"c.t.","voice_leading.c.t._is_distinct_category":true},"preference":"required","quality_binding":["any"],"falsifier":"A static voice omitted from or merged with moving voices in the analysis grid","anchor":"1 -> c.t.","source_page":27},
-    {"rule_id":"goodrick-v2-intervallic-functional-grid","name":"Analyze every voicing in paired Intervallic and Functional grids","when":{"voicing.family":["quartal","spread-clusters","seventh-chords"]},"then":{"analysis.grid_types":["intervallic","functional"],"analysis.intervallic_cell":"motion-interval-per-voice","analysis.functional_cell":"scale-degree-destination-per-voice"},"preference":"required","quality_binding":["any"],"falsifier":"An analysis grid that omits either intervallic or functional dimension","anchor":"5 -> 2nd / 2 -> 2nd / 1 -> 2nd","source_page":27},
-    {"rule_id":"goodrick-v2-cycles-2-7-dual-voice-leading","name":"Apply two distinct voice-leadings at Cycles 2 and 7","when":{"cycle.id":["2","7"]},"then":{"voice_leading.variant_count":2,"voice_leading.hazard":"voice-crossing-on-diatonic-5th"},"preference":"required","quality_binding":["any"],"falsifier":"Cycles 2 or 7 resolved with a single voice-leading without addressing the diatonic 5th voice-crossing","anchor":"Cycles 2 and 7 have two different voice-leadings.","source_page":21},
-    {"rule_id":"goodrick-v2-octave-insertion-expansion","name":"Derive new voicing variants by inserting an octave between any two voices","when":{"voicing.family":["quartal","triads","seventh-chords","spread-clusters"]},"then":{"voicing.expansion_method":"octave-insertion","voicing.insertion_positions":"any-adjacent-voice-pair"},"preference":"recommended","quality_binding":["any"],"falsifier":"A voicing expansion that adds a non-octave interval between voices","anchor":"inserting an octave between any 2 voices within a 3-part chord or a 4-part chord","source_page":14},
-    {"rule_id":"goodrick-v2-octave-insertion-applies-to-quartal","name":"Apply octave insertion equally to 3-part quartal voicings","when":{"voicing.family":"quartal","voicing.part_count":3},"then":{"voicing.expansion_method":"octave-insertion","voicing.result_families":["drop-2-drop-4","drop-3-and-4"]},"preference":"recommended","quality_binding":["any"],"falsifier":"Octave insertion applied only to tertial chord families and not quartal","anchor":"Of course, all of this applies to the 3-part 4th voicings as well","source_page":14},
-    {"rule_id":"goodrick-v2-drop-voicing-type-selection","name":"Select drop voicing type from canonical set","when":{"voicing.density":"open"},"then":{"voicing.drop_types":["Drop-2","Drop-3","Drop-4","Drop-2-and-3","Drop-2-and-4","Double-Drop-2-Drop-4","Drop-3-and-4"]},"preference":"recommended","quality_binding":["any"],"falsifier":"A drop voicing type not derivable from the canonical close-voicing octave-insertion process","anchor":"Drop 4 is an option.","source_page":15},
-    {"rule_id":"goodrick-v2-fingerstyle-drop-3-4-requirement","name":"Restrict Drop 3 and 4, Double Drop 2/Drop 4 to fingerstyle players","when":{"voicing.drop_type":["Drop-3-and-4","Double-Drop-2-Drop-4"]},"then":{"arrangement.technique":"fingerstyle-only"},"preference":"required","quality_binding":["any"],"falsifier":"Drop 3 and 4 executed comfortably with a pick","anchor":"only for finger-style guitarists] would be: Drop 3 and 4","source_page":15},
-    {"rule_id":"goodrick-v2-single-voice-omission","name":"Derive 3-part subset from any 4-part chord by dropping one voice","when":{"voicing.part_count":4},"then":{"voicing.omission_configurations":4,"voicing.result_part_count":3,"voicing.result_families":["7th-no-5th","7th-no-3rd","3-part-spread-cluster"]},"preference":"recommended","quality_binding":["any"],"falsifier":"Fewer than four valid omission configurations for a 4-part diatonic chord","anchor":"it just amounts to leaving out one of the voices... There are 4 possible configurations.","source_page":19},
-    {"rule_id":"goodrick-v2-passing-tone-third-fill","name":"Fill any voice motion of a 3rd with a diatonic passing tone","when":{"voice_leading.interval":"3rd"},"then":{"voicing.non_chord_tone":"passing-tone","nct.placement":"between-two-chord-tones-a-3rd-apart"},"preference":"recommended","quality_binding":["any"],"falsifier":"A voice motion by 3rd that cannot accommodate a diatonic passing tone","anchor":"Anytime one of the voices moves a distance of a 3rd, you can fill in that interval with a melodic passing tone.","source_page":17},
-    {"rule_id":"goodrick-v2-passing-tone-two-voices-in-thirds","name":"Apply passing tones to both voices when two voices simultaneously move in 3rds","when":{"voice_leading.interval":"3rd","voice_leading.simultaneous_thirds_count":2},"then":{"voicing.non_chord_tone":"passing-tone","nct.voice_count":2},"preference":"recommended","quality_binding":["any"],"falsifier":"Two voices moving in simultaneous 3rds where only one receives a passing tone","anchor":"two voices move in 3rds","source_page":18},
-    {"rule_id":"goodrick-v2-density-floor-4-way-close","name":"Begin voicing and arpeggio practice at 4-way close density","when":{"arrangement.style":"practice-context","voicing.family":["quartal","seventh-chords","spread-clusters"]},"then":{"voicing.density":"4-way-close","voicing.minimum_starting_density":"close"},"preference":"required","quality_binding":["any"],"falsifier":"Beginning M-Lode arpeggio practice with open or drop voicings before 4-way close","anchor":"look at all of the 4-way close options within the M-Lode","source_page":20},
-    {"rule_id":"goodrick-v2-open-string-voicing-priority","name":"Seek open-string-playable versions of 4-way close voicings","when":{"voicing.density":"4-way-close","arrangement.style":"guitar-idiomatic"},"then":{"voicing.open_strings":"preferred","voicing.playability":"maximize"},"preference":"preferred","quality_binding":["any"],"falsifier":"A 4-way close voicing position where no open-string variant exists on guitar","anchor":"find as many playable voicings for 4-way close as we can","source_page":21},
-    {"rule_id":"goodrick-v2-harmonic-minor-preference","name":"Prefer C Harmonic Minor as scale context for M-Lode voicing exploration","when":{"scale.context":["C-Major","C-Melodic-Minor","C-Harmonic-Minor"],"arrangement.style":"exploratory"},"then":{"scale.context":"C-Harmonic-Minor","scale.priority":1},"preference":"preferred","quality_binding":["any"],"falsifier":"C Major or C Melodic Minor producing equal or richer chromatic voice-leading density than C Harmonic Minor","anchor":"IT JUST SOUNDS BETTER IN HARMONIC MINOR","source_page":20},
-    {"rule_id":"goodrick-v2-harmonic-minor-chromatic-density","name":"Treat C Harmonic Minor as highest chromatic density voice-leading environment","when":{"scale.context":"C-Harmonic-Minor"},"then":{"voice_leading.chromatic_density":"maximum","voicing.sonic_reward":"highest"},"preference":"preferred","quality_binding":["any"],"falsifier":"C Major producing denser chromatic voice-leading than C Harmonic Minor","anchor":"ending in C Harmonic Minor, which the method identifies as the most sonically rewarding and the most chromatically dense voice-leading environment in the entire system","source_page":null},
-    {"rule_id":"goodrick-v2-24-arpeggio-permutations","name":"Generate all 24 arpeggio orderings for any 4-part voicing","when":{"voicing.part_count":4,"voicing.deployment_mode":"arpeggios"},"then":{"voicing.arpeggio_sequence_count":24,"voicing.permutation_method":"exhaustive-voice-ordering"},"preference":"recommended","quality_binding":["any"],"falsifier":"A 4-part voicing with fewer than 24 distinct arpeggio orderings","anchor":"Any [and ALL] 4-part voicings can be arpeggiated in 24 different sequences","source_page":20},
-    {"rule_id":"goodrick-v2-2-voice-combination-exhaustion","name":"Practice all 6 two-voice subsets of every 4-part chord","when":{"voicing.part_count":4,"voicing.deployment_mode":"counterpoint"},"then":{"voicing.2-voice-subset-count":6,"practice.traversal":"exhaustive"},"preference":"required","quality_binding":["any"],"falsifier":"A 4-part chord yielding more or fewer than 6 two-voice combinations","anchor":"Play all 6 possible combinations of 2 voices","source_page":12},
-    {"rule_id":"goodrick-v2-3-voice-combination-exhaustion","name":"Practice all 4 three-voice subsets of every 4-part chord","when":{"voicing.part_count":4,"voicing.deployment_mode":"3-part-chords"},"then":{"voicing.3-voice-subset-count":4,"practice.traversal":"exhaustive"},"preference":"required","quality_binding":["any"],"falsifier":"A 4-part chord yielding more or fewer than 4 three-voice combinations","anchor":"Play all 4 possible combinations of 3 voices","source_page":13},
-    {"rule_id":"goodrick-v2-joe-2-plus-2-call-response","name":"Divide 4-part chord into two alternating 2-note call-and-response pairs","when":{"voicing.part_count":4,"voicing.deployment_mode":"arpeggios"},"then":{"voicing.grouping":"2+2","voicing.pair_roles":["call","response"],"voicing.alternation":"pair-based"},"preference":"recommended","quality_binding":["any"],"falsifier":"A 4-part chord that cannot be divided into two meaningful 2-note groupings","anchor":"divide the 4-part chord into two 2-note groupings","source_page":16},
-    {"rule_id":"goodrick-v2-spread-cluster-physical-caution","name":"Approach spread cluster voicings with physical preparation","when":{"voicing.family":"spread-clusters"},"then":{"arrangement.technique":"fingerstyle-prepared","arrangement.physical_demand":"high","arrangement.caution":"required"},"preference":"avoid","quality_binding":["any"],"falsifier":"A spread cluster voicing that is physically undemanding on guitar","anchor":"BE VERY CAREFUL!!!","source_page":22},
-    {"rule_id":"goodrick-v2-chord-names-omitted","name":"Treat voicings as unnamed harmonic objects for functional flexibility","when":{"voicing.family":["quartal","seventh-chords","tbn-i","tbn-ii","spread-clusters"]},"then":{"voicing.naming_convention":"omit","harmonic.context":"function-agnostic"},"preference":"required","quality_binding":["any"],"falsifier":"A system that names chord qualities to restrict voicing function to one harmonic role","anchor":"chords are deliberately left unnamed to preserve their harmonic flexibility across functions","source_page":null},
-    {"rule_id":"goodrick-v2-six-cycle-traversal","name":"Traverse every voicing family through all six diatonic cycles","when":{"voicing.family":["quartal","triads","seventh-chords","tbn-i","tbn-ii","spread-clusters"]},"then":{"cycle.count":6,"progression.type":"diatonic-cycle","traversal.scope":"all-six-cycles"},"preference":"required","quality_binding":["any"],"falsifier":"A voicing family traversed through fewer than six diatonic cycles","anchor":"voice-led through six cycles in each of the three scales","source_page":null},
-    {"rule_id":"goodrick-v2-three-scale-contexts","name":"Realize every voicing family in all three diatonic scale contexts","when":{"voicing.family":["quartal","triads","seventh-chords","tbn-i","tbn-ii","spread-clusters"]},"then":{"scale.context":["C-Major","C-Melodic-Minor","C-Harmonic-Minor"]},"preference":"required","quality_binding":["any"],"falsifier":"A voicing family realized in only one or two of the three scale systems","anchor":"every 3-part and 4-part chord voicing available within the three diatonic scales - C Major, C Melodic Minor, and C Harmonic Minor","source_page":null},
-    {"rule_id":"goodrick-v2-4-part-family-completeness","name":"Use the five 4-part families as the complete diatonic 4-part taxonomy","when":{"voicing.part_count":4,"scale.context":["C-Major","C-Melodic-Minor","C-Harmonic-Minor"]},"then":{"voicing.families":["seventh-chords","tbn-i","tbn-ii","4-part-4ths","spread-clusters"],"voicing.family_count":5,"voicing.completeness":"exhaustive"},"preference":"required","quality_binding":["any"],"falsifier":"A 4-part chord type within a seven-note diatonic scale not covered by these five families","anchor":"these five 4-part chord families are not merely a selection but the only 4-part families possible within seven-note diatonic scales","source_page":null},
-    {"rule_id":"goodrick-v2-m-lode-voicing-count","name":"Target 1000+ total voicings across the complete M-Lode system","when":{"voicing.family":["quartal","triads","seventh-chords","tbn-i","tbn-ii","spread-clusters","3-part-spread-clusters","7th-no-5th","7th-no-3rd"]},"then":{"voicing.total_count_floor":1000,"voicing.3-part-chord-count_floor":20,"voicing.4-part-chord-count_floor":30},"preference":null,"quality_binding":["any"],"falsifier":"A complete M-Lode realization producing fewer than 1000 total voicings","anchor":"20 different 3-part chords (240 voicings), 30+ different 4-part chords (800+ voicings), and 1,000+ total voicings","source_page":null},
-    {"rule_id":"goodrick-v2-3-part-supplement-families","name":"Include 3-part Spread Clusters, 7th-no-5th, and 7th-no-3rd as M-Lode supplement families","when":{"voicing.part_count":3,"voicing.derivation":"omission-from-4-part"},"then":{"voicing.supplement_families":["3-part-spread-clusters","7th-no-5th","7th-no-3rd"],"voicing.guitar_playability":"high"},"preference":"recommended","quality_binding":["any"],"falsifier":"A 3-part omission-derived family outside these three types","anchor":"three additional 3-part chord families within the M-Lode: 3-part Spread Clusters, 7th Chord (no 5th), and 7th Chord (no 3rd)","source_page":null},
-    {"rule_id":"goodrick-v2-3-part-4ths-interval-count","name":"Enforce exact interval count for 3-part quartal voicing","when":{"voicing.family":"quartal","voicing.part_count":3},"then":{"voicing.interval_count":{"2nd":2,"4th":4,"5th":2,"7th":1}},"preference":"required","quality_binding":["any"],"falsifier":"A 3-part quartal voicing with interval counts deviating from Two 2nds, Four 4ths, Two 5ths, One 7th","anchor":"Two 2nds, Four 4ths, Two 5ths, One 7th","source_page":10},
-    {"rule_id":"goodrick-v2-msrp-memorization-drill","name":"Apply MSRP memorized note-sequence drill at 3-part 4ths level","when":{"voicing.family":"quartal","voicing.part_count":3,"arrangement.style":"practice-context"},"then":{"practice.drill":"M.S.R.P.","practice.method":"memorized-note-sequence-loop"},"preference":"recommended","quality_binding":["any"],"falsifier":"M.S.R.P. drill applied before the 3-part 4ths entry level","anchor":"The M.S.R.P. (memorized note-sequence) drill loop appears at the 3-part 4ths level","source_page":null},
-    {"rule_id":"goodrick-v2-index-card-voice-isolation","name":"Use index card strips for tactile voice isolation and reduction practice","when":{"arrangement.style":"practice-context","voicing.part_count":4},"then":{"practice.tool":"index-card-strips","practice.strip_count":8,"practice.purpose":"voice-isolation-and-reduction"},"preference":"recommended","quality_binding":["any"],"falsifier":"An alternative practice aid that achieves equivalent voice isolation without physical notation strips","anchor":"eight half-inch strips cut from a 4x6 card","source_page":null},
-    {"rule_id":"goodrick-v2-quartal-melody-generation","name":"Generate melodies by arpeggiation of quartal voicing shapes","when":{"voicing.family":"quartal","voicing.deployment_mode":"melodies"},"then":{"voicing.melodic_source":"arpeggio-of-quartal-shape","voice_leading.constraint":"chord-tone-sequence"},"preference":"recommended","quality_binding":["any"],"falsifier":"A quartal arpeggiation that produces no usable melodic material","anchor":"arpeggiate quartal voicings to discover melodies","source_page":10},
-    {"rule_id":"goodrick-v2-cycle-7-drop-2-three-common-tones","name":"Expect three common tones and one voice moving by 4th in Cycle 7 Drop 2","when":{"cycle.id":"7","voicing.drop_type":"Drop-2"},"then":{"voice_leading.common_tone_count":3,"voice_leading.moving_voice_count":1,"voice_leading.moving_voice_interval":"4th"},"preference":"required","quality_binding":["any"],"falsifier":"Cycle 7 Drop 2 position with fewer than three common tones between adjacent chords","anchor":"2 - c.t. / 7 - c.t. / 3 -> 4th / 1 - c.t.","source_page":159},
-    {"rule_id":"goodrick-v2-voice-leading-foundation-principle","name":"Ground every M-Lode voicing decision in voice-leading, not chord quality","when":{"voicing.family":["quartal","triads","seventh-chords","tbn-i","tbn-ii","spread-clusters"]},"then":{"voice_leading.constraint":"voice-leading-primary","harmonic.context":"voice-leading-derived"},"preference":"required","quality_binding":["any"],"falsifier":"An M-Lode voicing chosen by chord quality or function rather than voice-leading economy","anchor":"All of the M-Lode is based on voice-leading.","source_page":22}
+    {
+      "rule_id": "goodrick-v2-quartal-interval-inventory",
+      "name": "Restrict quartal voicing to 4ths, 5ths, 2nds, 7ths",
+      "when": {
+        "voicing.family": "quartal"
+      },
+      "then": {
+        "voicing.allowed_intervals": [
+          "2nd",
+          "4th",
+          "5th",
+          "7th"
+        ],
+        "voicing.excluded_intervals": [
+          "3rd",
+          "6th"
+        ]
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A quartal voicing containing a 3rd or 6th as primary structural interval",
+      "anchor": "Primary intervals: 4ths and 5ths",
+      "source_page": 10
+    },
+    {
+      "rule_id": "goodrick-v2-quartal-tertial-opposition",
+      "name": "Treat quartal and tertial harmony as structural opposites",
+      "when": {
+        "voicing.family": "quartal"
+      },
+      "then": {
+        "harmonic.context": "non-tertial",
+        "voicing.color_intervals": [
+          "3rd",
+          "6th"
+        ]
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Quartal voicing treated as tertial chord with added color tones",
+      "anchor": "tertial harmony and quartal harmony are pretty much exact opposites.",
+      "source_page": 9
+    },
+    {
+      "rule_id": "goodrick-v2-quartal-diminished-fourth-avoid",
+      "name": "Avoid B-Eb in quartal voicings",
+      "when": {
+        "voicing.family": "quartal",
+        "voicing.interval_pair": "B-Eb"
+      },
+      "then": {
+        "voicing.action": "exclude",
+        "voicing.reason": "enharmonic-collapse-to-major-3rd"
+      },
+      "preference": "avoid",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A B-Eb interval in quartal context that does not collapse to triadic sound",
+      "anchor": "they don't work very well in a 4th voicings context.",
+      "source_page": 9
+    },
+    {
+      "rule_id": "goodrick-v2-drop-d-pedal-dorian",
+      "name": "Use drop-D pedal for quartal cycle exploration in D Dorian",
+      "when": {
+        "voicing.family": "quartal",
+        "arrangement.style": "free-exploration"
+      },
+      "then": {
+        "scale.context": "D-Dorian",
+        "voicing.technique": "drop-D-pedal",
+        "tuning.low_string": "D"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "D Dorian containing an avoid note that obstructs free pedal exploration",
+      "anchor": "tune the low E string down a whole step to D. Use the low D string as a pedal",
+      "source_page": 10
+    },
+    {
+      "rule_id": "goodrick-v2-dorian-no-avoid-notes",
+      "name": "Prefer D Dorian as avoid-note-free quartal context",
+      "when": {
+        "voicing.family": "quartal",
+        "scale.context": "D-Dorian"
+      },
+      "then": {
+        "voicing.avoid_note_count": 0,
+        "arrangement.style": "unrestricted-cycle-traversal"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Another Dorian mode that also has zero avoid notes",
+      "anchor": "there aren't any \"avoid\" notes in Dorian",
+      "source_page": 10
+    },
+    {
+      "rule_id": "goodrick-v2-arpeggio-direction-alternation",
+      "name": "Alternate arpeggio direction on successive chord positions",
+      "when": {
+        "voicing.deployment_mode": "arpeggios",
+        "progression.type": "diatonic-cycle"
+      },
+      "then": {
+        "voicing.arpeggio_direction": "alternating-up-down",
+        "voice_leading.constraint": "ascend-odd-descend-even"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Two successive chords arpeggiated in the same direction",
+      "anchor": "Arpeggiate up the first chord, then down the second chord",
+      "source_page": 11
+    },
+    {
+      "rule_id": "goodrick-v2-five-application-modes",
+      "name": "Apply every voicing through all five M-Lode deployment modes",
+      "when": {
+        "voicing.family": [
+          "quartal",
+          "triads",
+          "seventh-chords",
+          "tbn-i",
+          "tbn-ii",
+          "spread-clusters"
+        ]
+      },
+      "then": {
+        "voicing.deployment_modes": [
+          "melodies",
+          "arpeggios",
+          "counterpoint",
+          "3-part-chords",
+          "4-part-chords"
+        ]
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A voicing family for which fewer than five deployment modes are applicable",
+      "anchor": "1. melodies 2. arpeggios 3. counterpoint (2 simultaneous voices) 4. 3-part chords 5. 4-part chords",
+      "source_page": 11
+    },
+    {
+      "rule_id": "goodrick-v2-stepwise-voice-motion",
+      "name": "Move each voice by 2nd, 3rd, or common tone across diatonic cycle positions",
+      "when": {
+        "progression.type": "diatonic-cycle",
+        "voicing.family": [
+          "quartal",
+          "seventh-chords",
+          "spread-clusters"
+        ]
+      },
+      "then": {
+        "voice_leading.constraint": "stepwise-or-common-tone",
+        "voice_leading.max_motion": "3rd"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A voice moving by a 4th or larger between adjacent cycle positions without common-tone annotation",
+      "anchor": "All of the M-Lode is based on voice-leading.",
+      "source_page": 22
+    },
+    {
+      "rule_id": "goodrick-v2-common-tone-annotation",
+      "name": "Mark non-moving voices as c.t. in voice-leading analysis",
+      "when": {
+        "voice_leading.constraint": "stepwise-or-common-tone"
+      },
+      "then": {
+        "voice_leading.static_voice_label": "c.t.",
+        "voice_leading.c.t._is_distinct_category": true
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A static voice omitted from or merged with moving voices in the analysis grid",
+      "anchor": "1 -> c.t.",
+      "source_page": 27
+    },
+    {
+      "rule_id": "goodrick-v2-intervallic-functional-grid",
+      "name": "Analyze every voicing in paired Intervallic and Functional grids",
+      "when": {
+        "voicing.family": [
+          "quartal",
+          "spread-clusters",
+          "seventh-chords"
+        ]
+      },
+      "then": {
+        "analysis.grid_types": [
+          "intervallic",
+          "functional"
+        ],
+        "analysis.intervallic_cell": "motion-interval-per-voice",
+        "analysis.functional_cell": "scale-degree-destination-per-voice"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "An analysis grid that omits either intervallic or functional dimension",
+      "anchor": "5 -> 2nd / 2 -> 2nd / 1 -> 2nd",
+      "source_page": 27
+    },
+    {
+      "rule_id": "goodrick-v2-cycles-2-7-dual-voice-leading",
+      "name": "Apply two distinct voice-leadings at Cycles 2 and 7",
+      "when": {
+        "cycle.id": [
+          "2",
+          "7"
+        ]
+      },
+      "then": {
+        "voice_leading.variant_count": 2,
+        "voice_leading.hazard": "voice-crossing-on-diatonic-5th"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Cycles 2 or 7 resolved with a single voice-leading without addressing the diatonic 5th voice-crossing",
+      "anchor": "Cycles 2 and 7 have two different voice-leadings.",
+      "source_page": 21
+    },
+    {
+      "rule_id": "goodrick-v2-octave-insertion-expansion",
+      "name": "Derive new voicing variants by inserting an octave between any two voices",
+      "when": {
+        "voicing.family": [
+          "quartal",
+          "triads",
+          "seventh-chords",
+          "spread-clusters"
+        ]
+      },
+      "then": {
+        "voicing.expansion_method": "octave-insertion",
+        "voicing.insertion_positions": "any-adjacent-voice-pair"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A voicing expansion that adds a non-octave interval between voices",
+      "anchor": "inserting an octave between any 2 voices within a 3-part chord or a 4-part chord",
+      "source_page": 14
+    },
+    {
+      "rule_id": "goodrick-v2-octave-insertion-applies-to-quartal",
+      "name": "Apply octave insertion equally to 3-part quartal voicings",
+      "when": {
+        "voicing.family": "quartal",
+        "voicing.part_count": 3
+      },
+      "then": {
+        "voicing.expansion_method": "octave-insertion",
+        "voicing.result_families": [
+          "drop-2-drop-4",
+          "drop-3-and-4"
+        ]
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Octave insertion applied only to tertial chord families and not quartal",
+      "anchor": "Of course, all of this applies to the 3-part 4th voicings as well",
+      "source_page": 14
+    },
+    {
+      "rule_id": "goodrick-v2-drop-voicing-type-selection",
+      "name": "Select drop voicing type from canonical set",
+      "when": {
+        "voicing.density": "open"
+      },
+      "then": {
+        "voicing.drop_types": [
+          "Drop-2",
+          "Drop-3",
+          "Drop-4",
+          "Drop-2-and-3",
+          "Drop-2-and-4",
+          "Double-Drop-2-Drop-4",
+          "Drop-3-and-4"
+        ]
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A drop voicing type not derivable from the canonical close-voicing octave-insertion process",
+      "anchor": "Drop 4 is an option.",
+      "source_page": 15
+    },
+    {
+      "rule_id": "goodrick-v2-fingerstyle-drop-3-4-requirement",
+      "name": "Restrict Drop 3 and 4, Double Drop 2/Drop 4 to fingerstyle players",
+      "when": {
+        "voicing.drop_type": [
+          "Drop-3-and-4",
+          "Double-Drop-2-Drop-4"
+        ]
+      },
+      "then": {
+        "arrangement.technique": "fingerstyle-only"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Drop 3 and 4 executed comfortably with a pick",
+      "anchor": "only for finger-style guitarists] would be: Drop 3 and 4",
+      "source_page": 15
+    },
+    {
+      "rule_id": "goodrick-v2-single-voice-omission",
+      "name": "Derive 3-part subset from any 4-part chord by dropping one voice",
+      "when": {
+        "voicing.part_count": 4
+      },
+      "then": {
+        "voicing.omission_configurations": 4,
+        "voicing.result_part_count": 3,
+        "voicing.result_families": [
+          "7th-no-5th",
+          "7th-no-3rd",
+          "3-part-spread-cluster"
+        ]
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Fewer than four valid omission configurations for a 4-part diatonic chord",
+      "anchor": "it just amounts to leaving out one of the voices... There are 4 possible configurations.",
+      "source_page": 19
+    },
+    {
+      "rule_id": "goodrick-v2-passing-tone-third-fill",
+      "name": "Fill any voice motion of a 3rd with a diatonic passing tone",
+      "when": {
+        "voice_leading.interval": "3rd"
+      },
+      "then": {
+        "voicing.non_chord_tone": "passing-tone",
+        "nct.placement": "between-two-chord-tones-a-3rd-apart"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A voice motion by 3rd that cannot accommodate a diatonic passing tone",
+      "anchor": "Anytime one of the voices moves a distance of a 3rd, you can fill in that interval with a melodic passing tone.",
+      "source_page": 17
+    },
+    {
+      "rule_id": "goodrick-v2-passing-tone-two-voices-in-thirds",
+      "name": "Apply passing tones to both voices when two voices simultaneously move in 3rds",
+      "when": {
+        "voice_leading.interval": "3rd",
+        "voice_leading.simultaneous_thirds_count": 2
+      },
+      "then": {
+        "voicing.non_chord_tone": "passing-tone",
+        "nct.voice_count": 2
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Two voices moving in simultaneous 3rds where only one receives a passing tone",
+      "anchor": "two voices move in 3rds",
+      "source_page": 18
+    },
+    {
+      "rule_id": "goodrick-v2-density-floor-4-way-close",
+      "name": "Begin voicing and arpeggio practice at 4-way close density",
+      "when": {
+        "arrangement.style": "practice-context",
+        "voicing.family": [
+          "quartal",
+          "seventh-chords",
+          "spread-clusters"
+        ]
+      },
+      "then": {
+        "voicing.density": "4-way-close",
+        "voicing.minimum_starting_density": "close"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Beginning M-Lode arpeggio practice with open or drop voicings before 4-way close",
+      "anchor": "look at all of the 4-way close options within the M-Lode",
+      "source_page": 20
+    },
+    {
+      "rule_id": "goodrick-v2-open-string-voicing-priority",
+      "name": "Seek open-string-playable versions of 4-way close voicings",
+      "when": {
+        "voicing.density": "4-way-close",
+        "arrangement.style": "guitar-idiomatic"
+      },
+      "then": {
+        "voicing.open_strings": "preferred",
+        "voicing.playability": "maximize"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 4-way close voicing position where no open-string variant exists on guitar",
+      "anchor": "find as many playable voicings for 4-way close as we can",
+      "source_page": 21
+    },
+    {
+      "rule_id": "goodrick-v2-harmonic-minor-preference",
+      "name": "Prefer C Harmonic Minor as scale context for M-Lode voicing exploration",
+      "when": {
+        "scale.context": [
+          "C-Major",
+          "C-Melodic-Minor",
+          "C-Harmonic-Minor"
+        ],
+        "arrangement.style": "exploratory"
+      },
+      "then": {
+        "scale.context": "C-Harmonic-Minor",
+        "scale.priority": 1
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "C Major or C Melodic Minor producing equal or richer chromatic voice-leading density than C Harmonic Minor",
+      "anchor": "IT JUST SOUNDS BETTER IN HARMONIC MINOR",
+      "source_page": 20
+    },
+    {
+      "rule_id": "goodrick-v2-harmonic-minor-chromatic-density",
+      "name": "Treat C Harmonic Minor as highest chromatic density voice-leading environment",
+      "when": {
+        "scale.context": "C-Harmonic-Minor"
+      },
+      "then": {
+        "voice_leading.chromatic_density": "maximum",
+        "voicing.sonic_reward": "highest"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "C Major producing denser chromatic voice-leading than C Harmonic Minor",
+      "anchor": "ending in C Harmonic Minor, which the method identifies as the most sonically rewarding and the most chromatically dense voice-leading environment in the entire system",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-24-arpeggio-permutations",
+      "name": "Generate all 24 arpeggio orderings for any 4-part voicing",
+      "when": {
+        "voicing.part_count": 4,
+        "voicing.deployment_mode": "arpeggios"
+      },
+      "then": {
+        "voicing.arpeggio_sequence_count": 24,
+        "voicing.permutation_method": "exhaustive-voice-ordering"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 4-part voicing with fewer than 24 distinct arpeggio orderings",
+      "anchor": "Any [and ALL] 4-part voicings can be arpeggiated in 24 different sequences",
+      "source_page": 20
+    },
+    {
+      "rule_id": "goodrick-v2-2-voice-combination-exhaustion",
+      "name": "Practice all 6 two-voice subsets of every 4-part chord",
+      "when": {
+        "voicing.part_count": 4,
+        "voicing.deployment_mode": "counterpoint"
+      },
+      "then": {
+        "voicing.2-voice-subset-count": 6,
+        "practice.traversal": "exhaustive"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 4-part chord yielding more or fewer than 6 two-voice combinations",
+      "anchor": "Play all 6 possible combinations of 2 voices",
+      "source_page": 12
+    },
+    {
+      "rule_id": "goodrick-v2-3-voice-combination-exhaustion",
+      "name": "Practice all 4 three-voice subsets of every 4-part chord",
+      "when": {
+        "voicing.part_count": 4,
+        "voicing.deployment_mode": "3-part-chords"
+      },
+      "then": {
+        "voicing.3-voice-subset-count": 4,
+        "practice.traversal": "exhaustive"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 4-part chord yielding more or fewer than 4 three-voice combinations",
+      "anchor": "Play all 4 possible combinations of 3 voices",
+      "source_page": 13
+    },
+    {
+      "rule_id": "goodrick-v2-joe-2-plus-2-call-response",
+      "name": "Divide 4-part chord into two alternating 2-note call-and-response pairs",
+      "when": {
+        "voicing.part_count": 4,
+        "voicing.deployment_mode": "arpeggios"
+      },
+      "then": {
+        "voicing.grouping": "2+2",
+        "voicing.pair_roles": [
+          "call",
+          "response"
+        ],
+        "voicing.alternation": "pair-based"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 4-part chord that cannot be divided into two meaningful 2-note groupings",
+      "anchor": "divide the 4-part chord into two 2-note groupings",
+      "source_page": 16
+    },
+    {
+      "rule_id": "goodrick-v2-spread-cluster-physical-caution",
+      "name": "Approach spread cluster voicings with physical preparation",
+      "when": {
+        "voicing.family": "spread-clusters"
+      },
+      "then": {
+        "arrangement.technique": "fingerstyle-prepared",
+        "arrangement.physical_demand": "high",
+        "arrangement.caution": "required"
+      },
+      "preference": "avoid",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A spread cluster voicing that is physically undemanding on guitar",
+      "anchor": "BE VERY CAREFUL!!!",
+      "source_page": 22
+    },
+    {
+      "rule_id": "goodrick-v2-chord-names-omitted",
+      "name": "Treat voicings as unnamed harmonic objects for functional flexibility",
+      "when": {
+        "voicing.family": [
+          "quartal",
+          "seventh-chords",
+          "tbn-i",
+          "tbn-ii",
+          "spread-clusters"
+        ]
+      },
+      "then": {
+        "voicing.naming_convention": "omit",
+        "harmonic.context": "function-agnostic"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A system that names chord qualities to restrict voicing function to one harmonic role",
+      "anchor": "chords are deliberately left unnamed to preserve their harmonic flexibility across functions",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-six-cycle-traversal",
+      "name": "Traverse every voicing family through all six diatonic cycles",
+      "when": {
+        "voicing.family": [
+          "quartal",
+          "triads",
+          "seventh-chords",
+          "tbn-i",
+          "tbn-ii",
+          "spread-clusters"
+        ]
+      },
+      "then": {
+        "cycle.count": 6,
+        "progression.type": "diatonic-cycle",
+        "traversal.scope": "all-six-cycles"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A voicing family traversed through fewer than six diatonic cycles",
+      "anchor": "voice-led through six cycles in each of the three scales",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-three-scale-contexts",
+      "name": "Realize every voicing family in all three diatonic scale contexts",
+      "when": {
+        "voicing.family": [
+          "quartal",
+          "triads",
+          "seventh-chords",
+          "tbn-i",
+          "tbn-ii",
+          "spread-clusters"
+        ]
+      },
+      "then": {
+        "scale.context": [
+          "C-Major",
+          "C-Melodic-Minor",
+          "C-Harmonic-Minor"
+        ]
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A voicing family realized in only one or two of the three scale systems",
+      "anchor": "every 3-part and 4-part chord voicing available within the three diatonic scales - C Major, C Melodic Minor, and C Harmonic Minor",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-4-part-family-completeness",
+      "name": "Use the five 4-part families as the complete diatonic 4-part taxonomy",
+      "when": {
+        "voicing.part_count": 4,
+        "scale.context": [
+          "C-Major",
+          "C-Melodic-Minor",
+          "C-Harmonic-Minor"
+        ]
+      },
+      "then": {
+        "voicing.families": [
+          "seventh-chords",
+          "tbn-i",
+          "tbn-ii",
+          "4-part-4ths",
+          "spread-clusters"
+        ],
+        "voicing.family_count": 5,
+        "voicing.completeness": "exhaustive"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 4-part chord type within a seven-note diatonic scale not covered by these five families",
+      "anchor": "these five 4-part chord families are not merely a selection but the only 4-part families possible within seven-note diatonic scales",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-m-lode-voicing-count",
+      "name": "Target 1000+ total voicings across the complete M-Lode system",
+      "when": {
+        "voicing.family": [
+          "quartal",
+          "triads",
+          "seventh-chords",
+          "tbn-i",
+          "tbn-ii",
+          "spread-clusters",
+          "3-part-spread-clusters",
+          "7th-no-5th",
+          "7th-no-3rd"
+        ]
+      },
+      "then": {
+        "voicing.total_count_floor": 1000,
+        "voicing.3-part-chord-count_floor": 20,
+        "voicing.4-part-chord-count_floor": 30
+      },
+      "preference": null,
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A complete M-Lode realization producing fewer than 1000 total voicings",
+      "anchor": "20 different 3-part chords (240 voicings), 30+ different 4-part chords (800+ voicings), and 1,000+ total voicings",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-3-part-supplement-families",
+      "name": "Include 3-part Spread Clusters, 7th-no-5th, and 7th-no-3rd as M-Lode supplement families",
+      "when": {
+        "voicing.part_count": 3,
+        "voicing.derivation": "omission-from-4-part"
+      },
+      "then": {
+        "voicing.supplement_families": [
+          "3-part-spread-clusters",
+          "7th-no-5th",
+          "7th-no-3rd"
+        ],
+        "voicing.guitar_playability": "high"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 3-part omission-derived family outside these three types",
+      "anchor": "three additional 3-part chord families within the M-Lode: 3-part Spread Clusters, 7th Chord (no 5th), and 7th Chord (no 3rd)",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-3-part-4ths-interval-count",
+      "name": "Enforce exact interval count for 3-part quartal voicing",
+      "when": {
+        "voicing.family": "quartal",
+        "voicing.part_count": 3
+      },
+      "then": {
+        "voicing.interval_count": {
+          "2nd": 2,
+          "4th": 4,
+          "5th": 2,
+          "7th": 1
+        }
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 3-part quartal voicing with interval counts deviating from Two 2nds, Four 4ths, Two 5ths, One 7th",
+      "anchor": "Two 2nds, Four 4ths, Two 5ths, One 7th",
+      "source_page": 10
+    },
+    {
+      "rule_id": "goodrick-v2-msrp-memorization-drill",
+      "name": "Apply MSRP memorized note-sequence drill at 3-part 4ths level",
+      "when": {
+        "voicing.family": "quartal",
+        "voicing.part_count": 3,
+        "arrangement.style": "practice-context"
+      },
+      "then": {
+        "practice.drill": "M.S.R.P.",
+        "practice.method": "memorized-note-sequence-loop"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "M.S.R.P. drill applied before the 3-part 4ths entry level",
+      "anchor": "The M.S.R.P. (memorized note-sequence) drill loop appears at the 3-part 4ths level",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-index-card-voice-isolation",
+      "name": "Use index card strips for tactile voice isolation and reduction practice",
+      "when": {
+        "arrangement.style": "practice-context",
+        "voicing.part_count": 4
+      },
+      "then": {
+        "practice.tool": "index-card-strips",
+        "practice.strip_count": 8,
+        "practice.purpose": "voice-isolation-and-reduction"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "An alternative practice aid that achieves equivalent voice isolation without physical notation strips",
+      "anchor": "eight half-inch strips cut from a 4x6 card",
+      "source_page": null
+    },
+    {
+      "rule_id": "goodrick-v2-quartal-melody-generation",
+      "name": "Generate melodies by arpeggiation of quartal voicing shapes",
+      "when": {
+        "voicing.family": "quartal",
+        "voicing.deployment_mode": "melodies"
+      },
+      "then": {
+        "voicing.melodic_source": "arpeggio-of-quartal-shape",
+        "voice_leading.constraint": "chord-tone-sequence"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A quartal arpeggiation that produces no usable melodic material",
+      "anchor": "arpeggiate quartal voicings to discover melodies",
+      "source_page": 10
+    },
+    {
+      "rule_id": "goodrick-v2-cycle-7-drop-2-three-common-tones",
+      "name": "Expect three common tones and one voice moving by 4th in Cycle 7 Drop 2",
+      "when": {
+        "cycle.id": "7",
+        "voicing.drop_type": "Drop-2"
+      },
+      "then": {
+        "voice_leading.common_tone_count": 3,
+        "voice_leading.moving_voice_count": 1,
+        "voice_leading.moving_voice_interval": "4th"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Cycle 7 Drop 2 position with fewer than three common tones between adjacent chords",
+      "anchor": "2 - c.t. / 7 - c.t. / 3 -> 4th / 1 - c.t.",
+      "source_page": 159
+    },
+    {
+      "rule_id": "goodrick-v2-voice-leading-foundation-principle",
+      "name": "Ground every M-Lode voicing decision in voice-leading, not chord quality",
+      "when": {
+        "voicing.family": [
+          "quartal",
+          "triads",
+          "seventh-chords",
+          "tbn-i",
+          "tbn-ii",
+          "spread-clusters"
+        ]
+      },
+      "then": {
+        "voice_leading.constraint": "voice-leading-primary",
+        "harmonic.context": "voice-leading-derived"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "An M-Lode voicing chosen by chord quality or function rather than voice-leading economy",
+      "anchor": "All of the M-Lode is based on voice-leading.",
+      "source_page": 22
+    }
   ]
 }

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-3/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-3/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-17-mick-goodrick-almanac-vol-3",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-17T09:44:43-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "mick-goodrick",
   "work_id": "almanac-vol-3",
   "engine_rules": [

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-4/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-4/derived/engine-rules.json
@@ -1,45 +1,781 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-17-mick-goodrick-almanac-vol-4",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-17T09:44:47-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "mick-goodrick",
   "work_id": "almanac-vol-4",
   "engine_rules": [
-    {"rule_id":"goodrick-v4-sus4-label-required","name":"Label Fourth-Based Chords sus4 Not C2 or add-2","when":{"voicing.family":"fourth-based"},"then":{"chord.label_format":"sus4"},"preference":"required","quality_binding":["any"],"falsifier":"Any fourth-based chord labeled C2 or add-2 rather than sus4","anchor":"My suggestion for a suitable name for this chord would be: G [sus4]","source_page":4},
-    {"rule_id":"goodrick-v4-sus4-inversion-consistency","name":"Maintain sus4 Label Across All Inversions","when":{"voicing.family":"fourth-based","voicing.inversion":["1st","2nd","3rd"]},"then":{"chord.label_format":"sus4"},"preference":"required","quality_binding":["any"],"falsifier":"An inversion of a fourth-based chord reverts to C2 or add-2 notation","anchor":"Of course, this applies to all of the inversions as well","source_page":4},
-    {"rule_id":"goodrick-v4-3pt-before-4pt-priority","name":"Route Through 3-Part Voicings Before 4-Part","when":{"arrangement.style":"guitar-idiomatic"},"then":{"voicing.density":"3-part","voicing.density_priority":"prefer-lower"},"preference":"preferred","quality_binding":["any"],"falsifier":"4-part voicings presented as foundational before 3-part voicings are established","anchor":"3-part chords are easier to play than 4-part chords","source_page":71},
-    {"rule_id":"goodrick-v4-density-ceiling-4pt","name":"Enforce 4-Part as Maximum Voicing Density","when":{"voicing.construction":"any"},"then":{"voicing.voice_count_max":4},"preference":"required","quality_binding":["any"],"falsifier":"A chord voicing is constructed with 5 or more simultaneous voices","anchor":"leaving out one voice of a 4-part chord","source_page":9},
-    {"rule_id":"goodrick-v4-voice-omission-single","name":"Derive 3-Part Chords by Removing Exactly One Voice from 4-Part","when":{"voicing.density":"3-part","voicing.derivation_method":"omission"},"then":{"voicing.voices_removed":1,"voicing.source_density":"4-part"},"preference":"required","quality_binding":["any"],"falsifier":"A 3-part chord is derived by removing more than one voice simultaneously from a 4-part source","anchor":"arrive at different 3-part chords by leaving out one voice","source_page":9},
-    {"rule_id":"goodrick-v4-3pt-appears-4x","name":"Each 3-Part Chord Type Appears Exactly Four Times in Derivation Table","when":{"voicing.derivation_method":"omission","voicing.source_density":"4-part"},"then":{"voicing.occurrence_count":4},"preference":"required","quality_binding":["any"],"falsifier":"A 3-part chord type appears fewer or more than 4 times in the voice-omission derivation table","anchor":"Each 3-part chord appears four times","source_page":9},
-    {"rule_id":"goodrick-v4-7th-no-3rd-distinct-type","name":"Catalog 7th(no 3rd) as Independent M-Lode Taxonomy Member","when":{"chord.tensions_omitted":["3rd"],"voicing.density":"3-part"},"then":{"chord.taxonomy_family":"m-lode-expanded","chord.collapse_to_other":false},"preference":"required","quality_binding":["dom7","maj7","min7","min7b5","dim7"],"falsifier":"7th(no 3rd) is collapsed into another chord category rather than cataloged as its own distinct type","anchor":"we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters","source_page":7},
-    {"rule_id":"goodrick-v4-7th-no-5th-distinct-type","name":"Catalog 7th(no 5th) as Independent M-Lode Taxonomy Member","when":{"chord.tensions_omitted":["5th"],"voicing.density":"3-part"},"then":{"chord.taxonomy_family":"m-lode-expanded","chord.collapse_to_other":false},"preference":"required","quality_binding":["dom7","maj7","min7","min7b5","dim7"],"falsifier":"7th(no 5th) is treated as a reduced or incomplete form of a 4-part chord rather than its own type","anchor":"we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters","source_page":7},
-    {"rule_id":"goodrick-v4-spread-cluster-3pt-distinct-type","name":"Catalog 3-Part Spread Clusters as Independent M-Lode Taxonomy Member","when":{"voicing.family":"spread-cluster","voicing.density":"3-part"},"then":{"chord.taxonomy_family":"m-lode-expanded","chord.subordinate_to":null},"preference":"required","quality_binding":["any"],"falsifier":"3-part Spread Clusters are treated as subordinate to or collapsed into another M-Lode category","anchor":"we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters","source_page":7},
-    {"rule_id":"goodrick-v4-m-lode-expanded-3-new-types","name":"Expand M-Lode Taxonomy With All Three New 3-Part Chord Types Simultaneously","when":{"chord.taxonomy_family":"m-lode-expanded"},"then":{"chord.new_types_added":["7th (no 3rd)","7th (no 5th)","3-part Spread Clusters"]},"preference":"required","quality_binding":["any"],"falsifier":"Only one or two of the three new types are added, leaving the M-Lode expansion incomplete","anchor":"we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters","source_page":7},
-    {"rule_id":"goodrick-v4-gdvl-before-scvl","name":"Establish GDVL Before Introducing SCVL","when":{"voice_leading.context":"introduction"},"then":{"voice_leading.sequence":["GDVL","SCVL"]},"preference":"required","quality_binding":["any"],"falsifier":"SCVL is introduced to a student before GDVL is operational as the working mode","anchor":"IVLs and FVLs are all examples of SCVL, as opposed to GDVL","source_page":161},
-    {"rule_id":"goodrick-v4-ivl-fvl-as-scvl","name":"Classify IVL and FVL as Sub-Types of SCVL","when":{"voice_leading.type":["IVL","FVL"]},"then":{"voice_leading.parent_type":"SCVL"},"preference":"required","quality_binding":["any"],"falsifier":"IVL or FVL is classified as a type of GDVL or as independent of SCVL","anchor":"The IVLs and the FVLs are all examples of SCVL","source_page":161},
-    {"rule_id":"goodrick-v4-melody-harmony-parity","name":"Treat Melodic and Harmonic Domains as Equal Weight","when":{"arrangement.style":"any"},"then":{"voice_leading.domain_weight.melody":1.0,"voice_leading.domain_weight.harmony":1.0},"preference":"required","quality_binding":["any"],"falsifier":"Voice-leading decisions systematically favor harmonic motion over melodic motion or vice versa","anchor":"excellent voice-leading treats both melody and harmony as equals","source_page":188},
-    {"rule_id":"goodrick-v4-event-diatonic-6-transpositions","name":"Diatonic Event Transposition Yields Up to 6 Variants","when":{"transposition.type":"diatonic","unit.type":"event"},"then":{"transposition.step_max":6,"transposition.collapse_identical_intervals":true},"preference":"required","quality_binding":["any"],"falsifier":"Diatonic transposition of an Event is applied beyond 6 steps without interval-collapse consolidation","anchor":"an event can be diatonically transposed to create 6 other events","source_page":3},
-    {"rule_id":"goodrick-v4-event-collapse-identical-intervals","name":"Collapse Intervallically Identical Event Transpositions to One Representative","when":{"transposition.type":"diatonic","unit.type":"event","transposition.interval_match":true},"then":{"transposition.retain_count":1,"transposition.duplicates_discarded":true},"preference":"required","quality_binding":["any"],"falsifier":"Intervallically identical diatonic event transpositions are listed as separate entries rather than collapsed","anchor":"but some of them will be intervallically identical","source_page":3},
-    {"rule_id":"goodrick-v4-episode-modal-one-to-one","name":"Episode Diatonic Transposition Yields Exactly 6 Modal Variants Without Collapse","when":{"transposition.type":"diatonic","unit.type":"episode"},"then":{"transposition.step_count":6,"transposition.modal_variants":6,"transposition.collapse_identical_intervals":false},"preference":"required","quality_binding":["any"],"falsifier":"Episode transposition produces fewer than 6 distinct modal variants or collapses any two modal variants together","anchor":"an episode can be diatonically transposed to create 6 other episodes","source_page":3},
-    {"rule_id":"goodrick-v4-episode-modal-correspondence","name":"Map Each Transposed Episode to a Distinct Mode","when":{"unit.type":"episode","transposition.type":"diatonic"},"then":{"transposition.modal_mapping":"one-to-one","transposition.shared_mode_assignments":0},"preference":"required","quality_binding":["any"],"falsifier":"Two different episode transpositions are assigned to the same mode","anchor":"each corresponds to a different mode","source_page":3},
-    {"rule_id":"goodrick-v4-event-episode-domain-agnostic","name":"Route Events and Episodes Identically Across Melodic, Contrapuntal, and Harmonic Domains","when":{"unit.type":["event","episode"]},"then":{"unit.valid_domains":["melodic","contrapuntal","harmonic","combination"]},"preference":"required","quality_binding":["any"],"falsifier":"An event or episode is restricted to only one domain when the source material permits all three","anchor":"Both events and episodes can be melodic, contrapuntal, harmonic","source_page":3},
-    {"rule_id":"goodrick-v4-event-episode-length-not-defining","name":"Classify Event vs Episode by Note Coverage Not by Length","when":{"unit.classification_criterion":"length"},"then":{"unit.classification_criterion":"note_coverage"},"preference":"required","quality_binding":["any"],"falsifier":"Event/Episode classification is determined solely by duration rather than by note coverage scope","anchor":"events as being shorter, while episodes are longer","source_page":3},
-    {"rule_id":"goodrick-v4-c-major-anchor-exercises","name":"Present Passing-Tone and Embellishment Exercises in C Major First","when":{"exercise.type":["passing-tone","melodic-embellishment"],"voicing.density":"3-part"},"then":{"scale.context":"C_major","scale.accidentals":0},"preference":"required","quality_binding":["any"],"falsifier":"Passing-tone or melodic embellishment exercises on 3-part voicings are initially presented in a key other than C Major","anchor":"All of the material that follows in this next section will be presented in C Major (no accidentals)","source_page":15},
-    {"rule_id":"goodrick-v4-transposition-student-responsibility","name":"Assign Key Transposition Responsibility to Student After C Major Presentation","when":{"exercise.type":["passing-tone","melodic-embellishment"],"scale.context":"C_major"},"then":{"transposition.agent":"student","transposition.target_scales":"all-7-note-scales"},"preference":"required","quality_binding":["any"],"falsifier":"The system automatically transposes embellishment exercises to other keys without requiring student-driven transposition","anchor":"developed the necessary skills to make the needed adjustments","source_page":15},
-    {"rule_id":"goodrick-v4-cycle3-cycle4-master-organize","name":"Organize Chord Catalog Traversal by Cycle-3 / Cycle-4 Alternation","when":{"catalog.id":"840-chord"},"then":{"catalog.traversal_pattern":"cycle3-cycle4-alternation"},"preference":"required","quality_binding":["any"],"falsifier":"The 840-chord catalog is traversed in a linear or non-alternating root-motion order","anchor":"this same approach could be applied to pretty much everything","source_page":145},
-    {"rule_id":"goodrick-v4-catalog-840-dimensions","name":"Constrain Catalog to 24 Voicings × 35 Chord Types = 840 Entries","when":{"catalog.id":"840-chord"},"then":{"catalog.voicing_count":24,"catalog.chord_type_count":35,"catalog.total_entries":840},"preference":"required","quality_binding":["any"],"falsifier":"The catalog is populated with a number of entries other than 840, or with dimensions other than 24×35","anchor":"3-part chords are easier to play than 4-part chords","source_page":71},
-    {"rule_id":"goodrick-v4-catalog-3pt-chapters-before-4pt","name":"Sequence 3-Part Catalog Chapters Before 4-Part Catalog Chapters","when":{"catalog.id":"840-chord","catalog.chapter_range":"6-9"},"then":{"catalog.3pt_chapters_precede_4pt":true},"preference":"required","quality_binding":["any"],"falsifier":"4-part catalog chapters are presented or indexed before 3-part catalog chapters in the 840 sequence","anchor":"3-part chords are easier to play than 4-part chords","source_page":71},
-    {"rule_id":"goodrick-v4-msrp-melodic-strand-replication","name":"Apply M.S.R.P. to Replicate a Melodic Strand Across Voices","when":{"technique.id":"MSRP"},"then":{"voice_leading.replication_source":"melodic_strand","voice_leading.replication_target":"all_voices"},"preference":"recommended","quality_binding":["any"],"falsifier":"M.S.R.P. is applied to a non-melodic (purely harmonic) strand","anchor":"grip-slipping: more on this later","source_page":2},
-    {"rule_id":"goodrick-v4-grip-slipping-position-continuity","name":"Apply Grip-Slipping to Maintain Fretboard Position Continuity","when":{"technique.id":"grip-slipping"},"then":{"voicing.position_shift":"minimal","voicing.continuity_constraint":"same-position-preferred"},"preference":"preferred","quality_binding":["any"],"falsifier":"Grip-slipping is applied in a context that forces large positional leaps rather than maintaining continuity","anchor":"grip-slipping: more on this later","source_page":2},
-    {"rule_id":"goodrick-v4-scvl-chromatic-superstructure","name":"Treat SCVL as the Chromatic Superstructure Over GDVL Diatonic Foundation","when":{"voice_leading.type":"SCVL"},"then":{"voice_leading.scope":"chromatic","voice_leading.prerequisite":"GDVL"},"preference":"required","quality_binding":["any"],"falsifier":"SCVL is applied without GDVL established as the operating diatonic foundation","anchor":"IVLs and FVLs are all examples of SCVL, as opposed to GDVL","source_page":161},
-    {"rule_id":"goodrick-v4-gdvl-volumes-1-2-scope","name":"Assign GDVL as the Voice-Leading Mode for Volumes 1 and 2 Material","when":{"work.volume":[1,2]},"then":{"voice_leading.type":"GDVL"},"preference":"required","quality_binding":["any"],"falsifier":"Volumes 1 or 2 material is classified under SCVL rather than GDVL","anchor":"IVLs and FVLs are all examples of SCVL, as opposed to GDVL","source_page":161},
-    {"rule_id":"goodrick-v4-fourth-based-3pt-sus4-scope","name":"Apply sus4 Labeling to Both 3-Part and 4-Part Fourth-Based Structures","when":{"voicing.family":"fourth-based","voicing.density":["3-part","4-part"]},"then":{"chord.label_format":"sus4"},"preference":"required","quality_binding":["any"],"falsifier":"sus4 labeling is applied to 4-part fourth-based structures but not to 3-part, or vice versa","anchor":"I will grant you that C2 is shorter, but","source_page":4},
-    {"rule_id":"goodrick-v4-7th-no-5th-omission-derivation","name":"Derive 7th(no 5th) Exclusively Via Single-Voice Omission from 4-Part 7th Chord","when":{"chord.quality":"7th-no-5th","voicing.derivation_method":"omission"},"then":{"voicing.voice_removed":"5th","voicing.source_quality":"7th-4-part"},"preference":"required","quality_binding":["dom7","maj7","min7","min7b5"],"falsifier":"7th(no 5th) is constructed by adding voices rather than by omission from a complete 4-part 7th chord","anchor":"arrive at different 3-part chords by leaving out one voice","source_page":9},
-    {"rule_id":"goodrick-v4-symmetry-4-omission-positions","name":"Expose All Four Omission Positions to Reveal Symmetric Derivation Structure","when":{"voicing.derivation_method":"omission","voicing.source_density":"4-part"},"then":{"voicing.omission_positions_shown":["root","3rd","5th","7th"],"voicing.symmetry_verified":true},"preference":"required","quality_binding":["any"],"falsifier":"Fewer than all four voice-omission positions are explored, leaving the symmetric structure incomplete","anchor":"Each 3-part chord appears four times","source_page":9},
-    {"rule_id":"goodrick-v4-episode-7-modal-total","name":"Account for All Seven Modes in Complete Episode Transposition Set","when":{"unit.type":"episode","transposition.type":"diatonic","transposition.scope":"complete"},"then":{"transposition.total_modal_forms":7},"preference":"required","quality_binding":["any"],"falsifier":"A complete episode transposition set contains fewer or more than 7 modal forms","anchor":"each corresponds to a different mode","source_page":3},
-    {"rule_id":"goodrick-v4-event-episode-combination-domain","name":"Allow Events and Episodes to Span Combined Domains Simultaneously","when":{"unit.type":["event","episode"],"unit.domain_count":"multiple"},"then":{"unit.multi_domain_allowed":true},"preference":"preferred","quality_binding":["any"],"falsifier":"A combined-domain event or episode is split into separate single-domain units","anchor":"or in any combination","source_page":3},
-    {"rule_id":"goodrick-v4-cycle3-cycle4-extensibility","name":"Apply Cycle-3 / Cycle-4 Alternation Principle to Any New Material Beyond the Core Catalog","when":{"catalog.extension":true},"then":{"catalog.traversal_pattern":"cycle3-cycle4-alternation"},"preference":"recommended","quality_binding":["any"],"falsifier":"Extended material beyond the 840-chord catalog is organized by a non-cycle-based traversal order","anchor":"this same approach could be applied to pretty much everything","source_page":145},
-    {"rule_id":"goodrick-v4-no-chord-exceeds-4-voices","name":"Reject Any Voicing Construction That Exceeds Four Simultaneous Voices","when":{"voicing.voice_count":">4"},"then":{"voicing.valid":false},"preference":"required","quality_binding":["any"],"falsifier":"A chord voicing with 5 or more voices passes validation within this system","anchor":"leaving out one voice of a 4-part chord","source_page":9},
-    {"rule_id":"goodrick-v4-spread-cluster-coordinate-not-subordinate","name":"Catalog Spread Clusters as Coordinate With Not Subordinate to Other M-Lode Types","when":{"voicing.family":"spread-cluster","voicing.density":"3-part"},"then":{"chord.taxonomy_rank":"coordinate","chord.taxonomy_parent":"m-lode-expanded"},"preference":"required","quality_binding":["any"],"falsifier":"3-part Spread Clusters are nested inside or subordinated to 7th(no 3rd) or 7th(no 5th) in the taxonomy","anchor":"we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters","source_page":7},
-    {"rule_id":"goodrick-v4-passing-tone-c-major-then-transpose","name":"Sequence Passing-Tone Learning as C Major Mastery Then Independent Transposition","when":{"exercise.type":"passing-tone","exercise.stage":"initial"},"then":{"scale.context":"C_major","exercise.next_stage":"student-transposed-7-note-scales"},"preference":"required","quality_binding":["any"],"falsifier":"Passing-tone exercises begin in a key with accidentals before C Major is mastered","anchor":"All of the material that follows in this next section will be presented in C Major (no accidentals)","source_page":15},
-    {"rule_id":"goodrick-v4-ivl-interval-relation-defines-motion","name":"Define IVL Voice Motion by Interval Relationships Between Voices","when":{"voice_leading.type":"IVL"},"then":{"voice_leading.motion_criterion":"interval","voice_leading.parent_type":"SCVL"},"preference":"required","quality_binding":["any"],"falsifier":"IVL voice motion is defined by functional harmonic role rather than interval distance","anchor":"The IVLs and the FVLs are all examples of SCVL","source_page":161},
-    {"rule_id":"goodrick-v4-fvl-function-defines-motion","name":"Define FVL Voice Motion by Harmonic Function","when":{"voice_leading.type":"FVL"},"then":{"voice_leading.motion_criterion":"harmonic_function","voice_leading.parent_type":"SCVL"},"preference":"required","quality_binding":["any"],"falsifier":"FVL voice motion is defined by pure interval distance rather than harmonic function","anchor":"The IVLs and the FVLs are all examples of SCVL","source_page":161}
+    {
+      "rule_id": "goodrick-v4-sus4-label-required",
+      "name": "Label Fourth-Based Chords sus4 Not C2 or add-2",
+      "when": {
+        "voicing.family": "fourth-based"
+      },
+      "then": {
+        "chord.label_format": "sus4"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Any fourth-based chord labeled C2 or add-2 rather than sus4",
+      "anchor": "My suggestion for a suitable name for this chord would be: G [sus4]",
+      "source_page": 4
+    },
+    {
+      "rule_id": "goodrick-v4-sus4-inversion-consistency",
+      "name": "Maintain sus4 Label Across All Inversions",
+      "when": {
+        "voicing.family": "fourth-based",
+        "voicing.inversion": [
+          "1st",
+          "2nd",
+          "3rd"
+        ]
+      },
+      "then": {
+        "chord.label_format": "sus4"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "An inversion of a fourth-based chord reverts to C2 or add-2 notation",
+      "anchor": "Of course, this applies to all of the inversions as well",
+      "source_page": 4
+    },
+    {
+      "rule_id": "goodrick-v4-3pt-before-4pt-priority",
+      "name": "Route Through 3-Part Voicings Before 4-Part",
+      "when": {
+        "arrangement.style": "guitar-idiomatic"
+      },
+      "then": {
+        "voicing.density": "3-part",
+        "voicing.density_priority": "prefer-lower"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "4-part voicings presented as foundational before 3-part voicings are established",
+      "anchor": "3-part chords are easier to play than 4-part chords",
+      "source_page": 71
+    },
+    {
+      "rule_id": "goodrick-v4-density-ceiling-4pt",
+      "name": "Enforce 4-Part as Maximum Voicing Density",
+      "when": {
+        "voicing.construction": "any"
+      },
+      "then": {
+        "voicing.voice_count_max": 4
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A chord voicing is constructed with 5 or more simultaneous voices",
+      "anchor": "leaving out one voice of a 4-part chord",
+      "source_page": 9
+    },
+    {
+      "rule_id": "goodrick-v4-voice-omission-single",
+      "name": "Derive 3-Part Chords by Removing Exactly One Voice from 4-Part",
+      "when": {
+        "voicing.density": "3-part",
+        "voicing.derivation_method": "omission"
+      },
+      "then": {
+        "voicing.voices_removed": 1,
+        "voicing.source_density": "4-part"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 3-part chord is derived by removing more than one voice simultaneously from a 4-part source",
+      "anchor": "arrive at different 3-part chords by leaving out one voice",
+      "source_page": 9
+    },
+    {
+      "rule_id": "goodrick-v4-3pt-appears-4x",
+      "name": "Each 3-Part Chord Type Appears Exactly Four Times in Derivation Table",
+      "when": {
+        "voicing.derivation_method": "omission",
+        "voicing.source_density": "4-part"
+      },
+      "then": {
+        "voicing.occurrence_count": 4
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A 3-part chord type appears fewer or more than 4 times in the voice-omission derivation table",
+      "anchor": "Each 3-part chord appears four times",
+      "source_page": 9
+    },
+    {
+      "rule_id": "goodrick-v4-7th-no-3rd-distinct-type",
+      "name": "Catalog 7th(no 3rd) as Independent M-Lode Taxonomy Member",
+      "when": {
+        "chord.tensions_omitted": [
+          "3rd"
+        ],
+        "voicing.density": "3-part"
+      },
+      "then": {
+        "chord.taxonomy_family": "m-lode-expanded",
+        "chord.collapse_to_other": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "dom7",
+        "maj7",
+        "min7",
+        "min7b5",
+        "dim7"
+      ],
+      "falsifier": "7th(no 3rd) is collapsed into another chord category rather than cataloged as its own distinct type",
+      "anchor": "we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters",
+      "source_page": 7
+    },
+    {
+      "rule_id": "goodrick-v4-7th-no-5th-distinct-type",
+      "name": "Catalog 7th(no 5th) as Independent M-Lode Taxonomy Member",
+      "when": {
+        "chord.tensions_omitted": [
+          "5th"
+        ],
+        "voicing.density": "3-part"
+      },
+      "then": {
+        "chord.taxonomy_family": "m-lode-expanded",
+        "chord.collapse_to_other": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "dom7",
+        "maj7",
+        "min7",
+        "min7b5",
+        "dim7"
+      ],
+      "falsifier": "7th(no 5th) is treated as a reduced or incomplete form of a 4-part chord rather than its own type",
+      "anchor": "we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters",
+      "source_page": 7
+    },
+    {
+      "rule_id": "goodrick-v4-spread-cluster-3pt-distinct-type",
+      "name": "Catalog 3-Part Spread Clusters as Independent M-Lode Taxonomy Member",
+      "when": {
+        "voicing.family": "spread-cluster",
+        "voicing.density": "3-part"
+      },
+      "then": {
+        "chord.taxonomy_family": "m-lode-expanded",
+        "chord.subordinate_to": null
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "3-part Spread Clusters are treated as subordinate to or collapsed into another M-Lode category",
+      "anchor": "we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters",
+      "source_page": 7
+    },
+    {
+      "rule_id": "goodrick-v4-m-lode-expanded-3-new-types",
+      "name": "Expand M-Lode Taxonomy With All Three New 3-Part Chord Types Simultaneously",
+      "when": {
+        "chord.taxonomy_family": "m-lode-expanded"
+      },
+      "then": {
+        "chord.new_types_added": [
+          "7th (no 3rd)",
+          "7th (no 5th)",
+          "3-part Spread Clusters"
+        ]
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Only one or two of the three new types are added, leaving the M-Lode expansion incomplete",
+      "anchor": "we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters",
+      "source_page": 7
+    },
+    {
+      "rule_id": "goodrick-v4-gdvl-before-scvl",
+      "name": "Establish GDVL Before Introducing SCVL",
+      "when": {
+        "voice_leading.context": "introduction"
+      },
+      "then": {
+        "voice_leading.sequence": [
+          "GDVL",
+          "SCVL"
+        ]
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "SCVL is introduced to a student before GDVL is operational as the working mode",
+      "anchor": "IVLs and FVLs are all examples of SCVL, as opposed to GDVL",
+      "source_page": 161
+    },
+    {
+      "rule_id": "goodrick-v4-ivl-fvl-as-scvl",
+      "name": "Classify IVL and FVL as Sub-Types of SCVL",
+      "when": {
+        "voice_leading.type": [
+          "IVL",
+          "FVL"
+        ]
+      },
+      "then": {
+        "voice_leading.parent_type": "SCVL"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "IVL or FVL is classified as a type of GDVL or as independent of SCVL",
+      "anchor": "The IVLs and the FVLs are all examples of SCVL",
+      "source_page": 161
+    },
+    {
+      "rule_id": "goodrick-v4-melody-harmony-parity",
+      "name": "Treat Melodic and Harmonic Domains as Equal Weight",
+      "when": {
+        "arrangement.style": "any"
+      },
+      "then": {
+        "voice_leading.domain_weight.melody": 1.0,
+        "voice_leading.domain_weight.harmony": 1.0
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Voice-leading decisions systematically favor harmonic motion over melodic motion or vice versa",
+      "anchor": "excellent voice-leading treats both melody and harmony as equals",
+      "source_page": 188
+    },
+    {
+      "rule_id": "goodrick-v4-event-diatonic-6-transpositions",
+      "name": "Diatonic Event Transposition Yields Up to 6 Variants",
+      "when": {
+        "transposition.type": "diatonic",
+        "unit.type": "event"
+      },
+      "then": {
+        "transposition.step_max": 6,
+        "transposition.collapse_identical_intervals": true
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Diatonic transposition of an Event is applied beyond 6 steps without interval-collapse consolidation",
+      "anchor": "an event can be diatonically transposed to create 6 other events",
+      "source_page": 3
+    },
+    {
+      "rule_id": "goodrick-v4-event-collapse-identical-intervals",
+      "name": "Collapse Intervallically Identical Event Transpositions to One Representative",
+      "when": {
+        "transposition.type": "diatonic",
+        "unit.type": "event",
+        "transposition.interval_match": true
+      },
+      "then": {
+        "transposition.retain_count": 1,
+        "transposition.duplicates_discarded": true
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Intervallically identical diatonic event transpositions are listed as separate entries rather than collapsed",
+      "anchor": "but some of them will be intervallically identical",
+      "source_page": 3
+    },
+    {
+      "rule_id": "goodrick-v4-episode-modal-one-to-one",
+      "name": "Episode Diatonic Transposition Yields Exactly 6 Modal Variants Without Collapse",
+      "when": {
+        "transposition.type": "diatonic",
+        "unit.type": "episode"
+      },
+      "then": {
+        "transposition.step_count": 6,
+        "transposition.modal_variants": 6,
+        "transposition.collapse_identical_intervals": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Episode transposition produces fewer than 6 distinct modal variants or collapses any two modal variants together",
+      "anchor": "an episode can be diatonically transposed to create 6 other episodes",
+      "source_page": 3
+    },
+    {
+      "rule_id": "goodrick-v4-episode-modal-correspondence",
+      "name": "Map Each Transposed Episode to a Distinct Mode",
+      "when": {
+        "unit.type": "episode",
+        "transposition.type": "diatonic"
+      },
+      "then": {
+        "transposition.modal_mapping": "one-to-one",
+        "transposition.shared_mode_assignments": 0
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Two different episode transpositions are assigned to the same mode",
+      "anchor": "each corresponds to a different mode",
+      "source_page": 3
+    },
+    {
+      "rule_id": "goodrick-v4-event-episode-domain-agnostic",
+      "name": "Route Events and Episodes Identically Across Melodic, Contrapuntal, and Harmonic Domains",
+      "when": {
+        "unit.type": [
+          "event",
+          "episode"
+        ]
+      },
+      "then": {
+        "unit.valid_domains": [
+          "melodic",
+          "contrapuntal",
+          "harmonic",
+          "combination"
+        ]
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "An event or episode is restricted to only one domain when the source material permits all three",
+      "anchor": "Both events and episodes can be melodic, contrapuntal, harmonic",
+      "source_page": 3
+    },
+    {
+      "rule_id": "goodrick-v4-event-episode-length-not-defining",
+      "name": "Classify Event vs Episode by Note Coverage Not by Length",
+      "when": {
+        "unit.classification_criterion": "length"
+      },
+      "then": {
+        "unit.classification_criterion": "note_coverage"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Event/Episode classification is determined solely by duration rather than by note coverage scope",
+      "anchor": "events as being shorter, while episodes are longer",
+      "source_page": 3
+    },
+    {
+      "rule_id": "goodrick-v4-c-major-anchor-exercises",
+      "name": "Present Passing-Tone and Embellishment Exercises in C Major First",
+      "when": {
+        "exercise.type": [
+          "passing-tone",
+          "melodic-embellishment"
+        ],
+        "voicing.density": "3-part"
+      },
+      "then": {
+        "scale.context": "C_major",
+        "scale.accidentals": 0
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Passing-tone or melodic embellishment exercises on 3-part voicings are initially presented in a key other than C Major",
+      "anchor": "All of the material that follows in this next section will be presented in C Major (no accidentals)",
+      "source_page": 15
+    },
+    {
+      "rule_id": "goodrick-v4-transposition-student-responsibility",
+      "name": "Assign Key Transposition Responsibility to Student After C Major Presentation",
+      "when": {
+        "exercise.type": [
+          "passing-tone",
+          "melodic-embellishment"
+        ],
+        "scale.context": "C_major"
+      },
+      "then": {
+        "transposition.agent": "student",
+        "transposition.target_scales": "all-7-note-scales"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "The system automatically transposes embellishment exercises to other keys without requiring student-driven transposition",
+      "anchor": "developed the necessary skills to make the needed adjustments",
+      "source_page": 15
+    },
+    {
+      "rule_id": "goodrick-v4-cycle3-cycle4-master-organize",
+      "name": "Organize Chord Catalog Traversal by Cycle-3 / Cycle-4 Alternation",
+      "when": {
+        "catalog.id": "840-chord"
+      },
+      "then": {
+        "catalog.traversal_pattern": "cycle3-cycle4-alternation"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "The 840-chord catalog is traversed in a linear or non-alternating root-motion order",
+      "anchor": "this same approach could be applied to pretty much everything",
+      "source_page": 145
+    },
+    {
+      "rule_id": "goodrick-v4-catalog-840-dimensions",
+      "name": "Constrain Catalog to 24 Voicings × 35 Chord Types = 840 Entries",
+      "when": {
+        "catalog.id": "840-chord"
+      },
+      "then": {
+        "catalog.voicing_count": 24,
+        "catalog.chord_type_count": 35,
+        "catalog.total_entries": 840
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "The catalog is populated with a number of entries other than 840, or with dimensions other than 24×35",
+      "anchor": "3-part chords are easier to play than 4-part chords",
+      "source_page": 71
+    },
+    {
+      "rule_id": "goodrick-v4-catalog-3pt-chapters-before-4pt",
+      "name": "Sequence 3-Part Catalog Chapters Before 4-Part Catalog Chapters",
+      "when": {
+        "catalog.id": "840-chord",
+        "catalog.chapter_range": "6-9"
+      },
+      "then": {
+        "catalog.3pt_chapters_precede_4pt": true
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "4-part catalog chapters are presented or indexed before 3-part catalog chapters in the 840 sequence",
+      "anchor": "3-part chords are easier to play than 4-part chords",
+      "source_page": 71
+    },
+    {
+      "rule_id": "goodrick-v4-msrp-melodic-strand-replication",
+      "name": "Apply M.S.R.P. to Replicate a Melodic Strand Across Voices",
+      "when": {
+        "technique.id": "MSRP"
+      },
+      "then": {
+        "voice_leading.replication_source": "melodic_strand",
+        "voice_leading.replication_target": "all_voices"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "M.S.R.P. is applied to a non-melodic (purely harmonic) strand",
+      "anchor": "grip-slipping: more on this later",
+      "source_page": 2
+    },
+    {
+      "rule_id": "goodrick-v4-grip-slipping-position-continuity",
+      "name": "Apply Grip-Slipping to Maintain Fretboard Position Continuity",
+      "when": {
+        "technique.id": "grip-slipping"
+      },
+      "then": {
+        "voicing.position_shift": "minimal",
+        "voicing.continuity_constraint": "same-position-preferred"
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Grip-slipping is applied in a context that forces large positional leaps rather than maintaining continuity",
+      "anchor": "grip-slipping: more on this later",
+      "source_page": 2
+    },
+    {
+      "rule_id": "goodrick-v4-scvl-chromatic-superstructure",
+      "name": "Treat SCVL as the Chromatic Superstructure Over GDVL Diatonic Foundation",
+      "when": {
+        "voice_leading.type": "SCVL"
+      },
+      "then": {
+        "voice_leading.scope": "chromatic",
+        "voice_leading.prerequisite": "GDVL"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "SCVL is applied without GDVL established as the operating diatonic foundation",
+      "anchor": "IVLs and FVLs are all examples of SCVL, as opposed to GDVL",
+      "source_page": 161
+    },
+    {
+      "rule_id": "goodrick-v4-gdvl-volumes-1-2-scope",
+      "name": "Assign GDVL as the Voice-Leading Mode for Volumes 1 and 2 Material",
+      "when": {
+        "work.volume": [
+          1,
+          2
+        ]
+      },
+      "then": {
+        "voice_leading.type": "GDVL"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Volumes 1 or 2 material is classified under SCVL rather than GDVL",
+      "anchor": "IVLs and FVLs are all examples of SCVL, as opposed to GDVL",
+      "source_page": 161
+    },
+    {
+      "rule_id": "goodrick-v4-fourth-based-3pt-sus4-scope",
+      "name": "Apply sus4 Labeling to Both 3-Part and 4-Part Fourth-Based Structures",
+      "when": {
+        "voicing.family": "fourth-based",
+        "voicing.density": [
+          "3-part",
+          "4-part"
+        ]
+      },
+      "then": {
+        "chord.label_format": "sus4"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "sus4 labeling is applied to 4-part fourth-based structures but not to 3-part, or vice versa",
+      "anchor": "I will grant you that C2 is shorter, but",
+      "source_page": 4
+    },
+    {
+      "rule_id": "goodrick-v4-7th-no-5th-omission-derivation",
+      "name": "Derive 7th(no 5th) Exclusively Via Single-Voice Omission from 4-Part 7th Chord",
+      "when": {
+        "chord.quality": "7th-no-5th",
+        "voicing.derivation_method": "omission"
+      },
+      "then": {
+        "voicing.voice_removed": "5th",
+        "voicing.source_quality": "7th-4-part"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "dom7",
+        "maj7",
+        "min7",
+        "min7b5"
+      ],
+      "falsifier": "7th(no 5th) is constructed by adding voices rather than by omission from a complete 4-part 7th chord",
+      "anchor": "arrive at different 3-part chords by leaving out one voice",
+      "source_page": 9
+    },
+    {
+      "rule_id": "goodrick-v4-symmetry-4-omission-positions",
+      "name": "Expose All Four Omission Positions to Reveal Symmetric Derivation Structure",
+      "when": {
+        "voicing.derivation_method": "omission",
+        "voicing.source_density": "4-part"
+      },
+      "then": {
+        "voicing.omission_positions_shown": [
+          "root",
+          "3rd",
+          "5th",
+          "7th"
+        ],
+        "voicing.symmetry_verified": true
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Fewer than all four voice-omission positions are explored, leaving the symmetric structure incomplete",
+      "anchor": "Each 3-part chord appears four times",
+      "source_page": 9
+    },
+    {
+      "rule_id": "goodrick-v4-episode-7-modal-total",
+      "name": "Account for All Seven Modes in Complete Episode Transposition Set",
+      "when": {
+        "unit.type": "episode",
+        "transposition.type": "diatonic",
+        "transposition.scope": "complete"
+      },
+      "then": {
+        "transposition.total_modal_forms": 7
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A complete episode transposition set contains fewer or more than 7 modal forms",
+      "anchor": "each corresponds to a different mode",
+      "source_page": 3
+    },
+    {
+      "rule_id": "goodrick-v4-event-episode-combination-domain",
+      "name": "Allow Events and Episodes to Span Combined Domains Simultaneously",
+      "when": {
+        "unit.type": [
+          "event",
+          "episode"
+        ],
+        "unit.domain_count": "multiple"
+      },
+      "then": {
+        "unit.multi_domain_allowed": true
+      },
+      "preference": "preferred",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A combined-domain event or episode is split into separate single-domain units",
+      "anchor": "or in any combination",
+      "source_page": 3
+    },
+    {
+      "rule_id": "goodrick-v4-cycle3-cycle4-extensibility",
+      "name": "Apply Cycle-3 / Cycle-4 Alternation Principle to Any New Material Beyond the Core Catalog",
+      "when": {
+        "catalog.extension": true
+      },
+      "then": {
+        "catalog.traversal_pattern": "cycle3-cycle4-alternation"
+      },
+      "preference": "recommended",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Extended material beyond the 840-chord catalog is organized by a non-cycle-based traversal order",
+      "anchor": "this same approach could be applied to pretty much everything",
+      "source_page": 145
+    },
+    {
+      "rule_id": "goodrick-v4-no-chord-exceeds-4-voices",
+      "name": "Reject Any Voicing Construction That Exceeds Four Simultaneous Voices",
+      "when": {
+        "voicing.voice_count": ">4"
+      },
+      "then": {
+        "voicing.valid": false
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "A chord voicing with 5 or more voices passes validation within this system",
+      "anchor": "leaving out one voice of a 4-part chord",
+      "source_page": 9
+    },
+    {
+      "rule_id": "goodrick-v4-spread-cluster-coordinate-not-subordinate",
+      "name": "Catalog Spread Clusters as Coordinate With Not Subordinate to Other M-Lode Types",
+      "when": {
+        "voicing.family": "spread-cluster",
+        "voicing.density": "3-part"
+      },
+      "then": {
+        "chord.taxonomy_rank": "coordinate",
+        "chord.taxonomy_parent": "m-lode-expanded"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "3-part Spread Clusters are nested inside or subordinated to 7th(no 3rd) or 7th(no 5th) in the taxonomy",
+      "anchor": "we add 3 different 3-part chords: 7th (no 3rd), 7th (no 5th), 3-part Spread Clusters",
+      "source_page": 7
+    },
+    {
+      "rule_id": "goodrick-v4-passing-tone-c-major-then-transpose",
+      "name": "Sequence Passing-Tone Learning as C Major Mastery Then Independent Transposition",
+      "when": {
+        "exercise.type": "passing-tone",
+        "exercise.stage": "initial"
+      },
+      "then": {
+        "scale.context": "C_major",
+        "exercise.next_stage": "student-transposed-7-note-scales"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "Passing-tone exercises begin in a key with accidentals before C Major is mastered",
+      "anchor": "All of the material that follows in this next section will be presented in C Major (no accidentals)",
+      "source_page": 15
+    },
+    {
+      "rule_id": "goodrick-v4-ivl-interval-relation-defines-motion",
+      "name": "Define IVL Voice Motion by Interval Relationships Between Voices",
+      "when": {
+        "voice_leading.type": "IVL"
+      },
+      "then": {
+        "voice_leading.motion_criterion": "interval",
+        "voice_leading.parent_type": "SCVL"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "IVL voice motion is defined by functional harmonic role rather than interval distance",
+      "anchor": "The IVLs and the FVLs are all examples of SCVL",
+      "source_page": 161
+    },
+    {
+      "rule_id": "goodrick-v4-fvl-function-defines-motion",
+      "name": "Define FVL Voice Motion by Harmonic Function",
+      "when": {
+        "voice_leading.type": "FVL"
+      },
+      "then": {
+        "voice_leading.motion_criterion": "harmonic_function",
+        "voice_leading.parent_type": "SCVL"
+      },
+      "preference": "required",
+      "quality_binding": [
+        "any"
+      ],
+      "falsifier": "FVL voice motion is defined by pure interval distance rather than harmonic function",
+      "anchor": "The IVLs and the FVLs are all examples of SCVL",
+      "source_page": 161
+    }
   ]
 }

--- a/plugin/data/masters-corpus/mickey-baker/complete-course-in-jazz-guitar/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mickey-baker/complete-course-in-jazz-guitar/derived/engine-rules.json
@@ -1,4 +1,13 @@
 {
+  "_provenance": {
+    "run_id": "2026-06-16-mickey-baker-complete-course-in-jazz-guitar",
+    "stage": "s6-engine-rules",
+    "source_pdf": null,
+    "extracted_at": "2026-06-16T23:00:55-05:00",
+    "schema_version": "0.1",
+    "model": "claude-opus-4-7",
+    "ticket": "#527"
+  },
   "master_id": "mickey-baker",
   "work_id": "complete-course-in-jazz-guitar",
   "engine_rules": [


### PR DESCRIPTION
Closes #547.

## Summary
13 of 14 engine-rules.json files lacked a top-level `_provenance` block. Only Greene had it. This PR adds the canonical `_provenance` shape (matching Greene exactly) to the other 13 files.

## Provenance shape

```json
"_provenance": {
  "run_id": "<date>-<master>-<work>",
  "stage": "s6-engine-rules",
  "source_pdf": null,
  "extracted_at": "<ISO 8601 of first-add commit>",
  "schema_version": "0.1",
  "model": "claude-opus-4-7",
  "ticket": "#527"
}
```

`extracted_at` is sourced from `git log --diff-filter=A` (the commit that first added the file), so the timestamp reflects when rules were extracted, not when this backfill PR lands.

`source_pdf` is intentionally null — backfill is deferred to #550 which tracks the source-book locator metadata.

## Verification

| Gate | Result |
|---|---|
| Files with `_provenance` after backfill | 14/14 (was 1/14) |
| Total engine_rules across all 14 files | 750 (unchanged from develop) |
| rule_ids preserved per file (spot-checked 3 files) | IDENTICAL |
| Mutation of engine_rules content | None (key-insert only; some files reformatted from minified to pretty-printed) |

## Diff stats note
2648 insertions / 134 deletions is larger than the 13×7-key insertion would suggest. Two files (Goodrick V2, V4) were stored as minified JSON before; `json.dump(indent=2)` pretty-printed them. No rule content changed — `rule_ids` string-comparison confirms identity. See [audit comment on #547](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/547#issuecomment-4732671320).

## Unblocks
- #548 (engine-rules release pipeline) — bundle build can now fail loudly on missing `schema_version`