### PR TITLE
feat(#558): clean bundle layout — drop plugin-internal path prefix

### DIFF
--- a/scripts/build_engine_rules_bundle.py
+++ b/scripts/build_engine_rules_bundle.py
@@ -129,10 +129,21 @@ def validate_manifest_against_schema(manifest: dict) -> None:
     jsonschema.validate(instance=manifest, schema=schema)
 
 
+def bundle_arcname(f: Path) -> str:
+    """Map a repo-internal engine-rules.json path to its bundle-canonical arcname.
+
+    The bundle layout (per #558) is ``masters/<master_id>/<work_id>/derived/engine-rules.json``.
+    This avoids leaking the plugin's internal ``plugin/data/masters-corpus/`` directory
+    structure to downstream consumers. Matches the fixture tarball's layout.
+    """
+    rel = f.relative_to(MASTERS_CORPUS)
+    return "masters/" + str(rel)
+
+
 def write_bundle_tarball(out_path: Path, files: list[Path]) -> None:
     with tarfile.open(out_path, "w:gz") as tar:
         for f in files:
-            tar.add(f, arcname=str(f.relative_to(REPO_ROOT)))
+            tar.add(f, arcname=bundle_arcname(f))
 
 
 def write_fixture_tarball(


### PR DESCRIPTION
Closes #558.

## Summary
Bundle tarball entries now use `masters/<master_id>/<work_id>/derived/engine-rules.json` instead of the leaky `plugin/data/masters-corpus/<master_id>/<work_id>/derived/engine-rules.json`.

## Why
Surfaced during hostile review of [Ellington PR #99](https://github.com/siege-analytics/ellington-web/pull/99): their consumer regex matched my fixture's clean layout but not my bundle's leaky layout — silent zero-rule import. The bundle and fixture should agree.

## Verification

```
$ tar -tzf engine-rules-bundle.tar.gz | head -3
masters/barry-harris/jazz-workshop/derived/engine-rules.json
masters/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
masters/dirk-laukens/complete-chord-melody/derived/engine-rules.json

$ tar -tzf engine-rules-fixture.tar.gz | head -3
fixtures/expected-fires.json
fixtures/sample-slices.json
masters/joe-pass/guitar-chords/derived/engine-rules.json
```

750 rules / 14 books / 134KB. Identical content; just cleaner arcnames.

## Next
After merge, cut `engine-rules-v0.1.1` tag → release pipeline publishes the cleaned bundle.