### PR TITLE
fix(#552): normalize master_id/work_id keys (3 files used master/work)

### DIFF
--- a/plugin/data/masters-corpus/barry-harris/jazz-workshop/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/barry-harris/jazz-workshop/derived/engine-rules.json
@@ -8,9 +8,8 @@
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
-  "master": "barry-harris",
-  "work": "jazz-workshop",
-  "schema_version": "0.1",
+  "master_id": "barry-harris",
+  "work_id": "jazz-workshop",
   "count": 38,
   "engine_rules": [
     {

--- a/plugin/data/masters-corpus/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
@@ -8,9 +8,8 @@
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
-  "schema_version": "0.1",
-  "master": "bert-ligon",
-  "work": "connecting-chords-with-linear-harmony",
+  "master_id": "bert-ligon",
+  "work_id": "connecting-chords-with-linear-harmony",
   "source_pdf": "Ligon, Bert - Connecting Chords with Linear Harmony.pdf",
   "run_id": "2026-06-12T09-48-05-ligon-connecting-chords",
   "rule_id_prefix": "ligon-",

--- a/plugin/data/masters-corpus/howard-roberts/chord-melody/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/howard-roberts/chord-melody/derived/engine-rules.json
@@ -8,8 +8,8 @@
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
-  "master": "howard-roberts",
-  "work": "chord-melody",
+  "master_id": "howard-roberts",
+  "work_id": "chord-melody",
   "rule_id_prefix": "roberts-",
   "count": 22,
   "engine_rules": [


### PR DESCRIPTION
Closes #552.

## Summary
3 engine-rules.json files used `master` / `work` instead of canonical `master_id` / `work_id`. Same class as #546 (rules→engine_rules) and #547 (\_provenance). Bundle validator (#548) caught it.

## Files
- barry-harris/jazz-workshop
- bert-ligon/connecting-chords-with-linear-harmony (also removed vestigial top-level `schema_version`; canonical location is inside `_provenance` per #547)
- howard-roberts/chord-melody

## Verification
| Gate | Result |
|---|---|
| All 14 files have `master_id` + `work_id` at root | YES |
| Total engine_rules | 750 (unchanged) |

## Unblocks
- #548 release pipeline (bundle script can now validate uniform canonical shape)