### PR TITLE
feat(#555): firing-semantics spec v0.2 — Greene family-hierarchical matching

### DIFF
--- a/plugin/docs/engine-rules-firing-spec.md
+++ b/plugin/docs/engine-rules-firing-spec.md
@@ -1,8 +1,21 @@
-# Engine-Rules Firing Semantics — v0.1
+# Engine-Rules Firing Semantics — v0.2
 
-**Status**: canonical, ratified by maintainer 2026-06-17 (issue #549)
-**Schema version**: `_provenance.schema_version = "0.1"`
+**Status**: canonical, ratified by maintainer 2026-06-17 (#549 v0.1, #555 v0.2 extension)
+**Schema version**: `_provenance.schema_version = "0.2"`
 **Consumers**: Ellington `apps.engine_rules` (#97), #71 comparator, future Phase 7 melodic-rules engine.
+
+## v0.2 changes (additive over v0.1)
+
+v0.2 extends the canonical chord-quality token set and introduces **family-hierarchical matching** for `quality_binding`, codifying Ted Greene's three-family taxonomy (MAJOR / MINOR / DOMINANT + DIMINISHED + AUGMENTED) as the parent layer over specific qualities.
+
+The extension is **strict additive** — every rule that fires under v0.1 still fires the same way under v0.2. New surface area:
+
+- Extended canonical token set (was 11, now 36 tokens)
+- Family tokens (`maj`, `min`, `dom7`, `dim`, `aug`) explicitly defined as **family parents** that match any specific quality in their family
+- Family-hierarchical matching rules (§2.2)
+- Expanded alias table covering common shorthand (§2.3)
+
+v0.1 bundles remain consumable by v0.2 engines (any rule's `quality_binding` still works); v0.2 bundles require `min_consumer_version >= 0.2.0` so older consumers don't silently mis-parse the new family-token semantics.
 
 ## Scope
 
@@ -63,51 +76,153 @@ If the slice lacks a dimension the rule's `when` requires (e.g. `melody_note: nu
 `quality_binding` is an array of canonical chord-quality tokens. Semantics:
 
 - `["any"]` — rule applies to any chord quality. Fires if other `when` conditions match.
-- `["dom7", "alt7"]` — rule fires only if the slice's augmented `chord_quality` is in the list. Hard prefilter — overrides any `chord_quality` value inside `when`.
+- `["dom7", "alt7"]` — rule fires only if the slice's augmented `chord_quality` is in the list (with family-hierarchical matching per §2.2). Hard prefilter — overrides any `chord_quality` value inside `when`.
 
-### Canonical chord-quality token set
+### §2.1 Canonical chord-quality token set
 
+Per Ted Greene's three-family framework (Chord Chemistry Ch. 5–6), the token set is organized as:
+
+**Family parents** (match any specific quality in their family per §2.2):
 ```
-maj7, dom7, min7, min7b5, dim7, maj6, min6, sus2, sus4, alt7, any
+maj, min, dom7, dim, aug, sus, any
 ```
 
-### Aliases (resolved at firing time, not at corpus migration)
+**Specific qualities under MAJOR family**:
+```
+maj, maj6, maj69, maj7, maj9, maj13, maj7#11, maj7b5
+```
+
+**Specific qualities under MINOR family**:
+```
+min, min6, min69, min7, min9, min11, min13, minMaj7, min7b5
+```
+(Note: `min7b5` is also conventionally classified under DOMINANT-function in jazz analysis when it leads to V; classification here is by structural quality, not function.)
+
+**Specific qualities under DOMINANT family**:
+```
+dom7, dom9, dom11, dom13,
+dom7b5, dom7#5, dom7b9, dom7#9, dom7#11,
+dom7sus4,
+alt7
+```
+
+**Specific qualities under DIMINISHED family**:
+```
+dim, dim7
+```
+
+**Specific qualities under AUGMENTED family**:
+```
+aug, aug7
+```
+
+**Specific qualities under SUS family** (Greene treats sus as its own boundary family):
+```
+sus2, sus4
+```
+
+**Wildcard**: `any`
+
+### §2.2 Family-hierarchical matching
+
+A rule keyed off a **family parent token** matches any specific quality in that family. A rule keyed off a **specific token** matches only that exact quality.
+
+| Rule's `quality_binding` | Slice's augmented `chord_quality` | Fires? | Reason |
+|---|---|---|---|
+| `["maj"]` | `maj7` | ✅ | family parent matches family member |
+| `["maj"]` | `maj9` | ✅ | family parent matches family member |
+| `["maj7"]` | `maj9` | ❌ | specific mismatch (maj7 ≠ maj9) |
+| `["maj7", "maj9"]` | `maj9` | ✅ | specific match in array |
+| `["dom7"]` | `dom7b9` | ✅ | family parent (`dom7` is the DOMINANT family head) matches family member |
+| `["dom7b9"]` | `dom7` | ❌ | specific mismatch — plain dom7 is not altered |
+| `["dom7", "min7"]` | `dom9` | ✅ | DOMINANT family parent matches dom9 |
+| `["sus"]` | `sus4` | ✅ | family parent matches family member |
+| `["sus4"]` | `sus2` | ❌ | specific mismatch |
+| `["any"]` | any | ✅ | wildcard |
+
+**Edge case — `dom7` as both family parent and specific token**: `dom7` is the family head AND a specific quality (plain dominant 7th, no extensions/alterations). When a rule has `quality_binding: ["dom7"]`, it matches:
+- a slice with `chord_quality = "dom7"` (specific match), AND
+- a slice with `chord_quality = "dom9"` / `"dom7b9"` / etc. (family match)
+
+This collapsing is intentional — most rules authored against `dom7` mean "any dominant," not specifically the un-extended dom7. To restrict to plain dom7 only, authors should use the explicit token `dom7_plain` (reserved for future use; for v0.2, write `quality_binding: ["dom7"], when: {"chord_quality": "dom7"}` — the redundant `when` clause makes intent explicit).
+
+The same collapsing applies to `min7`-as-specific vs `min`-as-family-head and `maj7`-as-specific vs `maj`-as-family-head. The rule: **family parent name does NOT require the `7` suffix**, while specific quality names DO require their full canonical form.
+
+### §2.3 Alias table
+
+Authors may write any of these legacy / shorthand tokens; engines normalize at firing time:
 
 | Author wrote | Engine resolves to |
 |---|---|
 | `"seventh"` | `dom7` |
 | `"7"` | `dom7` |
-| `"major7"` | `maj7` |
-| `"minor7"` | `min7` |
-| `"dominant7"` | `dom7` |
+| `"major"` | `maj` (family) |
+| `"major7"` | `maj7` (specific) |
+| `"minor"` | `min` (family) |
+| `"minor7"` | `min7` (specific) |
+| `"dominant"` | `dom7` (family) |
+| `"dominant7"` | `dom7` (specific) |
+| `"dominant_7"` | `dom7` |
 | `"half-diminished"` | `min7b5` |
 | `"diminished"` | `dim7` |
+| `"+"` | `aug` |
+| `"°"` | `dim` |
+| `"ø"` | `min7b5` |
+| `"m"` | `min` (family) |
+| `"M"` | `maj` (family) |
+| `"Δ"` | `maj7` |
 
-The corpus migration in #555 normalizes `quality_binding` values to canonical tokens. Aliases above ensure rules authored before migration still fire correctly during the transition window.
+### §2.4 Non-canonical values → `applicability_reasons`
 
-### Non-canonical values → `applicability_reasons`
+Per #549/#555: non-canonical values in `quality_binding` (e.g. Laukens's `["voice_leading", "clarity"]`) are NOT chord qualities — they are authorial annotations on **why** the rule applies. The #555 corpus migration moves them into the optional `applicability_reasons` field. The review UI surfaces them as "this rule applies because of *X*."
 
-Per #549/#555: non-canonical values in `quality_binding` (e.g. Laukens's `["voice_leading", "clarity"]`) are NOT chord qualities — they are authorial annotations on **why** the rule applies. These move into the optional `applicability_reasons` field during the #555 migration. The review UI surfaces them as "this rule applies because of *X*."
-
-After #555 lands, every rule's `quality_binding` contains canonical tokens only. Until then, the engine treats non-canonical values as passthrough (rule fires regardless of chord quality on those tokens).
+After #555 lands, every rule's `quality_binding` contains canonical tokens only. Consumers reading v0.1 bundles should split non-canonical tokens out at sync time using the conservative whitelist documented in #555.
 
 ## §3 — Augmented slice facets
 
 The engine MUST produce these facets deterministically from the raw slice:
 
-### `chord_quality`
+### `chord_quality` (v0.2 — extended specificity)
 
-Extract from `target_chord_canonical` by canonical-quality-token mapping:
+Extract from `target_chord_canonical` to the most-specific canonical token. Engine extracts the FULL specificity available:
 
-- `Cmaj7`, `Cmaj7#11` → `maj7`
-- `C7`, `C7b9`, `C13` → `dom7` (or `alt7` when explicitly altered — see #555 follow-up)
-- `Cm7`, `Cmin7` → `min7`
-- `Cm7b5`, `C∅` → `min7b5`
-- `Cdim7`, `C°7` → `dim7`
-- `C6/9`, `Cmaj6` → `maj6`
-- `Cm6` → `min6`
-- `Csus2` → `sus2`
-- `Csus4`, `C7sus4` → `sus4` (sus4 takes precedence over dom7 when both apply)
+| Slice's `target_chord_canonical` | Augmented `chord_quality` |
+|---|---|
+| `Cmaj7` | `maj7` |
+| `Cmaj9`, `Cmaj7add9` | `maj9` |
+| `Cmaj13` | `maj13` |
+| `Cmaj7#11`, `Cmaj7(#11)` | `maj7#11` |
+| `C6` | `maj6` |
+| `C6/9`, `C69` | `maj69` |
+| `C7` | `dom7` |
+| `C9` | `dom9` |
+| `C11`, `C7sus4(11)` | `dom11` |
+| `C13` | `dom13` |
+| `C7b5` | `dom7b5` |
+| `C7#5`, `C7+5` | `dom7#5` |
+| `C7b9`, `C7(b9)` | `dom7b9` |
+| `C7#9` | `dom7#9` |
+| `C7#11` | `dom7#11` |
+| `C7sus4`, `C7sus` | `dom7sus4` |
+| `C7alt`, `Calt`, `C7(alt)` | `alt7` |
+| `Cm7`, `Cmin7` | `min7` |
+| `Cm9`, `Cmin9` | `min9` |
+| `Cm11` | `min11` |
+| `Cm13` | `min13` |
+| `Cm6`, `Cmin6` | `min6` |
+| `Cm6/9`, `Cm69` | `min69` |
+| `CmMaj7`, `Cm(maj7)` | `minMaj7` |
+| `Cm7b5`, `C∅`, `Cø` | `min7b5` |
+| `Cdim`, `C°` | `dim` |
+| `Cdim7`, `C°7` | `dim7` |
+| `Caug`, `C+` | `aug` |
+| `Caug7`, `C7+5`, `C+7` | `aug7` |
+| `Csus2` | `sus2` |
+| `Csus4`, `Csus` (bare) | `sus4` (sus4 wins if no number) |
+
+When the engine encounters an ambiguous symbol it cannot disambiguate (e.g. `C(13)` without `7`), it MUST augment to the most general canonical token (here: `maj13`) and surface the disambiguation in matched_dimensions for review-UI visibility.
+
+**Family-augmentation invariant**: every specific token belongs to exactly one family per §2.1. The engine SHOULD ALSO produce a `chord_family` facet alongside `chord_quality` so rules keyed off `quality_binding: ["dom7"]` (family) match through to slices augmented with `dom9` or `dom7b9`. This is the dual-keying mechanism that makes §2.2 family-hierarchical matching efficient at firing time.
 
 ### `scale.context`
 
@@ -263,13 +378,14 @@ Strong avoid (−2) renders with extra visual severity. Anchor: *"Avoid skipping
 
 ## §9 — Open follow-ups
 
-- **#555**: corpus migration splitting `quality_binding` into canonical + `applicability_reasons`; normalizing `preference` prose into Likert integers. Lands before any consumer reads the rules.
+- **#555**: corpus migration splitting `quality_binding` into canonical + `applicability_reasons`; normalizing `preference` prose into Likert integers. Targets bundle `engine-rules-v0.2.0`.
 - **#550**: source-book locator metadata for anchor deep-links (review UI v2 feature).
 - **#554** (Phase 7): melodic_rules artifact + Slonimsky distillation.
-- **v0.2**: canonical `then` action vocabulary; structured `falsifier` predicates; comparator-confidence model.
+- **v0.3** (future): canonical `then` action vocabulary; structured `falsifier` predicates; comparator-confidence model; melodic-layer composition with v0.2 harmonic engine.
 
 ## Version history
 
 | Version | Date | Note |
 |---|---|---|
 | 0.1 | 2026-06-17 | Initial spec, ratified per #549 |
+| 0.2 | 2026-06-17 | Extended canonical token set via Ted Greene's three-family taxonomy (Chord Chemistry Ch. 5–6); family-hierarchical matching for `quality_binding`; expanded alias table including symbols (`+`, `°`, `ø`, `Δ`). Ratified per #555. Strict additive over v0.1. |


### PR DESCRIPTION
## Summary
v0.2 of the firing-semantics spec, extending v0.1 with Ted Greene's three-family taxonomy and family-hierarchical `quality_binding` matching. Strict additive — every v0.1 rule fires identically under v0.2.

This is the spec patch that unblocks the [#555 corpus migration](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/555). Once ratified, the migration script normalizes the corpus to canonical tokens + Likert preferences, and bundle `engine-rules-v0.2.0` ships.

## What v0.2 adds

- **§2.1** — Canonical token set extended **11 → 36** tokens (family parents + MAJOR/MINOR/DOMINANT/DIMINISHED/AUGMENTED/SUS specifics)
- **§2.2** — Family-hierarchical matching: `quality_binding: ["maj"]` matches any major-family quality; `["maj7"]` matches only `maj7` exactly
- **§2.3** — Expanded alias table: `+`, `°`, `ø`, `Δ`, `m`/`M`, `major`/`minor` and friends
- **§3** — Extended `chord_quality` augmentation table (37 mapping rows for full specificity from `target_chord_canonical`)
- **§9** — `v0.3` becomes the future bucket; `v0.2` is now the migration target

## What v0.2 explicitly preserves

- v0.1 `when`/`then`/`falsifier` semantics — unchanged
- Likert preference (−2..+2) — unchanged
- Polarity derivation from sign — unchanged
- `applicability_reasons` (already in v0.1) — unchanged

## Consumer impact

- v0.1 bundles remain consumable by v0.2 engines (every existing rule still fires identically)
- v0.2 bundles set `manifest.min_consumer_version >= 0.2.0` so older consumers don't silently mis-parse family-token semantics
- Ellington `apps.engine_rules` (#97) can adopt v0.2 at PR 3 cadence per our coordination on PR #99

## Diff
1 file changed, 144 insertions, 28 deletions on `plugin/docs/engine-rules-firing-spec.md`.

## Refs
- #549 (v0.1 spec)
- #555 (corpus migration that lands against this spec)
- Ellington #97 (consumer)