### PR TITLE
fix(#555): corpus migration to spec v0.2 (Likert + Greene tokens)

### DIFF
--- a/plugin/data/masters-corpus/barry-harris/jazz-workshop/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/barry-harris/jazz-workshop/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:28-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -21,7 +21,7 @@
       "then": {
         "voicing.quality": "always embed technical exercise within a musical phrase or progression"
       },
-      "preference": "Never practice technique in isolation from musical meaning",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -40,7 +40,7 @@
       "then": {
         "voicing.quality": "maintain internal awareness of drums, bass, and chord changes at tempo"
       },
-      "preference": "Always practice in tempo with an imagined rhythm section",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -60,7 +60,7 @@
       "then": {
         "voicing.shape": "ascend from tonic to 7th degree, then descend straight back to tonic, producing a 2-bar phrase"
       },
-      "preference": "The 'up and down' form is the standard scale exercise unit",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -80,9 +80,9 @@
       "then": {
         "voicing.shape": "prioritize arpeggios built on scale degrees 1, 5, and 7"
       },
-      "preference": "On a C dominant 7th, practice the arpeggios rooted on C, G, and Bb",
+      "preference": 1,
       "quality_binding": [
-        "dominant_7th"
+        "dom7"
       ],
       "falsifier": "Treating an arpeggio built on the 2nd or 4th degree of the dominant 7th scale as equally important would contradict this rule.",
       "anchor": "The three important arpeggios on the dominant 7th scale are found\non the tonic, the Sth and the 7th.",
@@ -100,7 +100,7 @@
       "then": {
         "voicing.shape": "insert pivot point to create new highest or lowest note, generating natural rhythmic accent"
       },
-      "preference": "Use pivoting when a melodic line would otherwise exceed instrumental range or when rhythmic reaccentuation is desired",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -120,11 +120,11 @@
       "then": {
         "scale.insert_half_step_at": "position determined by scale-type-specific rules"
       },
-      "preference": "Half-steps appear in the descending form only; each scale type has its own rule set",
+      "preference": 2,
       "quality_binding": [
-        "dominant_7th",
-        "major",
-        "minor"
+        "dom7",
+        "maj",
+        "min"
       ],
       "falsifier": "Adding half-steps to the ascending form of the scale, or applying dominant 7th half-step placements to the major scale, would violate this rule.",
       "anchor": "In their basic role, they appear as notes added to the\ndescending form of the scale.",
@@ -143,9 +143,9 @@
       "then": {
         "scale.insert_half_step_at": "between_6_and_5"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "major"
+        "maj"
       ],
       "falsifier": "Inserting a half-step between 2 and 1 instead of 6 and 5 when descending from scale degree 1 violates Rule 1.",
       "anchor": "The first rule for descending from the 1-3-5 and major7 is: 1\nadded half-step between the 6-5.",
@@ -164,9 +164,9 @@
       "then": {
         "scale.insert_half_step_at": "between_3_2_and_2_1_and_6_5_or_variant_3_2_maj7_6_6_5"
       },
-      "preference": "Two valid placements; practice both",
+      "preference": 1,
       "quality_binding": [
-        "major"
+        "maj"
       ],
       "falsifier": "Using only one or two half-steps when applying Rule 2 to the 3-5-maj7 group would be incomplete.",
       "anchor": "The second rule applying to the 3-5 and major7 is: 3 added half-\nsteps between the 3-2; 2-1; 6-5.",
@@ -185,9 +185,9 @@
       "then": {
         "scale.insert_half_step_at": "none"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "major"
+        "maj"
       ],
       "falsifier": "Adding any half-step when applying Rule 1 from scale degree 2, 4, or 6 violates this rule.",
       "anchor": "The first rule for descending from the 2-4-6 is: no added half-\nsteps.",
@@ -206,9 +206,9 @@
       "then": {
         "scale.insert_half_step_at": "between_2_1_and_6_5_or_variant_maj7_6_and_6_5"
       },
-      "preference": "Practice both placements",
+      "preference": 1,
       "quality_binding": [
-        "major"
+        "maj"
       ],
       "falsifier": "Using three half-steps (as in Rule 2 for 1-3-5-maj7) when applying Rule 2 to the 2-4-6 group violates this rule.",
       "anchor": "The second rule for the 2-4-6 is: 2 added half-steps which can\ncome between the 2-1; 6-5 or between the major7-6; 6-5.",
@@ -226,9 +226,9 @@
       "then": {
         "scale.insert_half_step_at": "same positions as major rules applied to ascending melodic minor (1-2-b3-4-5-6-maj7)"
       },
-      "preference": "Use ascending melodic minor, never natural or harmonic minor, as the base",
+      "preference": 2,
       "quality_binding": [
-        "minor"
+        "min"
       ],
       "falsifier": "Applying Harris half-step rules to a natural minor scale instead of ascending melodic minor would violate this rule.",
       "anchor": "The minor scale that the half-steps are added to is the melodic minor in\nascending form-tonic - 2 - b3 - 4 - 5 - 6 - major7.",
@@ -247,9 +247,9 @@
       "then": {
         "scale.insert_half_step_at": "any note other than b3 (already present); alternatively use interval jump or repeat the same note twice"
       },
-      "preference": "b3 is the single exception; all other placements identical to major",
+      "preference": 1,
       "quality_binding": [
-        "minor"
+        "min"
       ],
       "falsifier": "Inserting an additional b3 via the half-step rule in ascending melodic minor would be redundant and contradicts the exception.",
       "anchor": "The one exception to this is where\nthe major scale rules add a b3rd. Because this note is already present in\nthe melodic minor scale, any other note may be used in its place.",
@@ -267,9 +267,9 @@
       "then": {
         "chord_symbol.substitute": "diminished chord built on the note a major 3rd above the dominant 7th root"
       },
-      "preference": "For any dominant 7th, go up a major 3rd from the root",
+      "preference": 1,
       "quality_binding": [
-        "dominant_7th"
+        "dom7"
       ],
       "falsifier": "Building the related diminished a minor 3rd above the dominant root (e.g., Eb° for C7) would not yield the Harris related diminished.",
       "anchor": "The rule of thumb for finding a related diminished chord is to\nbuild it a major 3rd above the dominant note.",
@@ -286,7 +286,7 @@
       "then": {
         "scale.type": "scale(s) that outline the chord progression"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -305,7 +305,7 @@
       "then": {
         "voicing.quality": "transposed_across_all_keys"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -324,7 +324,7 @@
       "then": {
         "voicing.quality": "progression_portable_phrase"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -344,9 +344,9 @@
       "then": {
         "chord_symbol.substitute": "diminished7 chord rooted a major 3rd above the dominant note"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "Building the diminished a minor 3rd above (B° in key of D rather than C#°) is the standard vii°/V, not the Harris related diminished.",
       "anchor": "The related diminished chord is built from a major 3rd above the domi-\nnant note, For instance, in the key of D the dominant note is A anda\nthird above is C#.",
@@ -365,9 +365,9 @@
       "then": {
         "chord_symbol.substitute": "minor7 chord rooted on the 5th degree of the dominant 7th scale (V/V)"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "Labeling the chord on the 4th degree (IVm7) as 'important minor' violates this definition; it must be on the 5th degree.",
       "anchor": "\"Important minor' is the term given to the chord found on the Sth\ndegree of a dominant 7th scale (5 of 5),",
@@ -386,9 +386,9 @@
       "then": {
         "scale.insert_half_step_at": "diminished chord tones built a major 3rd above the dominant note of the scale, merged with the minor 6 chord tones"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "minor_6_diminished"
+        "dim7"
       ],
       "falsifier": "Building with a minor 7 chord (Cm7 + B°) instead of minor 6 does not yield the Harris Minor 6 Diminished Scale.",
       "anchor": "This scale is formed by combining a minor 6 chord with its related\ndiminished chord, The diminished chord is built from a major 3rd\nabove the dominant note of the scale.",
@@ -405,10 +405,10 @@
       "then": {
         "scale.type": "major_6_diminished_or_minor_6_diminished"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "major_6_diminished",
-        "minor_6_diminished"
+        "min7b5",
+        "dim7"
       ],
       "falsifier": "A chord that cannot be mapped to either 6-diminished scale would refute the universality claim (Harris asserts none exists in standard jazz vocabulary).",
       "anchor": "a 'scale for chording,' and a method of assigning virtually any chord to one of two scales—the major 6 diminished and the minor 6 diminished.",
@@ -426,15 +426,18 @@
       "then": {
         "voicing.shape": "apply scale-based movement to generate alternative voicings"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "movable_voicing"
+        "any"
       ],
       "falsifier": "A pedal-tone ostinato that intentionally repeats a single voicing for expressive effect would not be refuted by this rule (intent matters).",
       "anchor": "The misconception that chords are fixed points in the tune, bound by vertical harmonic movement, may be the culprit behind the tendency to play the same two or three voicings over and over for the same change.",
       "source_page": 66,
       "chapter": 3,
-      "section": "Harmonic Rigidity Misconception"
+      "section": "Harmonic Rigidity Misconception",
+      "applicability_reasons": [
+        "movable_voicing"
+      ]
     },
     {
       "rule_id": "harris-c6dim-scale-three-diminished-triads",
@@ -446,16 +449,18 @@
       "then": {
         "voicing.quality": "partition scale tones into three diminished-chord groups: {C,A}, {E,G}, and B-diminished {B,D,F,Ab}"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "diminished_triad",
-        "major_6_diminished"
+        "min7b5"
       ],
       "falsifier": "If any scale tone cannot be assigned to one of the three diminished chords, the decomposition fails (all 8 tones are accounted for in Harris's claim).",
       "anchor": "This scale is actually comprised of all 3 diminished chords. The C and A belong to one diminished, the E and G to a second, and the B diminished chord provides the other four notes of the scale.",
       "source_page": 67,
       "chapter": 3,
-      "section": "C6 Diminished Scale Construction"
+      "section": "C6 Diminished Scale Construction",
+      "applicability_reasons": [
+        "diminished_triad"
+      ]
     },
     {
       "rule_id": "harris-shared-diminished-dominant-substitution",
@@ -467,16 +472,18 @@
       "then": {
         "chord_symbol.substitute": "any of the four dominant 7 chords sharing the same diminished triad are interchangeable"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "diminished_triad",
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "A dominant substitute that does NOT share a common diminished triad with the target (e.g., E7 substituted for D7 — different diminished families) is not licensed by this rule.",
       "anchor": "The C and A belong to one diminished, the E and G to a second, and the B diminished chord provides the other four notes of the scale.",
       "source_page": 67,
       "chapter": 3,
-      "section": "C6 Diminished Scale Construction"
+      "section": "C6 Diminished Scale Construction",
+      "applicability_reasons": [
+        "diminished_triad"
+      ]
     },
     {
       "rule_id": "harris-m7-equals-inverted-major6",
@@ -488,16 +495,18 @@
         "chord_symbol.substitute": "major6 chord rooted a minor third above the m7 root (e.g., Dm7 = F6/D)",
         "scale.type": "major_6_diminished"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "minor_7",
-        "major_6_diminished"
+        "min7b5"
       ],
       "falsifier": "A minor 7 spelling that cannot be rewritten as an inversion of a major 6 chord would falsify the equivalence; no such spelling exists in 12-TET.",
       "anchor": "Every minor 7 chord is an inversion of a major 6th chord, and every minor? flat5 chord is an inversion of a minor 6th chord.",
       "source_page": 69,
       "chapter": 3,
-      "section": "m7 and m7b5 Re-thinking"
+      "section": "m7 and m7b5 Re-thinking",
+      "applicability_reasons": [
+        "minor_7"
+      ]
     },
     {
       "rule_id": "harris-m7b5-equals-inverted-minor6",
@@ -509,16 +518,18 @@
         "chord_symbol.substitute": "minor6 chord rooted a minor third above the m7b5 root (e.g., Bm7b5 = Dm6/B)",
         "scale.type": "minor_6_diminished"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "minor_7_flat5",
-        "minor_6_diminished"
+        "dim7"
       ],
       "falsifier": "A half-diminished spelling that cannot be rewritten as an inversion of a minor 6 chord would falsify the equivalence; no such spelling exists in 12-TET.",
       "anchor": "Every minor 7 chord is an inversion of a major 6th chord, and every minor? flat5 chord is an inversion of a minor 6th chord.",
       "source_page": 69,
       "chapter": 3,
-      "section": "m7 and m7b5 Re-thinking"
+      "section": "m7 and m7b5 Re-thinking",
+      "applicability_reasons": [
+        "minor_7_flat5"
+      ]
     },
     {
       "rule_id": "harris-move-each-note-to-next-scale-step",
@@ -530,10 +541,10 @@
       "then": {
         "voicing.shape": "displace each chord tone to the immediately adjacent note (up or down) in the governing 6-diminished scale"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "major_6_diminished",
-        "minor_6_diminished"
+        "min7b5",
+        "dim7"
       ],
       "falsifier": "A voicing movement that skips a scale degree (moves by a whole step when a scale-internal half step is available) violates this rule — e.g., C to E bypassing D in C6 diminished.",
       "anchor": "Remember to move each note to the next note of the scale.",
@@ -552,9 +563,9 @@
       "then": {
         "chord_symbol.substitute": "any of the four dominants sharing the same diminished triad"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "A dominant that does NOT share the same diminished triad as the V7 (e.g., E7 in place of D7→Gmaj7, since E7 derives from G#-diminished, not F#-diminished) is not a valid related-dominant substitute.",
       "anchor": "we have illustrations of how related dominant 7th chords may be used to substitute 'for eachother' when the V7 chord moves back to the I.",
@@ -575,9 +586,9 @@
         "chord_symbol.substitute": "any_of_D7_F7_Ab7_B7",
         "voicing.shape": "upper_structure_of_chosen_related_dominant_over_D_in_bass"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "Using E7 or Bb7 over a D bass when resolving to Gmaj7 — neither derives from F#-diminished, so neither qualifies as a related dominant in this family.",
       "anchor": "D7 going to G major is outlined. The diminished that D7 comes from is F# (F#-A-C-Eb). Given that F7, Ab7, and B7 are also related to F# diminished, they make very interesting voicings when played against D in the bass.",
@@ -595,9 +606,9 @@
       "then": {
         "voicing.shape": "keep_original_V7_root_in_bass_while_placing_substitute_dominant_voicing_in_upper_voices"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "Moving the bass to the root of the substitute (e.g., F in bass for F7 instead of D) dissolves the bass-continuity effect Harris identifies.",
       "anchor": "they make very interesting voicings when played against D in the bass.",
@@ -616,9 +627,9 @@
         "voicing.quality": "minor_chord_with_6th_in_bass",
         "voicing.shape": "Xmaj_to_Xmin_to_Xmin_over_6th"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "minor"
+        "min"
       ],
       "falsifier": "Placing the 5th in the bass on the third chord (Gm/D instead of Gm/E) breaks the specific bass-line formula Harris names.",
       "anchor": "This figure shows the progression from major to minor to minor with the 6th degree in the bass:(Bb major-G minor-Gm/E).",
@@ -637,12 +648,12 @@
         "voicing.quality": "sequence_of_major_dominant7_minor_diminished_majorOver5_minorOver6",
         "voicing.shape": "transportable_six_chord_unit_transposable_to_any_key"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "major",
-        "dominant_7",
-        "minor",
-        "diminished"
+        "maj",
+        "dom7",
+        "min",
+        "dim7"
       ],
       "falsifier": "Substituting IVmaj7 for bVIdim removes the diminished-color pivot Harris identifies as structural; the bVIdim is not freely replaceable.",
       "anchor": "The chord movements are I major- IlI7-relative minor-bVIdim-Imaj/5-minor/6.",
@@ -661,7 +672,7 @@
         "voicing.quality": "internally_metered",
         "voicing.shape": "phrase_against_not_with_rhythm_section"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -681,7 +692,7 @@
       "then": {
         "voicing.quality": "scalar_rhythmical_fluency_before_expression"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -704,9 +715,9 @@
         "chord_symbol.substitute": "E_diminished",
         "voicing.quality": "diminished_triad_shared_with_dominant"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "Using B-diminished over C7 in F minor violates this rule; B-diminished is reserved for G7 in C minor.",
       "anchor": "C7 (in the key of F minor) uses the E-diminished chord; while G7 (in the key of C minor) uses the B diminished chord.",
@@ -727,9 +738,9 @@
         "chord_symbol.substitute": "B_diminished",
         "voicing.quality": "diminished_triad_shared_with_dominant"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "Using E-diminished over G7 in C minor violates this rule; E-diminished is reserved for C7 in F minor.",
       "anchor": "C7 (in the key of F minor) uses the E-diminished chord; while G7 (in the key of C minor) uses the B diminished chord.",
@@ -748,9 +759,9 @@
       "then": {
         "chord_symbol.substitute": "diminished chord built a major 3rd above the dominant 7 root"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "dominant_7"
+        "dom7"
       ],
       "falsifier": "Choosing a diminished a tritone or minor-third away from the dominant root (rather than a major 3rd above) does not produce the Harris related-diminished substitution. (E.g., for C7, F#° instead of E°.)",
       "anchor": "C7 (in the key of F minor) uses the E-diminished chord; while G7 (in the key of C minor) uses the B diminished chord.",
@@ -771,15 +782,18 @@
           "#5"
         ]
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "augmented"
+        "any"
       ],
       "falsifier": "Playing a major arpeggio without raising the 5th, or raising the 4th instead, does not constitute an augmented arpeggio under Harris's definition.",
       "anchor": "An Ab augmented arpeggio (the 5th degree is raised a half-step from the major)",
       "source_page": 95,
       "chapter": 5,
-      "section": "Augmented Arpeggio Definition"
+      "section": "Augmented Arpeggio Definition",
+      "applicability_reasons": [
+        "augmented"
+      ]
     },
     {
       "rule_id": "harris-whole-tone-scale-definition",
@@ -797,15 +811,18 @@
           "#11"
         ]
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
-        "whole_tone"
+        "any"
       ],
       "falsifier": "A seven-note scale, or one containing any half-step interval anywhere in the series, is not a whole tone scale under Harris's definition.",
       "anchor": "The Ab whole tone scale (a six note scale built on whole-steps above the root)",
       "source_page": 95,
       "chapter": 5,
-      "section": "Whole Tone Scale Definition"
+      "section": "Whole Tone Scale Definition",
+      "applicability_reasons": [
+        "whole_tone"
+      ]
     }
   ]
 }

--- a/plugin/data/masters-corpus/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/bert-ligon/connecting-chords-with-linear-harmony/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:34-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -25,15 +25,18 @@
         "line.preference": "harmonic_specificity",
         "line.target_tone": "chord_third_or_seventh"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "specificity",
-        "clarity"
+        "any"
       ],
       "falsifier": "Line outlines the chord with non-chord-tones on strong beats while skipping 3rd/7th entirely.",
       "anchor": "Harmonic Specificity: Careful attention to the implications of harmony. Reliance on proper thirds, sevenths resolving appropriately.",
       "source_page": 1,
-      "source_chapter": 1
+      "source_chapter": 1,
+      "applicability_reasons": [
+        "specificity",
+        "clarity"
+      ]
     },
     {
       "rule_id": "ligon-vagueness-is-informed-choice",
@@ -46,14 +49,17 @@
         "line.preference": "informed_avoidance",
         "line.target_tone": "non_harmonic_chosen_with_awareness"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "intentionality"
+        "any"
       ],
       "falsifier": "Player avoids chord tones without being able to name the 3rd/7th they are avoiding.",
       "anchor": "When an experienced jazz improviser plays deliberately vague, he does so knowing the harmonic implications, and therefore knowing just what tones to avoid.",
       "source_page": 2,
-      "source_chapter": 1
+      "source_chapter": 1,
+      "applicability_reasons": [
+        "intentionality"
+      ]
     },
     {
       "rule_id": "ligon-linear-not-vertical",
@@ -66,14 +72,17 @@
         "line.analysis_mode": "linear_across_time",
         "line.metric_placement": "honor_anticipation_and_suspension"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Note over barline is judged dissonant by vertical snapshot without considering anticipation or suspension.",
       "anchor": "Do not fall into the trap of labeling everything by its vertical arrangement. Music is heard and conceived in a linear manner and should be studied in the same way.",
       "source_page": 4,
-      "source_chapter": 1
+      "source_chapter": 1,
+      "applicability_reasons": [
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-bass-as-counterpoint-reference",
@@ -86,15 +95,18 @@
         "line.reference": "bass_line",
         "line.target_tone": "counterpoint_against_bass"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "independence",
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Note selection assumes a particular piano voicing rather than the bass pitch.",
       "anchor": "The experienced jazz improviser does not depend on a piano playing chords for his lines to make sense. The lines make sense because of well chosen and well placed notes in relation to the bass line.",
       "source_page": 5,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "independence",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-omit-root-from-line",
@@ -107,15 +119,18 @@
         "line.exclude_pitch_class": "chord_root",
         "line.candidate_pool": "remaining_11_pitches"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "counterpoint",
-        "specificity"
+        "any"
       ],
       "falsifier": "Root is played in the line on a strong beat solely because it is the chord root.",
       "anchor": "if the roots are sounding in the bass and the melody there is no counter point, just parallel octaves, Eliminating the root leaves eleven other notes to choose from",
       "source_page": 5,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "counterpoint",
+        "specificity"
+      ]
     },
     {
       "rule_id": "ligon-third-as-primary-target",
@@ -128,15 +143,18 @@
         "line.target_tone": "chord_third",
         "line.metric_placement": "downbeat"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "specificity",
-        "clarity"
+        "any"
       ],
       "falsifier": "Strong beat over a chord lands on a non-3rd/7th and no other guide tone is voice-led in.",
       "anchor": "F reveals the minor quality of the chord and is the best choice for harmonically specific counterpoint over the D in the bass.",
       "source_page": 5,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "specificity",
+        "clarity"
+      ]
     },
     {
       "rule_id": "ligon-seventh-resolves-to-third",
@@ -151,15 +169,18 @@
         "line.approach_method": "stepwise_down",
         "line.metric_placement": "next_downbeat"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_leading",
-        "specificity"
+        "any"
       ],
       "falsifier": "7th leaps up or jumps to a non-3rd on the next chord while a stepwise resolution to the 3rd was available.",
       "anchor": "the 7th of chords in these progressions resolve downward to the third of the following chord. The seventh is the pointer.",
       "source_page": 5,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "voice_leading",
+        "specificity"
+      ]
     },
     {
       "rule_id": "ligon-ninth-resolves-to-fifth",
@@ -172,14 +193,17 @@
         "line.target_tone": "fifth_of_same_or_next_chord",
         "line.approach_method": "stepwise_down"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "voice_leading"
+        "any"
       ],
       "falsifier": "9th leaps away with no resolution to the 5th anywhere in the phrase.",
       "anchor": "Good voice leading is observed; sevenths resolve to thirds, ninths to fifths.",
       "source_page": 6,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-third-before-seventh",
@@ -191,14 +215,17 @@
         "line.metric_placement": "third_on_beat_one_seventh_on_beat_four",
         "line.approach_method": "stepwise"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Phrase opens on the 7th with the 3rd appearing only after the chord changes.",
       "anchor": "Thirds are more consonant and usually occur earlier in a melody line before the more dissonant sevenths.",
       "source_page": 6,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-outline-1-stepwise-descent",
@@ -214,15 +241,18 @@
         "line.approach_method": "stepwise_descending_scale",
         "line.metric_placement": "third_on_beat_one_seventh_on_beat_four"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_leading",
-        "outline_integrity"
+        "any"
       ],
       "falsifier": "Line claims Outline No.1 but ascends or skips the stepwise connective scale.",
       "anchor": "By moving down the scale, a stepwise line is created from the third of the ii chord through the V7 chord and down to the third of the I chord.",
       "source_page": 6,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "voice_leading",
+        "outline_integrity"
+      ]
     },
     {
       "rule_id": "ligon-outline-2-ascending-arpeggio",
@@ -237,14 +267,17 @@
         "line.approach_method": "arpeggio_ascending_1_3_5_7",
         "line.target_tone": "third_of_V7"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "outline_integrity"
+        "any"
       ],
       "falsifier": "Ascending arpeggio omits the 7th before resolving, or starts on the 5th rather than the root.",
       "anchor": "Outline no.2 is an ascending arpeggio of the ii chord (1-3-5) with the added restless tone (7) above the chord, which resolves to the third of the V7 chord.",
       "source_page": 8,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "outline_integrity"
+      ]
     },
     {
       "rule_id": "ligon-outline-3-descending-arpeggio",
@@ -260,15 +293,18 @@
         "line.target_tone": "third_of_V7",
         "line.metric_placement": "seventh_on_upbeat_third_on_downbeat"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "outline_integrity",
-        "metric_alignment"
+        "any"
       ],
       "falsifier": "Target 3rd of V7 lands on an upbeat or the 7th lands on a strong downbeat.",
       "anchor": "outline no.3 begins with the descending arpeggio of the ii chord (5-3-1), adds the restless tone (7) below the chord, which resolves to the third of the V7 chord. The seventh usually occurs on the upbeat; the target third on the strong downbeat.",
       "source_page": 9,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "outline_integrity",
+        "metric_alignment"
+      ]
     },
     {
       "rule_id": "ligon-outlines-not-constraints",
@@ -281,14 +317,17 @@
         "line.outline_id": "selected_outline",
         "line.preference": "skeleton_then_personalize"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "creativity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "The outlines are skeletons. Our bodies all have similar skeletons yet we all look unique.",
       "source_page": 6,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "creativity"
+      ]
     },
     {
       "rule_id": "ligon-chromatic-direction-continues",
@@ -301,14 +340,17 @@
         "line.chromatic_insertion": "continue_in_altered_direction",
         "line.approach_method": "flat_descends_sharp_ascends"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Flatted note ascends or sharped note descends without an intervening enclosure.",
       "anchor": "Chromatically altered tones tend to continue in the direction in which they have been altered. Flatted notes are lowered and therefore have downward tendencies, sharped notes are raised and have upward tendencies.",
       "source_page": 11,
-      "source_chapter": 3
+      "source_chapter": 3,
+      "applicability_reasons": [
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-unt-diatonic-lnt-chromatic",
@@ -320,15 +362,18 @@
         "line.chromatic_insertion": "lnt_chromatic_unt_diatonic",
         "line.approach_method": "neighbor_tone"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "idiom",
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Chromatic upper neighbor used without functional pull, or diatonic lower neighbor used where chromatic LNT is idiomatic.",
       "anchor": "The common practice (from Mozart to Charlie Parker) is to use the diatonic (from the key) upper neighbor tone (UNT) and the chromatic lower neighbor tone (LNT).",
       "source_page": 11,
-      "source_chapter": 3
+      "source_chapter": 3,
+      "applicability_reasons": [
+        "idiom",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-octave-displacement-placement",
@@ -341,15 +386,18 @@
         "line.approach_method": "leap_after_guide_tone",
         "line.metric_placement": "downbeat_to_upbeat_never_over_barline"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "metric_alignment",
-        "phrasing"
+        "any"
       ],
       "falsifier": "Octave-displacement leap occurs across the barline or from a weak beat to a strong beat.",
       "anchor": "Leaps most often occur after the main guide-tone, leap from down beat to upbeat; never over the barline and rarely from a weak beat to a strong beat.",
       "source_page": 14,
-      "source_chapter": 3
+      "source_chapter": 3,
+      "applicability_reasons": [
+        "metric_alignment",
+        "phrasing"
+      ]
     },
     {
       "rule_id": "ligon-3-up-to-9-displacement",
@@ -363,15 +411,18 @@
         "line.approach_method": "leap_up_seventh_to_ninth_or_flat_ninth",
         "line.chromatic_insertion": "flat_nine_optional"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "idiom",
-        "drama"
+        "any"
       ],
       "falsifier": null,
       "anchor": "3rd up to the 9th or flat 9th: A simple descending scale step (3-2) becomes dramatic when a descending second is replaced with a leap of a seventh.",
       "source_page": 14,
-      "source_chapter": 3
+      "source_chapter": 3,
+      "applicability_reasons": [
+        "idiom",
+        "drama"
+      ]
     },
     {
       "rule_id": "ligon-cesh-descending-chromatic",
@@ -384,15 +435,18 @@
         "line.chromatic_insertion": "cesh_descent_root_to_third_of_V7",
         "line.approach_method": "stepwise_chromatic_descent"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "idiom",
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Chromatic descent skips the chromatic passing tone or fails to land the target 3rd of V7.",
       "anchor": "Jerry Coker's acronym for Chromatic Elaboration of Static Harmony. The most common example in a ii - V progression is the descending movement from the root of the ii chord to the third of the V7 chord, In the key of C (D minor - G7), the movement of D-C#-C-B.",
       "source_page": 15,
-      "source_chapter": 3
+      "source_chapter": 3,
+      "applicability_reasons": [
+        "idiom",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-borrowed-parallel-minor",
@@ -405,15 +459,18 @@
         "line.chromatic_insertion": "borrowed_b9_sharp9_b13_from_parallel_minor",
         "line.target_tone": "altered_extension"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "color",
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Altered extensions are used over a non-dominant chord with no functional justification.",
       "anchor": "Over G7, the dominant of C major, jazz musicians often use A-flat (flat 9) , B-flat (sharp 9) and E-flat (flat 13) from the parallel key of C minor.",
       "source_page": 16,
-      "source_chapter": 3
+      "source_chapter": 3,
+      "applicability_reasons": [
+        "color",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-iteration-for-eighth-motion",
@@ -426,14 +483,17 @@
         "line.approach_method": "repeat_target_tones_as_iteration",
         "line.metric_placement": "eighth_note_grid"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "rhythm"
+        "any"
       ],
       "falsifier": null,
       "anchor": "With the outline in quarter note values, an easy way to get eighth note motion is to repeat notes, sometimes called iteration.",
       "source_page": 21,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "rhythm"
+      ]
     },
     {
       "rule_id": "ligon-outlines-generalize-to-fifths",
@@ -446,14 +506,17 @@
         "line.outline_id": "any_of_three",
         "line.preference": "outline_application_generalizes"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "generalization"
+        "any"
       ],
       "falsifier": "Outline assumed to work despite root motion not being down a fifth.",
       "anchor": "These outlines will work with many other progressions. Anytime the root movement is down in fifths any of theses outlines will work, regardless of the quality of the chord.",
       "source_page": 29,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "generalization"
+      ]
     },
     {
       "rule_id": "ligon-cesh-applies-all-outlines",
@@ -466,14 +529,17 @@
         "line.chromatic_insertion": "cesh_layer",
         "line.outline_id": "selected_outline"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "idiom"
+        "any"
       ],
       "falsifier": null,
       "anchor": "This type of chromatic elaboration is found with all three outlines.",
       "source_page": 39,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "idiom"
+      ]
     },
     {
       "rule_id": "ligon-cesh-encircles-ii-root",
@@ -486,15 +552,18 @@
         "line.approach_method": "encircle_root_of_ii_before_descent",
         "line.target_tone": "third_of_V7"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "voice_leading",
-        "idiom"
+        "any"
       ],
       "falsifier": "C.E.S.H. line treats the chromatic note as a passing tone with no upward pull or encirclement.",
       "anchor": "The chromatic altered tone stops the descent of the line; since it is a leading tone to the ii chord it pulls upwards. Often this momentarily changes the direction of the line, encircling the root of the ii chord before descending through the diatonic tones and finally resolving to the third of the V chord.",
       "source_page": 39,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "voice_leading",
+        "idiom"
+      ]
     },
     {
       "rule_id": "ligon-chromatic-justified-linearly",
@@ -507,14 +576,17 @@
         "line.analysis_mode": "linear_targeting",
         "line.chromatic_insertion": "point_to_target_tone"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Chromatic tone is rejected solely because it is dissonant against the vertical chord, without considering its linear target.",
       "anchor": "Viewing harmony as strictly vertical, these notes would not sound good; but when viewing them in a linear context we see and hear how these notes point to the target notes and make the line more interesting by creating and releasing tension.",
       "source_page": 38,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-all-twelve-pitches-target-anchored",
@@ -528,15 +600,18 @@
         "line.metric_placement": "target_tones_on_strong_beats",
         "line.target_tone": "resolved_chord_tone"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "clarity",
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Chromatic notes land on strong beats while chord tones land on weak beats with no resolution.",
       "anchor": "All twelve chromatic pitches are used in this example, yet it remains harmonically clear; it is not random chromaticism. Target notes occur in rhythmically significant spots, non-harmonic chromatic notes resolve when and where we expect them.",
       "source_page": 43,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "clarity",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-break-scale-to-avoid-target",
@@ -549,14 +624,17 @@
         "line.approach_method": "skip_target_note_in_scale_run",
         "line.metric_placement": "reserve_target_for_target_chord"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "punch_line_integrity"
+        "any"
       ],
       "falsifier": "Ascending scale runs through the next chord's target note before that chord arrives.",
       "anchor": "Notice that the ascending scale breaks to avoid the upcoming target note. In ex.57, the scale that starts on beat three from C, goes to G, skips the A natural because it is the target note for the F7 chord.",
       "source_page": 32,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "punch_line_integrity"
+      ]
     },
     {
       "rule_id": "ligon-strip-embellishments-as-reduction",
@@ -569,14 +647,17 @@
         "line.analysis_mode": "reduce_to_outline",
         "line.outline_id": "underlying_outline"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "analytical_clarity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "taking away the insertions, ornaments, and embellishments also reveals interesting lines by the realignment of the original notes of the outline.",
       "source_page": 45,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "analytical_clarity"
+      ]
     },
     {
       "rule_id": "ligon-compound-melody-from-lower-tones",
@@ -589,14 +670,17 @@
         "line.approach_method": "imply_counterline_via_lower_tones",
         "line.outline_id": "any_of_three"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "texture"
+        "any"
       ],
       "falsifier": null,
       "anchor": "There is a counterline (indicated by the arrows below the staff) implied by some of the lower tones making this a compound melody.",
       "source_page": 45,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "texture"
+      ]
     },
     {
       "rule_id": "ligon-outline-2-diatonic-passing",
@@ -608,14 +692,17 @@
         "line.outline_id": "ligon_outline_2",
         "line.chromatic_insertion": "diatonic_passing_only_between_chord_tones"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "outline_integrity"
+        "any"
       ],
       "falsifier": "Chromatic passing tones are used between chord tones of Outline No.2 without functional purpose.",
       "anchor": "Passing tones: Since outline no.2 is an arpeggiated outline, it lends itself to diatonic passing tones between the chord tones.",
       "source_page": 54,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "outline_integrity"
+      ]
     },
     {
       "rule_id": "ligon-punch-line-rule",
@@ -629,15 +716,18 @@
         "line.metric_placement": "delay_target_to_V7_arrival",
         "line.target_tone": "third_of_V7_on_V7_downbeat"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "punch_line_integrity",
-        "narrative"
+        "any"
       ],
       "falsifier": "Tone between 5th and 7th of ii is played as a passing tone before V7 arrives, giving away the punch line.",
       "anchor": "The tone between the 5th and 7th of the ii chord is the target note of the V7 chord. This tone is usually saved for the V7 chord. It is the punch line, the denouement of the story, that is not given away by using it ahead of time as a passing tone.",
       "source_page": 54,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "punch_line_integrity",
+        "narrative"
+      ]
     },
     {
       "rule_id": "ligon-minor-ii-V-applicability",
@@ -650,14 +740,17 @@
         "line.outline_id": "any_of_three",
         "line.preference": "outlines_generalize_to_minor"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "generalization"
+        "any"
       ],
       "falsifier": "Outline avoided in minor ii-V context despite root motion down a fifth.",
       "anchor": "All the outlines work as well for ii@ - V7 in minor as they do in major.",
       "source_page": 52,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "generalization"
+      ]
     },
     {
       "rule_id": "ligon-add-notes-before-within-after",
@@ -669,14 +762,17 @@
         "line.approach_method": "insert_before_within_or_after",
         "line.outline_id": "selected_outline"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "elaboration_taxonomy"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Any musical motive can be embellished by adding notes. Notes can be added before, within, and after the motive.",
       "source_page": 52,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "elaboration_taxonomy"
+      ]
     },
     {
       "rule_id": "ligon-encircle-target",
@@ -688,15 +784,18 @@
         "line.approach_method": "encircle_target_from_above_and_below",
         "line.target_tone": "delayed_chord_tone"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "voice_leading",
-        "tension"
+        "any"
       ],
       "falsifier": "Target tone is approached only from one side and labeled as encirclement.",
       "anchor": "He chooses to encircle the target note, creating a slight tension and ambiguity.",
       "source_page": 52,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "voice_leading",
+        "tension"
+      ]
     },
     {
       "rule_id": "ligon-outline-2-standard-direction",
@@ -708,14 +807,17 @@
         "line.outline_id": "ligon_outline_2",
         "line.approach_method": "ascend_root_third_fifth_seventh"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "outline_integrity"
+        "any"
       ],
       "falsifier": "Outline No.2 invoked but starts on a non-root chord tone without explicit inversion.",
       "anchor": "Outline no.2 usually begins on the root of the ii chord and spells the arpeggio to the seventh: 1-3-5-7.",
       "source_page": 60,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "outline_integrity"
+      ]
     },
     {
       "rule_id": "ligon-outline-2-inverted",
@@ -727,14 +829,17 @@
         "line.outline_id": "ligon_outline_2",
         "line.approach_method": "arpeggio_descending_inverted"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "variation"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Instead of ascending the arpeggio of the ii chord, the arpeggio is turned upside down and descends in some way.",
       "source_page": 61,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "variation"
+      ]
     },
     {
       "rule_id": "ligon-punch-line-break-with-extension",
@@ -747,14 +852,17 @@
         "line.approach_method": "extend_line_to_ninth_of_ii",
         "line.preference": "mitigate_negative_effect"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "punch_line_integrity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "The F sharp appears as a passing tone before the D7 chord, but the negative effect is diminished by the extension of the line to the ninth of the ii chord.",
       "source_page": 58,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "punch_line_integrity"
+      ]
     },
     {
       "rule_id": "ligon-combine-outlines-2-then-1",
@@ -767,14 +875,17 @@
         "line.outline_id": "combination_outline_2_then_1",
         "line.approach_method": "join_outlines_at_target_tone"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "vocabulary"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Parker begins with outline no.2 and ends with outline no.1. There are many occurrences of this line in different guises throughout Parker solos.",
       "source_page": 59,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "vocabulary"
+      ]
     },
     {
       "rule_id": "ligon-fragment-preserves-clarity",
@@ -787,14 +898,17 @@
         "line.outline_id": "outline_fragment",
         "line.target_tone": "third_of_ii_emphasized"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "clarity"
+        "any"
       ],
       "falsifier": "Fragment omits both the root and the target third, leaving no anchor.",
       "anchor": "These omissions take none of the clarity away from the lines. They all emphasize the target note (third of ii) even more, and the root of the chord is covered by the bass.",
       "source_page": 63,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "clarity"
+      ]
     },
     {
       "rule_id": "ligon-sus-equals-ii-V-for-outlines",
@@ -807,14 +921,17 @@
         "line.outline_id": "any_of_three",
         "line.preference": "treat_sus_as_ii_V"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "generalization"
+        "any"
       ],
       "falsifier": "Player avoids outlines over sus chord despite the chord functioning as ii-V composite.",
       "anchor": "Since this sound is essentially the ii and V7 chord together, any of the outlines will work for this harmony.",
       "source_page": 65,
-      "source_chapter": 6
+      "source_chapter": 6,
+      "applicability_reasons": [
+        "generalization"
+      ]
     },
     {
       "rule_id": "ligon-outline-3-octave-displacement-variation",
@@ -826,14 +943,17 @@
         "line.outline_id": "ligon_outline_3",
         "line.approach_method": "continue_down_scale_with_octave_displacement"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "idiom"
+        "any"
       ],
       "falsifier": null,
       "anchor": "The second variation of outline no.3 that continues down the scale with octave displacement is very common.",
       "source_page": 66,
-      "source_chapter": 6
+      "source_chapter": 6,
+      "applicability_reasons": [
+        "idiom"
+      ]
     },
     {
       "rule_id": "ligon-third-to-flat-nine-leap",
@@ -848,15 +968,18 @@
         "line.approach_method": "leap_third_to_flat_nine",
         "line.chromatic_insertion": "flat_nine_over_V7"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "compound_melody",
-        "idiom"
+        "any"
       ],
       "falsifier": "Leap from 3rd lands on natural 9 without functional justification.",
       "anchor": "The leap from the third to the flat nine on the dominant is one of its attractive elements; giving it characteristics of a compound melody.",
       "source_page": 66,
-      "source_chapter": 6
+      "source_chapter": 6,
+      "applicability_reasons": [
+        "compound_melody",
+        "idiom"
+      ]
     },
     {
       "rule_id": "ligon-outline-3-cesh-affinity",
@@ -868,14 +991,17 @@
         "line.outline_id": "ligon_outline_3",
         "line.chromatic_insertion": "cesh_preferred"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "idiom"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Outline no.3 seems to lend itself to the C.E.S.H. more than the other outlines, the chromatic motion often suggesting a compound melody.",
       "source_page": 68,
-      "source_chapter": 6
+      "source_chapter": 6,
+      "applicability_reasons": [
+        "idiom"
+      ]
     },
     {
       "rule_id": "ligon-lower-pivot-note",
@@ -887,14 +1013,17 @@
         "line.approach_method": "add_single_lower_pivot_note",
         "line.outline_id": "selected_outline"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "contour"
+        "any"
       ],
       "falsifier": null,
       "anchor": "One note added below adds angularity and rhythmic interest to this outline.",
       "source_page": 71,
-      "source_chapter": 6
+      "source_chapter": 6,
+      "applicability_reasons": [
+        "contour"
+      ]
     },
     {
       "rule_id": "ligon-chromatic-passing-on-weak-beats",
@@ -906,15 +1035,18 @@
         "line.chromatic_insertion": "chromatic_on_weak_beats",
         "line.metric_placement": "diatonic_on_strong_beats"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "clarity",
-        "metric_alignment"
+        "any"
       ],
       "falsifier": "Chromatic passing tone lands on a strong beat while a diatonic chord tone lands on a weak beat without resolution.",
       "anchor": "These chromatic passing tones do not blur the distinct harmonic clarity as the diatonic notes fall on strong beats.",
       "source_page": 74,
-      "source_chapter": 6
+      "source_chapter": 6,
+      "applicability_reasons": [
+        "clarity",
+        "metric_alignment"
+      ]
     },
     {
       "rule_id": "ligon-function-over-taxonomy",
@@ -927,14 +1059,17 @@
         "line.analysis_mode": "judge_by_target_tone_clarity",
         "line.outline_id": "any_or_hybrid"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "clarity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "The central point is their harmonic clarity; thirds and seventh delineate the harmony.",
       "source_page": 73,
-      "source_chapter": 6
+      "source_chapter": 6,
+      "applicability_reasons": [
+        "clarity"
+      ]
     },
     {
       "rule_id": "ligon-fragment-minimal-kernel",
@@ -946,14 +1081,17 @@
         "line.outline_id": "fragment_kernel_7ii_to_3V7",
         "line.target_tone": "third_of_V7"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "clarity"
+        "any"
       ],
       "falsifier": "Claimed fragment lacks both the 7 of ii and the 3 of V7.",
       "anchor": "Parker's sequence in ex.249 relies on the seventh of ii resolving to the third of V7 for clarity.",
       "source_page": 76,
-      "source_chapter": 7
+      "source_chapter": 7,
+      "applicability_reasons": [
+        "clarity"
+      ]
     },
     {
       "rule_id": "ligon-fragment-omit-third-of-ii",
@@ -966,14 +1104,17 @@
         "line.outline_id": "ligon_outline_1_fragment",
         "line.approach_method": "anticipate_V7_arpeggio"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "clarity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "The only note missing from Morgan's excerpt is the third of the iig chord. The V7 chord is anticipated and arpeggiated.",
       "source_page": 77,
-      "source_chapter": 7
+      "source_chapter": 7,
+      "applicability_reasons": [
+        "clarity"
+      ]
     },
     {
       "rule_id": "ligon-target-rhythm-7-upbeat-3-downbeat",
@@ -985,15 +1126,18 @@
         "line.metric_placement": "seventh_on_upbeat_target_on_downbeat",
         "line.target_tone": "next_chord_third"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "metric_alignment",
-        "voice_leading"
+        "any"
       ],
       "falsifier": "7th lands on the downbeat with target tone on the upbeat in a fragment context.",
       "anchor": "The seventh on the upbeat is followed by the next target note on the downb",
       "source_page": 77,
-      "source_chapter": 7
+      "source_chapter": 7,
+      "applicability_reasons": [
+        "metric_alignment",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-modal-leading-tone-approach",
@@ -1005,14 +1149,17 @@
         "line.approach_method": "leading_tone_approach_to_modal_third",
         "line.target_tone": "third_of_modal_chord"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "modal_voice_leading"
+        "any"
       ],
       "falsifier": "Modal chord third approached only diatonically with no leading-tone color over an entire chorus.",
       "anchor": "the third of the G minor chord is approached by its leading tone. The F# and A encircle the root. E natural implies C7 and is approached from above and below.",
       "source_page": 78,
-      "source_chapter": 8
+      "source_chapter": 8,
+      "applicability_reasons": [
+        "modal_voice_leading"
+      ]
     },
     {
       "rule_id": "ligon-sawtooth-from-leading-tones",
@@ -1024,14 +1171,17 @@
         "line.approach_method": "add_leading_tones_below_targets",
         "line.outline_id": "ligon_outline_1"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "contour"
+        "any"
       ],
       "falsifier": null,
       "anchor": "outline no.1 can be clearly heard on the downbeats; leading tones have been added giving the line more of a sawtooth shape.",
       "source_page": 78,
-      "source_chapter": 8
+      "source_chapter": 8,
+      "applicability_reasons": [
+        "contour"
+      ]
     },
     {
       "rule_id": "ligon-cesh-outline-3-in-modal-blues",
@@ -1045,14 +1195,17 @@
         "line.chromatic_insertion": "cesh",
         "line.preference": "deploy_for_contrast"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "narrative_contrast"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Cannonball Adderley uses this C.E.S.H. version of outline no.3 several times in the solo to contrast with his modal, motivic, and down and dirty blues playing on this modal blues tune.",
       "source_page": 78,
-      "source_chapter": 8
+      "source_chapter": 8,
+      "applicability_reasons": [
+        "narrative_contrast"
+      ]
     },
     {
       "rule_id": "ligon-stop-and-go-delay-resolution",
@@ -1064,15 +1217,18 @@
         "line.metric_placement": "delay_resolution_to_beat_three",
         "line.outline_id": "ligon_outline_1"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "rhythm",
-        "drama"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Outline No.1: Stop and go rhythms delay the resolution of E7 until beat three; arpeggio on E7 (3- 5-7-9) dela",
       "source_page": 145,
-      "source_chapter": 16
+      "source_chapter": 16,
+      "applicability_reasons": [
+        "rhythm",
+        "drama"
+      ]
     },
     {
       "rule_id": "ligon-sawtooth-leap-back-to-chord-tone",
@@ -1085,14 +1241,17 @@
         "line.metric_placement": "delay_resolution",
         "line.chromatic_insertion": "chromatic_leading_tone_precedes_target"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "contour"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Outline No.2: Leap back to a chord tone creates sawtooth shape, delays resolution of C7; chromatic leading tone (D#) precedes target note (E); leap from third to root of C7,",
       "source_page": 145,
-      "source_chapter": 16
+      "source_chapter": 16,
+      "applicability_reasons": [
+        "contour"
+      ]
     },
     {
       "rule_id": "ligon-neighbor-tone-surrounding",
@@ -1104,15 +1263,18 @@
         "line.approach_method": "surround_target_with_upper_then_lower_neighbor",
         "line.target_tone": "delayed_chord_tone"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "voice_leading",
-        "tension"
+        "any"
       ],
       "falsifier": "Single neighbor used and labeled as surrounding.",
       "anchor": "Outline No.3: arpeggiated tone is used below; target note (A) is delayed by its upper and lower neighbor tones; target note (A) is approached from above (C — Bb — A) and below (G — G# — A).",
       "source_page": 145,
-      "source_chapter": 16
+      "source_chapter": 16,
+      "applicability_reasons": [
+        "voice_leading",
+        "tension"
+      ]
     }
   ]
 }

--- a/plugin/data/masters-corpus/dirk-laukens/complete-chord-melody/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/dirk-laukens/complete-chord-melody/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:51-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -21,9 +21,9 @@
         "voicing.quality": "classic_pass_style",
         "voicing.density": "full_solo_guitar"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "solo_chord_melody"
+        "any"
       ],
       "falsifier": null,
       "anchor": "every bar Joe plays in this performance is a jazz education in itself",
@@ -33,7 +33,10 @@
         "chapter_title": "Listening Exercises — Great Chord Melody Renditions",
         "section_title": "Joe Pass — Satin Doll",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "solo_chord_melody"
+      ]
     },
     {
       "rule_id": "laukens-kessel-two-contexts",
@@ -44,10 +47,9 @@
       "then": {
         "voicing.density": "context_dependent_solo_or_trio"
       },
-      "preference": "informational",
+      "preference": 0,
       "quality_binding": [
-        "solo_guitar",
-        "trio"
+        "any"
       ],
       "falsifier": null,
       "anchor": "unaccompanied solo guitar version before moving into a chord melody he plays along with the band",
@@ -57,7 +59,11 @@
         "chapter_title": "Listening Exercises — Great Chord Melody Renditions",
         "section_title": "Barney Kessel — Autumn Leaves",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "solo_guitar",
+        "trio"
+      ]
     },
     {
       "rule_id": "laukens-bickert-trio-interchange",
@@ -68,9 +74,9 @@
       "then": {
         "voicing.density": "variable_interchange_single_to_full"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "trio_chord_melody"
+        "any"
       ],
       "falsifier": "Playing only full chords throughout without single-line passages in a trio setting",
       "anchor": "often interchanges between single line, chord stabs, and full chord soloing, skilfully creating interest and variety",
@@ -80,7 +86,10 @@
         "chapter_title": "Listening Exercises — Great Chord Melody Renditions",
         "section_title": "Ed Bickert — Do Nothing Till You Hear From Me",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "trio_chord_melody"
+      ]
     },
     {
       "rule_id": "laukens-bickert-voicing-economy",
@@ -91,10 +100,9 @@
       "then": {
         "voicing.shape": "ergonomic_sophisticated"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "harmonic_color"
+        "any"
       ],
       "falsifier": "Voicings that are technically demanding without additional harmonic payoff",
       "anchor": "easy on the hands, but very sophisticated",
@@ -104,7 +112,11 @@
         "chapter_title": "Listening Exercises — Great Chord Melody Renditions",
         "section_title": "Ed Bickert — Do Nothing Till You Hear From Me",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "harmonic_color"
+      ]
     },
     {
       "rule_id": "laukens-greene-texture-ornament",
@@ -115,10 +127,9 @@
       "then": {
         "voicing.quality": "lush_textural_with_ornaments"
       },
-      "preference": "optional_advanced",
+      "preference": 0,
       "quality_binding": [
-        "solo_guitar",
-        "advanced_arranging"
+        "any"
       ],
       "falsifier": null,
       "anchor": "lush chord voicings on a 7-string guitar, with captivating texture and delicate ornaments such as harp harmonics",
@@ -128,7 +139,11 @@
         "chapter_title": "Listening Exercises — Great Chord Melody Renditions",
         "section_title": "Ted Greene — Send In The Clowns",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "solo_guitar",
+        "advanced_arranging"
+      ]
     },
     {
       "rule_id": "laukens-breau-two-note-chord",
@@ -141,10 +156,9 @@
         "voicing.density": "bare_bones_two_note",
         "voicing.strings": "minimal"
       },
-      "preference": "advanced_alternative",
+      "preference": 0,
       "quality_binding": [
-        "melodic_freedom",
-        "rhythmic_complexity"
+        "any"
       ],
       "falsifier": "Using full chord voicings when they restrict execution of the melody line",
       "anchor": "innovative technique enabled him to execute complex melodies and rhythmic approaches over the chords, making it sound like 2 guitars are playing at once",
@@ -154,7 +168,11 @@
         "chapter_title": "Listening Exercises — Great Chord Melody Renditions",
         "section_title": "Lenny Breau — All Blues",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melodic_freedom",
+        "rhythmic_complexity"
+      ]
     },
     {
       "rule_id": "laukens-farlow-plectrum-solo",
@@ -165,10 +183,9 @@
       "then": {
         "voicing.shape": "plectrum_compatible_block_chords"
       },
-      "preference": "valid_alternative",
+      "preference": 0,
       "quality_binding": [
-        "solo_chord_melody",
-        "plectrum_technique"
+        "any"
       ],
       "falsifier": "Claiming fingerstyle is mandatory for solo chord melody",
       "anchor": "an example of solo chord melody played entirely with a plectrum rather than fingerstyle",
@@ -178,7 +195,11 @@
         "chapter_title": "Listening Exercises — Great Chord Melody Renditions",
         "section_title": "Tal Farlow — Misty",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "solo_chord_melody",
+        "plectrum_technique"
+      ]
     },
     {
       "rule_id": "laukens-van-eps-7string-bass",
@@ -190,10 +211,9 @@
       "then": {
         "voicing.strings": "7_string_extended_bass"
       },
-      "preference": "advanced_optional",
+      "preference": 0,
       "quality_binding": [
-        "solo_guitar",
-        "bass_line"
+        "any"
       ],
       "falsifier": null,
       "anchor": "invented a model of guitar adding an extra bass string to a standard six-string instrument",
@@ -203,7 +223,11 @@
         "chapter_title": "Listening Exercises — Great Chord Melody Renditions",
         "section_title": "George Van Eps — Kisses",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "solo_guitar",
+        "bass_line"
+      ]
     },
     {
       "rule_id": "laukens-quickstart-4step-sequence",
@@ -214,10 +238,9 @@
       "then": {
         "voicing.shape": "sequence_tune_key_melody_chords"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "chord_melody",
-        "arranging_workflow"
+        "any"
       ],
       "falsifier": "Skipping any of the four steps when beginning a new arrangement",
       "anchor": "Pick a suitable tune • Change the key if necessary for better range and playability • Learn the melody on top 2 (or 3) strings • Choose chord voicings to add below melody notes",
@@ -227,7 +250,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "How to Arrange Chord Melodies — The Basic in a Nutshell",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "chord_melody",
+        "arranging_workflow"
+      ]
     },
     {
       "rule_id": "laukens-step1-choose-ballad",
@@ -238,10 +265,9 @@
       "then": {
         "tune.choice": "ballad_not_bebop"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "first_arrangement",
-        "playability"
+        "any"
       ],
       "falsifier": "Choosing a fast bebop tune for a first chord melody project",
       "anchor": "I recommend you stick to ballads, rather than the faster bebop tunes",
@@ -251,7 +277,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 1 — Picking a Suitable Tune",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "first_arrangement",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-step1-long-melody-notes",
@@ -262,10 +292,9 @@
       "then": {
         "tune.choice": "long_held_melody_notes"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "first_arrangement",
-        "chord_melody"
+        "any"
       ],
       "falsifier": "Selecting a tune with predominantly short, fast melody notes for a beginner arrangement",
       "anchor": "The slower tempo and longer-held melody notes in ballads will be much easier for your first project.",
@@ -275,7 +304,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 1 — Picking a Suitable Tune",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "first_arrangement",
+        "chord_melody"
+      ]
     },
     {
       "rule_id": "laukens-step2-target-fret-range",
@@ -287,11 +320,9 @@
         "melody.string": "strings_1_2_3",
         "melody.fret": "fret_3_to_9"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "range",
-        "playability",
-        "tonal_balance"
+        "any"
       ],
       "falsifier": "Arrangement where melody consistently falls above the 12th fret or below the 3rd fret on the top strings",
       "anchor": "Search for a key where you can play the melody on the top 3 strings, roughly anywhere from the 3rd to the 9th fret.",
@@ -301,7 +332,12 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 2 — Change Key if Necessary for Range and Playability",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "range",
+        "playability",
+        "tonal_balance"
+      ]
     },
     {
       "rule_id": "laukens-step2-avoid-too-high",
@@ -313,9 +349,9 @@
       "then": {
         "key.transpose_target": "lower_key"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "tonal_balance"
+        "any"
       ],
       "falsifier": "Arrangement with melody on top strings but above 12th fret sounding balanced",
       "anchor": "If the arrangement is too high, it will sound like it doesn't have enough depth.",
@@ -325,7 +361,10 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 2 — Change Key if Necessary for Range and Playability",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tonal_balance"
+      ]
     },
     {
       "rule_id": "laukens-step2-avoid-too-low",
@@ -337,10 +376,9 @@
       "then": {
         "key.transpose_target": "higher_key"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "tonal_balance",
-        "clarity"
+        "any"
       ],
       "falsifier": "Arrangement with melody on lower strings below 3rd fret sounding clear and balanced",
       "anchor": "if your arrangement is too low in the register, it will sound too dark and muddy.",
@@ -350,7 +388,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 2 — Change Key if Necessary for Range and Playability",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tonal_balance",
+        "clarity"
+      ]
     },
     {
       "rule_id": "laukens-step2-experiment-key",
@@ -361,10 +403,9 @@
       "then": {
         "key.transpose_target": "experiment_until_3rd_to_9th_fret"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "range",
-        "playability"
+        "any"
       ],
       "falsifier": "Committing to original key without testing register suitability",
       "anchor": "Finding the ideal range is usually what will dictate your choice of key. You'll need to experiment to find a key that works.",
@@ -374,7 +415,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 2 — Change Key if Necessary for Range and Playability",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "range",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-step2-autumn-leaves-em",
@@ -386,10 +431,9 @@
       "then": {
         "key.transpose_target": "Em"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
-        "range",
-        "playability"
+        "any"
       ],
       "falsifier": "Autumn Leaves in Gm with melody confined to top 3 strings between 3rd and 9th fret",
       "anchor": "Some of those notes of Autumn Leaves in Gm are too low",
@@ -399,7 +443,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 2 — Change Key if Necessary for Range and Playability",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "range",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-step3-melody-top2-strings",
@@ -410,10 +458,9 @@
       "then": {
         "melody.string": "string_1_2_primary_3_occasional"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "chord_melody",
-        "voicing_space"
+        "any"
       ],
       "falsifier": "Melody confined to strings 4–6 preventing chord voicings underneath",
       "anchor": "We need to be able to play the melody on the top 2 strings (maybe dipping into the 3rd string occasionally)",
@@ -423,7 +470,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 3 — Learn the Melody on the Top 2 (or 3) Strings",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "chord_melody",
+        "voicing_space"
+      ]
     },
     {
       "rule_id": "laukens-step3-horizontal-playing",
@@ -434,10 +485,9 @@
       "then": {
         "voicing.shape": "horizontal_across_fretboard"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "melody_placement",
-        "playability"
+        "any"
       ],
       "falsifier": "Melody stays in a single positional box on the top strings",
       "anchor": "you will need to play more horizontally over the fretboard, rather than staying in a single position",
@@ -447,7 +497,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 3 — Learn the Melody on the Top 2 (or 3) Strings",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melody_placement",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-step3-adapt-fingering",
@@ -458,9 +512,9 @@
       "then": {
         "voicing.shape": "refingered_for_top_strings"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "melody_placement"
+        "any"
       ],
       "falsifier": null,
       "anchor": "notice how the fingering has been adapted with this in mind",
@@ -470,7 +524,10 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 3 — Learn the Melody on the Top 2 (or 3) Strings",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melody_placement"
+      ]
     },
     {
       "rule_id": "laukens-step4-voicings-below-melody",
@@ -481,10 +538,9 @@
       "then": {
         "voicing.strings": "strings_3_4_5_6_below_melody"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "chord_melody",
-        "voice_independence"
+        "any"
       ],
       "falsifier": "Chord voicings placed on strings 1 or 2 competing with the melody",
       "anchor": "With the melody notes fingered on the high strings, we can now place chord voicings underneath the melody notes.",
@@ -494,7 +550,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 4 — Choose Chord Voicings to Add Below Melody Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "chord_melody",
+        "voice_independence"
+      ]
     },
     {
       "rule_id": "laukens-step4-not-every-note",
@@ -505,10 +565,9 @@
       "then": {
         "voicing.density": "selective_not_every_melody_note"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "clarity",
-        "playability"
+        "any"
       ],
       "falsifier": "Every single melody note harmonized with a chord voicing causing clutter",
       "anchor": "You don't need a chord on every melody note.",
@@ -518,7 +577,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 4 — Choose Chord Voicings to Add Below Melody Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "clarity",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-step4-chord-on-long-notes",
@@ -530,11 +593,9 @@
       "then": {
         "voicing.density": "chord_on_long_held_notes_only"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "clarity",
-        "playability",
-        "natural_phrasing"
+        "any"
       ],
       "falsifier": "Avoiding chords on long-held notes while harmonizing short passing tones",
       "anchor": "I mainly place chords on the long-held melody notes. It sounds great and is easy on the hands.",
@@ -544,7 +605,12 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 4 — Choose Chord Voicings to Add Below Melody Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "clarity",
+        "playability",
+        "natural_phrasing"
+      ]
     },
     {
       "rule_id": "laukens-step4-too-many-chords-cluttered",
@@ -555,10 +621,9 @@
       "then": {
         "voicing.density": "reduce_to_key_points_only"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "clarity",
-        "playability"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Too many chords can make your arrangement sound cluttered and make it difficult to play.",
@@ -568,7 +633,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 4 — Choose Chord Voicings to Add Below Melody Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "clarity",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-step4-chord-on-chord-change",
@@ -580,10 +649,9 @@
       "then": {
         "voicing.shape": "place_chord_at_chord_change_point"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "chord_melody",
-        "harmonic_clarity"
+        "any"
       ],
       "falsifier": "Avoiding chord placement at chord change points",
       "anchor": "rather than trying to hold them for their full length, I place a chord voicing to emphasize the change of chord instead.",
@@ -593,7 +661,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 4 — Choose Chord Voicings to Add Below Melody Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "chord_melody",
+        "harmonic_clarity"
+      ]
     },
     {
       "rule_id": "laukens-step4-adapt-melody-for-decay",
@@ -604,9 +676,9 @@
       "then": {
         "voicing.density": "chord_substitutes_for_sustained_melody_note"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "natural_guitar_idiom"
+        "any"
       ],
       "falsifier": "Writing melody as if guitar can sustain notes for their full written duration",
       "anchor": "The long melody notes ring out quickly on guitar, so rather than trying to hold them for their full length",
@@ -616,7 +688,10 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Step 4 — Choose Chord Voicings to Add Below Melody Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "natural_guitar_idiom"
+      ]
     },
     {
       "rule_id": "laukens-rh-choose-one-technique",
@@ -627,10 +702,9 @@
       "then": {
         "voicing.shape": "single_technique_commitment"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "consistency",
-        "technique_development"
+        "any"
       ],
       "falsifier": null,
       "anchor": "think about which approach you would like to use for this course and what you are familiar with technique-wise already",
@@ -640,7 +714,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Techniques — Overview",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "consistency",
+        "technique_development"
+      ]
     },
     {
       "rule_id": "laukens-fingerstyle-arpeggio-figures",
@@ -651,10 +729,9 @@
       "then": {
         "voicing.density": "arpeggio_independent_voices"
       },
-      "preference": "preferred_fingerstyle",
+      "preference": 1,
       "quality_binding": [
-        "fingerstyle",
-        "creative_possibilities"
+        "any"
       ],
       "falsifier": "Fingerstyle producing only block chords without independent voice movement",
       "anchor": "Notice the intricate arpeggio figures I can create with this technique.",
@@ -664,7 +741,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 1 — Fingerstyle",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "fingerstyle",
+        "creative_possibilities"
+      ]
     },
     {
       "rule_id": "laukens-fingerstyle-thumb-bass",
@@ -676,10 +757,9 @@
       "then": {
         "voicing.strings": "thumb_on_bass_strings"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "fingerstyle",
-        "bass_line"
+        "any"
       ],
       "falsifier": "Using fingers rather than thumb for bass string articulation in fingerstyle",
       "anchor": "To pluck the bass notes, you can use your thumb by itself",
@@ -689,7 +769,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 1 — Fingerstyle",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "fingerstyle",
+        "bass_line"
+      ]
     },
     {
       "rule_id": "laukens-fingerstyle-thumbpick-single-lines",
@@ -701,10 +785,9 @@
       "then": {
         "voicing.shape": "thumbpick_for_single_lines"
       },
-      "preference": "optional",
+      "preference": 0,
       "quality_binding": [
-        "fingerstyle",
-        "single_line_clarity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "consider Lenny Breau's approach of using a thumb pick. This can be helpful to play single lines easily like a plectrum player when you need it.",
@@ -714,7 +797,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 1 — Fingerstyle",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "fingerstyle",
+        "single_line_clarity"
+      ]
     },
     {
       "rule_id": "laukens-plectrum-block-chords",
@@ -726,9 +813,9 @@
       "then": {
         "voicing.density": "block_chord_strum"
       },
-      "preference": "required_plectrum",
+      "preference": 2,
       "quality_binding": [
-        "plectrum_technique"
+        "any"
       ],
       "falsifier": "Attempting intricate polyphonic arpeggio figures with plectrum only",
       "anchor": "your options may be more limited as you need to find voicings where you can strum the chord mostly as block chords rather than the more intricate polyphony of fingerstyle",
@@ -738,7 +825,10 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 2 — Plectrum",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "plectrum_technique"
+      ]
     },
     {
       "rule_id": "laukens-plectrum-drive-swing",
@@ -750,10 +840,9 @@
       "then": {
         "voicing.quality": "block_chord_drive_and_swing"
       },
-      "preference": "advantage_of_plectrum",
+      "preference": 1,
       "quality_binding": [
-        "plectrum_technique",
-        "swing_feel"
+        "any"
       ],
       "falsifier": null,
       "anchor": "strumming block chords in this way can give the arrangement more drive and swing",
@@ -763,7 +852,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 2 — Plectrum",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "plectrum_technique",
+        "swing_feel"
+      ]
     },
     {
       "rule_id": "laukens-plectrum-bass-then-strum",
@@ -775,10 +868,9 @@
       "then": {
         "voicing.shape": "bass_note_first_then_strum_top_strings"
       },
-      "preference": "required_plectrum",
+      "preference": 2,
       "quality_binding": [
-        "plectrum_technique",
-        "string_skip_negotiation"
+        "any"
       ],
       "falsifier": "Strumming all strings simultaneously from bass to treble with plectrum",
       "anchor": "pluck the bass note first, followed by a quick strum of the rest of the chord",
@@ -788,7 +880,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 2 — Plectrum",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "plectrum_technique",
+        "string_skip_negotiation"
+      ]
     },
     {
       "rule_id": "laukens-hybrid-not-recommended",
@@ -799,10 +895,9 @@
       "then": {
         "voicing.shape": "avoid_hybrid_picking"
       },
-      "preference": "discouraged",
+      "preference": -1,
       "quality_binding": [
-        "chord_melody",
-        "technique_ergonomics"
+        "any"
       ],
       "falsifier": null,
       "anchor": "for chord melody, we usually recommend using either fingerstyle or using a regular plectrum.",
@@ -812,7 +907,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 3 — Hybrid Picking",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "chord_melody",
+        "technique_ergonomics"
+      ]
     },
     {
       "rule_id": "laukens-hybrid-awkward-pinky",
@@ -824,9 +923,9 @@
       "then": {
         "voicing.shape": "revert_to_fingerstyle_or_plectrum"
       },
-      "preference": "caution",
+      "preference": -1,
       "quality_binding": [
-        "ergonomics"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Personally, I find this technique awkward especially due to the shorter length of the pinky finger.",
@@ -836,7 +935,10 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 3 — Hybrid Picking",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "ergonomics"
+      ]
     },
     {
       "rule_id": "laukens-most-examples-fingerstyle",
@@ -847,10 +949,9 @@
       "then": {
         "voicing.density": "fingerstyle_or_block_chord_equivalent"
       },
-      "preference": "flexible",
+      "preference": 0,
       "quality_binding": [
-        "chord_melody",
-        "technique_choice"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Most of the examples in the course will be fingerstyle, but you can easily tweak the examples to use block chords suitable for the strumming plectrum style.",
@@ -860,7 +961,11 @@
         "chapter_title": "Module 1 — Chord Melody Quickstart",
         "section_title": "Right-Hand Technique 3 — Hybrid Picking",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "chord_melody",
+        "technique_choice"
+      ]
     },
     {
       "rule_id": "laukens-harmonize-every-scale-degree",
@@ -874,10 +979,9 @@
         "voicing.collection": "one voicing per scale degree of the target key",
         "voicing.density": "full chord under each melody note"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "completeness",
-        "harmonization coverage"
+        "any"
       ],
       "falsifier": "A scale degree exists with no assigned voicing in the collection",
       "anchor": "You'll be able to harmonize any melody note that's on a chord from the G Major chord family",
@@ -887,7 +991,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Step 1–4: Building the First Major Chord Collection (G Major)",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "completeness",
+        "harmonization coverage"
+      ]
     },
     {
       "rule_id": "laukens-transpose-by-shape-shift",
@@ -901,10 +1009,9 @@
         "voicing.shape": "identical shapes shifted to start on the new root fret",
         "voicing.fret_offset": "distance from original root fret to new root fret"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "shape consistency",
-        "transposability"
+        "any"
       ],
       "falsifier": "Shapes change form rather than merely shifting position when moving to the new key",
       "anchor": "Notice how the shapes are exactly the same as G Major, I've just shifted them up to start on the 8th fret instead of the third fret.",
@@ -914,7 +1021,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Step 5: Transpose the Chord Collection to Other Keys",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "shape consistency",
+        "transposability"
+      ]
     },
     {
       "rule_id": "laukens-octave-drop-high-shapes",
@@ -929,10 +1040,9 @@
         "voicing.fret_offset": "-12 frets (one octave lower)",
         "voicing.density": "same shape, lower octave"
       },
-      "preference": "strongly preferred",
+      "preference": 2,
       "quality_binding": [
-        "playability",
-        "practical arranging"
+        "any"
       ],
       "falsifier": "Shape stays at high position and remains playable without strain",
       "anchor": "So, let's drop some shapes down the octave when they start to get a bit too high. This is a much more practical way to practice the chord shapes for this key.",
@@ -942,7 +1052,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Step 5: Transpose the Chord Collection to Other Keys",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "practical arranging"
+      ]
     },
     {
       "rule_id": "laukens-free-finger-additions",
@@ -955,11 +1069,9 @@
         "voicing.tensions": "add available extensions with unused fingers on adjacent strings",
         "voicing.density": "enriched basic shape"
       },
-      "preference": "recommended for interest",
+      "preference": 1,
       "quality_binding": [
-        "color",
-        "texture",
-        "voice-leading interest"
+        "any"
       ],
       "falsifier": "All fingers are already assigned in the base voicing with no free fingers available",
       "anchor": "Experiment with adding extra notes with your free fingers to the chord voicings for more interest.",
@@ -969,7 +1081,12 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Exercise — A Summer's Day",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "color",
+        "texture",
+        "voice-leading interest"
+      ]
     },
     {
       "rule_id": "laukens-single-lines-between-chords",
@@ -980,10 +1097,9 @@
       "then": {
         "voicing.density": "alternate between full chord voicings and single-note lines"
       },
-      "preference": "recommended for variety",
+      "preference": 1,
       "quality_binding": [
-        "texture contrast",
-        "melodic interest"
+        "any"
       ],
       "falsifier": "Arrangement consists exclusively of unbroken chord voicings with no linear passages",
       "anchor": "You can also play some single lines in between the chord voicings to mix things up.",
@@ -993,7 +1109,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Exercise — A Summer's Day",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "texture contrast",
+        "melodic interest"
+      ]
     },
     {
       "rule_id": "laukens-any-order-within-collection",
@@ -1006,9 +1126,9 @@
         "voicing.collection": "any shape from the key's collection in any order",
         "voicing.shape": "freely chosen per musical moment"
       },
-      "preference": "permissive",
+      "preference": 0,
       "quality_binding": [
-        "harmonic compatibility"
+        "any"
       ],
       "falsifier": "A specific ordering is required for harmonic coherence with the backing",
       "anchor": "any of the shapes in any order will generally sound fine.",
@@ -1018,7 +1138,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Exercise — A Summer's Day",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic compatibility"
+      ]
     },
     {
       "rule_id": "laukens-three-family-coverage",
@@ -1029,10 +1152,9 @@
       "then": {
         "voicing.collection": "includes major voicings, minor voicings, and dominant voicings"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic completeness",
-        "arranging flexibility"
+        "any"
       ],
       "falsifier": "Collection lacks any one of: major voicings, minor voicings, dominant voicings",
       "anchor": "we also need minor and dominant chords in addition to major chords if we are going to be able to make chord melody arrangements.",
@@ -1042,7 +1164,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I Chord Collections — Overview and Three Harmonic Families",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic completeness",
+        "arranging flexibility"
+      ]
     },
     {
       "rule_id": "laukens-ii-v-i-as-family-vehicle",
@@ -1055,10 +1181,9 @@
         "voicing.collection": "ii chord = minor voicing, V chord = dominant voicing, I chord = major voicing",
         "voicing.quality": "one from each harmonic family per progression"
       },
-      "preference": "strongly preferred as a learning framework",
+      "preference": 1,
       "quality_binding": [
-        "efficiency",
-        "contextual pairing"
+        "any"
       ],
       "falsifier": "Voicings for the three families are learned in isolation with no ii-V-I context",
       "anchor": "The ii-V-I progression contains a chord from each harmonic family: ii — minor, V - dominant, I - major",
@@ -1068,7 +1193,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I Chord Collections — Overview and Three Harmonic Families",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "efficiency",
+        "contextual pairing"
+      ]
     },
     {
       "rule_id": "laukens-i-chord-major-collection",
@@ -1082,10 +1211,9 @@
         "voicing.collection": "C Major chord collection (Cmaj7, C6, C6/9, CMaj9, etc.)",
         "voicing.string_set": "1st string as highest note"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic accuracy",
-        "melodic compatibility"
+        "any"
       ],
       "falsifier": "Minor or dominant voicing assigned to the I chord",
       "anchor": "C Major Chord Collection (I in C Major)",
@@ -1095,7 +1223,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 1: The Three Core Collections (C Major, D Minor, G Dominant)",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "melodic compatibility"
+      ]
     },
     {
       "rule_id": "laukens-ii-chord-minor-collection",
@@ -1109,9 +1241,9 @@
         "voicing.collection": "D Minor chord collection (Dm7, Dm9, Dm11, Dm13, etc.)",
         "voicing.string_set": "1st string as highest note"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic accuracy"
+        "any"
       ],
       "falsifier": "Major or dominant voicing assigned to the ii chord",
       "anchor": "D Minor Chord Collection (ii in C Major)",
@@ -1121,7 +1253,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 1: The Three Core Collections (C Major, D Minor, G Dominant)",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy"
+      ]
     },
     {
       "rule_id": "laukens-v-chord-dominant-collection",
@@ -1135,10 +1270,9 @@
         "voicing.collection": "G Dominant chord collection (G7, G9, G13, G7b13, etc.)",
         "voicing.string_set": "1st string as highest note"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic accuracy",
-        "tension provision"
+        "any"
       ],
       "falsifier": "Major or minor voicing assigned to the V chord",
       "anchor": "G Dominant Chord Collection (V in C Major)",
@@ -1148,7 +1282,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 1: The Three Core Collections (C Major, D Minor, G Dominant)",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "tension provision"
+      ]
     },
     {
       "rule_id": "laukens-caged-proximity-voicing",
@@ -1161,11 +1299,9 @@
         "voicing.shape": "voicing from the relevant collection nearest the current fretboard area",
         "voicing.fret_offset": "minimal hand movement from position"
       },
-      "preference": "required for positional playing",
+      "preference": 2,
       "quality_binding": [
-        "ergonomics",
-        "position economy",
-        "smooth chord changes"
+        "any"
       ],
       "falsifier": "Voicing chosen requires a large positional jump away from the fretboard area",
       "anchor": "play a ii V I using chord shapes from the above collections closest to each fretboard area.",
@@ -1175,7 +1311,12 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 2: Create ii V I Progressions in CAGED Positions",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "ergonomics",
+        "position economy",
+        "smooth chord changes"
+      ]
     },
     {
       "rule_id": "laukens-caged-scale-orientation",
@@ -1187,10 +1328,9 @@
       "then": {
         "voicing.collection": "scale pattern played first to identify position, then chords chosen from that area"
       },
-      "preference": "strongly preferred as orientation device",
+      "preference": 1,
       "quality_binding": [
-        "positional awareness",
-        "fretboard navigation"
+        "any"
       ],
       "falsifier": "Chords chosen without referencing the scale pattern of the area",
       "anchor": "To orientate yourself, first play a C major Scale in each fretboard area, then play a ii V I using chord shapes from the above collections closest to each fretboard area.",
@@ -1200,7 +1340,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 2: Create ii V I Progressions in CAGED Positions",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "positional awareness",
+        "fretboard navigation"
+      ]
     },
     {
       "rule_id": "laukens-four-caged-positions-coverage",
@@ -1213,10 +1357,9 @@
         "voicing.collection": "ii-V-I voicings at A, G, E, and D/C CAGED positions",
         "voicing.strings": "position-appropriate strings per area"
       },
-      "preference": "required for fretboard fluency",
+      "preference": 2,
       "quality_binding": [
-        "fretboard coverage",
-        "arranging flexibility"
+        "any"
       ],
       "falsifier": "Any CAGED position lacks a usable ii-V-I voicing set",
       "anchor": "CAGED 'A' Position … CAGED 'G' Position … CAGED 'E' Position … CAGED 'D/C' Position",
@@ -1226,7 +1369,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 2: Create ii V I Progressions in CAGED Positions",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "fretboard coverage",
+        "arranging flexibility"
+      ]
     },
     {
       "rule_id": "laukens-area-by-area-practice",
@@ -1237,10 +1384,9 @@
       "then": {
         "voicing.collection": "one CAGED position at a time, slow then medium tempo"
       },
-      "preference": "strongly preferred",
+      "preference": 2,
       "quality_binding": [
-        "retention",
-        "fluency"
+        "any"
       ],
       "falsifier": "All positions are practiced simultaneously before any individual one is comfortable",
       "anchor": "Practice each fretboard area until comfortable before moving to the next",
@@ -1250,7 +1396,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 3: Practice Over Backing Track",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "retention",
+        "fluency"
+      ]
     },
     {
       "rule_id": "laukens-melody-on-2nd-string",
@@ -1263,10 +1413,9 @@
         "voicing.string_set": "2nd string as highest note",
         "voicing.collection": "2nd-string variant of the relevant harmonic-family collection"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "melodic placement",
-        "voicing ergonomics"
+        "any"
       ],
       "falsifier": "1st-string voicing is used when melody note sits on the 2nd string",
       "anchor": "when arranging chord melodies it's helpful to have the melody mainly on the top 1st and 2nd strings.",
@@ -1276,7 +1425,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 4: 2nd-String Chord Collections",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melodic placement",
+        "voicing ergonomics"
+      ]
     },
     {
       "rule_id": "laukens-dual-string-set-per-family",
@@ -1288,10 +1441,9 @@
       "then": {
         "voicing.collection": "two parallel sets per family: one with highest note on string 1, one with highest note on string 2"
       },
-      "preference": "required for full melodic coverage",
+      "preference": 2,
       "quality_binding": [
-        "melodic flexibility",
-        "harmonic completeness"
+        "any"
       ],
       "falsifier": "Only one string-set variant exists for any harmonic family",
       "anchor": "So far, the chord voicings we have learned in this lesson have the highest note on the 1st string. Now let's add additional chord collections that have their highest note on the 2nd string.",
@@ -1301,7 +1453,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 4: 2nd-String Chord Collections",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melodic flexibility",
+        "harmonic completeness"
+      ]
     },
     {
       "rule_id": "laukens-2nd-string-caged-challenge",
@@ -1314,10 +1470,9 @@
       "then": {
         "voicing.collection": "2nd-string voicings assembled into positional ii-V-I sets matching CAGED areas"
       },
-      "preference": "required for full-position coverage",
+      "preference": 2,
       "quality_binding": [
-        "positional completeness",
-        "melodic placement"
+        "any"
       ],
       "falsifier": "2nd-string voicings cannot be organized into positional ii-V-I sets",
       "anchor": "experiment with the above '2nd string' voicings and see if you can work out how to play ii V I progressions in each of the fretboard areas",
@@ -1327,7 +1482,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Major ii V I — Step 4: 2nd-String Chord Collections",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "positional completeness",
+        "melodic placement"
+      ]
     },
     {
       "rule_id": "laukens-minor-ii-m7b5",
@@ -1342,10 +1501,9 @@
         "voicing.quality": "m7b5 (half-diminished)",
         "voicing.collection": "Dm7b5 chord collection"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic accuracy",
-        "minor key color"
+        "any"
       ],
       "falsifier": "Plain minor 7th voicing used on ii chord in minor context",
       "anchor": "Minor 7th chords with a b5 (m7b5) aka half-diminished chords.",
@@ -1355,7 +1513,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i Chord Collections — Overview",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "minor key color"
+      ]
     },
     {
       "rule_id": "laukens-minor-v-7alt",
@@ -1371,10 +1533,9 @@
         "voicing.tensions": "b9, #9, b13, or combinations thereof",
         "voicing.collection": "G7alt chord collection"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic tension",
-        "minor-key resolution"
+        "any"
       ],
       "falsifier": "Unaltered G7 used as V chord in a minor ii-V-i context",
       "anchor": "Altered dominant chords (7alt) - dominant chords with altered tensions applied to it.",
@@ -1384,7 +1545,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i Chord Collections — Overview",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic tension",
+        "minor-key resolution"
+      ]
     },
     {
       "rule_id": "laukens-minor-iivi-as-subtype-vehicle",
@@ -1396,10 +1561,9 @@
       "then": {
         "voicing.collection": "m7b5 at ii position, 7alt at V position, minor chord at i position"
       },
-      "preference": "strongly preferred as learning framework",
+      "preference": 1,
       "quality_binding": [
-        "contextual pairing",
-        "harmonic coherence"
+        "any"
       ],
       "falsifier": "m7b5 and 7alt learned in isolation without progression context",
       "anchor": "A great way to learn these new kinds of chords is by studying minor ii V i progressions, as they include m7b5 for the ii chord and 7alt for the V chord.",
@@ -1409,7 +1573,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i Chord Collections — Overview",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "contextual pairing",
+        "harmonic coherence"
+      ]
     },
     {
       "rule_id": "laukens-dictionary-not-memorization",
@@ -1421,10 +1589,9 @@
       "then": {
         "voicing.collection": "reference library for lookup during arrangement; not required to be memorized upfront"
       },
-      "preference": "strongly preferred approach to learning",
+      "preference": 1,
       "quality_binding": [
-        "sustainable learning",
-        "practical utility"
+        "any"
       ],
       "falsifier": "Arranger waits until all voicings are memorized before attempting an arrangement",
       "anchor": "we are more building a dictionary of chords rather than trying to memorize every single one at this stage.",
@@ -1434,7 +1601,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i Chord Collections — Overview",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "sustainable learning",
+        "practical utility"
+      ]
     },
     {
       "rule_id": "laukens-minor-i-chord-collection",
@@ -1449,9 +1620,9 @@
         "voicing.collection": "C Minor chord collection (Cm7, Cm9, Cm11, etc.)",
         "voicing.string_set": "1st string as highest note"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic accuracy"
+        "any"
       ],
       "falsifier": "Major chord voicing used at i position in minor key",
       "anchor": "C Minor Chord Collection (i of C Minor)",
@@ -1461,7 +1632,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i — Step 1: Three Core Collections (C Minor, Dm7b5, G7alt)",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy"
+      ]
     },
     {
       "rule_id": "laukens-minor-ii-m7b5-collection",
@@ -1476,10 +1650,9 @@
         "voicing.collection": "Dm7b5 chord collection (Dm7b5, D7b9b5, Dm11b5, etc.)",
         "voicing.string_set": "1st string as highest note"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic accuracy",
-        "minor-key color"
+        "any"
       ],
       "falsifier": "Dm7 (plain minor 7th) used instead of Dm7b5 at ii in minor context",
       "anchor": "Dm7b5 Chord Collection (ii of C Minor)",
@@ -1489,7 +1662,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i — Step 1: Three Core Collections (C Minor, Dm7b5, G7alt)",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "minor-key color"
+      ]
     },
     {
       "rule_id": "laukens-minor-v-alt-collection",
@@ -1505,10 +1682,9 @@
         "voicing.tensions": "b9, #9, b13 or combinations",
         "voicing.string_set": "1st string as highest note"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic tension",
-        "minor-key resolution drive"
+        "any"
       ],
       "falsifier": "Unaltered G7 or G9 used as V in minor ii-V-i",
       "anchor": "G Altered Dominant Chord Collection (V of C Minor)",
@@ -1518,7 +1694,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i — Step 1: Three Core Collections (C Minor, Dm7b5, G7alt)",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic tension",
+        "minor-key resolution drive"
+      ]
     },
     {
       "rule_id": "laukens-minor-caged-natural-minor-orientation",
@@ -1530,9 +1710,9 @@
       "then": {
         "voicing.collection": "natural minor scale played first to identify position, then minor ii-V-i chords from that area"
       },
-      "preference": "required as orientation step",
+      "preference": 2,
       "quality_binding": [
-        "positional awareness"
+        "any"
       ],
       "falsifier": "Chords selected without first referencing the natural minor scale pattern of the area",
       "anchor": "play a C natural minor scale in each fretboard area, then play a ii V i using chord shapes from the above collections closest to each fretboard area.",
@@ -1542,7 +1722,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i — Step 2: CAGED Positions for Minor ii-V-i",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "positional awareness"
+      ]
     },
     {
       "rule_id": "laukens-minor-four-position-coverage",
@@ -1554,10 +1737,9 @@
       "then": {
         "voicing.collection": "minor ii-V-i voicings at A, G, E, and D/C CAGED positions"
       },
-      "preference": "required for fretboard fluency",
+      "preference": 2,
       "quality_binding": [
-        "fretboard coverage",
-        "minor key arranging flexibility"
+        "any"
       ],
       "falsifier": "Any CAGED position lacks a usable minor ii-V-i voicing set",
       "anchor": "Caged 'A' Position (Minor) … Caged 'G' Position (Minor) … Caged 'E' Position (Minor) … Caged 'D/C' Position (Minor)",
@@ -1567,7 +1749,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i — Step 2: CAGED Positions for Minor ii-V-i",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "fretboard coverage",
+        "minor key arranging flexibility"
+      ]
     },
     {
       "rule_id": "laukens-minor-area-by-area-practice",
@@ -1578,10 +1764,9 @@
       "then": {
         "voicing.collection": "one minor CAGED position at a time, slow then medium tempo"
       },
-      "preference": "strongly preferred",
+      "preference": 2,
       "quality_binding": [
-        "retention",
-        "fluency"
+        "any"
       ],
       "falsifier": "All minor positions practiced simultaneously before any is comfortable",
       "anchor": "Practice each fretboard area until comfortable before moving to the next",
@@ -1591,7 +1776,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i — Step 3: Practice Over Backing Track",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "retention",
+        "fluency"
+      ]
     },
     {
       "rule_id": "laukens-2nd-string-minor-collections",
@@ -1605,10 +1794,9 @@
         "voicing.string_set": "2nd string as highest note",
         "voicing.collection": "2nd-string variants of Cm, Dm7b5, and G7alt collections"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "melodic placement",
-        "voicing ergonomics"
+        "any"
       ],
       "falsifier": "1st-string voicing used when melody note is on 2nd string in minor context",
       "anchor": "Now let's add additional chord collections that have their highest note on the 2nd string.",
@@ -1618,7 +1806,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i — Step 4: 2nd-String Minor Collections",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melodic placement",
+        "voicing ergonomics"
+      ]
     },
     {
       "rule_id": "laukens-2nd-string-minor-caged-challenge",
@@ -1630,10 +1822,9 @@
       "then": {
         "voicing.collection": "2nd-string minor voicings assembled into positional ii-V-i sets at each CAGED area"
       },
-      "preference": "required for full positional coverage",
+      "preference": 2,
       "quality_binding": [
-        "positional completeness",
-        "minor melodic coverage"
+        "any"
       ],
       "falsifier": "2nd-string minor voicings used only in isolation without positional ii-V-i context",
       "anchor": "experiment with the above '2nd string' voicings and see if you can work out how to play ii V i progressions in each of the fretboard areas, similar to how you played the ist string voicings earlier in the lesson.",
@@ -1643,7 +1834,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Minor ii V i — Step 4: 2nd-String Minor Collections",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "positional completeness",
+        "minor melodic coverage"
+      ]
     },
     {
       "rule_id": "laukens-chord-symbol-as-formula",
@@ -1654,10 +1849,9 @@
       "then": {
         "voicing.quality": "derived from the interval formula encoded in the symbol (e.g., Maj7 = 1-3-5-7)"
       },
-      "preference": "required for chord construction",
+      "preference": 2,
       "quality_binding": [
-        "theoretical accuracy",
-        "voicing correctness"
+        "any"
       ],
       "falsifier": "Chord voicing contradicts the interval formula of its symbol",
       "anchor": "Each symbol you see stands for a formula of intervals: For example: Maj7 formula = 1357 So Cmaj7 =CEGB",
@@ -1667,7 +1861,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Understanding Chord Labels",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "theoretical accuracy",
+        "voicing correctness"
+      ]
     },
     {
       "rule_id": "laukens-stacked-thirds-construction",
@@ -1679,10 +1877,9 @@
         "voicing.quality": "built by adding thirds: root → 3rd → 5th = triad; add 7th = jazz chord",
         "voicing.density": "3 notes minimum (triad), 4 notes for 7th chord"
       },
-      "preference": "standard construction method",
+      "preference": 1,
       "quality_binding": [
-        "harmonic correctness",
-        "jazz vocabulary"
+        "any"
       ],
       "falsifier": "Chord notes are not a stack of consecutive thirds from the root",
       "anchor": "Chords are constructed most often by stacking thirds.",
@@ -1692,7 +1889,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Constructing Chords — Stacking Thirds",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic correctness",
+        "jazz vocabulary"
+      ]
     },
     {
       "rule_id": "laukens-triad-minimum",
@@ -1703,9 +1904,9 @@
       "then": {
         "voicing.density": "minimum 3 notes"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "harmonic completeness"
+        "any"
       ],
       "falsifier": "Two-note dyad presented as a full chord",
       "anchor": "A triad is the smallest amount of notes you can have for a chord.",
@@ -1715,7 +1916,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Constructing Chords — Stacking Thirds",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic completeness"
+      ]
     },
     {
       "rule_id": "laukens-fourth-third-jazz-color",
@@ -1729,10 +1933,9 @@
         "voicing.tensions": "added major or minor 7th",
         "voicing.density": "4 notes"
       },
-      "preference": "standard jazz chord construction",
+      "preference": 1,
       "quality_binding": [
-        "jazz color",
-        "harmonic richness"
+        "any"
       ],
       "falsifier": "Fourth stacked third does not produce a 7th-chord quality",
       "anchor": "We can continue to stack an extra third on top of these triads, giving us 4 note chords or 'jazz' chords - aptly named because of the jazzy sound this extra 3rd gives us",
@@ -1742,7 +1945,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Constructing Chords — Stacking Thirds",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "jazz color",
+        "harmonic richness"
+      ]
     },
     {
       "rule_id": "laukens-extensions-from-second-octave",
@@ -1753,10 +1960,9 @@
       "then": {
         "voicing.tensions": "use second-octave interval names: 9 (not 2), 11 (not 4), 13 (not 6)"
       },
-      "preference": "required by convention",
+      "preference": 2,
       "quality_binding": [
-        "theoretical accuracy",
-        "symbol clarity"
+        "any"
       ],
       "falsifier": "Extension above the 7th labeled as 2, 4, or 6 in a chord symbol",
       "anchor": "as we continue through the series of 3rds, we get into numbers like 9,11, and 13. This is where chords like GMaji3 come from",
@@ -1766,7 +1972,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Understanding Numbers in Chord Symbols — Extensions: 9, 11, 13",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "theoretical accuracy",
+        "symbol clarity"
+      ]
     },
     {
       "rule_id": "laukens-second-octave-structures",
@@ -1778,9 +1988,9 @@
         "voicing.quality": "second-octave structure",
         "voicing.density": "enriched beyond basic 7th chord"
       },
-      "preference": "definitional",
+      "preference": 0,
       "quality_binding": [
-        "vocabulary precision"
+        "any"
       ],
       "falsifier": null,
       "anchor": "chords that include the 9th, 11th, or 13th are often called 'second octave structures'.",
@@ -1790,7 +2000,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Understanding Numbers in Chord Symbols — Extensions: 9, 11, 13",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "vocabulary precision"
+      ]
     },
     {
       "rule_id": "laukens-omit-fifth",
@@ -1803,10 +2016,9 @@
         "voicing.density": "remove 5th from the voicing",
         "voicing.quality": "preserved without 5th"
       },
-      "preference": "first omission candidate",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "harmonic completeness"
+        "any"
       ],
       "falsifier": "Removing the 5th changes the essential harmonic quality of the chord",
       "anchor": "Intervals most commonly omitted include the 5th, the root (1st), the 11th, and the 9th.",
@@ -1816,7 +2028,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Omittable Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "harmonic completeness"
+      ]
     },
     {
       "rule_id": "laukens-omit-root",
@@ -1829,10 +2045,9 @@
         "voicing.density": "remove root from guitar voicing (bass player covers it)",
         "voicing.quality": "rootless voicing"
       },
-      "preference": "commonly used in jazz ensemble context",
+      "preference": 0,
       "quality_binding": [
-        "playability",
-        "voice independence"
+        "any"
       ],
       "falsifier": "Chord loses harmonic identity when root is removed and no bass instrument covers it",
       "anchor": "Intervals most commonly omitted include the 5th, the root (1st), the 11th, and the 9th.",
@@ -1842,7 +2057,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Omittable Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "voice independence"
+      ]
     },
     {
       "rule_id": "laukens-omit-11th",
@@ -1854,9 +2073,9 @@
       "then": {
         "voicing.density": "remove 11th from voicing"
       },
-      "preference": "available simplification",
+      "preference": 0,
       "quality_binding": [
-        "playability"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Intervals most commonly omitted include the 5th, the root (1st), the 11th, and the 9th.",
@@ -1866,7 +2085,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Omittable Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-omit-third-seventh-complex",
@@ -1878,9 +2100,9 @@
       "then": {
         "voicing.density": "3rd or 7th removed as last resort"
       },
-      "preference": "exceptional use only",
+      "preference": -1,
       "quality_binding": [
-        "playability over completeness"
+        "any"
       ],
       "falsifier": "Chord retains clear harmonic identity without 3rd or 7th",
       "anchor": "even the 3rd and the 7th can be omitted for more complex chords in certain situations as well.",
@@ -1890,7 +2112,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Omittable Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability over completeness"
+      ]
     },
     {
       "rule_id": "laukens-theory-vs-playable-voicing",
@@ -1901,10 +2126,9 @@
       "then": {
         "voicing.density": "omit non-essential notes to achieve playability while preserving chord essence"
       },
-      "preference": "required awareness for guitar arranging",
+      "preference": 2,
       "quality_binding": [
-        "practical arranging",
-        "instrument-specific adaptation"
+        "any"
       ],
       "falsifier": "Guitar voicing contains every theoretical note of the chord with no playability issues",
       "anchor": "On the guitar, there is a difference between the theoretically correct chord and the playable chord.",
@@ -1914,7 +2138,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Omittable Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "practical arranging",
+        "instrument-specific adaptation"
+      ]
     },
     {
       "rule_id": "laukens-extension-notation",
@@ -1925,9 +2153,9 @@
       "then": {
         "voicing.quality": "extension written as part of the chord name (e.g., G9, G13, GMaj9)"
       },
-      "preference": "required by notation convention",
+      "preference": 2,
       "quality_binding": [
-        "notational accuracy"
+        "any"
       ],
       "falsifier": "Diatonic extension enclosed in parentheses in the chord symbol",
       "anchor": "An extension (sometimes called a 'natural' or 'diatonic' tension) is an interval of the chord which naturally occurs in the parent scale of the key of the progression. Extensions are included as part of the chord name.",
@@ -1937,7 +2165,10 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Labelling Extensions and Altered Tensions",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "notational accuracy"
+      ]
     },
     {
       "rule_id": "laukens-altered-tension-notation",
@@ -1948,10 +2179,9 @@
       "then": {
         "voicing.quality": "altered tension written in parentheses after the chord name (e.g., G7(b13#9))"
       },
-      "preference": "required by notation convention",
+      "preference": 2,
       "quality_binding": [
-        "notational accuracy",
-        "altered-tension clarity"
+        "any"
       ],
       "falsifier": "Altered tension written without parentheses as if it were a diatonic extension",
       "anchor": "Altered tensions are notes that are outside the parent scale of the key of the progression, and are (usually) added in parentheses after the chord name.",
@@ -1961,7 +2191,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Labelling Extensions and Altered Tensions",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "notational accuracy",
+        "altered-tension clarity"
+      ]
     },
     {
       "rule_id": "laukens-slash-chord-bass-note",
@@ -1973,10 +2207,9 @@
         "voicing.quality": "play chord X with Y as the lowest sounding note",
         "voicing.strings": "lowest string carries the bass note Y"
       },
-      "preference": "required for correct interpretation",
+      "preference": 2,
       "quality_binding": [
-        "harmonic accuracy",
-        "bass-line fidelity"
+        "any"
       ],
       "falsifier": "Chord played without the indicated bass note as the lowest pitch",
       "anchor": "Slash chords are a way to indicate what note should be in the bass of a chord. For example: G6/E means to play a G6 chord with an E as the lowest note.",
@@ -1986,7 +2219,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Slash Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "bass-line fidelity"
+      ]
     },
     {
       "rule_id": "laukens-slash-chord-solo-guitar-utility",
@@ -1997,10 +2234,9 @@
       "then": {
         "voicing.strings": "bass note voiced on lowest available string as specified by slash symbol"
       },
-      "preference": "important in solo context (no separate bass player)",
+      "preference": 1,
       "quality_binding": [
-        "bass-line independence",
-        "harmonic completeness"
+        "any"
       ],
       "falsifier": "Solo arrangement ignores the slash bass note entirely",
       "anchor": "they are useful to know what this means and can give you some interesting possibilities, especially for solo jazz guitar.",
@@ -2010,7 +2246,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Slash Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "bass-line independence",
+        "harmonic completeness"
+      ]
     },
     {
       "rule_id": "laukens-context-determines-chord-name",
@@ -2021,10 +2261,9 @@
       "then": {
         "voicing.quality": "name that best describes the chord's function in the surrounding progression"
       },
-      "preference": "required for accurate analysis",
+      "preference": 2,
       "quality_binding": [
-        "harmonic clarity",
-        "theoretical accuracy"
+        "any"
       ],
       "falsifier": "The same note group always receives the same chord name regardless of progression context",
       "anchor": "A chord's sound is as much defined by the chords that are around it in the progression, just as much as the notes of the chord themselves.",
@@ -2034,7 +2273,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Same Notes, Different Chord Names",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic clarity",
+        "theoretical accuracy"
+      ]
     },
     {
       "rule_id": "laukens-rootless-voicing-recontextualization",
@@ -2046,10 +2289,9 @@
       "then": {
         "voicing.quality": "re-labeled as the chord whose root is implied by the new context (e.g., CMaj7 without root = Am9)"
       },
-      "preference": "available reharmonization technique",
+      "preference": 0,
       "quality_binding": [
-        "harmonic flexibility",
-        "voice economy"
+        "any"
       ],
       "falsifier": "Re-labeled chord is not actually spelled by the notes of the voicing in the new context",
       "anchor": "it could also be an Am9 chord (with the A root omitted) if you place it in this progression instead",
@@ -2059,7 +2301,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Same Notes, Different Chord Names",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic flexibility",
+        "voice economy"
+      ]
     },
     {
       "rule_id": "laukens-generate-voicings-by-alteration",
@@ -2072,11 +2318,9 @@
         "voicing.shape": "modified from base by adding/removing/raising/lowering one note at a time",
         "voicing.tensions": "new extension or alteration introduced by the changed note"
       },
-      "preference": "highly recommended for expanding vocabulary",
+      "preference": 1,
       "quality_binding": [
-        "creativity",
-        "color",
-        "vocabulary breadth"
+        "any"
       ],
       "falsifier": "No new voicing quality emerges from the modification (identical chord quality)",
       "anchor": "Notice how I can turn this into a new voicing by simply adding a note",
@@ -2086,7 +2330,12 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Finding More Interesting Voicings by Adding, Removing, or Altering Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "creativity",
+        "color",
+        "vocabulary breadth"
+      ]
     },
     {
       "rule_id": "laukens-track-top-note-interval",
@@ -2098,10 +2347,9 @@
         "voicing.quality": "top note interval identified and labeled (e.g., 9, #4, #9, b13, etc.)",
         "voicing.string_set": "highest string carries the melody note whose interval is catalogued"
       },
-      "preference": "required for chord melody voicing selection",
+      "preference": 2,
       "quality_binding": [
-        "melodic targeting",
-        "interval-to-voicing mapping"
+        "any"
       ],
       "falsifier": "Voicing selected for chord melody without knowing which interval of the chord appears on top",
       "anchor": "The number below each voicing indicates the interval of the top note of the voicing, which is very useful to know for chord melody arranging as you'll see in future lessons!",
@@ -2111,7 +2359,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Finding More Interesting Voicings by Adding, Removing, or Altering Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melodic targeting",
+        "interval-to-voicing mapping"
+      ]
     },
     {
       "rule_id": "laukens-name-new-voicings",
@@ -2122,10 +2374,9 @@
       "then": {
         "voicing.quality": "chord name derived from the interval content of the new voicing"
       },
-      "preference": "recommended for theoretical understanding",
+      "preference": 1,
       "quality_binding": [
-        "theoretical literacy",
-        "vocabulary internalization"
+        "any"
       ],
       "falsifier": "New voicing used without identifying its chord name",
       "anchor": "see if you can work out what the chord name would be for the new voicings you have created.",
@@ -2135,7 +2386,11 @@
         "chapter_title": "Module 2 — Chord Vocabulary",
         "section_title": "Finding More Interesting Voicings by Adding, Removing, or Altering Notes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "theoretical literacy",
+        "vocabulary internalization"
+      ]
     },
     {
       "rule_id": "laukens-interval-label-first",
@@ -2148,10 +2403,9 @@
         "arrangement.add_element": "interval_analysis_map",
         "voicing.collection": "defer until interval map complete"
       },
-      "preference": "mandatory first step; voicing selection is downstream of interval labelling",
+      "preference": 2,
       "quality_binding": [
-        "harmonic clarity",
-        "systematic voicing selection"
+        "any"
       ],
       "falsifier": "Arrangement where voicings are chosen without prior interval analysis and still achieves consistent chord-tone melody alignment",
       "anchor": "Carefully going through the progression in this way, we can label the intervals in the melody in relation to the chords in the progression as follows",
@@ -2161,7 +2415,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Melodic Interval Analysis — Fly Me to the Moon",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic clarity",
+        "systematic voicing selection"
+      ]
     },
     {
       "rule_id": "laukens-anticipation-assign",
@@ -2173,10 +2431,9 @@
       "then": {
         "arrangement.add_element": "re-label note as interval of next chord"
       },
-      "preference": "strong — determines correct interval and hence correct voicing lookup",
+      "preference": 1,
       "quality_binding": [
-        "harmonic accuracy",
-        "voicing selection accuracy"
+        "any"
       ],
       "falsifier": "Anticipation note that resolves correctly when labelled as interval of the *current* chord rather than the next",
       "anchor": "Sometimes a melody note anticipates the next chord so is considered an interval of that chord (see the ends of bar 1, 3, 5, 7).",
@@ -2186,7 +2443,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Melodic Interval Analysis — Fly Me to the Moon",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "voicing selection accuracy"
+      ]
     },
     {
       "rule_id": "laukens-chord-placement-barstart",
@@ -2198,10 +2459,9 @@
       "then": {
         "arrangement.add_element": "chord voicing on downbeat or chord-change beat only"
       },
-      "preference": "strong default; sparse placement preferred over dense",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "musical flow"
+        "any"
       ],
       "falsifier": "Arrangement with chord on every melody note that is still rated more playable and musical than one with bar-start placement only",
       "anchor": "This final step is a straightforward process of applying a chord to the first melody note of each bar and/or chord change in the lead sheet.",
@@ -2211,7 +2471,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Applying Chords to the Melody — The Chord-Dictionary Method",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "musical flow"
+      ]
     },
     {
       "rule_id": "laukens-three-key-lookup",
@@ -2223,10 +2487,9 @@
       "then": {
         "voicing.collection": "chord dictionary filtered by [melody.string, chord_quality, melody.interval]"
       },
-      "preference": "mandatory; all three keys must be resolved before dictionary lookup",
+      "preference": 2,
       "quality_binding": [
-        "harmonic accuracy",
-        "tonal clarity"
+        "any"
       ],
       "falsifier": "Voicing selected without knowing melody string, chord quality, or interval that nonetheless produces consistent chord-tone melody alignment",
       "anchor": "To know which voicing to pick we need to establish: 1. The string the melody note is on 2. The type of chord that is in the chord progression whilst that melody note is played 3. The interval of the melody note in relation to that chord.",
@@ -2236,7 +2499,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Applying Chords to the Melody — The Chord-Dictionary Method",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "tonal clarity"
+      ]
     },
     {
       "rule_id": "laukens-top-note-equals-melody",
@@ -2248,10 +2515,9 @@
         "voicing.quality": "highest note matches melody interval",
         "voicing.strings": "top note on same string as melody note"
       },
-      "preference": "primary selection criterion; adaptable voicings accepted as fallback",
+      "preference": 2,
       "quality_binding": [
-        "melody clarity",
-        "harmonic accuracy"
+        "any"
       ],
       "falsifier": "Voicing where inner-voice note equals melody and top note does not, yet melody remains audible and clear",
       "anchor": "Choose chord voicings that have the same interval of the melody note as the highest note in the chord shape.",
@@ -2261,7 +2527,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Applying Chords to the Melody — The Chord-Dictionary Method",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melody clarity",
+        "harmonic accuracy"
+      ]
     },
     {
       "rule_id": "laukens-transpose-to-melody-fret",
@@ -2274,10 +2544,9 @@
         "voicing.shape": "same shape, transposed up/down so top note = melody fret",
         "voicing.strings": "unchanged from dictionary shape"
       },
-      "preference": "standard transposition procedure; shape quality preserved",
+      "preference": 1,
       "quality_binding": [
-        "harmonic accuracy",
-        "shape consistency"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Easily fixed - just shift the shape down on the fretboard so that the top note matches the same fret where the melody note is on our score",
@@ -2287,7 +2556,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Applying Chords to the Melody — The Chord-Dictionary Method",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "shape consistency"
+      ]
     },
     {
       "rule_id": "laukens-string1-minor-b3-voicing",
@@ -2301,10 +2574,9 @@
         "voicing.shape": "x x 1 3 2 2 (relative), top note = b3 on string 1",
         "voicing.density": "4-note voicing"
       },
-      "preference": "worked example from Fly Me to the Moon bar 1 (Am7, C melody, b3 interval)",
+      "preference": 0,
       "quality_binding": [
-        "harmonic accuracy",
-        "melody clarity"
+        "any"
       ],
       "falsifier": "Minor voicing with 5th or root as top note on string 1 that produces clearer chord-tone melody than b3-top voicing",
       "anchor": "So, we need to pick a chord from our dictionary with a b3 as the note on the top string",
@@ -2314,7 +2586,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Applying Chords to the Melody — The Chord-Dictionary Method",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy",
+        "melody clarity"
+      ]
     },
     {
       "rule_id": "laukens-sparse-over-dense",
@@ -2326,10 +2602,9 @@
       "then": {
         "voicing.density": "reduced — chords at key structural points only"
       },
-      "preference": "strong aesthetic default; over-harmonisation degrades playability and musical flow",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "musical naturalness"
+        "any"
       ],
       "falsifier": "Arrangement rated superior by musician panel where every melody note carries a chord voicing",
       "anchor": "less is more — placing chords at key places 'here and there' is easier on the hands and is usually more than enough to imply the harmony beneath the melody line. So don't get carried away!",
@@ -2339,7 +2614,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Making Arrangements Playable — Density, Voicing Cuts, and Alternatives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "musical naturalness"
+      ]
     },
     {
       "rule_id": "laukens-cut-low-notes",
@@ -2352,10 +2631,9 @@
         "voicing.density": "reduced by removing lowest or doubled note",
         "voicing.shape": "trimmed version of original"
       },
-      "preference": "first playability remedy before resorting to alternative voicing or removal",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "harmonic retention"
+        "any"
       ],
       "falsifier": "Removed low note causes harmonic ambiguity that full voicing would not",
       "anchor": "Cut out notes from the chord - e.g. we could cut that low B to make it easier to change to the next chord",
@@ -2365,7 +2643,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Making Arrangements Playable — Density, Voicing Cuts, and Alternatives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "harmonic retention"
+      ]
     },
     {
       "rule_id": "laukens-diads-as-substitute",
@@ -2379,10 +2661,9 @@
         "voicing.density": "2-note diad",
         "voicing.quality": "parallel 3rds or 6ths below melody note"
       },
-      "preference": "second-level playability remedy; preserves harmonic implication with less hand strain",
+      "preference": 0,
       "quality_binding": [
-        "playability",
-        "harmonic suggestion"
+        "any"
       ],
       "falsifier": "Context where diads produce more hand strain than block chord due to string-skip patterns",
       "anchor": "Choose a different harmonization approach - e.g. instead of block chords I could use parallel octaves or diads (a \"chord\" with only two notes). Here's an example of diads in 3rds",
@@ -2392,7 +2673,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Making Arrangements Playable — Density, Voicing Cuts, and Alternatives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "harmonic suggestion"
+      ]
     },
     {
       "rule_id": "laukens-remove-chord-entirely",
@@ -2404,11 +2689,9 @@
       "then": {
         "arrangement.add_element": "melody note only, no harmonisation"
       },
-      "preference": "strongly preferred over retaining awkward voicing; hand relaxation improves whole-passage flow",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "musical flow",
-        "hand health"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Removing the difficult voicings completely often makes the whole passage work much better on the guitar — it helps my hands to relax.",
@@ -2418,7 +2701,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Making Arrangements Playable — Density, Voicing Cuts, and Alternatives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "musical flow",
+        "hand health"
+      ]
     },
     {
       "rule_id": "laukens-easy-hands-music-flows",
@@ -2430,11 +2718,9 @@
       "then": {
         "voicing.quality": "choose most ergonomic realisation of harmonic intent"
       },
-      "preference": "aesthetic principle from Tim Kain; not a fallback but a positive artistic guideline",
+      "preference": 1,
       "quality_binding": [
-        "musical flow",
-        "playability",
-        "performance consistency"
+        "any"
       ],
       "falsifier": "Passage where technically difficult voicing is unanimously judged to sound better than easier alternative in controlled listener study",
       "anchor": "If it's easy on the hands, the music will flow better - so most of the time making things as easy as possible is musically the best option anyway",
@@ -2444,7 +2730,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Making Arrangements Playable — Density, Voicing Cuts, and Alternatives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "musical flow",
+        "playability",
+        "performance consistency"
+      ]
     },
     {
       "rule_id": "laukens-dominant-tension-required",
@@ -2458,10 +2749,9 @@
         "voicing.tensions": "add one alteration or extension (b9, #9, b13, #11, 13 etc.)",
         "voicing.quality": "altered or extended dominant"
       },
-      "preference": "strong aesthetic standard for jazz idiom; plain dom7 voicing is acceptable only in rare contexts",
+      "preference": 1,
       "quality_binding": [
-        "jazz authenticity",
-        "harmonic interest"
+        "any"
       ],
       "falsifier": "Dominant chord with no extensions judged more jazz-idiomatic than extended version in a recording context",
       "anchor": "The jazzy sound in arrangements usually comes from adding extensions and tensions to voicings - particularly to dominant chords.",
@@ -2471,7 +2761,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Adding Tension to Dominant Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "jazz authenticity",
+        "harmonic interest"
+      ]
     },
     {
       "rule_id": "laukens-b13-on-G7",
@@ -2485,10 +2779,9 @@
         "voicing.tensions": "b13",
         "voicing.quality": "V7(b13)"
       },
-      "preference": "example-level recommendation; b13 is one of several effective tensions",
+      "preference": 0,
       "quality_binding": [
-        "jazz authenticity",
-        "tonal colour"
+        "any"
       ],
       "falsifier": "G7(b13) voicing rated less interesting than plain G7 in blind jazz-guitar arrangement evaluation",
       "anchor": "Let's add an Eb to that chord shape to make it a G7(b13) — the Eb is acting as the b13 giving it some cool tension",
@@ -2498,7 +2791,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Adding Tension to Dominant Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "jazz authenticity",
+        "tonal colour"
+      ]
     },
     {
       "rule_id": "laukens-single-tension-sufficient",
@@ -2511,10 +2808,9 @@
         "voicing.density": "base shell or dictionary voicing + one tension note",
         "voicing.tensions": "one alteration chosen from b9 / #9 / b13 / #11"
       },
-      "preference": "economy principle; more tensions can muddy the voicing on guitar",
+      "preference": 1,
       "quality_binding": [
-        "clarity",
-        "jazz idiom balance"
+        "any"
       ],
       "falsifier": "Voicing with three tensions rated clearer and more idiomatic than single-tension version on guitar",
       "anchor": "See how just a small touch of tension can make an arrangement sound far more interesting.",
@@ -2524,7 +2820,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Adding Tension to Dominant Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "clarity",
+        "jazz idiom balance"
+      ]
     },
     {
       "rule_id": "laukens-up-tempo-cut-bass",
@@ -2537,10 +2837,9 @@
         "voicing.density": "reduced — lower tones cut, upper chord tones retained",
         "voicing.strings": "focus on upper strings"
       },
-      "preference": "up-tempo standard; bass-note density inversely related to tempo",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "tempo fidelity"
+        "any"
       ],
       "falsifier": "Up-tempo arrangement where retaining low bass notes in every voicing is rated more playable than trimmed versions",
       "anchor": "Notice how I'm often cutting the lower tones out of the chords to make them more playable for this up-tempo tune.",
@@ -2550,7 +2849,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Complete Arrangements — Fly Me to the Moon and Alone Together",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "tempo fidelity"
+      ]
     },
     {
       "rule_id": "laukens-alter-melody-rhythm",
@@ -2562,10 +2865,9 @@
       "then": {
         "arrangement.add_element": "rhythmic alteration of melody to suit guitar voicing transitions"
       },
-      "preference": "acceptable creative licence in arranging; melodic identity preserved even if rhythm shifts",
+      "preference": 0,
       "quality_binding": [
-        "playability",
-        "musical naturalness"
+        "any"
       ],
       "falsifier": null,
       "anchor": "I also had to alter the rhythm of the melody quite a bit to enable the arrangement to be more natural under the hands.",
@@ -2575,7 +2877,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Complete Arrangements — Fly Me to the Moon and Alone Together",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "musical naturalness"
+      ]
     },
     {
       "rule_id": "laukens-arrangements-as-templates",
@@ -2586,10 +2892,9 @@
       "then": {
         "arrangement.add_element": "learn arrangement verbatim, then adapt personal voicing choices"
       },
-      "preference": "pedagogical recommendation — imitation before innovation",
+      "preference": 1,
       "quality_binding": [
-        "skill development",
-        "stylistic understanding"
+        "any"
       ],
       "falsifier": null,
       "anchor": "You can treat these arrangements as an example to learn on your guitar, or you could use them as a starting point for your own arrangement in the lessons that follow.",
@@ -2599,7 +2904,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Complete Arrangements — Fly Me to the Moon and Alone Together",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "skill development",
+        "stylistic understanding"
+      ]
     },
     {
       "rule_id": "laukens-solo-guitar-illusion",
@@ -2611,11 +2920,9 @@
       "then": {
         "arrangement.add_element": "rotation of bass / chord / single-line textures across measures"
       },
-      "preference": "fundamental solo guitar principle; constant simultaneous bass+melody+chords is too difficult and musically stiff",
+      "preference": 2,
       "quality_binding": [
-        "playability",
-        "musical naturalness",
-        "stylistic authenticity"
+        "any"
       ],
       "falsifier": "Solo guitar arrangement sustaining all three layers simultaneously rated more natural than alternating-texture version",
       "anchor": "A good solo guitar arranger simply suggests these elements throughout the performance. Play a measure of walking bass, followed by a chord line, followed by unaccompanied single lines — alternating through these different devices gives the 'illusion' to the audience of a complete band.",
@@ -2625,7 +2932,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Introduction to Solo Guitar Arranging",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "musical naturalness",
+        "stylistic authenticity"
+      ]
     },
     {
       "rule_id": "laukens-fingerstyle-for-solo-guitar",
@@ -2637,11 +2949,9 @@
       "then": {
         "arrangement.add_element": "fingerstyle plucking technique"
       },
-      "preference": "strongly preferred; pick technique requires complex muting and is harder for simultaneous voicings",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "tonal clarity",
-        "voicing integrity"
+        "any"
       ],
       "falsifier": "Plectrum technique demonstrated to produce cleaner simultaneous voicings than fingerstyle across a range of solo guitar passages",
       "anchor": "many of the voicings you are about to learn are quite difficult to play with a pick if you intend to sound the notes simultaneously without tricky muting techniques. For this reason, I gravitate to using fingerstyle picking for solo guitar.",
@@ -2651,7 +2961,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Introduction to Solo Guitar Arranging",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "tonal clarity",
+        "voicing integrity"
+      ]
     },
     {
       "rule_id": "laukens-open-string-key-selection",
@@ -2664,11 +2979,9 @@
         "target.key": "prefer A, E, or D for open-string bass availability",
         "voicing.strings": "use open 5th/6th string bass where available"
       },
-      "preference": "strong design-time decision; unlocks free fingers and lower bass register",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "bass register depth",
-        "harmonic richness"
+        "any"
       ],
       "falsifier": "Solo guitar arrangement in Bb or Eb rated more playable than A/E/D arrangement of same piece due to higher-position voicing availability",
       "anchor": "Choosing a key like A, E, or D gives you essentially another set of free fingers. Without needing to fret the occasional bass note, you can make things much easier technically.",
@@ -2678,7 +2991,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Introduction to Solo Guitar Arranging",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "bass register depth",
+        "harmonic richness"
+      ]
     },
     {
       "rule_id": "laukens-bass-register-separation",
@@ -2690,10 +3008,9 @@
       "then": {
         "voicing.strings": "bass note on 5th or 6th string, separated from upper harmony by at least one octave where possible"
       },
-      "preference": "design concern specific to solo guitar; bass crowding upper harmony produces thin, muddy texture",
+      "preference": 1,
       "quality_binding": [
-        "tonal depth",
-        "harmonic clarity"
+        "any"
       ],
       "falsifier": "Solo guitar arrangement with bass and melody within one octave rated as full-sounding by listener panel",
       "anchor": "A common issue with many jazz guitar arrangements is that the bass is too close to the upper harmony, which results in a thin sound.",
@@ -2703,7 +3020,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Introduction to Solo Guitar Arranging",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tonal depth",
+        "harmonic clarity"
+      ]
     },
     {
       "rule_id": "laukens-shell-definition",
@@ -2716,10 +3037,9 @@
         "voicing.density": "3-note shell: root, 3rd, 7th",
         "voicing.quality": "no 5th, no doubled tones"
       },
-      "preference": "definitional; shell voicing is the atomic unit of solo jazz guitar harmony",
+      "preference": 2,
       "quality_binding": [
-        "harmonic clarity",
-        "playability"
+        "any"
       ],
       "falsifier": null,
       "anchor": "All we have left is now the root on the bass, the 3rd, and the 7th in these shapes. These are called shell voicings — i.e. the 'bare bones' of what you need to define the sound of the chord: the root, 3rd, and 7th.",
@@ -2729,7 +3049,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic clarity",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-remove-5th-from-jazz-voicing",
@@ -2743,10 +3067,9 @@
         "voicing.shape": "5th removed",
         "voicing.density": "reduced by one note"
       },
-      "preference": "strong jazz-harmony standard; 5th is the weakest chord tone in jazz context",
+      "preference": 1,
       "quality_binding": [
-        "tonal clarity",
-        "playability"
+        "any"
       ],
       "falsifier": "Voicing including 5th judged clearer or more jazz-idiomatic than 5th-omitted version in blind test",
       "anchor": "You can remove the 5th from the chord and still retain the essential character of the sound.",
@@ -2756,7 +3079,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tonal clarity",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-6th-instead-of-7th",
@@ -2770,10 +3097,9 @@
         "voicing.quality": "shell with 6th replacing 7th",
         "voicing.tensions": "6th (major or minor)"
       },
-      "preference": "alternative shell colour; 6th = warmer/resolved, 7th = more open/jazzy",
+      "preference": 0,
       "quality_binding": [
-        "harmonic colour",
-        "resolution quality"
+        "any"
       ],
       "falsifier": "Context where 7th-shell produces a warmer resolved sound than 6th-shell on same chord",
       "anchor": "note that the 6th interval can also be used instead of the 7th which gives a warmer, more resolved sound",
@@ -2783,7 +3109,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic colour",
+        "resolution quality"
+      ]
     },
     {
       "rule_id": "laukens-shell-root-6th-string",
@@ -2797,10 +3127,9 @@
         "voicing.collection": "root-on-6-string shell voicing set",
         "voicing.density": "3-note shell"
       },
-      "preference": "standard; 6th-string root shells provide deepest bass register on guitar",
+      "preference": 1,
       "quality_binding": [
-        "bass depth",
-        "harmonic clarity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Root on the 6th String / MAJOR DOMINANT MINOR / CMa7 C6 C7 Cm7",
@@ -2810,7 +3139,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "bass depth",
+        "harmonic clarity"
+      ]
     },
     {
       "rule_id": "laukens-shell-root-5th-string",
@@ -2824,10 +3157,9 @@
         "voicing.collection": "root-on-5-string shell voicing set, both inversions",
         "voicing.density": "3-note shell"
       },
-      "preference": "standard; learn both top-note options for voice-leading flexibility",
+      "preference": 1,
       "quality_binding": [
-        "voice leading",
-        "melodic flexibility"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Notice how, for some positions of voicings, you can either have the 3rd as the highest note or the 7th on top instead — it's good to learn both versions.",
@@ -2837,7 +3169,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "voice leading",
+        "melodic flexibility"
+      ]
     },
     {
       "rule_id": "laukens-open-string-shell-priority",
@@ -2851,10 +3187,9 @@
         "voicing.shape": "open-string variant of shell",
         "voicing.strings": "open string on bass or inner voice"
       },
-      "preference": "strongly preferred; frees fretting fingers for melody extension notes",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "tone quality"
+        "any"
       ],
       "falsifier": "Open-string shell voicing that produces unwanted ringing open string causing harmonic clash in a specific progression",
       "anchor": "Always look for opportunities to use open strings for these voicings where possible",
@@ -2864,7 +3199,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "tone quality"
+      ]
     },
     {
       "rule_id": "laukens-shell-plus-melody-extension",
@@ -2878,10 +3217,9 @@
         "voicing.density": "4-note: shell (root+3rd+7th) + melody note above",
         "voicing.collection": "shell-extension grid for matching chord type and root-string"
       },
-      "preference": "primary solo guitar harmonisation method; shell provides bass/harmony, top note carries melody",
+      "preference": 1,
       "quality_binding": [
-        "melody clarity",
-        "harmonic completeness"
+        "any"
       ],
       "falsifier": "Shell-plus-extension voicing where melody note is audibly masked by inner shell voices",
       "anchor": "Shell voicings are a convenient way to add a chord underneath melody notes.",
@@ -2891,7 +3229,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melody clarity",
+        "harmonic completeness"
+      ]
     },
     {
       "rule_id": "laukens-avoid-doubling-in-shell-extension",
@@ -2905,10 +3247,9 @@
         "voicing.density": "remove doubled note from shell",
         "voicing.quality": "no unnecessary doublings"
       },
-      "preference": "standard — doublings dilute jazz clarity; acceptable only when sound is still satisfactory",
+      "preference": 1,
       "quality_binding": [
-        "harmonic clarity",
-        "tonal efficiency"
+        "any"
       ],
       "falsifier": "Case where doubled note within shell-plus-extension voicing is judged to improve clarity or warmth",
       "anchor": "Generally, try to avoid doubling notes in the chord - I've usually cut out notes from the voicing when doubling occurs. However, sometimes it still sounds ok so I've left doublings in when this is the case.",
@@ -2918,7 +3259,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic clarity",
+        "tonal efficiency"
+      ]
     },
     {
       "rule_id": "laukens-shell-fingering-adaptation",
@@ -2931,9 +3276,9 @@
       "then": {
         "voicing.shape": "re-finger shell to accommodate extension note"
       },
-      "preference": "case-by-case; standard shell fingering may not accommodate all extension intervals",
+      "preference": 0,
       "quality_binding": [
-        "playability"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Sometimes the fingering of the shell voicing needs to be adapted (e.g. different fingers used for the shell voicing or the addition of a barre.)",
@@ -2943,7 +3288,10 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Shell Voicings for Solo Guitar",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-solo-step-1-check-key",
@@ -2956,10 +3304,9 @@
         "target.key": "confirm or transpose to key with open-string bass notes",
         "arrangement.add_element": "note which open strings will serve as bass notes"
       },
-      "preference": "mandatory first step of solo guitar arrangement process",
+      "preference": 2,
       "quality_binding": [
-        "playability",
-        "bass register"
+        "any"
       ],
       "falsifier": null,
       "anchor": "The first thing to look at is the key of the progression and register. The second bar has an Am7, which is a good sign — I can use an open A on the 5th string as the bass note in that bar.",
@@ -2969,7 +3316,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "bass register"
+      ]
     },
     {
       "rule_id": "laukens-solo-step-2-raise-melody",
@@ -2983,10 +3334,9 @@
         "arrangement.add_element": "melody transposed up one octave",
         "voicing.strings": "melody on strings 1–2"
       },
-      "preference": "strong; low-register melody leaves no room for harmony voicings above it",
+      "preference": 1,
       "quality_binding": [
-        "harmonic space",
-        "playability"
+        "any"
       ],
       "falsifier": "Solo arrangement with melody on strings 3–4 that accommodates full shell voicings below without octave shift",
       "anchor": "the melody is too low. Let's shift it up the octave so it's in a better register to fit voicings underneath (also remembering to keep the melody notes mostly on the top 2 strings)",
@@ -2996,7 +3346,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic space",
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-solo-step-3-bass-note-first",
@@ -3009,10 +3363,9 @@
         "arrangement.add_element": "single bass note on 5th or 6th string at each chord change",
         "voicing.density": "1-note bass placeholder"
       },
-      "preference": "useful exercise step; bass-note-only pass reveals suitable shell positions before committing to full voicings",
+      "preference": 1,
       "quality_binding": [
-        "harmonic planning",
-        "playability assessment"
+        "any"
       ],
       "falsifier": null,
       "anchor": "To get a feel for where to place shell voicings, a good exercise is to add a bass note underneath the melody at each chord change, like this",
@@ -3022,7 +3375,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic planning",
+        "playability assessment"
+      ]
     },
     {
       "rule_id": "laukens-solo-step-4-interval-analysis",
@@ -3034,9 +3391,9 @@
       "then": {
         "arrangement.add_element": "interval label for each melody note against active chord"
       },
-      "preference": "same principle as trio chord melody; interval map drives shell extension selection",
+      "preference": 1,
       "quality_binding": [
-        "harmonic accuracy"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Just like we did in the previous module, it's useful to know the interval of the melody notes in relation to the chord progression",
@@ -3046,7 +3403,10 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic accuracy"
+      ]
     },
     {
       "rule_id": "laukens-solo-step-5-apply-shells",
@@ -3059,9 +3419,9 @@
         "voicing.collection": "shell voicing grid (root-on-5 or root-on-6 as appropriate)",
         "arrangement.add_element": "shell voicing at each bass-note position"
       },
-      "preference": "starting-point application; expect refinement to follow",
+      "preference": 1,
       "quality_binding": [
-        "harmonic coverage"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Now it's a straightforward case of adding chord voicings where I have placed each bass note in the progression — let's use those shell voicings we covered in the last lesson",
@@ -3071,7 +3431,10 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic coverage"
+      ]
     },
     {
       "rule_id": "laukens-solo-step-6-refine",
@@ -3083,11 +3446,9 @@
       "then": {
         "arrangement.add_element": "iterative voicing adjustments: cut notes / swap shapes / adapt fingerings"
       },
-      "preference": "highest-priority step; refinement is where arrangements go from academic to musical",
+      "preference": 2,
       "quality_binding": [
-        "playability",
-        "musical flow",
-        "tonal quality"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Refining an arrangement is the most important step of solo guitar arranging. Making small tweaks, cutting unessential notes, and looking for skillful ways to finger passages to get the arrangement to feel good under the hands and sound good is the aim.",
@@ -3097,7 +3458,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "musical flow",
+        "tonal quality"
+      ]
     },
     {
       "rule_id": "laukens-open-string-for-difficult-bass-fret",
@@ -3111,9 +3477,9 @@
       "then": {
         "voicing.strings": "open 5th or 6th string instead of fretted bass note"
       },
-      "preference": "strong playability remedy; open string is functionally identical in pitch to fretted equivalent",
+      "preference": 1,
       "quality_binding": [
-        "playability"
+        "any"
       ],
       "falsifier": null,
       "anchor": "you can change the A bass note to the open 5th string instead",
@@ -3123,7 +3489,10 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability"
+      ]
     },
     {
       "rule_id": "laukens-no-doubling-in-shell-melody",
@@ -3137,10 +3506,9 @@
         "voicing.shape": "alternative voicing from dictionary that avoids doubling",
         "voicing.density": "adjusted to eliminate doubled pitch"
       },
-      "preference": "strong; doubled melody note in inner voice is inefficient and can sound muddy",
+      "preference": 1,
       "quality_binding": [
-        "harmonic clarity",
-        "melodic prominence"
+        "any"
       ],
       "falsifier": "Inner-voice doubling of melody judged to improve warmth or resonance in specific context",
       "anchor": "the shell voicing is doubling the 3rd in the melody when that D falls to a C in the melody... This is inefficient and it doesn't sound very good to have that note doubled. So let's resort to an alternative voicing for the D melody note.",
@@ -3150,7 +3518,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic clarity",
+        "melodic prominence"
+      ]
     },
     {
       "rule_id": "laukens-remove-doubled-root-in-voicing",
@@ -3164,10 +3536,9 @@
         "voicing.density": "remove inner-voice root note",
         "voicing.strings": "bass string carries root only"
       },
-      "preference": "preferred for fingerstyle efficiency; 5 simultaneous notes is harder to pluck cleanly",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "tonal clarity"
+        "any"
       ],
       "falsifier": "Arrangement where doubling the root in bass and inner voice produces audibly fuller sound worth the added difficulty",
       "anchor": "Doubling the root directly above isn't a big deal and can still sound good, but it is unnecessary. It also makes it a bit awkward to sound 5 notes at once with my plucking hand using fingerstyle. So let's remove the A on the 4th string",
@@ -3177,7 +3548,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "tonal clarity"
+      ]
     },
     {
       "rule_id": "laukens-add-passing-chord",
@@ -3191,10 +3566,9 @@
         "arrangement.add_element": "passing chord or V7/V interpolated at appropriate beat",
         "voicing.quality": "passing dominant or secondary dominant voicing"
       },
-      "preference": "creative option in refinement phase; do not add if it complicates hands unnecessarily",
+      "preference": 0,
       "quality_binding": [
-        "harmonic interest",
-        "jazz idiom"
+        "any"
       ],
       "falsifier": "Passing chord that creates hand coordination problem without audible harmonic benefit",
       "anchor": "Let's see what happens if you embellish the chord progression and add a V7 chord to the G on the 3rd beat.",
@@ -3204,7 +3578,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic interest",
+        "jazz idiom"
+      ]
     },
     {
       "rule_id": "laukens-vary-voicing-shapes",
@@ -3217,10 +3595,9 @@
         "voicing.shape": "alternative voicing from dictionary for same chord/interval",
         "voicing.collection": "alternate form of previously used shape"
       },
-      "preference": "aesthetic recommendation; repetition of identical shapes makes arrangement sound mechanical",
+      "preference": 1,
       "quality_binding": [
-        "variety",
-        "musical interest"
+        "any"
       ],
       "falsifier": "Repeated identical shapes judged to provide consistent tone preferred over varied shapes in specific arrangement context",
       "anchor": "The final chord seems a bit boring to me as it's the same chord shape we used at the start of the arrangement. So let's swap out that shape for another one from our chord dictionary",
@@ -3230,7 +3607,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "variety",
+        "musical interest"
+      ]
     },
     {
       "rule_id": "laukens-add-bass-to-voicing",
@@ -3243,10 +3624,9 @@
       "then": {
         "arrangement.add_element": "bass note on 5th or 6th string added to existing upper voicing"
       },
-      "preference": "targeted fix for register thinness; apply when upper voicing alone sounds unsupported",
+      "preference": 1,
       "quality_binding": [
-        "tonal depth",
-        "harmonic completeness"
+        "any"
       ],
       "falsifier": null,
       "anchor": "It sounds a bit empty without a bass note though — let's add a C bass note to that chord voicing",
@@ -3256,7 +3636,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tonal depth",
+        "harmonic completeness"
+      ]
     },
     {
       "rule_id": "laukens-solo-guitar-trial-and-error",
@@ -3268,11 +3652,9 @@
       "then": {
         "arrangement.add_element": "iterative experimentation — listen, feel hands, adjust"
       },
-      "preference": "overarching process principle; no algorithm fully replaces instrument-at-hand discovery",
+      "preference": 1,
       "quality_binding": [
-        "musical authenticity",
-        "playability",
-        "personal style"
+        "any"
       ],
       "falsifier": null,
       "anchor": "solo guitar is very much about experimentation and trial and error — starting with a standard approach and then tweaking through a careful process to listening to the sound and noticing what it feels like in the hands.",
@@ -3282,7 +3664,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Solo Guitar Arrangement Process — Moon River Case Study",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "musical authenticity",
+        "playability",
+        "personal style"
+      ]
     },
     {
       "rule_id": "laukens-arpeggiation-for-lyricism",
@@ -3295,11 +3682,9 @@
       "then": {
         "arrangement.add_element": "arpeggio pattern — pluck notes of voicing sequentially rather than simultaneously"
       },
-      "preference": "effective especially in ballads; use contextually rather than constantly",
+      "preference": 1,
       "quality_binding": [
-        "lyricism",
-        "musical expression",
-        "textural variety"
+        "any"
       ],
       "falsifier": "Arpeggio applied to up-tempo passage that produces rhythmic confusion rather than lyrical effect",
       "anchor": "An easy way to get a more impressive sound in your solo guitar arrangements is through arpeggiation. Arpeggiation is when you pluck the notes of a chord one at a time, instead of a block of notes played simultaneously. This can give a more lyrical sound and is especially effective in arrangements of jazz ballads.",
@@ -3309,7 +3694,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Arpeggiation, Octaves, and Diads",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "lyricism",
+        "musical expression",
+        "textural variety"
+      ]
     },
     {
       "rule_id": "laukens-octaves-for-melody-punch",
@@ -3323,10 +3713,9 @@
         "voicing.density": "2-note octave pair — melody + note one octave below",
         "arrangement.add_element": "mute intervening string with first finger"
       },
-      "preference": "use liberally; especially powerful in contrast with chordal passages",
+      "preference": 1,
       "quality_binding": [
-        "melodic power",
-        "textural contrast"
+        "any"
       ],
       "falsifier": "Octave technique that produces muddier sound than single-note melody in a specific high-register passage",
       "anchor": "Octaves are a case of doubling the melody one octave down.",
@@ -3336,7 +3725,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Arpeggiation, Octaves, and Diads",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melodic power",
+        "textural contrast"
+      ]
     },
     {
       "rule_id": "laukens-octave-muting-technique",
@@ -3349,10 +3742,9 @@
       "then": {
         "arrangement.add_element": "first finger lightly touches intervening string to mute it"
       },
-      "preference": "mandatory technique for clean octave execution on guitar",
+      "preference": 2,
       "quality_binding": [
-        "tonal clarity",
-        "technique correctness"
+        "any"
       ],
       "falsifier": null,
       "anchor": "When playing the octaves, mute the unwanted open string between the octave notes by gently touching the string with your first finger.",
@@ -3362,7 +3754,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Arpeggiation, Octaves, and Diads",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tonal clarity",
+        "technique correctness"
+      ]
     },
     {
       "rule_id": "laukens-octave-strum-vs-pluck",
@@ -3374,10 +3770,9 @@
       "then": {
         "arrangement.add_element": "strum both strings together OR pluck each note individually — choose by feel and context"
       },
-      "preference": "context-dependent; strum = more powerful, pluck = more controlled",
+      "preference": 0,
       "quality_binding": [
-        "dynamic control",
-        "tonal character"
+        "any"
       ],
       "falsifier": null,
       "anchor": "I tend to strum the strings to give them a powerful sound but other guitarists prefer to individually pluck each note - experiment!",
@@ -3387,7 +3782,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Arpeggiation, Octaves, and Diads",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "dynamic control",
+        "tonal character"
+      ]
     },
     {
       "rule_id": "laukens-diads-parallel-3rds",
@@ -3401,11 +3800,9 @@
         "voicing.density": "2-note diad — melody + diatonic 3rd below",
         "voicing.quality": "parallel diatonic 3rds"
       },
-      "preference": "useful for fast passages and transitions; less demanding than full voicings",
+      "preference": 1,
       "quality_binding": [
-        "harmonic suggestion",
-        "playability",
-        "textural variety"
+        "any"
       ],
       "falsifier": "Parallel 3rds creating non-diatonic clashes in minor-key context where 3rds are not adjusted",
       "anchor": "Diads are when you harmonize a line in a parallel interval, usually 3rds or 6ths.",
@@ -3415,7 +3812,12 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Arpeggiation, Octaves, and Diads",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic suggestion",
+        "playability",
+        "textural variety"
+      ]
     },
     {
       "rule_id": "laukens-diads-parallel-6ths",
@@ -3429,10 +3831,9 @@
         "voicing.density": "2-note diad — melody + diatonic 6th below",
         "voicing.quality": "parallel diatonic 6ths"
       },
-      "preference": "alternative to 3rds; 6ths produce warmer, more open sound",
+      "preference": 1,
       "quality_binding": [
-        "harmonic warmth",
-        "textural variety"
+        "any"
       ],
       "falsifier": "Context where 6ths produce thinner sound than 3rds due to string-skip execution difficulty",
       "anchor": "C Major Scale Diads (Harmonized in 6ths)",
@@ -3442,7 +3843,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Arpeggiation, Octaves, and Diads",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic warmth",
+        "textural variety"
+      ]
     },
     {
       "rule_id": "laukens-diads-for-fast-passages",
@@ -3455,10 +3860,9 @@
         "voicing.density": "diad (2-note) rather than full block chord",
         "voicing.quality": "parallel 3rds or 6ths"
       },
-      "preference": "standard up-tempo texture tool; aligns with Barney Kessel's solo approach",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "tempo fidelity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "They are particularly useful for faster-moving tunes when you want some padding underneath a melody without it getting too technically tricky.",
@@ -3468,7 +3872,11 @@
         "chapter_title": "Complete Chord Melody — Module 3: Creating a Chord Melody Arrangement",
         "section_title": "Arpeggiation, Octaves, and Diads",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "tempo fidelity"
+      ]
     },
     {
       "rule_id": "laukens-diad-vs-octave-texture",
@@ -3483,11 +3891,9 @@
         "arrangement.add_element": "inner_harmony_note_below_melody",
         "voicing.density": "two_note_interval"
       },
-      "preference": "Use diads instead of octaves when a softer but richer sound is desired; diads are more harmonically coloured than bare octaves.",
+      "preference": 1,
       "quality_binding": [
-        "authenticity",
-        "richness",
-        "softness"
+        "any"
       ],
       "falsifier": "If the context demands a stark, powerful unison effect, octaves may be preferred over diads.",
       "anchor": "This is an alternative approach to using octaves and is a softer but richer sound, which sounds very authentic in the jazz guitar tradition.",
@@ -3497,7 +3903,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Diads as an Alternative to Octaves",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "authenticity",
+        "richness",
+        "softness"
+      ]
     },
     {
       "rule_id": "laukens-diad-a-section-swap",
@@ -3511,10 +3922,9 @@
         "voicing.shape": "diad",
         "arrangement.add_element": "substitute_octave_with_diad_on_second_pass"
       },
-      "preference": "On the second pass through the A section, swap octaves for diads to add variety.",
+      "preference": 1,
       "quality_binding": [
-        "variety",
-        "authenticity"
+        "any"
       ],
       "falsifier": "If the song only has one pass through the A section, this swap cannot apply.",
       "anchor": "the second line has swapped in diads instead of octaves",
@@ -3524,7 +3934,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Diads as an Alternative to Octaves",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "variety",
+        "authenticity"
+      ]
     },
     {
       "rule_id": "laukens-walking-bass-root-beat1",
@@ -3537,10 +3951,9 @@
       "then": {
         "bass.line_pattern": "root_on_beat_1"
       },
-      "preference": "Always place the chord root on beat 1 of each bar as the foundation of a walking bass line.",
+      "preference": 2,
       "quality_binding": [
-        "swing_feel",
-        "rhythmic_anchor"
+        "any"
       ],
       "falsifier": "If the arrangement uses a displaced bass entry (anacrusis/pickup), root may not fall on beat 1.",
       "anchor": "Place the root on beat 1 of each bar",
@@ -3550,7 +3963,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Walking Bass Techniques",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "swing_feel",
+        "rhythmic_anchor"
+      ]
     },
     {
       "rule_id": "laukens-walking-bass-beat4-approach",
@@ -3564,10 +3981,9 @@
         "bass.line_pattern": "approach_note_beat_4_to_next_root",
         "walking_bass.pattern": "diatonic_or_chromatic_step_above_or_below_following_root"
       },
-      "preference": "On beat 4, place a diatonic or chromatic note that approaches (from above or below) the root of the next bar.",
+      "preference": 1,
       "quality_binding": [
-        "forward_motion",
-        "swing_feel"
+        "any"
       ],
       "falsifier": "If the tempo is too fast or the melody occupies beat 4, the approach note may be omitted.",
       "anchor": "Now add either a diatonic or chromatic note on beat 4, above or below the following root note",
@@ -3577,7 +3993,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Walking Bass Techniques",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "forward_motion",
+        "swing_feel"
+      ]
     },
     {
       "rule_id": "laukens-walking-bass-fill-beats23",
@@ -3591,10 +4011,9 @@
         "bass.line_pattern": "fill_inner_beats_diatonic_chromatic_or_arpeggio",
         "walking_bass.pattern": "root(1)_fill(2)_fill(3)_approach(4)"
       },
-      "preference": "Complete the four-beat walking line by filling beats 2 and 3 with diatonic scale notes, chromatic passing tones, or arpeggio tones from the current chord.",
+      "preference": 1,
       "quality_binding": [
-        "melodic_bass_line",
-        "four_beat_drive"
+        "any"
       ],
       "falsifier": "In a two-beat or cut-time feel, beats 2 and 3 may not receive individual bass notes.",
       "anchor": "To complete your walking bassline, you just need to add two more notes in between the root note of beat 1, and the approach note of beat 4. These can be any of the following: Diatonic notes from the scale of the given key. Chromatic notes, or Arpeggios.",
@@ -3604,7 +4023,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Walking Bass Techniques",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "melodic_bass_line",
+        "four_beat_drive"
+      ]
     },
     {
       "rule_id": "laukens-walking-bass-shell-voicing-overlay",
@@ -3618,10 +4041,9 @@
         "voicing.shape": "shell_voicing",
         "arrangement.add_element": "shell_voicing_on_root_of_each_bar"
       },
-      "preference": "Once the four-beat walking line is established, layer shell voicings on the root note of each bar to add harmonic content.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_fullness",
-        "jazz_authenticity"
+        "any"
       ],
       "falsifier": "If the texture is deliberately sparse or the melody is very active, shell voicings may be dropped.",
       "anchor": "Now you can add shell voicings on the root notes on each bar.",
@@ -3631,7 +4053,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Walking Bass Techniques",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_fullness",
+        "jazz_authenticity"
+      ]
     },
     {
       "rule_id": "laukens-shell-voicing-downbeat-vs-and-of-1",
@@ -3645,10 +4071,9 @@
         "voicing.density": "shell_voicing",
         "fill.placement": "downbeat_or_and_of_1_mixed"
       },
-      "preference": "Alternate shell voicing attacks between the downbeat (beat 1) and the '& of 1' (the upbeat after beat 1) to create rhythmic variety.",
+      "preference": 1,
       "quality_binding": [
-        "rhythmic_variety",
-        "swing_feel"
+        "any"
       ],
       "falsifier": "If a strict, metronomic feel is required, always placing on the downbeat may be preferred.",
       "anchor": "It's good to mix up playing them on the downbeat and on the '& of 1' to create variety",
@@ -3658,7 +4083,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Walking Bass Techniques",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "rhythmic_variety",
+        "swing_feel"
+      ]
     },
     {
       "rule_id": "laukens-walking-bass-joe-pass-substitute-section",
@@ -3672,10 +4101,9 @@
         "bass.line_pattern": "full_section_walking_bass_only",
         "arrangement.add_element": "omit_melody_play_walking_bass_entire_section"
       },
-      "preference": "Following Joe Pass's approach, occasionally swap out an entire section's melody and chords and play only walking bass to provide contrast.",
+      "preference": 1,
       "quality_binding": [
-        "contrast",
-        "dynamic_variety"
+        "any"
       ],
       "falsifier": "If the melody is the primary feature throughout, this wholesale substitution would be inappropriate.",
       "anchor": "Joe Pass would often swap out an entire section of the melody and only play walking bass, as a way to provide some contrast from the constant melody & chords.",
@@ -3685,7 +4113,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Walking Bass Techniques",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "contrast",
+        "dynamic_variety"
+      ]
     },
     {
       "rule_id": "laukens-walking-bass-fill-long-melody-notes",
@@ -3699,11 +4131,9 @@
         "bass.line_pattern": "walking_bass_under_sustained_melody",
         "fill.placement": "under_long_melody_note"
       },
-      "preference": "When a melody note is held for multiple beats or bars, deploy walking bass beneath it to maintain rhythmic drive and swing.",
+      "preference": 1,
       "quality_binding": [
-        "drive",
-        "swing",
-        "forward_motion"
+        "any"
       ],
       "falsifier": "If a still, meditative texture is desired under a long note, walking bass would be inappropriate.",
       "anchor": "Notice how the walking bass is used to fill out sections where there is a long-held melody note — this helps keep the drive and swing moving.",
@@ -3713,7 +4143,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Walking Bass Techniques",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "drive",
+        "swing",
+        "forward_motion"
+      ]
     },
     {
       "rule_id": "laukens-walking-bass-turnaround-energy",
@@ -3727,11 +4162,9 @@
         "bass.line_pattern": "walking_bass_through_turnaround",
         "fill.placement": "end_of_A_section_turnaround"
       },
-      "preference": "Walking bass is particularly effective over the I–vi–ii–V turnaround at the end of the A section, where the rapid chord changes create natural walking targets.",
+      "preference": 1,
       "quality_binding": [
-        "energy",
-        "swing",
-        "jazz_authenticity"
+        "any"
       ],
       "falsifier": "If the turnaround is played rubato or very slowly, walking bass may not suit the feel.",
       "anchor": "It's particularly effective towards the end of the A Section with that I vi ii V turnaround progression",
@@ -3741,7 +4174,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Walking Bass Techniques",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "energy",
+        "swing",
+        "jazz_authenticity"
+      ]
     },
     {
       "rule_id": "laukens-passing-chord-diatonic-option",
@@ -3755,11 +4193,9 @@
         "voicing.shape": "chord_dictionary_voicing",
         "arrangement.add_element": "harmonize_additional_diatonic_melody_notes"
       },
-      "preference": "For diatonic melody notes that need harmonization beyond the primary chord points, use voicings from the chord dictionary; moving voicings through a melody line creates a special effect.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_richness",
-        "special_effect",
-        "completeness"
+        "any"
       ],
       "falsifier": "If the melody note is non-diatonic (accidental), the chord dictionary alone cannot provide harmonization.",
       "anchor": "If you see extra notes you want to harmonize in the melody, and the notes are diatonic, you already have what you need from this course. Simply use voicings from the chord dictionary provided in Appendix 1 to harmonize the melody at additional points.",
@@ -3769,7 +4205,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Passing Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_richness",
+        "special_effect",
+        "completeness"
+      ]
     },
     {
       "rule_id": "laukens-passing-chord-moving-voicings-effect",
@@ -3783,10 +4224,9 @@
         "voicing.shape": "successive_chord_dictionary_voicings",
         "arrangement.add_element": "harmonize_each_melody_note_with_matching_voicing"
       },
-      "preference": "Harmonizing multiple consecutive melody notes with individual voicings creates a cool special effect, even if technically complex.",
+      "preference": 1,
       "quality_binding": [
-        "special_effect",
-        "harmonic_density"
+        "any"
       ],
       "falsifier": "If tempo is too fast to execute individual voicings per note, this technique becomes impractical.",
       "anchor": "Although this can make things tricky, the voicings moving through a melody line creates a very cool special effect",
@@ -3796,7 +4236,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Passing Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "special_effect",
+        "harmonic_density"
+      ]
     },
     {
       "rule_id": "laukens-passing-chord-chromatic-approach",
@@ -3810,10 +4254,9 @@
         "voicing.shape": "same_voicing_one_fret_away",
         "arrangement.add_element": "chromatic_approach_chord_before_target"
       },
-      "preference": "When an approach (chromatic/accidental) note appears in the melody, play the target chord voicing then the identical voicing shifted one fret in the direction of the approach note.",
+      "preference": 1,
       "quality_binding": [
-        "chromatic_color",
-        "smooth_voice_leading"
+        "any"
       ],
       "falsifier": "If the approach note is diatonic, the chromatic one-fret shift may clash with the underlying harmony.",
       "anchor": "you can use a voicing on the note being approached, then play the same voicing one fret away for the approach note in the melody",
@@ -3823,7 +4266,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Passing Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "chromatic_color",
+        "smooth_voice_leading"
+      ]
     },
     {
       "rule_id": "laukens-passing-chord-chromatic-good-choice-approach-note",
@@ -3837,10 +4284,9 @@
         "voicing.shape": "chromatic_approach_voicing",
         "fill.placement": "on_approach_note_beat"
       },
-      "preference": "Chromatic approach chords are the best choice specifically when the melody contains an approach note (e.g., bars 4 and 6 of There Is No Greater Love).",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_fit",
-        "idiomatic_jazz"
+        "any"
       ],
       "falsifier": "If the melody moves in purely diatonic steps with no chromatic approach tones, this technique is unnecessary.",
       "anchor": "This is a good choice if you have an approach note in the melody, as is the case in There Is No Greater Love on the 4th and 6th bars",
@@ -3850,7 +4296,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Passing Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_fit",
+        "idiomatic_jazz"
+      ]
     },
     {
       "rule_id": "laukens-passing-chord-combination",
@@ -3864,10 +4314,9 @@
         "voicing.shape": "mixed_diatonic_and_chromatic_voicings",
         "arrangement.add_element": "combine_both_passing_chord_options"
       },
-      "preference": "For a complete phrase with both diatonic and non-diatonic melody notes, combine option 1 (chord dictionary) and option 2 (chromatic approach) as appropriate note-by-note.",
+      "preference": 1,
       "quality_binding": [
-        "completeness",
-        "harmonic_sophistication"
+        "any"
       ],
       "falsifier": "If the phrase is entirely diatonic or entirely chromatic, only one technique is needed.",
       "anchor": "Here's what the full 8 bars would sound like using a combination of the above passing chord techniques",
@@ -3877,7 +4326,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Passing Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "completeness",
+        "harmonic_sophistication"
+      ]
     },
     {
       "rule_id": "laukens-arpeggiation-fill-slow-ballad",
@@ -3891,11 +4344,9 @@
         "fill.placement": "between_melody_notes",
         "arrangement.add_element": "arpeggio_fill_under_sustained_melody"
       },
-      "preference": "In slow ballads with long gaps between melody notes, fill those spaces with arpeggiation of the underlying chord to maintain interest and motion.",
+      "preference": 1,
       "quality_binding": [
-        "continuity",
-        "interest",
-        "ballad_texture"
+        "any"
       ],
       "falsifier": "In up-tempo arrangements, arpeggiation fills may clutter the texture; use rhythmic punches instead.",
       "anchor": "This rendition is a good example of using arpeggiation to fill in the long spaces between each melody note in this slow ballad.",
@@ -3905,7 +4356,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Solo Guitar Arrangement Examples",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "continuity",
+        "interest",
+        "ballad_texture"
+      ]
     },
     {
       "rule_id": "laukens-diad-support-melody",
@@ -3920,11 +4376,9 @@
         "voicing.density": "two_note",
         "arrangement.add_element": "inner_harmony_below_melody"
       },
-      "preference": "Diads are used frequently throughout an arrangement to provide harmonic support to the melody line without the weight of full chord voicings.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_support",
-        "lightness",
-        "authenticity"
+        "any"
       ],
       "falsifier": "If a thick, chordal sound is specifically desired, full voicings replace diads.",
       "anchor": "Diads are also used frequently to provide support to the melody line.",
@@ -3934,7 +4388,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Solo Guitar Arrangement Examples",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_support",
+        "lightness",
+        "authenticity"
+      ]
     },
     {
       "rule_id": "laukens-big-band-emulation-melody-breaks",
@@ -3948,11 +4407,9 @@
         "voicing.shape": "octave_or_diad_punches",
         "arrangement.add_element": "big_band_section_emulation_at_breaks"
       },
-      "preference": "In up-tempo arrangements, emulate the big band brass section sound during melody breaks by using strong octaves or diads in rhythmically punchy figures.",
+      "preference": 1,
       "quality_binding": [
-        "energy",
-        "authenticity",
-        "big_band_feel"
+        "any"
       ],
       "falsifier": "In introspective or ballad arrangements, big-band emulation would be stylistically incongruous.",
       "anchor": "Notice how the big band section is being emulated in the melody breaks as per the original.",
@@ -3962,7 +4419,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Solo Guitar Arrangement Examples",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "energy",
+        "authenticity",
+        "big_band_feel"
+      ]
     },
     {
       "rule_id": "laukens-rhythm-manipulation-fretboard-jumps",
@@ -3975,10 +4437,9 @@
       "then": {
         "arrangement.add_element": "modify_melody_rhythm_to_allow_position_shift"
       },
-      "preference": "When a melody note requires a large jump across the fretboard, adapt the rhythmic value of surrounding notes to give the fretting hand time to shift position without disrupting the musical line.",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "musical_continuity"
+        "any"
       ],
       "falsifier": "If the original rhythm is sacrosanct (e.g., in a faithful transcription), rhythm manipulation is inappropriate.",
       "anchor": "I needed to manipulate the rhythm of the melody in places to facilitate easier jumps across the fretboard.",
@@ -3988,7 +4449,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Solo Guitar Arrangement Examples",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "playability",
+        "musical_continuity"
+      ]
     },
     {
       "rule_id": "laukens-learn-example-arrangements-internalize",
@@ -4000,10 +4465,9 @@
       "then": {
         "arrangement.add_element": "learn_full_arrangement_examples_hands_on"
       },
-      "preference": "Actually learning complete arrangement examples ('getting hands dirty') is one of the best ways to internalize arranging techniques for transfer to original work.",
+      "preference": 1,
       "quality_binding": [
-        "skill_transfer",
-        "internalization"
+        "any"
       ],
       "falsifier": "Purely analytical study without physical practice is less effective for technique internalization.",
       "anchor": "it would be very beneficial to actually learn these arrangements - getting your 'hands dirty' with some examples is one of the best ways to internalize the techniques that are being used",
@@ -4013,7 +4477,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Solo Guitar Arrangement Examples",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "skill_transfer",
+        "internalization"
+      ]
     },
     {
       "rule_id": "laukens-tritone-sub-dominant",
@@ -4027,11 +4495,9 @@
         "voicing.shape": "dominant_7_tritone_away",
         "arrangement.add_element": "replace_V7_with_bII7"
       },
-      "preference": "Replace any dominant 7 chord with the dominant 7 chord whose root is a tritone (6 semitones) away; this is the single most impactful substitution in jazz arranging.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_color",
-        "jazz_authenticity",
-        "classic_jazz_sound"
+        "any"
       ],
       "falsifier": "If the root-movement logic of the original progression is critical (e.g., pedagogical context), substitution would obscure it.",
       "anchor": "Tritone substitution is the process of substituting one chord for another a tritone away.",
@@ -4041,7 +4507,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_color",
+        "jazz_authenticity",
+        "classic_jazz_sound"
+      ]
     },
     {
       "rule_id": "laukens-tritone-guide-tones-swap",
@@ -4055,10 +4526,9 @@
         "voicing.shape": "same_guide_tones_root_changed",
         "arrangement.add_element": "note_3rd_and_7th_swap_between_original_and_sub"
       },
-      "preference": "Recognize that tritone-related dominants share the same 3rd and 7th (guide tones), merely swapping roles — this is the acoustic reason the substitution works.",
+      "preference": 1,
       "quality_binding": [
-        "voice_leading_smoothness",
-        "harmonic_validity"
+        "any"
       ],
       "falsifier": null,
       "anchor": "C7 has E as the 3rd and Bb as the 7th. F#7 has E as the 7th and A# (which is the same as Bb) as the 3rd. The guide tones have essentially swapped places between these two chords.",
@@ -4068,7 +4538,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "voice_leading_smoothness",
+        "harmonic_validity"
+      ]
     },
     {
       "rule_id": "laukens-tritone-sub-non-dominant",
@@ -4082,10 +4556,9 @@
         "voicing.shape": "chord_root_tritone_away_any_quality",
         "arrangement.add_element": "tritone_distance_sub_non_dominant"
       },
-      "preference": "Although tritone substitution strictly applies to dominants, experiment with major and minor chords a tritone away — they can create great effects even if not technically tritone substitution.",
+      "preference": 0,
       "quality_binding": [
-        "experimental_color",
-        "harmonic_adventure"
+        "any"
       ],
       "falsifier": "If the non-dominant tritone sub creates unacceptable dissonance against the melody, revert to original.",
       "anchor": "Although this isn't a tritone substitution in the strictest sense (the term usually applied to dominant chords), you can often create great effects by experimenting with major and minor chords as well.",
@@ -4095,7 +4568,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "experimental_color",
+        "harmonic_adventure"
+      ]
     },
     {
       "rule_id": "laukens-tritone-sub-maj7-quality-change",
@@ -4109,10 +4586,9 @@
         "chord_quality": "major_7",
         "voicing.shape": "maj7_on_tritone_sub_root"
       },
-      "preference": "After placing a dominant tritone sub, experiment with raising the sub to maj7 quality for a softer, more colorful sound.",
+      "preference": 0,
       "quality_binding": [
-        "softness",
-        "harmonic_color"
+        "any"
       ],
       "falsifier": "If a strong dominant pull is needed (e.g., approaching a cadence), maj7 quality weakens the resolution.",
       "anchor": "Let's see what happens if we make that chord an Emaj7 instead",
@@ -4122,7 +4598,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "softness",
+        "harmonic_color"
+      ]
     },
     {
       "rule_id": "laukens-tritone-sub-all-maj7",
@@ -4136,10 +4616,9 @@
         "chord_quality": "all_maj7_quality_on_substitutes",
         "arrangement.add_element": "full_maj7_substitute_progression"
       },
-      "preference": "As an advanced experiment, change all tritone substitutes to maj7 chords to create a lush, harmonically rich reharmonization of the entire passage.",
+      "preference": 0,
       "quality_binding": [
-        "lushness",
-        "harmonic_sophistication"
+        "any"
       ],
       "falsifier": "If the song is interpreted with a traditional harmonic language, all-maj7 subs would sound too modernist.",
       "anchor": "Let's try making ALL the substitute chords maj7 now",
@@ -4149,7 +4628,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "lushness",
+        "harmonic_sophistication"
+      ]
     },
     {
       "rule_id": "laukens-tritone-sub-beat1-plus-later-beat",
@@ -4163,10 +4646,9 @@
         "fill.placement": "beat_1_original_chord_then_tritone_sub_on_inner_beat",
         "arrangement.add_element": "original_chord_beat1_tritone_sub_later_beat"
       },
-      "preference": "Play the original chord on beat 1 and introduce the tritone substitution on a later beat within the same bar; this often sounds more natural to the ear than replacing beat 1 outright.",
+      "preference": 1,
       "quality_binding": [
-        "naturalness",
-        "ear_friendliness"
+        "any"
       ],
       "falsifier": "If the tritone sub chord carries the melody on beat 1, it must fall on beat 1.",
       "anchor": "Another option is to play the original chord on beat 1, then add the tritone substitution later in the bar on other melody notes (this often makes more sense to the ears)",
@@ -4176,7 +4658,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "naturalness",
+        "ear_friendliness"
+      ]
     },
     {
       "rule_id": "laukens-tritone-sub-solo-guitar-freedom",
@@ -4188,10 +4674,9 @@
       "then": {
         "arrangement.add_element": "liberal_tritone_substitution_throughout"
       },
-      "preference": "In solo guitar contexts, tritone and other substitutions can be used liberally because there are no other musicians to clash with over the chord changes.",
+      "preference": 1,
       "quality_binding": [
-        "freedom",
-        "harmonic_adventure"
+        "any"
       ],
       "falsifier": "When playing with a rhythm section or other musicians who expect standard changes, liberal substitution causes ensemble clashes.",
       "anchor": "When it comes to solo guitar, you have the freedom to do these kinds of substitutions liberally as it's just you on stage.",
@@ -4201,7 +4686,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "freedom",
+        "harmonic_adventure"
+      ]
     },
     {
       "rule_id": "laukens-tritone-sub-subtlety-rule",
@@ -4213,11 +4702,9 @@
       "then": {
         "arrangement.add_element": "use_substitution_occasionally_not_constantly"
       },
-      "preference": "Keep arrangements simple most of the time, adding substitutions occasionally to brighten things; overuse is the equivalent of adding too much spice to a curry.",
+      "preference": 1,
       "quality_binding": [
-        "subtlety",
-        "taste",
-        "balance"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Keeping things simple most of the time and just adding a substitution occasionally to brighten up the arrangement is the approach I find works best — a good arrangement is all about subtlety!",
@@ -4227,7 +4714,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "subtlety",
+        "taste",
+        "balance"
+      ]
     },
     {
       "rule_id": "laukens-tritone-find-six-frets-up",
@@ -4239,10 +4731,9 @@
       "then": {
         "voicing.shape": "root_6_frets_higher_or_lower"
       },
-      "preference": "To locate the tritone substitute root on the guitar, move up (or down) 6 frets from the original chord root — both directions arrive at the same pitch class.",
+      "preference": 1,
       "quality_binding": [
-        "practicality",
-        "fretboard_navigation"
+        "any"
       ],
       "falsifier": null,
       "anchor": "To find a tritone, start with a note then move upwards 3 tones (which equals 3 whole steps or 6 frets).",
@@ -4252,7 +4743,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #1 — Tritone Substitution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "practicality",
+        "fretboard_navigation"
+      ]
     },
     {
       "rule_id": "laukens-relative-sub-I-to-vi",
@@ -4266,11 +4761,9 @@
         "voicing.shape": "minor_7_vi_chord",
         "arrangement.add_element": "replace_I_with_vi"
       },
-      "preference": "Replace the tonic major chord (I) with the vi minor chord of the same key; they share all key signature notes and function interchangeably.",
+      "preference": 1,
       "quality_binding": [
-        "freshness",
-        "minor_color",
-        "avoids_static_tonic"
+        "any"
       ],
       "falsifier": "If the bass player is outlining the I chord root, replacing with vi creates a harmonic clash.",
       "anchor": "Rule: you can replace the I chord of a key with the vi chord of the key.",
@@ -4280,7 +4773,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #2 — Major Chords to Minor Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "freshness",
+        "minor_color",
+        "avoids_static_tonic"
+      ]
     },
     {
       "rule_id": "laukens-relative-sub-shared-key-sig",
@@ -4292,10 +4790,9 @@
       "then": {
         "arrangement.add_element": "substitute_major_chord_with_relative_minor"
       },
-      "preference": "Because relative major and minor keys share identical pitch content, their chords can substitute freely for one another.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_validity",
-        "color_change"
+        "any"
       ],
       "falsifier": null,
       "anchor": "If these two keys have the same notes, you can often substitute the chords from those keys for each other. We call this a relative substitution.",
@@ -4305,7 +4802,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #2 — Major Chords to Minor Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_validity",
+        "color_change"
+      ]
     },
     {
       "rule_id": "laukens-sub-I-to-iii-avoid-static-root",
@@ -4320,11 +4821,9 @@
         "voicing.shape": "minor_7_iii_chord",
         "arrangement.add_element": "replace_I_with_iii_for_bass_movement"
       },
-      "preference": "When the tonic chord is static across multiple bars, substitute chord iii (e.g., Bm7 for Gmaj7) to get away from constant root-tone bass and provide bass-line movement.",
+      "preference": 1,
       "quality_binding": [
-        "bass_motion",
-        "freshness",
-        "avoids_staleness"
+        "any"
       ],
       "falsifier": "If the tonic root is the melodic foundation of the section, moving away from it harmonically may destabilize the melody.",
       "anchor": "These kinds of substitutions are great to use as it gets you away from being stuck with the root tone in the bass the whole time, which can get a bit stale after a while.",
@@ -4334,7 +4833,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #2 — Major Chords to Minor Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "bass_motion",
+        "freshness",
+        "avoids_staleness"
+      ]
     },
     {
       "rule_id": "laukens-chord-I-to-iii-rule",
@@ -4348,10 +4852,9 @@
         "voicing.shape": "minor_7_on_third_degree",
         "arrangement.add_element": "iii_chord_substitution"
       },
-      "preference": "Any major chord can be substituted by the minor 7 chord built on the 3rd degree of that major chord's key (e.g., Gmaj7 → Bm7).",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_color",
-        "upper_structure"
+        "any"
       ],
       "falsifier": "If the melody note is the root of the original major chord, the iii chord substitution changes the bass note but must still support the melody.",
       "anchor": "Rule: you can substitute a major chord for chord iii of its key.",
@@ -4361,7 +4864,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #2 — Major Chords to Minor Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_color",
+        "upper_structure"
+      ]
     },
     {
       "rule_id": "laukens-chord-addition-extra-chords",
@@ -4375,11 +4882,9 @@
         "arrangement.add_element": "add_vi_or_iii_chord_alongside_original",
         "fill.placement": "second_bar_of_sustained_chord"
       },
-      "preference": "Rather than replacing the original chord entirely, add a vi or iii substitute chord in the second bar of a prolonged harmonic area, creating chord addition rather than pure substitution.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_interest",
-        "motion",
-        "energy"
+        "any"
       ],
       "falsifier": "If the harmonic rhythm is already fast, adding extra chords will crowd the progression.",
       "anchor": "This process is referred to as chord addition — adding extra chords to the harmony.",
@@ -4389,7 +4894,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #2 — Major Chords to Minor Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_interest",
+        "motion",
+        "energy"
+      ]
     },
     {
       "rule_id": "laukens-major-minor-sub-solo-energy",
@@ -4401,11 +4911,9 @@
       "then": {
         "arrangement.add_element": "major_to_minor_substitution_for_motion"
       },
-      "preference": "Keeping things fresh and moving through major-to-minor substitutions is part of the solo jazz guitarist's core role.",
+      "preference": 1,
       "quality_binding": [
-        "freshness",
-        "motion",
-        "interest"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Keeping things fresh and moving is your job as a solo jazz guitarist.",
@@ -4415,7 +4923,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #2 — Major Chords to Minor Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "freshness",
+        "motion",
+        "interest"
+      ]
     },
     {
       "rule_id": "laukens-minor-for-dominant-rule",
@@ -4429,11 +4942,9 @@
         "voicing.shape": "minor_7_on_5th_of_dominant",
         "arrangement.add_element": "replace_V7_with_iim7_of_V"
       },
-      "preference": "Replace a dominant 7 chord with the minor 7 chord built on the 5th of that dominant (its iim7); they share nearly identical notes and function interchangeably.",
+      "preference": 1,
       "quality_binding": [
-        "minor_color",
-        "harmonic_interest",
-        "Pat_Martino_sound"
+        "any"
       ],
       "falsifier": "If the tritone resolution voice-leading of the dominant 7 is critical to the passage, replacing it with iim7 removes that tension.",
       "anchor": "You can use a minor 7 chord from the 5th of any dominant chord (which is like using the iim7 that belongs to the dominant chord).",
@@ -4443,7 +4954,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #3 — Minor 7th for Dominant 7th",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "minor_color",
+        "harmonic_interest",
+        "Pat_Martino_sound"
+      ]
     },
     {
       "rule_id": "laukens-ii-v-interchangeable-joe-pass",
@@ -4456,10 +4972,9 @@
       "then": {
         "arrangement.add_element": "swap_ii_for_V_or_V_for_ii_freely"
       },
-      "preference": "Because ii and V differ by only one note, follow Joe Pass's practice of interchanging them freely to create variety over either chord.",
+      "preference": 1,
       "quality_binding": [
-        "variety",
-        "Joe_Pass_style"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Joe Pass would often mention that the ii and the V chord can be interchanged with one another, and this is the reason - they are very similar in their construction.",
@@ -4469,7 +4984,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #3 — Minor 7th for Dominant 7th",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "variety",
+        "Joe_Pass_style"
+      ]
     },
     {
       "rule_id": "laukens-minor-dominant-embellish-long-dominant",
@@ -4483,11 +5002,9 @@
         "arrangement.add_element": "alternate_ii_and_V_chords_over_dominant_area",
         "fill.placement": "within_dominant_chord_duration"
       },
-      "preference": "Over a long dominant chord, move between the ii and V chord to prevent stagnation and create more energy.",
+      "preference": 1,
       "quality_binding": [
-        "energy",
-        "motion",
-        "avoids_stagnation"
+        "any"
       ],
       "falsifier": "If the dominant is very brief (one beat), oscillation is not practical.",
       "anchor": "By moving chords between ii and V instead of sticking just to the V chord, you can help the music sound less stagnant.",
@@ -4497,7 +5014,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #3 — Minor 7th for Dominant 7th",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "energy",
+        "motion",
+        "avoids_stagnation"
+      ]
     },
     {
       "rule_id": "laukens-minor-dominant-any-chord-as-V",
@@ -4510,10 +5032,9 @@
       "then": {
         "arrangement.add_element": "treat_any_dominant_as_local_V_find_its_ii"
       },
-      "preference": "Even if a dominant chord is not the V7 of the overall key, temporarily treat it as a local V and find its ii chord for substitution.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_flexibility",
-        "local_ii_V_thinking"
+        "any"
       ],
       "falsifier": null,
       "anchor": "Even if it's not the V7 chord of the overall key of the tune, I can pretend for a moment that it is chord V, then think of what the ii chord would be in its key.",
@@ -4523,7 +5044,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #3 — Minor 7th for Dominant 7th",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_flexibility",
+        "local_ii_V_thinking"
+      ]
     },
     {
       "rule_id": "laukens-minor-dominant-triplet-joe-pass-style",
@@ -4537,11 +5062,9 @@
         "arrangement.add_element": "triplet_rhythm_on_ii_V_exchange",
         "fill.placement": "triplet_on_ii_before_V"
       },
-      "preference": "Apply a Joe Pass-style triplet rhythmic figure when oscillating between ii and V chords for an authentic bebop jazz feel.",
+      "preference": 1,
       "quality_binding": [
-        "bebop_feel",
-        "rhythmic_interest",
-        "Joe_Pass_style"
+        "any"
       ],
       "falsifier": "If the arrangement is a ballad or rubato, a triplet figure may disrupt the feel.",
       "anchor": "Let's add this 'ii V' effect on bar 8 as well, this time with a cool Joe Pass style triplet rhythm.",
@@ -4551,7 +5074,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #3 — Minor 7th for Dominant 7th",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "bebop_feel",
+        "rhythmic_interest",
+        "Joe_Pass_style"
+      ]
     },
     {
       "rule_id": "laukens-minor-conversion-any-chord",
@@ -4565,11 +5093,9 @@
         "voicing.shape": "minor_7_substitute",
         "arrangement.add_element": "minor_conversion_substitution"
       },
-      "preference": "Following Pat Martino's minor conversion concept, any chord in any progression can theoretically be substituted with a minor chord — keep this as a broad creative option.",
+      "preference": 0,
       "quality_binding": [
-        "harmonic_flexibility",
-        "minor_color",
-        "Pat_Martino_concept"
+        "any"
       ],
       "falsifier": "Not all minor substitutions will produce musically effective results; ear-test each case.",
       "anchor": "Pat Martino was a great proponent of what's known as the 'minor conversion concept' - a theory that any chord you see in a progression could be substituted for a minor chord instead.",
@@ -4579,7 +5105,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #3 — Minor 7th for Dominant 7th",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_flexibility",
+        "minor_color",
+        "Pat_Martino_concept"
+      ]
     },
     {
       "rule_id": "laukens-backcycle-definition",
@@ -4592,11 +5123,9 @@
         "arrangement.add_element": "prepend_chords_a_4th_apart_leading_to_target",
         "walking_bass.pattern": "root_movement_by_4th_toward_target"
       },
-      "preference": "Extend the approach to any target chord by prepending one or more chords whose roots move anti-clockwise through the circle of 5ths (i.e., each root a 4th above the last), back-cycling into the target.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_richness",
-        "forward_motion",
-        "jazz_authenticity"
+        "any"
       ],
       "falsifier": "If the harmonic rhythm is already very dense, adding back-cycle chords will crowd the progression.",
       "anchor": "The term 'back cycling' refers to the circle of 5ths … When one cycles anti-clockwise (backward) through the cycle of 5ths, we get a sequence of root tones that are separated by the interval of a 4th.",
@@ -4606,7 +5135,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #4 — Back Cycling",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_richness",
+        "forward_motion",
+        "jazz_authenticity"
+      ]
     },
     {
       "rule_id": "laukens-backcycle-cycle4-root-most-common",
@@ -4618,10 +5152,9 @@
       "then": {
         "bass.line_pattern": "root_movement_up_4th_or_down_5th_as_primary_motion"
       },
-      "preference": "When constructing or analyzing bass lines and chord progressions, recognize that root movement by a 4th (up) or 5th (down) is the most natural and common harmonic motion — back cycling harnesses this.",
+      "preference": 1,
       "quality_binding": [
-        "naturalness",
-        "harmonic_logic"
+        "any"
       ],
       "falsifier": null,
       "anchor": "This cycle of root notes a 4th apart is the most common root movement in Western music.",
@@ -4631,7 +5164,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #4 — Back Cycling",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "naturalness",
+        "harmonic_logic"
+      ]
     },
     {
       "rule_id": "laukens-backcycle-ii-V-I-as-back-cycle-example",
@@ -4643,10 +5180,9 @@
       "then": {
         "arrangement.add_element": "understand_ii_V_I_as_3_step_back_cycle"
       },
-      "preference": "Understand ii–V–I as a three-chord back-cycle (Dm7 → G7 → Cmaj7 moves by 4ths); this insight allows extension of any target chord approach by further back-cycling.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_insight",
-        "structural_understanding"
+        "any"
       ],
       "falsifier": null,
       "anchor": "In fact, a ii V I progression is an example of this 'cycle 4 root movement'",
@@ -4656,7 +5192,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #4 — Back Cycling",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_insight",
+        "structural_understanding"
+      ]
     },
     {
       "rule_id": "laukens-backcycle-as-substitution-device",
@@ -4668,11 +5208,9 @@
       "then": {
         "arrangement.add_element": "insert_back_cycle_chords_before_target"
       },
-      "preference": "Back cycling is a common substitution device for solo jazz guitarists to create more interest in a chord progression by extending dominant motion toward a resolution.",
+      "preference": 1,
       "quality_binding": [
-        "interest",
-        "harmonic_sophistication",
-        "jazz_authenticity"
+        "any"
       ],
       "falsifier": "If the original harmonic progression is already fast-moving, back cycling may over-complicate it.",
       "anchor": "'Back cycling' is another common form of substitution that solo jazz guitarists use to create more interest in a chord progression.",
@@ -4682,7 +5220,12 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #4 — Back Cycling",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "interest",
+        "harmonic_sophistication",
+        "jazz_authenticity"
+      ]
     },
     {
       "rule_id": "laukens-backcycle-in-jazz-standards",
@@ -4694,10 +5237,9 @@
       "then": {
         "arrangement.add_element": "identify_back_cycle_sequences_in_lead_sheet"
       },
-      "preference": "When analyzing a jazz standard, look for back-cycling sequences (strings of dominants or ii–V pairs moving by 4ths) — these are common structural features to highlight or embellish in an arrangement.",
+      "preference": 1,
       "quality_binding": [
-        "harmonic_awareness",
-        "arrangement_insight"
+        "any"
       ],
       "falsifier": null,
       "anchor": "You will also see this harmonic device used liberally in common jazz standards.",
@@ -4707,7 +5249,11 @@
         "chapter_title": "Module 4 — Arranging for Solo Guitar",
         "section_title": "Substitution Approach #4 — Back Cycling",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_awareness",
+        "arrangement_insight"
+      ]
     },
     {
       "rule_id": "laukens-back-cycling-cycle4",
@@ -4721,7 +5267,7 @@
         "chord_symbol.substitute": "cycle4_chain_before_target",
         "reharm.target": "any_chord"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -4746,7 +5292,7 @@
         "chord_symbol.substitute": "extend_cycle4_chain_before_ii",
         "reharm.target": "the_ii_V_pair"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "dom7"
       ],
@@ -4770,7 +5316,7 @@
       "then": {
         "chord_symbol.substitute": "cycle4_chain"
       },
-      "preference": "preferred_for_inside_energy",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -4793,7 +5339,7 @@
       "then": {
         "chord_symbol.substitute": "none_use_original_chart"
       },
-      "preference": "avoid",
+      "preference": -1,
       "quality_binding": [
         "any"
       ],
@@ -4816,7 +5362,7 @@
       "then": {
         "chord_symbol.substitute": "cycle4_chain"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -4841,7 +5387,7 @@
         "chord_symbol.substitute": "chord_containing_melody_note",
         "voicing.shape": "melody_note_on_top"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -4866,7 +5412,7 @@
         "chord_symbol.substitute": "G7",
         "voicing.shape": "G_on_top"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "dom7"
       ],
@@ -4892,7 +5438,7 @@
           "#11"
         ]
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -4915,7 +5461,7 @@
       "then": {
         "chord_symbol.substitute": "complex_common_tone"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -4938,7 +5484,7 @@
       "then": {
         "chord_symbol.substitute": "common_tone_subs"
       },
-      "preference": "recommended_for_modern",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -4962,7 +5508,7 @@
       "then": {
         "arrangement.add_element": "chord_phrase_in_place_of_melody"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -4985,7 +5531,7 @@
       "then": {
         "arrangement.add_element": "prepared_or_spontaneous_chord_phrase"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -5009,7 +5555,7 @@
       "then": {
         "arrangement.add_element": "minor_ii_V_i_lick_in_place_of_melody"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "min7b5",
         "dom7b9",
@@ -5035,7 +5581,7 @@
       "then": {
         "arrangement.add_element": "rubato_push_and_pull"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -5058,7 +5604,7 @@
       "then": {
         "arrangement.add_element": "equal_practice_and_performance_prep"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -5081,7 +5627,7 @@
       "then": {
         "arrangement.add_element": "metronome_every_beat"
       },
-      "preference": "required_first_stage",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -5104,7 +5650,7 @@
       "then": {
         "arrangement.add_element": "metronome_beats_1_3"
       },
-      "preference": "required_second_stage",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -5127,7 +5673,7 @@
       "then": {
         "arrangement.add_element": "metronome_beats_2_4"
       },
-      "preference": "required_final_stage_for_jazz",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -5150,7 +5696,7 @@
       "then": {
         "arrangement.add_element": "steady_rhythm_no_drag"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -5173,7 +5719,7 @@
       "then": {
         "arrangement.add_element": "daily_practice_10_15min"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -5197,7 +5743,7 @@
       "then": {
         "arrangement.add_element": "1_to_2_bars_per_session_slow"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -5220,7 +5766,7 @@
       "then": {
         "arrangement.add_element": "intro_before_head"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -5244,7 +5790,7 @@
       "then": {
         "arrangement.add_element": "single_line_run"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -5280,10 +5826,9 @@
           "b5+b9"
         ]
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "tension_richness",
-        "harmonic_colour"
+        "any"
       ],
       "falsifier": "A dominant voicing that uses a tension not listed here (e.g. natural 13 over #9 simultaneously without b13 resolution) would falsify the completeness claim.",
       "anchor": "TENSIONS & EXTENSIONS ON DOMINANT CHORDS",
@@ -5293,7 +5838,11 @@
         "chapter_title": "Appendix 1 — Chord Dictionaries",
         "section_title": "Tensions & Extensions on Dominant Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tension_richness",
+        "harmonic_colour"
+      ]
     },
     {
       "rule_id": "laukens-shell-voicing-root6",
@@ -5312,10 +5861,9 @@
         "voicing.construction": "shell (root + 3rd + 7th, omit 5th)",
         "voicing.root_string": 6
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_leading",
-        "clarity"
+        "any"
       ],
       "falsifier": "A shell voicing with 5th included on string 6 root would falsify shell definition.",
       "anchor": "Root on the 6th String",
@@ -5325,7 +5873,11 @@
         "chapter_title": "Appendix 1 — Chord Dictionaries",
         "section_title": "Solo Guitar Chord Dictionary — Shell Voicings",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "voice_leading",
+        "clarity"
+      ]
     },
     {
       "rule_id": "laukens-shell-voicing-root5",
@@ -5344,10 +5896,9 @@
         "voicing.construction": "shell (root + 3rd + 7th, omit 5th)",
         "voicing.root_string": 5
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_leading",
-        "clarity"
+        "any"
       ],
       "falsifier": "A shell voicing with 5th present on string 5 root would falsify shell definition.",
       "anchor": "Root on the 5th String",
@@ -5357,7 +5908,11 @@
         "chapter_title": "Appendix 1 — Chord Dictionaries",
         "section_title": "Solo Guitar Chord Dictionary — Shell Voicings",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "voice_leading",
+        "clarity"
+      ]
     },
     {
       "rule_id": "laukens-shell-ext-major-dominant",
@@ -5385,10 +5940,9 @@
           "13"
         ]
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "tension_richness",
-        "harmonic_colour"
+        "any"
       ],
       "falsifier": "An extension not in these lists applied to a shell voicing on string 6 root would falsify.",
       "anchor": "SHELL VOICING EXTENSIONS",
@@ -5398,7 +5952,11 @@
         "chapter_title": "Appendix 1 — Chord Dictionaries",
         "section_title": "Solo Guitar Chord Dictionary — Shell Voicings",
         "level": "paragraph"
-      }
+      },
+      "applicability_reasons": [
+        "tension_richness",
+        "harmonic_colour"
+      ]
     },
     {
       "rule_id": "laukens-finger-naming-convention",
@@ -5416,10 +5974,9 @@
           "c": "pinky (chiquito)"
         }
       },
-      "preference": "invariant",
+      "preference": 2,
       "quality_binding": [
-        "notational_clarity",
-        "technique_precision"
+        "any"
       ],
       "falsifier": null,
       "anchor": "p = thumb (\"pulgar\" in Spanish) / i = index (\"indice\" in Spanish) / m = middle (\"medio\" in Spanish) / a = ring finger (\"anular\" in Spanish) / c = pinky finger (\"chiquito\" in Spanish)",
@@ -5429,7 +5986,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Introduction & Finger Naming",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "notational_clarity",
+        "technique_precision"
+      ]
     },
     {
       "rule_id": "laukens-hand-position-wrist",
@@ -5441,11 +6002,9 @@
       "then": {
         "picking.technique": "wrist naturally curved, aligned with arm, no kinking, hand relaxed, frequent breaks during learning"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "ergonomics",
-        "injury_prevention",
-        "tone_quality"
+        "any"
       ],
       "falsifier": "A flat or overarched wrist, or a wrist kinked at an angle to the arm, falsifies correct placement.",
       "anchor": "Keep the wrist naturally curved in your plucking hand — avoid flatting or overarching the wrist too much. Keep the wrist in alignment with the arm, avoid kinking the wrist at an angle",
@@ -5455,7 +6014,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Introduction & Finger Naming",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "ergonomics",
+        "injury_prevention",
+        "tone_quality"
+      ]
     },
     {
       "rule_id": "laukens-free-stroke-primary",
@@ -5468,10 +6032,9 @@
       "then": {
         "picking.technique": "free_stroke_primary — finger flies freely above strings after pluck; rest stroke used only as introductory learning phase"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "stylistic_appropriateness",
-        "agility"
+        "any"
       ],
       "falsifier": "Habitually using rest stroke as the primary picking motion in a jazz context falsifies this rule.",
       "anchor": "free stroke is a more much more useful for jazz guitar than rest stroke",
@@ -5481,7 +6044,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Rest Stroke vs Free Stroke & Walking Finger Workouts",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "stylistic_appropriateness",
+        "agility"
+      ]
     },
     {
       "rule_id": "laukens-walking-finger-alternation",
@@ -5499,10 +6066,9 @@
           "note": "i–a may yield more speed for some players; practice both and choose"
         }
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "speed",
-        "coordination"
+        "any"
       ],
       "falsifier": "Using only i–m and never practising i–a falsifies the prescribed dual-combination training.",
       "anchor": "I personally have found I get much more speed with alternating i and a, rather than i and m. But everyone's hands are different, so practice both combinations for now",
@@ -5512,7 +6078,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Rest Stroke vs Free Stroke & Walking Finger Workouts",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "speed",
+        "coordination"
+      ]
     },
     {
       "rule_id": "laukens-moonwalker-string-crossing",
@@ -5524,10 +6094,9 @@
       "then": {
         "picking.technique": "alternate i–m or i–a across adjacent strings simultaneously; once fluent, replace separate walking + crossing drills with this single exercise"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "practice_efficiency",
-        "coordination"
+        "any"
       ],
       "falsifier": "Practising walking fingers and string crossing as separate exercises indefinitely instead of merging into Moonwalker falsifies the efficiency rationale.",
       "anchor": "It simultaneously works out walking finger technique and string crossing all at once — saving you practice time.",
@@ -5537,7 +6106,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Rest Stroke vs Free Stroke & Walking Finger Workouts",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "practice_efficiency",
+        "coordination"
+      ]
     },
     {
       "rule_id": "laukens-thumb-bass-role",
@@ -5552,11 +6125,9 @@
           "i_m_a": "upper string melody and inner voices"
         }
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_independence",
-        "clarity",
-        "stylistic_appropriateness"
+        "any"
       ],
       "falsifier": "Using i or m exclusively for bass notes while p plays melody strings falsifies this assignment.",
       "anchor": "the thumb is generally reserved for playing bass notes in chords or to play basslines alongside melodies on the higher strings",
@@ -5566,7 +6137,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Using the Thumb — Thumb Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "voice_independence",
+        "clarity",
+        "stylistic_appropriateness"
+      ]
     },
     {
       "rule_id": "laukens-thumb-motion-3rd-joint",
@@ -5578,11 +6154,9 @@
       "then": {
         "picking.technique": "circular motion from lowest (3rd) joint of thumb — analogous to a paddle on a rowing boat"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "tone_quality",
-        "ergonomics",
-        "control"
+        "any"
       ],
       "falsifier": "Bending only the tip joint of the thumb without engaging the 3rd joint falsifies the prescribed motion.",
       "anchor": "The motion should come from the lowest \"3rd\" joint of the thumb, with a small circular motion as you pluck — similar to the motion of a paddle on a rowing boat.",
@@ -5592,7 +6166,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Using the Thumb — Thumb Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tone_quality",
+        "ergonomics",
+        "control"
+      ]
     },
     {
       "rule_id": "laukens-thumb-exercise-1-scale",
@@ -5607,10 +6186,9 @@
         },
         "picking.technique": "p-only strokes; practice thumb across all strings including treble, for situations requiring thumb on non-bass strings"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "thumb_agility",
-        "range_of_motion"
+        "any"
       ],
       "falsifier": "Restricting thumb strokes to bass strings only during this exercise falsifies its stated purpose of all-string thumb training.",
       "anchor": "Although the thumb is usually reserved for playing bass notes, it's still a good idea to practice thumb strokes over all strings, as there are situations where you'll need to use the thumb like this from time to time.",
@@ -5620,7 +6198,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Using the Thumb — Thumb Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "thumb_agility",
+        "range_of_motion"
+      ]
     },
     {
       "rule_id": "laukens-thumb-exercise-4-montuno-combination",
@@ -5636,11 +6218,9 @@
         },
         "picking.technique": "pinch/combination — p plays bass layer simultaneously or in alternation with upper finger notes"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "thumb_independence",
-        "coordination",
-        "latin_feel"
+        "any"
       ],
       "falsifier": "Playing the montuno pattern with a single finger type (all p or all i) rather than the combined p + upper finger assignment falsifies the independence goal.",
       "anchor": "Most of the time, you'll find yourself playing the thumb in combination with other fingers like this, so it's a good idea to get used to this technique at this point.",
@@ -5650,7 +6230,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Using the Thumb — Thumb Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "thumb_independence",
+        "coordination",
+        "latin_feel"
+      ]
     },
     {
       "rule_id": "laukens-two-string-wrist-roll",
@@ -5665,11 +6250,9 @@
       "then": {
         "picking.technique": "wrist rolled slightly toward headstock to create space between index finger and thumb so they do not obstruct each other"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "ergonomics",
-        "clarity",
-        "simultaneous_attack"
+        "any"
       ],
       "falsifier": "Standard wrist position (not rolled) causing p and i to collide or mute each other during plucking falsifies the adequacy of default position for this technique.",
       "anchor": "Ensure that your wrist is rolled slightly more towards the headstock to allow more space between the index finger and thumb. If your hand position is incorrect, these two fingers will obstruct each other's motion",
@@ -5679,7 +6262,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Two-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "ergonomics",
+        "clarity",
+        "simultaneous_attack"
+      ]
     },
     {
       "rule_id": "laukens-two-string-finger-pairs",
@@ -5704,11 +6292,9 @@
         },
         "picking.technique": "all assigned fingers sound notes simultaneously"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "clarity",
-        "balance",
-        "voice_independence"
+        "any"
       ],
       "falsifier": "Using c (pinky) as a primary plucking finger in 2- or 3-string contexts falsifies this assignment (c is explicitly excluded).",
       "anchor": "The main ways to pluck adjacent strings is with the p and i fingers, or i and m fingers. For 3 notes at once, it's preferable to use pi m, or i ma",
@@ -5718,7 +6304,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Two-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "clarity",
+        "balance",
+        "voice_independence"
+      ]
     },
     {
       "rule_id": "laukens-sixths-string-skip-pm-ia",
@@ -5737,10 +6328,9 @@
         },
         "picking.technique": "pinch across skipped string; both notes simultaneous"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "clarity",
-        "ergonomics"
+        "any"
       ],
       "falsifier": "Using p+i or i+m for a skipped-string 6th interval (where the intermediate string must be silenced) falsifies the prescribed skip-pair assignment.",
       "anchor": "Now you need to negotiate a string skip in the plucking hand, hence the use of pm and ia as marked.",
@@ -5750,7 +6340,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Two-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "clarity",
+        "ergonomics"
+      ]
     },
     {
       "rule_id": "laukens-thumb-double-pluck",
@@ -5766,10 +6360,9 @@
         },
         "picking.technique": "thumb double-pluck is idiomatic and simplifies picking fingering in Metheny-style 3rds patterns"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "naturalness",
-        "fingering_economy"
+        "any"
       ],
       "falsifier": "Forcing i or m to take the second consecutive bass note specifically to avoid a thumb double-pluck falsifies the naturalness claim for this pattern type.",
       "anchor": "Notice that the thumb plays a note twice in a row. It's quite natural for the thumb to do a double pluck in these situations as it simplifies the picking fingering greatly.",
@@ -5779,7 +6372,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Two-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "naturalness",
+        "fingering_economy"
+      ]
     },
     {
       "rule_id": "laukens-multi-string-simultaneous-attack",
@@ -5791,10 +6388,9 @@
       "then": {
         "picking.technique": "pinch — all assigned fingers release simultaneously so no arpeggiation arises unintentionally"
       },
-      "preference": "invariant",
+      "preference": 2,
       "quality_binding": [
-        "rhythmic_precision",
-        "harmonic_clarity"
+        "any"
       ],
       "falsifier": "Sequential plucking (one finger after another) in a block-chord context falsifies simultaneity requirement.",
       "anchor": "ensure that both fingers sound the notes simultaneously",
@@ -5804,7 +6400,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Two-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "rhythmic_precision",
+        "harmonic_clarity"
+      ]
     },
     {
       "rule_id": "laukens-three-string-simultaneous",
@@ -5816,10 +6416,9 @@
       "then": {
         "picking.technique": "pinch with p+i+m or i+m+a; all three notes released at exactly the same time"
       },
-      "preference": "invariant",
+      "preference": 2,
       "quality_binding": [
-        "rhythmic_precision",
-        "harmonic_clarity"
+        "any"
       ],
       "falsifier": "Any staggered attack across the three strings in a block-chord context falsifies the simultaneity requirement.",
       "anchor": "make sure all notes sound at exactly the same time on each chord",
@@ -5829,7 +6428,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Three-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "rhythmic_precision",
+        "harmonic_clarity"
+      ]
     },
     {
       "rule_id": "laukens-cross-string-arpeggio",
@@ -5841,11 +6444,9 @@
       "then": {
         "picking.technique": "arpeggio — sequential plucking across strings in a repeating cross-string pattern; particularly effective in solo guitar arrangements"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "texture",
-        "voice_independence",
-        "solo_guitar_arrangement"
+        "any"
       ],
       "falsifier": "Playing all three strings simultaneously (block) instead of in sequence falsifies the cross-string arpeggio texture.",
       "anchor": "This exercise is excellent for developing cross-string arpeggio picking technique. It's a neat texture that can sound particularly good in solo guitar arrangements.",
@@ -5855,7 +6456,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Three-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "texture",
+        "voice_independence",
+        "solo_guitar_arrangement"
+      ]
     },
     {
       "rule_id": "laukens-giuliani-thumb-alternation-45",
@@ -5871,11 +6477,9 @@
         },
         "picking.technique": "thumb independence — p moves between two bass strings while upper fingers maintain consistent treble pattern"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "thumb_independence",
-        "bass_variety",
-        "voice_leading"
+        "any"
       ],
       "falsifier": "Keeping the thumb on a single string for the entire Giuliani exercise falsifies the alternation principle.",
       "anchor": "It's a great way to develop thumb independence in a picking pattern context — the thumb moves between the 5th and 4th strings as you play the exercise.",
@@ -5885,7 +6489,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Three-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "thumb_independence",
+        "bass_variety",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "laukens-irregular-picking-pattern-flexibility",
@@ -5897,11 +6506,9 @@
       "then": {
         "picking.technique": "non-predictable picking sequence (e.g. Barry's Burger) trains adaptability for comping and chord melody beyond regular block or arpeggio patterns"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "flexibility",
-        "comping_naturalness",
-        "chord_melody"
+        "any"
       ],
       "falsifier": "Exclusively practising regular (block or ascending arpeggio) patterns while neglecting irregular patterns falsifies the flexibility claim.",
       "anchor": "This is a good exercise to play because it's a less predictable picking pattern in the plucking hand. This will give you more flexibility in applying these techniques to your comping and chord melodies.",
@@ -5911,7 +6518,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Three-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "flexibility",
+        "comping_naturalness",
+        "chord_melody"
+      ]
     },
     {
       "rule_id": "laukens-four-string-four-fingers",
@@ -5929,11 +6541,9 @@
         },
         "picking.technique": "four strongest fingers only; c reserved for exceptional cases"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "control",
-        "clarity",
-        "voice_balance"
+        "any"
       ],
       "falsifier": "Routinely assigning c to the fourth string instead of a in four-string contexts falsifies the p+i+m+a assignment.",
       "anchor": "I rarely use the little finger (c) on the right hand with fingerstyle technique — I tend to stick to 4-note voicings as a maximum which means you will only need to use your four strongest fingers - pi ma.",
@@ -5943,7 +6553,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Four-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "control",
+        "clarity",
+        "voice_balance"
+      ]
     },
     {
       "rule_id": "laukens-four-string-block-simultaneous",
@@ -5956,10 +6571,9 @@
       "then": {
         "picking.technique": "pinch — all four fingers release simultaneously; no stagger"
       },
-      "preference": "invariant",
+      "preference": 2,
       "quality_binding": [
-        "rhythmic_precision",
-        "harmonic_clarity"
+        "any"
       ],
       "falsifier": "Staggered release of any of the four fingers producing audible arpeggio in Danny Dreamer 1 falsifies simultaneous attack.",
       "anchor": "ensure that you're sounding all the notes in each chord at the same time",
@@ -5969,7 +6583,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Four-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "rhythmic_precision",
+        "harmonic_clarity"
+      ]
     },
     {
       "rule_id": "laukens-four-string-sequential-variant",
@@ -5982,10 +6600,9 @@
       "then": {
         "picking.technique": "arpeggio — same voicings as Danny Dreamer 1 but plucked sequentially (one finger after another) rather than simultaneously"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "texture_variety",
-        "technique_range"
+        "any"
       ],
       "falsifier": "Playing Danny Dreamer 2 as a simultaneous block (same as #1) falsifies the sequential/arpeggio contrast intent.",
       "anchor": "Here's a variation of the above \"Danny the Dreamer\" exercise, using sequential plucking instead of block chords.",
@@ -5995,7 +6612,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Four-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "texture_variety",
+        "technique_range"
+      ]
     },
     {
       "rule_id": "laukens-southern-land-16th-arpeggio",
@@ -6007,11 +6628,9 @@
       "then": {
         "picking.technique": "arpeggio — same pattern as Danny Dreamer 2 but in 16th notes (twice as fast); classified as more advanced workout"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "speed",
-        "control",
-        "agility"
+        "any"
       ],
       "falsifier": "Playing Southern Land at 8th-note speed (same as Danny Dreamer 2) without progressing to 16th notes falsifies the advanced tempo goal.",
       "anchor": "the pattern is now twice as fast, incorporating 16th notes, so this is a more advanced workout",
@@ -6021,7 +6640,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Four-String Exercises",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "speed",
+        "control",
+        "agility"
+      ]
     },
     {
       "rule_id": "laukens-etude1-walking-bass-thumb",
@@ -6037,11 +6661,9 @@
         },
         "picking.technique": "simultaneous or near-simultaneous p + upper fingers; bass line moves chromatically while upper chord voices sustain or move independently"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "voice_independence",
-        "walking_bass_feel",
-        "jazz_authenticity"
+        "any"
       ],
       "falsifier": "Using i or m exclusively for bass-line notes in this etude while p plays upper voices falsifies the thumb-bass assignment.",
       "anchor": "This first etude is a walking bass study over a Bb blues. Although this sort of study is quite well known, it's brilliant for gaining control over plucking multiple strings.",
@@ -6051,7 +6673,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Fingerstyle Etudes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "voice_independence",
+        "walking_bass_feel",
+        "jazz_authenticity"
+      ]
     },
     {
       "rule_id": "laukens-etude1-learn-bar-by-bar",
@@ -6063,10 +6690,9 @@
       "then": {
         "picking.technique": "isolate and master one bar before joining; do not attempt full run-through until each bar is secure"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "accuracy",
-        "practice_efficiency"
+        "any"
       ],
       "falsifier": "Attempting the full 24-bar etude immediately without bar-by-bar isolation falsifies the prescribed learning order.",
       "anchor": "Practice this study one bar at a time, until you can play it all the way through.",
@@ -6076,7 +6702,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Fingerstyle Etudes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "accuracy",
+        "practice_efficiency"
+      ]
     },
     {
       "rule_id": "laukens-etude2-bossa-nova-picking-pattern",
@@ -6092,11 +6722,9 @@
         },
         "picking.technique": "bossa nova pattern — thumb plays bass independently from upper finger syncopation; thumb independence is primary training goal"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "latin_feel",
-        "thumb_independence",
-        "rhythmic_accuracy"
+        "any"
       ],
       "falsifier": "Playing the bossa nova etude with thumb and fingers locked in unison rhythmically (no independence) falsifies the thumb-independence training purpose.",
       "anchor": "This exercise is a great workout for fingerstyle technique and enables you to quickly gain facility in the plucking hand as well as the independence of the thumb.",
@@ -6106,7 +6734,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Fingerstyle Etudes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "latin_feel",
+        "thumb_independence",
+        "rhythmic_accuracy"
+      ]
     },
     {
       "rule_id": "laukens-etude2-learn-pattern-then-progression",
@@ -6118,11 +6751,9 @@
       "then": {
         "picking.technique": "step 1: practise picking pattern on one static chord until internalised; step 2: add fretting-hand chord changes across full descending ii–V–I progression"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "practice_efficiency",
-        "accuracy",
-        "hand_independence"
+        "any"
       ],
       "falsifier": "Attempting picking pattern and chord changes simultaneously from the first repetition falsifies the two-phase learning sequence.",
       "anchor": "I would suggest practicing the picking pattern over a single chord for a while until you get it under your fingers first. After that, start to build the pattern over the full chord progression.",
@@ -6132,7 +6763,12 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Fingerstyle Etudes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "practice_efficiency",
+        "accuracy",
+        "hand_independence"
+      ]
     },
     {
       "rule_id": "laukens-etude2-ii-V-I-descending-whole-steps",
@@ -6144,10 +6780,9 @@
       "then": {
         "voicing.harmonic_motion": "ii–V–I cell, transposed down one whole step (two frets) per repetition"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "harmonic_clarity",
-        "pattern_transposition"
+        "any"
       ],
       "falsifier": "Transposing by a non-whole-step interval or ascending rather than descending falsifies the stated harmonic direction.",
       "anchor": "The exercise comprises a straightforward ii V I sequence, moving down two frets at a time.",
@@ -6157,7 +6792,11 @@
         "chapter_title": "Appendix 2 — Fingerstyle Training",
         "section_title": "Fingerstyle Etudes",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "harmonic_clarity",
+        "pattern_transposition"
+      ]
     }
   ]
 }

--- a/plugin/data/masters-corpus/howard-roberts/chord-melody/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/howard-roberts/chord-melody/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:31-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -22,7 +22,7 @@
       "then": {
         "voicing.strings": "string_set_with_greatest_vibrating_length"
       },
-      "preference": "soft — yields to mechanical necessity when sustain gain is negligible",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -49,7 +49,7 @@
       "then": {
         "voicing.shape": "fingering_with_fewest_unnecessary_or_awkward_movements"
       },
-      "preference": "soft — large interval jumps are permitted when musically required",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -79,7 +79,7 @@
         "octave.shift": "move one or more chordal tones up or down one octave",
         "voicing.selection_order": "as far as reach permits"
       },
-      "preference": "expand spread as far as hand reach allows",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -107,7 +107,7 @@
       "then": {
         "voicing.strings": "second voice from top"
       },
-      "preference": "place counter line in second voice from top on guitar",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -134,7 +134,7 @@
       "then": {
         "voicing.shape": "activate counter line with more motion"
       },
-      "preference": "increase counter line activity when melody rests or sustains",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -163,7 +163,7 @@
         "voicing.shape": "change voicing or inversion",
         "voicing.strings": "move chordal tones in same direction as melody where possible"
       },
-      "preference": "chordal tones move with melody and preferably in the same direction",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -191,7 +191,7 @@
       "then": {
         "voicing.quality": "Gm7"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "maj9"
       ],
@@ -219,7 +219,7 @@
         "voicing.shape": "drop one or more chordal tones as needed",
         "voicing.selection_order": "sustain each chordal tone for as long as possible before dropping"
       },
-      "preference": "listener's harmonic memory compensates for dropped tones if each tone was sustained maximally before release",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -248,7 +248,7 @@
         "voicing.shape": "short chord punctuation played with authority",
         "voicing.selection_order": "prefer voicings that emphasize chordal tones in melody"
       },
-      "preference": "reinforce harmonic continuity by choosing melodies that emphasize chordal tones",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -277,7 +277,7 @@
         "voicing.density": "close",
         "voicing.selection_order": "prefer-close-interval-stack"
       },
-      "preference": "deploy close voicings sparingly for contrast rather than as default texture",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -307,7 +307,7 @@
         "voicing.tensions": "b9",
         "voicing.shape": "retain-maj6-fingering"
       },
-      "preference": "interpret maj6 voicing as dom7b9 substitute when surrounding harmonic context implies dominant function a tritone away",
+      "preference": 0,
       "quality_binding": [
         "maj6"
       ],
@@ -337,7 +337,7 @@
         "voicing.shape": "diminished-seventh-built-on-chord-third",
         "voicing.tensions": "b9"
       },
-      "preference": "prefer dim7 substitute when diatonic context risks monotony; the dim7 built on the 3rd of any dom7b9 contains the full upper structure",
+      "preference": 1,
       "quality_binding": [
         "dom7b9"
       ],
@@ -365,7 +365,7 @@
         "voicing.selection_order": "hold-all-fretted-notes-until-physically-forced-to-move",
         "voicing.shape": "delay-finger-movement-to-last-necessary-moment"
       },
-      "preference": "always default to sustaining; movement is the exception, not the rule",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -395,7 +395,7 @@
         "voicing.density": "implied",
         "voicing.quality": "dyad-suggestive-of-parent-chord"
       },
-      "preference": "prefer dyads when full voicings would interrupt melodic momentum; the listener's ear completes the harmony",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -426,9 +426,9 @@
         "voicing.fret_offset": "half-step-below-target-diatonic-chord-root",
         "voicing.shape": "minor-seventh-sharp-five"
       },
-      "preference": "prefer m7+5 passing chord a half-step below each diatonic target to create smooth chromatic approach",
+      "preference": 1,
       "quality_binding": [
-        "m7+5"
+        "any"
       ],
       "falsifier": "If the diatonic chords are a whole step apart and a half-step passing chord would land on another diatonic chord, the chromatic passing function is absorbed and a different passing quality may be required.",
       "anchor": "Example 35 shows the primary progression consisting of G6, Am7, Bm7, Cmaj 7 (one chord per bart being connected by the passing chords G#m7+5, Am7+5, et",
@@ -442,7 +442,10 @@
           31
         ],
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "m7+5"
+      ]
     },
     {
       "rule_id": "roberts-passing-tone-to-counter-line-development",
@@ -455,7 +458,7 @@
         "voicing.selection_order": "extend-passing-tone-to-continuous-counter-line-then-to-melodic-pattern",
         "voicing.shape": "sustain-and-connect-inner-voice-movement"
       },
-      "preference": "prefer to develop isolated inner-voice passing tones into sustained counter lines before elevating them to foreground melodic patterns",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -483,7 +486,7 @@
       "then": {
         "voicing.density": "reduced-or-fragment"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -511,7 +514,7 @@
         "octave.shift": "+1",
         "voicing.selection_order": "restart-with-transposed-melody"
       },
-      "preference": "invariant",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -540,7 +543,7 @@
         "octave.shift": "+1",
         "voicing.strings": "recalculate-from-transposed-melody-position"
       },
-      "preference": "strong — apply whenever low register prevents satisfactory voicing",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -569,7 +572,7 @@
         "voicing.tensions": "add-maj7-6-or-9-freely",
         "voicing.quality": "enriched-color-same-function"
       },
-      "preference": "permissive — extensions never alter scale function or progression role",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -598,7 +601,7 @@
         "voicing.shape": "any-reachable-form-of-given-chord",
         "voicing.tensions": "accept-dissonance"
       },
-      "preference": "permissive — no chromatic note within finger range is unharmonizable",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -626,7 +629,7 @@
         "voicing.tensions": "accept-emergent-extensions",
         "voicing.quality": "coloristically-enriched-by-independence"
       },
-      "preference": "compositional principle — let melody and harmony move with their own force",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],

--- a/plugin/data/masters-corpus/howard-roberts/jazz-guitar-technique-in-20-weeks/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/howard-roberts/jazz-guitar-technique-in-20-weeks/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-17T09:44:51-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -22,7 +22,7 @@
         "stroke.dynamic_equality": true,
         "stroke.direction": "strict-alternate"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -44,7 +44,7 @@
         "hammer_ons": false,
         "pull_offs": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -64,7 +64,7 @@
         "glissandi": true,
         "notes_per_stroke": ">=2"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -83,7 +83,7 @@
         "scale.type": "whole-tone",
         "scale.interval_pattern": "W-W-W-W-W-W"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "dom7"
       ],
@@ -102,7 +102,7 @@
         "scale.type": "diminished",
         "scale.interval_pattern": "W-H-W-H-W-H-W-H"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "dim"
@@ -126,13 +126,16 @@
         ],
         "gravitational_pull": "low"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "maj6/9"
+        "any"
       ],
       "falsifier": "Scale includes the 4th or 7th degree",
       "anchor": "The Major Pentatonic Scale (same as diatonic major with the active tones 3rd and 7th left out). When harmonized creates inversions of a Major 6/9 chord",
-      "source_page": 13
+      "source_page": 13,
+      "applicability_reasons": [
+        "maj6/9"
+      ]
     },
     {
       "rule_id": "roberts-20w-key-center-nav",
@@ -145,7 +148,7 @@
         "navigation.unit": "key-center",
         "pattern.selection": "one-of-five-movable"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -164,7 +167,7 @@
         "harmonic.key_center": "parent-major-of-V",
         "analysis.confidence": "high"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7"
       ],
@@ -184,7 +187,7 @@
         "pattern.type": "finger-per-fret-movable",
         "fingerboard.coverage": "full"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -205,7 +208,7 @@
           "slide-on-half-step"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -224,7 +227,7 @@
         "arpeggio.placement": "within-key-center-pattern",
         "arpeggio.isolation": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -242,7 +245,7 @@
       "then": {
         "line.consecutive_scale_tones.max": 4
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -262,7 +265,7 @@
         "interval.parallel": false,
         "interval.mixed_major_minor": true
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -281,7 +284,7 @@
         "melody.device": "common-tone-sustain",
         "line.flattening": true
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -301,7 +304,7 @@
         "line.angle": "steep",
         "line.texture": "rolling"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -320,7 +323,7 @@
         "melody.device": "large-interval-skip",
         "line.scalar_monotony": false
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -339,7 +342,7 @@
         "scale.modification": "raise-degree-5",
         "scale.new_type": "harmonic-minor"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "min",
         "minMaj7"
@@ -359,7 +362,7 @@
         "scale.ascending_descending_rule": "optional",
         "scale.priority": "bar-harmony"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "min",
         "min7"
@@ -379,7 +382,7 @@
         "substitution.validity": "ear-determined",
         "analysis.override": "allowed"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -398,7 +401,7 @@
         "analysis.exclusivity": false,
         "substitution.allowed": true
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -419,7 +422,7 @@
         ],
         "fingering.flexibility": true
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -438,7 +441,7 @@
         "tempo.increase": false,
         "accuracy.priority": "absolute"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -456,7 +459,7 @@
         "metronome.mode": "record-only",
         "tempo.preset_target": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -475,7 +478,7 @@
         "skill.imprint": "permanent",
         "retention.after_layoff": "restorable-2-3-weeks"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -493,7 +496,7 @@
         "right_hand.anchor": "none",
         "right_hand.adaptability": "required"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -511,7 +514,7 @@
         "technique.right_hand": "free",
         "speed_ceiling": "removed"
       },
-      "preference": "avoid",
+      "preference": -1,
       "quality_binding": [
         "any"
       ],
@@ -530,7 +533,7 @@
         "attack.simultaneity": true,
         "flam.tolerance": 0
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -553,7 +556,7 @@
           "high"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -571,7 +574,7 @@
         "finger.angle": "perpendicular",
         "finger.axis": "right-angle-to-board"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -588,7 +591,7 @@
       "then": {
         "finger.lift_height": "minimum-to-avoid-noise"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -606,7 +609,7 @@
         "wrist.posture": "flat",
         "wrist.arch": "minimal"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -624,7 +627,7 @@
         "string.gauge_first": ">=.012",
         "string.set": "medium-heavy"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -644,7 +647,7 @@
         "pick.material": "celluloid",
         "pick.shape": "standard"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -663,7 +666,7 @@
         "tools.recorder": true,
         "tools.timer": true
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -682,7 +685,7 @@
         "line.form": "question-answer",
         "line.repetition_unit": "sequence"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -700,7 +703,7 @@
         "workflow.step": "sing-first",
         "ear_to_hand.priority": "high"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -722,7 +725,7 @@
         ],
         "line.form": "fills-around-melody"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -741,7 +744,7 @@
         "practice.priority": "memorize-changes-first",
         "reading.from_page": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -761,7 +764,7 @@
         "session.days_per_week": 6,
         "rest.days_per_week": 1
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -783,7 +786,7 @@
         ],
         "phase.skip": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -801,7 +804,7 @@
         "session.skip": false,
         "regularity": "daily-non-negotiable"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -821,7 +824,7 @@
         "fingering.patterns": "new",
         "melodic.ideas": "fresh"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -840,7 +843,7 @@
         "practice.format": "ensemble-exchange",
         "acceleration.factor": "superior-to-solo"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -858,7 +861,7 @@
         "output.goal": "spontaneous-invention",
         "model_solos.status": "reference-only"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -877,7 +880,7 @@
         "response.action": "play-different-next-pass",
         "response.stop": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -897,7 +900,7 @@
         "rush": false,
         "drag": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],

--- a/plugin/data/masters-corpus/jerry-bergonzi/melodic-rhythms-vol-4/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/jerry-bergonzi/melodic-rhythms-vol-4/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:48-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -21,7 +21,7 @@
       "then": {
         "phrase.cell_id": "density_awareness_check"
       },
-      "preference": "Prefer rhythmic awareness and variety over maximizing note count per bar",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -49,7 +49,7 @@
       "then": {
         "phrase.cell_id": "rhythm_position_tracking"
       },
-      "preference": "Track which rhythms are in use and bar-position at all times",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -77,7 +77,7 @@
         "line.metric_placement": "independent_of_bar_line",
         "displacement.step": "within_over_or_through"
       },
-      "preference": "Play fixed-count groupings without anchoring start or end to bar lines",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -105,7 +105,7 @@
       "then": {
         "phrase.cell_id": "articulation_shaped_by_grouping"
       },
-      "preference": "Conceive notes in explicit groupings even when groupings overlap or are invisible to listeners",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -133,7 +133,7 @@
         "polyrhythm.ratio": "5:variable",
         "phrase.cell_id": "polyrhythm_awareness_onset"
       },
-      "preference": "Use five-note eighth-note groupings to begin hearing polyrhythmic cross-rhythms",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -161,7 +161,7 @@
         "displacement.step": "any_beat_span",
         "time_zone.gear": "variable"
       },
-      "preference": "Play five consecutive notes occupying 1, 1.5, 2, 3, or 4 beats",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -192,7 +192,7 @@
       "then": {
         "phrase.cell_id": "exclusion_enforced"
       },
-      "preference": "Use only quarter notes and eighth notes in the 22 one-bar rhythms; defer sixteenth notes and triplets",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -218,7 +218,7 @@
       "then": {
         "phrase.cell_id": "body_internalization"
       },
-      "preference": "Feel each rhythm inside the body as a rhythm instrument would",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -250,7 +250,7 @@
         ],
         "line.metric_placement": "displaced_from_original"
       },
-      "preference": "Systematically play each of the 22 rhythms one beat early, two beats early, and one beat late",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -281,7 +281,7 @@
       "then": {
         "line.metric_placement": "perceptually_distinct_rhythm"
       },
-      "preference": "Use half-beat offsets (1/2, 1 1/2, 2 1/2 beats) to generate new rhythmic identities from existing patterns",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -309,7 +309,7 @@
         "displacement.step": "all_eight_entry_points",
         "line.metric_placement": "systematic_position_traversal"
       },
-      "preference": "Begin with beat 1 entry, then systematically start on each of the eight eighth-note positions in the bar",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -342,7 +342,7 @@
         "line.metric_placement": "next_chord_anticipated",
         "phrase.cell_id": "approach_or_direct_next_chord"
       },
-      "preference": "At positions 6, 7, 8, approach the next chord or state it directly",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -370,7 +370,7 @@
       "then": {
         "phrase.cell_id": "final_note_is_next_chord_tone"
       },
-      "preference": "At displacement position 5, let the final eighth note sound a tone of the next chord",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -402,7 +402,7 @@
           "4_bars"
         ]
       },
-      "preference": "Combine two, three, and four one-bar rhythms and play through a tune",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -431,7 +431,7 @@
         "polyrhythm.ratio": "3:4",
         "displacement.cycle": "3_bars_of_4/4_to_resolve"
       },
-      "preference": "Play a four-note grouping continuously to create felt 3/4 over 4/4; note the three-bar resolution cycle",
+      "preference": 1,
       "quality_binding": [
         "dom7"
       ],
@@ -458,7 +458,7 @@
         "displacement.step": "random",
         "line.metric_placement": "free_improvisation"
       },
-      "preference": "After completing all eight ordered positions, mix starting beats randomly",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -486,7 +486,7 @@
         "displacement.step": "all_eight_entry_points",
         "line.metric_placement": "systematic_position_traversal"
       },
-      "preference": "Drill five consecutive eighth notes starting on each of the eight eighth-note positions in the bar using Tunes 1, 2, 3",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -519,7 +519,7 @@
         "line.metric_placement": "next_chord_anticipated",
         "phrase.cell_id": "approach_or_direct_next_chord"
       },
-      "preference": "When five-note groups cross the bar line at positions 5-7, anticipate the next chord",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -547,7 +547,7 @@
         "displacement.step": "random",
         "line.metric_placement": "free_improvisation"
       },
-      "preference": "After mastering steps 1-8 in order, mix starting points freely and randomly",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -573,7 +573,7 @@
       "then": {
         "phrase.cell_id": "large_scale_form_perception"
       },
-      "preference": "Practice systematic entry-point displacement as means to internalize perception of larger time spans and form",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -601,7 +601,7 @@
         "polyrhythm.ratio": "3:4",
         "line.metric_placement": "upbeat_initiated_superimposition"
       },
-      "preference": "Initiate 3/4 superimposition on the 'and' of beat rather than on beat 1 for additional textural variety",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -629,7 +629,7 @@
         "polyrhythm.ratio": "7:4",
         "displacement.cycle": "8_bars_of_4/4_to_resolve"
       },
-      "preference": "Sustain a seven-beat phrase pattern over 4/4 for the full eight-bar resolution cycle",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -656,7 +656,7 @@
       "then": {
         "polyrhythm.ratio": "9:4"
       },
-      "preference": "Sustain a nine-beat phrase pattern over 4/4",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -685,7 +685,7 @@
         "polyrhythm.ratio": "5:4",
         "displacement.cycle": "aligns_beat_1_on_bar_6"
       },
-      "preference": "Play five-beat pattern over 4/4 for full cycle; note that the pattern returns to beat 1 on the sixth bar",
+      "preference": 1,
       "quality_binding": [
         "dom7"
       ],
@@ -716,7 +716,7 @@
       "then": {
         "phrase.cell_id": "next_chord_anticipate_or_approach_or_current"
       },
-      "preference": "At late entry positions (beat 3 through and-of-4), choose from: anticipate next chord, approach it via passing tones, or sound current chord",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -743,7 +743,7 @@
         "displacement.step": "random_with_metric_superimposition",
         "line.metric_placement": "free_with_time_signature_devices"
       },
-      "preference": "After drilling polymetric patterns 10-14, return to exercise 9 (random starts) and apply the superimposition techniques within it",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -771,7 +771,7 @@
         "displacement.step": "random",
         "line.metric_placement": "free_improvisation"
       },
-      "preference": "After mastering all ordered entry points for seven-note groups, mix starting beats randomly",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -807,7 +807,7 @@
           "and_of_4"
         ]
       },
-      "preference": "Define eight starting positions as the complete set of metrical entry points for all consecutive-note displacement work",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -834,7 +834,7 @@
       "then": {
         "polyrhythm.ratio": "11:4"
       },
-      "preference": "Sustain an eleven-beat pattern over 4/4 as an advanced cross-rhythm device",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -861,7 +861,7 @@
       "then": {
         "polyrhythm.ratio": "6:4"
       },
-      "preference": "Sustain a six-beat pattern over 4/4",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -887,7 +887,7 @@
       "then": {
         "displacement.step": "random_with_metric_superimposition"
       },
-      "preference": "After exercises 10-14, return to random-start exercise 9 deploying time-signature devices spontaneously",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -915,7 +915,7 @@
         "displacement.step": "all_eight_entry_points",
         "line.metric_placement": "systematic_position_traversal"
       },
-      "preference": "Practice three consecutive eighth-note triplets starting from different positions within the bar using the same eight-position grid",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -943,7 +943,7 @@
         "polyrhythm.ratio": "variable_odd_over_4",
         "line.metric_placement": "superimposed_over_4_4"
       },
-      "preference": "Notate in odd time signatures but always feel and play as superimposition over 4/4",
+      "preference": 1,
       "quality_binding": [
         "dom7"
       ],
@@ -968,7 +968,7 @@
       "then": {
         "phrase.cell_id": "four_of_six_notes_sounded"
       },
-      "preference": "Across two consecutive triplet groups (six total subdivisions), sound only four; let two remain silent",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -996,7 +996,7 @@
         "displacement.step": "melodic_starting_point_variation",
         "phrase.cell_id": "same_melody_different_beats"
       },
-      "preference": "Play the same short melody starting on each entry point to get used to the feel of triplet displacement",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -1023,7 +1023,7 @@
       "then": {
         "displacement.step": "random"
       },
-      "preference": "After completing all ordered positions for triplet groupings, mix them randomly",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -1051,7 +1051,7 @@
         "polyrhythm.ratio": "7:4",
         "time_zone.gear": "triplet"
       },
-      "preference": "Sustain a seven-unit triplet phrase over 4/4 for the full resolution cycle",
+      "preference": 1,
       "quality_binding": [
         "dom7"
       ],
@@ -1078,7 +1078,7 @@
         "displacement.step": "random",
         "line.metric_placement": "free_improvisation"
       },
-      "preference": "After ordered drilling, practice six consecutive triplets starting randomly",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -1107,7 +1107,7 @@
         "displacement.step": "random",
         "line.metric_placement": "free_improvisation"
       },
-      "preference": "After mastering ordered positions for seven triplets, mix starts freely",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -1135,7 +1135,7 @@
         "polyrhythm.ratio": "5:4",
         "time_zone.gear": "triplet"
       },
-      "preference": "Sustain a five-unit triplet phrase over 4/4 for full resolution cycle",
+      "preference": 1,
       "quality_binding": [
         "dom7"
       ],

--- a/plugin/data/masters-corpus/jimmy-bruno/the-art-of-picking/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/jimmy-bruno/the-art-of-picking/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:44-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -20,7 +20,7 @@
       "then": {
         "picking.direction": "down"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -43,7 +43,7 @@
       "then": {
         "picking.direction": "up"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -66,7 +66,7 @@
       "then": {
         "picking.direction": "alternate"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -89,7 +89,7 @@
       "then": {
         "picking.economy_path": "minimum_travel"
       },
-      "preference": "always choose the stroke direction that requires the shortest pick arc",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -112,7 +112,7 @@
       "then": {
         "hand.position_rule": "elbow_drives_wrist_still"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -135,7 +135,7 @@
       "then": {
         "hand.position_rule": "no_finger_anchor"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -158,7 +158,7 @@
       "then": {
         "hand.position_rule": "relaxed_no_tilt"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -181,7 +181,7 @@
       "then": {
         "practice.drill_id": "both_starting_strokes"
       },
-      "preference": "only a very slight difference in sound should exist between the two starts",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -204,7 +204,7 @@
       "then": {
         "practice.drill_id": "metronome_60_to_120"
       },
-      "preference": "begin at MM 60, increase incrementally to 120 before pushing beyond",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -227,7 +227,7 @@
       "then": {
         "practice.drill_id": "sequential_A_to_Z"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -251,7 +251,7 @@
         "picking.direction": "up",
         "picking.economy_path": "equal_attack_to_down"
       },
-      "preference": "accent on upstroke should equal downstroke volume and tone",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -274,7 +274,7 @@
       "then": {
         "hand.position_rule": "wrist_straight_not_stiff_elbow_moves"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -297,7 +297,7 @@
       "then": {
         "hand.position_rule": "no_contact_pickguard_or_strings"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -320,7 +320,7 @@
       "then": {
         "string.crossing_rule": "adjacent_no_sustain"
       },
-      "preference": "take extra time mastering this stroke before moving forward",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -343,7 +343,7 @@
       "then": {
         "practice.drill_id": "extended_in_between_practice"
       },
-      "preference": "take your time with this one",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -367,7 +367,7 @@
       "then": {
         "string.crossing_rule": "mute_no_sustain"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -390,7 +390,7 @@
       "then": {
         "practice.drill_id": "even_eighth_notes_before_speed"
       },
-      "preference": "evenness is the prerequisite; speed follows",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -414,7 +414,7 @@
       "then": {
         "picking.direction": "three_down_then_three_up"
       },
-      "preference": "three consecutive strokes same direction across three adjacent strings",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -438,7 +438,7 @@
       "then": {
         "picking.direction": "adhere_to_main_rule"
       },
-      "preference": "in a real phrase context, revert to higher-string/lower-string directional rule",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -462,7 +462,7 @@
       "then": {
         "picking.direction": "reverse_on_same_string"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -485,7 +485,7 @@
       "then": {
         "picking.economy_path": "directional_rule_applies"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -509,7 +509,7 @@
         "picking.direction": "down",
         "string.crossing_rule": "marked_by_double_star"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -533,7 +533,7 @@
         "picking.direction": "up",
         "string.crossing_rule": "marked_by_single_star"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -556,7 +556,7 @@
       "then": {
         "practice.drill_id": "articulation_before_speed"
       },
-      "preference": "never increase tempo until note separation is clean",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -579,7 +579,7 @@
       "then": {
         "picking.economy_path": "directional_rule_same_as_single_line"
       },
-      "preference": "reject any framing that treats arpeggios as requiring a different picking system",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -603,9 +603,9 @@
         "arpeggio.sextuplet_id": "minor11_sextuplet_four_string",
         "picking.direction": "consecutive_down_then_up"
       },
-      "preference": "choose the fingering that places six notes across four adjacent strings",
+      "preference": 1,
       "quality_binding": [
-        "minor_11"
+        "any"
       ],
       "falsifier": "A minor 11 fingering that does not span four strings cannot produce the sextuplet pattern",
       "anchor": "Minor 11 arpeggios: Because of the fingering it is possible to play 6 notes in one beat.(sextuplet)\n      The fingering sets up the consecutive down and up strokes to go across four strings.",
@@ -615,7 +615,10 @@
         "chapter_title": "Arpeggios",
         "section_title": "Minor 11 sextuplet arpeggio",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "minor_11"
+      ]
     },
     {
       "rule_id": "bruno-minor9-adjacent-string-design",
@@ -626,9 +629,9 @@
       "then": {
         "picking.economy_path": "adjacent_string_directional_rule"
       },
-      "preference": "use fingerings that keep successive arpeggio notes on adjacent strings",
+      "preference": 1,
       "quality_binding": [
-        "minor_9"
+        "any"
       ],
       "falsifier": "A minor 9 fingering with string skips between every note cannot apply the adjacent-string consecutive rule",
       "anchor": "Minor 9th arpeggios:By using fingerings that place notes on adjacent strings, either higher or lower,\n       these large two octave arpeggios become possible.",
@@ -638,7 +641,10 @@
         "chapter_title": "Arpeggios",
         "section_title": "Minor 9 arpeggio — fingering enables speed",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "minor_9"
+      ]
     },
     {
       "rule_id": "bruno-fingering-enables-speed",
@@ -649,7 +655,7 @@
       "then": {
         "picking.economy_path": "fingering_unlocks_velocity"
       },
-      "preference": "optimize the left-hand fingering before trying to pick faster",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -672,7 +678,7 @@
       "then": {
         "picking.direction": "either_stroke_permitted"
       },
-      "preference": "use whichever stroke feels natural after the rest",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -695,7 +701,7 @@
       "then": {
         "picking.economy_path": "unified_directional_rule"
       },
-      "preference": "reject the misconception that arpeggios require a different picking approach",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -718,7 +724,7 @@
       "then": {
         "picking.economy_path": "serve_musical_intent"
       },
-      "preference": "always subordinate mechanical efficiency to musical expression",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -742,7 +748,7 @@
       "then": {
         "practice.drill_id": "major_triad_warmup_articulation"
       },
-      "preference": "use this exercise daily to develop note separation transferable to all arpeggio fragments",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -765,7 +771,7 @@
       "then": {
         "picking.economy_path": "directional_rule_applies"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -788,7 +794,7 @@
       "then": {
         "practice.drill_id": "both_starting_strokes_skip"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -812,7 +818,7 @@
       "then": {
         "picking.direction": "alternate_preferred"
       },
-      "preference": "author finds alternating down-up easier for accented in-between skip figures",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -836,7 +842,7 @@
       "then": {
         "picking.economy_path": "rederive_from_directional_rule"
       },
-      "preference": "do not assume the same picking applies when a phrase moves positions",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -859,7 +865,7 @@
       "then": {
         "picking.direction": "slurred_preferred_over_picked"
       },
-      "preference": "prefer the slurred example as it sounds more horn-like",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -883,7 +889,7 @@
       "then": {
         "practice.drill_id": "slur_triplet_both_starting_strokes"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -906,7 +912,7 @@
       "then": {
         "picking.direction": "one_stroke_two_notes"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -929,7 +935,7 @@
       "then": {
         "string.crossing_rule": "same_string_required_for_slur"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -953,7 +959,7 @@
       "then": {
         "picking.economy_path": "variable_slur_placement_for_inflection"
       },
-      "preference": "experiment with placing slurs at different beats to discover expressive alternatives",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -976,7 +982,7 @@
       "then": {
         "picking.direction": "long_short_articulation"
       },
-      "preference": "the two final notes of a bebop phrase should be long followed by short",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -999,7 +1005,7 @@
       "then": {
         "practice.drill_id": "self_directed_slur_placement"
       },
-      "preference": "do not treat slur placement as fixed; internalize it as a creative choice",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -1022,7 +1028,7 @@
       "then": {
         "picking.direction": "consecutive_down_for_accent"
       },
-      "preference": "use when emulating horn-section accent patterns",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -1045,7 +1051,7 @@
       "then": {
         "picking.direction": "consecutive_down_permitted"
       },
-      "preference": "use two downs when a rest separates notes rather than forcing directional-rule alternation",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -1068,7 +1074,7 @@
       "then": {
         "picking.direction": "slur_as_alternative_to_consecutive_down"
       },
-      "preference": "slurs and consecutive downs are interchangeable expressive options for this context",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -1091,7 +1097,7 @@
       "then": {
         "practice.drill_id": "repetition_no_overanalysis"
       },
-      "preference": "do not stop to analyze mid-stroke; trust repetition to automate the pattern",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -1114,7 +1120,7 @@
       "then": {
         "practice.drill_id": "extended_patience_for_experienced_players"
       },
-      "preference": "set expectations that the habit change will take more time for advanced players",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],

--- a/plugin/data/masters-corpus/joe-pass/guitar-chords/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/joe-pass/guitar-chords/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:41-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -22,11 +22,10 @@
         "voicing.shape": "seventh_catalog_form",
         "voicing.role": "cycle_origin_or_target"
       },
-      "preference": "default to catalog seventh form at each cycle node",
+      "preference": 1,
       "quality_binding": [
-        "7",
-        "maj7",
-        "dom7"
+        "dom7",
+        "maj7"
       ],
       "falsifier": null,
       "anchor": "Seventh Chord Forms",
@@ -49,10 +48,9 @@
         "voicing.role": "chromatic_approach",
         "voicing.shape": "augmented_catalog_form"
       },
-      "preference": "sustain augmented color across multiple beats before resolving",
+      "preference": 1,
       "quality_binding": [
-        "aug",
-        "+"
+        "aug"
       ],
       "falsifier": "augmented chord used as tonic with no subsequent cycle resolution",
       "anchor": "Augmented Chord Forms",
@@ -76,11 +74,9 @@
         "voicing.shape": "minor_catalog_form",
         "voicing.role": "ii_chord"
       },
-      "preference": "use catalog minor form at ii position before chromatic approach to V",
+      "preference": 1,
       "quality_binding": [
-        "m",
-        "min",
-        "m7"
+        "min"
       ],
       "falsifier": "minor form used at tonic position in major key",
       "anchor": "Minor Chord Forms",
@@ -90,7 +86,10 @@
         "chapter_title": "CHORD FORMS",
         "section_title": "Minor Chord Forms",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "m7"
+      ]
     },
     {
       "rule_id": "pass-diminished-mobile-approach",
@@ -103,10 +102,9 @@
         "voicing.role": "approach_chord",
         "voicing.shape": "diminished_catalog_form"
       },
-      "preference": "treat diminished voicing as approach rather than destination",
+      "preference": 1,
       "quality_binding": [
         "dim",
-        "°",
         "dim7"
       ],
       "falsifier": "diminished chord used as stable tonic with no subsequent resolution",
@@ -131,11 +129,9 @@
         "voicing.shape": "half_diminished_catalog_form",
         "voicing.role": "iio_pre_dominant"
       },
-      "preference": "resolve half-diminished to dominant 7b9 then to augmented",
+      "preference": 1,
       "quality_binding": [
-        "m7b5",
-        "ø7",
-        "ø"
+        "min7b5"
       ],
       "falsifier": "half-diminished form used at tonic position",
       "anchor": "Minor Seventh Flat Fifth Chord Forms",
@@ -145,7 +141,11 @@
         "chapter_title": "CHORD FORMS",
         "section_title": "Minor Seventh Flat Fifth Chord Forms",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "m7b5",
+        "ø7"
+      ]
     },
     {
       "rule_id": "pass-tritone-sub-major-resolution",
@@ -158,12 +158,10 @@
         "chord_symbol.substitute": "tritone_substitute_dominant",
         "voicing.role": "tritone_sub_approach"
       },
-      "preference": "prefer tritone sub (bII7) over direct V7 when resolving to major tonic",
+      "preference": 1,
       "quality_binding": [
-        "7",
-        "13",
-        "13b5",
-        "7+9b5"
+        "dom7",
+        "dom13"
       ],
       "falsifier": "tritone sub used in context where resolution target is minor or non-tonic",
       "anchor": "G13b5 (or Db7+9b5) which re-solves into Cma9",
@@ -173,7 +171,11 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Major Sounds Resolution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "13b5",
+        "7+9b5"
+      ]
     },
     {
       "rule_id": "pass-major-sound-cma9-target",
@@ -188,10 +190,9 @@
         ],
         "voicing.role": "tonic_major_with_ninth"
       },
-      "preference": "add ninth to major tonic voicing when arriving via tritone sub",
+      "preference": 1,
       "quality_binding": [
-        "maj9",
-        "ma9"
+        "maj9"
       ],
       "falsifier": "plain major triad used as tonic after tritone sub resolution",
       "anchor": "G13b5 (or Db7+9b5) which re-solves into Cma9",
@@ -201,7 +202,10 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Major Sounds Resolution",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "ma9"
+      ]
     },
     {
       "rule_id": "pass-db7-as-g7-substitute",
@@ -215,11 +219,10 @@
         "chord_symbol.substitute": "Db7",
         "voicing.role": "tritone_sub"
       },
-      "preference": "use Db7+9b5 voicing shape when substituting for G13",
+      "preference": 1,
       "quality_binding": [
-        "7",
-        "13",
-        "13b5"
+        "dom7",
+        "dom13"
       ],
       "falsifier": "G7 used directly without tritone sub option in major resolution passage",
       "anchor": "G13b5 (or Db7+9b5) which re-solves into Cma9",
@@ -229,7 +232,10 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Major Sounds Resolution",
         "level": "paragraph"
-      }
+      },
+      "applicability_reasons": [
+        "13b5"
+      ]
     },
     {
       "rule_id": "pass-chromatic-approach-to-dominant",
@@ -243,10 +249,9 @@
         "chord_symbol.substitute": "bVI13_chromatic_approach",
         "voicing.role": "chromatic_approach_to_V"
       },
-      "preference": "insert chromatic dominant (bVI13) between ii and V for smooth bass descent",
+      "preference": 1,
       "quality_binding": [
-        "m7",
-        "13"
+        "dom13"
       ],
       "falsifier": "direct ii-V motion with no chromatic approach chord",
       "anchor": "movement in Dm7, resolving into Abl13 to G13",
@@ -256,7 +261,10 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Minor Seventh to Seventh Movement",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "m7"
+      ]
     },
     {
       "rule_id": "pass-bass-half-step-into-V",
@@ -269,11 +277,11 @@
         "voicing.shape": "chromatic_bass_approach",
         "voicing.role": "half_step_below_dominant"
       },
-      "preference": "use bVI13 voicing whose root is a half-step above the V root",
+      "preference": 1,
       "quality_binding": [
-        "13",
-        "7",
-        "9"
+        "dom13",
+        "dom7",
+        "dom9"
       ],
       "falsifier": "approach chord a whole step or tritone away from V root",
       "anchor": "resolving into Abl13 to G13",
@@ -296,11 +304,11 @@
         "chord_symbol.substitute": "substitute_turnaround_sequence",
         "voicing.role": "turnaround_substitute"
       },
-      "preference": "prefer substitute turnaround over standard I-VI-II-V when returning to G13",
+      "preference": 1,
       "quality_binding": [
-        "7",
-        "9",
-        "13"
+        "dom7",
+        "dom9",
+        "dom13"
       ],
       "falsifier": "standard I-VI-II-V used when substitute turnaround passage is available",
       "anchor": "substitute turn-around back to G13",
@@ -323,11 +331,11 @@
         "voicing.role": "cycle_node",
         "voicing.shape": "seventh_catalog_form"
       },
-      "preference": "follow cycle of fifths as default armature for connecting seventh-chord members",
+      "preference": 1,
       "quality_binding": [
-        "7",
-        "9",
-        "13",
+        "dom7",
+        "dom9",
+        "dom13",
         "maj7"
       ],
       "falsifier": null,
@@ -350,10 +358,9 @@
       "then": {
         "voicing.role": "free_approach_chord"
       },
-      "preference": "treat destination as open; any resolution target is valid",
+      "preference": 0,
       "quality_binding": [
         "dim",
-        "°",
         "dim7"
       ],
       "falsifier": null,
@@ -378,10 +385,9 @@
         "chord_symbol.substitute": "Dm7_G7_Cma7",
         "voicing.role": "approach_to_ii_V_I"
       },
-      "preference": "prefer Dm7-G7-Cma7 resolution path when targeting major tonic",
+      "preference": 1,
       "quality_binding": [
-        "dim",
-        "°"
+        "dim"
       ],
       "falsifier": "diminished chord resolving directly to tonic without ii or V intermediary",
       "anchor": "Dm7 — G7 — Cma'7",
@@ -405,10 +411,9 @@
         "chord_symbol.substitute": "Em7_Eb9_Dm9_Db9",
         "voicing.role": "chromatic_descending_bass_approach"
       },
-      "preference": "prefer chromatic descending bass path (Em7-Eb9-Dm9-Db9) when targeting minor sound",
+      "preference": 1,
       "quality_binding": [
-        "dim",
-        "°"
+        "dim"
       ],
       "falsifier": "non-chromatic bass motion in this resolution path",
       "anchor": "Em7 — Eb9 — Dm9 — Db9",
@@ -431,12 +436,11 @@
         "chord_symbol.substitute": "diminished_chord",
         "voicing.shape": "diminished_catalog_form"
       },
-      "preference": "use diminished voicing wherever 7b9 appears; treat as freely interchangeable",
+      "preference": 1,
       "quality_binding": [
-        "7b9",
+        "dom7b9",
         "dim",
-        "dim7",
-        "°7"
+        "dim7"
       ],
       "falsifier": "7b9 chord that cannot be replaced by its corresponding diminished form",
       "anchor": "Use of diminished chords for seventh flat ninth chord movement",
@@ -446,7 +450,10 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Diminished as Flat-Nine Substitute",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "°7"
+      ]
     },
     {
       "rule_id": "pass-dim-passage-anchor-skeleton",
@@ -459,9 +466,9 @@
         "chord_symbol.substitute": "diminished_chord",
         "voicing.role": "approach_in_skeleton"
       },
-      "preference": "apply diminished-for-7b9 substitution at VI and V positions in the I-VI-II-V pattern",
+      "preference": 1,
       "quality_binding": [
-        "7b9",
+        "dom7b9",
         "dim7"
       ],
       "falsifier": "diminished substitution outside of recognizable harmonic skeleton",
@@ -485,11 +492,9 @@
         "voicing.role": "sustained_color_approach",
         "voicing.shape": "augmented_catalog_form"
       },
-      "preference": "sustain augmented voicing across multiple chord positions before chromatic resolution",
+      "preference": 1,
       "quality_binding": [
-        "aug",
-        "+",
-        "+7"
+        "aug"
       ],
       "falsifier": "augmented chord used as a single passing chord with no sustained color function",
       "anchor": "first six chords are basically G aug. Movement is used chromatically to get to the basic cycle",
@@ -499,7 +504,10 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Augmented Chromatic Approach",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "+7"
+      ]
     },
     {
       "rule_id": "pass-aug-chromatic-into-cycle",
@@ -512,10 +520,9 @@
         "voicing.role": "chromatic_approach_to_cycle",
         "chord_symbol.substitute": "cycle_dominant_entry"
       },
-      "preference": "resolve augmented color via half-step voice leading into the first chord of the cycle",
+      "preference": 1,
       "quality_binding": [
-        "aug",
-        "+"
+        "aug"
       ],
       "falsifier": "augmented chord resolved by leap rather than chromatic motion",
       "anchor": "Movement is used chromatically to get to the basic cycle (A7 — D7 —G)",
@@ -537,7 +544,7 @@
         "voicing.shape": "qualifier_order_maps_to_voice_layer",
         "voicing.role": "read_symbol_left_to_right_as_bottom_to_top"
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -565,10 +572,9 @@
         ],
         "voicing.shape": "D7_core_with_raised_ninth_then_raised_fifth"
       },
-      "preference": "place raised ninth in next available voice above D7 core; place raised fifth on top string",
+      "preference": 1,
       "quality_binding": [
-        "7+9+5",
-        "7#9#5"
+        "any"
       ],
       "falsifier": "D7+9+5 voiced with raised fifth below raised ninth",
       "anchor": "D7+9+5 means D7 with the raised 9th next, and the raised 5th on top",
@@ -578,7 +584,11 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Chord Symbol Spelling Convention",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "7+9+5",
+        "7#9#5"
+      ]
     },
     {
       "rule_id": "pass-sustain-common-top-voice",
@@ -590,7 +600,7 @@
       "then": {
         "voicing.shape": "sustain_top_voice_across_change"
       },
-      "preference": "always sustain rather than rearticulate a top-voice note that is common to both chords",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -616,10 +626,10 @@
         "voicing.shape": "sustain_G_on_top_string",
         "voicing.string_set_label": "top_voice_sustain"
       },
-      "preference": "use voicing shapes for C9 and F13 that share G on the same top string",
+      "preference": 1,
       "quality_binding": [
-        "9",
-        "13"
+        "dom9",
+        "dom13"
       ],
       "falsifier": "C9 and F13 voiced without G on top",
       "anchor": "C9 to F13, sustain the G on top",
@@ -643,10 +653,9 @@
         "voicing.role": "iio_pre_V7b9_pre_aug",
         "chord_symbol.substitute": "V7b9_then_aug_resolution"
       },
-      "preference": "resolve half-diminished through 7b9 dominant to augmented, not directly to tonic",
+      "preference": 1,
       "quality_binding": [
-        "m7b5",
-        "ø7"
+        "any"
       ],
       "falsifier": "half-diminished resolving directly to tonic without 7b9 and augmented intermediaries",
       "anchor": "A7b9 to Dm7}5 resolving finally to G aug",
@@ -656,7 +665,11 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Minor Seventh Flat Fifth to Seventh Passage",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "m7b5",
+        "ø7"
+      ]
     },
     {
       "rule_id": "pass-half-dim-to-aug-voicing-inspection",
@@ -669,12 +682,9 @@
         "voicing.shape": "catalog_form_for_half_dim_to_aug",
         "voicing.role": "shape_specific_approach_to_augmented"
       },
-      "preference": "inspect and memorize the specific voicing shapes rather than any generic half-dim form",
+      "preference": 1,
       "quality_binding": [
-        "m7b5",
-        "ø7",
-        "aug",
-        "+"
+        "aug"
       ],
       "falsifier": "generic half-diminished voicing substituted without regard to specific catalog shape",
       "anchor": "Notice the chords used to obtain these sounds",
@@ -684,7 +694,11 @@
         "chapter_title": "CHORD PASSAGES",
         "section_title": "Minor Seventh Flat Fifth to Augmented Sounds",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "m7b5",
+        "ø7"
+      ]
     }
   ]
 }

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-1/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-1/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:58-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -39,12 +39,9 @@
         "voicing.cycle_index": "read entry at (cycle.id × scale.context) cell",
         "voicing.scale_context": "constrain all voice-leading analysis to the parent scale of the cell"
       },
-      "preference": "mandatory",
+      "preference": 2,
       "quality_binding": [
-        "triad",
-        "seventh",
-        "tbn-i",
-        "tbn-ii"
+        "dom7"
       ],
       "falsifier": "A voicing entry that produces valid output when cycle.id or scale.context is unspecified",
       "anchor": "six cycles (2-7) within three parent scales: C Major, C Melodic Minor, and C Harmonic Minor",
@@ -53,7 +50,12 @@
         "chapter_n": 1,
         "section_title": "Cycle × Scale Grid — 18 Environments",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "triad",
+        "tbn-i",
+        "tbn-ii"
+      ]
     },
     {
       "rule_id": "goodrick-cycle-defines-root-motion",
@@ -71,8 +73,10 @@
       "then": {
         "voicing.cycle_index": "root moves by interval N where N equals cycle number"
       },
-      "preference": "required",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A cycle labeled cycle-4 that produces root motion by an interval other than a fourth",
       "anchor": "cycles (cycles 2 through 7, representing the interval of motion between successive diatonic chords)",
       "source_page": 12,
@@ -93,8 +97,10 @@
         "voicing.cycle_index": "cycle axis may be varied independently of scale axis",
         "voicing.scale_context": "scale axis may be varied independently of cycle axis"
       },
-      "preference": "design invariant",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "Any (cycle, scale) cell found to be empty",
       "anchor": "six cycles × 3 parent scales produces 18 distinct voice-leading environments",
       "source_page": 12,
@@ -117,8 +123,10 @@
       "then": {
         "voicing.shape": "select the voice-leading table specific to voicing.position"
       },
-      "preference": "mandatory",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A case where Close and Spread entries produce identical intervallic voice-leading profiles",
       "anchor": "Each voicing is displayed in both close and spread positions",
       "source_page": 12,
@@ -141,8 +149,10 @@
         "voicing.shape": "toggle between close and spread to modify contrapuntal texture; harmonic content preserved",
         "voicing.functional_class": "unchanged by position toggle"
       },
-      "preference": "preferred",
-      "quality_binding": [],
+      "preference": 1,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A position toggle that changes the pitch-class set",
       "anchor": "the guitarist can trace how register choice reshapes the contrapuntal texture without changing the harmonic content",
       "source_page": 12,
@@ -161,8 +171,10 @@
       "then": {
         "voicing.cycle_index": "identify common tone, step voices, leap voices"
       },
-      "preference": "required first step",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A voicing selection that contradicts the intervallic profile listed",
       "anchor": "intervallic voice-leading relationships",
       "source_page": 12,
@@ -181,8 +193,10 @@
       "then": {
         "voicing.functional_class": "assign each voice a scale-degree function and track which function moves to which"
       },
-      "preference": "required second step",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "An entry where two voices carry the same scale-degree function within the same chord",
       "anchor": "functional voice-leading information",
       "source_page": 12,
@@ -201,8 +215,10 @@
       "then": {
         "voicing.msrp": "prefer voicing sequence whose top voice matches M.S.R.P. encoding"
       },
-      "preference": "tie-breaker",
-      "quality_binding": [],
+      "preference": 0,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A voicing path preferred over M.S.R.P. despite producing less stepwise top-voice",
       "anchor": "Most Stepwise Resolution Pattern (M.S.R.P.) strings",
       "source_page": 12,
@@ -221,8 +237,10 @@
       "then": {
         "voicing.cycle_index": "hold or minimally displace common-tone voice across cycle step"
       },
-      "preference": "strong preference",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A cycle environment where no voice carries interval 0",
       "anchor": "intervallic voice-leading relationships, functional voice-leading information",
       "source_page": 12,
@@ -241,8 +259,10 @@
       "then": {
         "voicing.functional_class": "treat entries as interchangeable substitutes"
       },
-      "preference": "available",
-      "quality_binding": [],
+      "preference": 0,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "Two entries with identical functional profiles that produce non-substitutable results",
       "anchor": "functional voice-leading information",
       "source_page": 12,
@@ -266,9 +286,9 @@
         "voicing.shape": "apply 3-voice intervallic/functional tables",
         "voicing.functional_class": "assign root, 3rd, 5th"
       },
-      "preference": "mandatory",
+      "preference": 2,
       "quality_binding": [
-        "triad"
+        "any"
       ],
       "falsifier": "A triad entry with fewer than 3 or more than 3 distinct voices",
       "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs — in both Close and Spread voicings",
@@ -277,7 +297,10 @@
         "chapter_n": 1,
         "section_title": "Tertian Voicing Families — Triads and Seventh Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "triad"
+      ]
     },
     {
       "rule_id": "goodrick-seventh-4voice-close-spread",
@@ -293,9 +316,9 @@
         "voicing.shape": "apply 4-voice intervallic/functional tables",
         "voicing.functional_class": "assign root, 3rd, 5th, 7th"
       },
-      "preference": "mandatory",
+      "preference": 2,
       "quality_binding": [
-        "seventh"
+        "dom7"
       ],
       "falsifier": "A seventh-chord entry with fewer than 4 or more than 4 distinct voices",
       "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs — in both Close and Spread voicings",
@@ -323,10 +346,9 @@
         "voicing.cycle_index": "expect one or more common tones per cycle step",
         "voicing.msrp": "M.S.R.P. reflects predominantly stepwise or common-tone top-voice motion"
       },
-      "preference": "descriptive",
+      "preference": 0,
       "quality_binding": [
-        "triad",
-        "seventh"
+        "dom7"
       ],
       "falsifier": "A cycle-4 or cycle-5 cell where no voice carries interval 0",
       "anchor": "some cycles (particularly cycles producing common-tone-rich motion) yield smooth voice-leading almost automatically",
@@ -335,7 +357,10 @@
         "chapter_n": 1,
         "section_title": "Tertian Voicing Families — Triads and Seventh Chords",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "triad"
+      ]
     },
     {
       "rule_id": "goodrick-tbn-same-analytical-layers",
@@ -355,10 +380,9 @@
         "voicing.functional_class": "assign functional labels to TBN voices",
         "voicing.msrp": "read M.S.R.P. string identically to tertian procedure"
       },
-      "preference": "mandatory",
+      "preference": 2,
       "quality_binding": [
-        "tbn-i",
-        "tbn-ii"
+        "any"
       ],
       "falsifier": "A TBN entry that omits one of the three analytical layers",
       "anchor": "triads, seventh chords, and Goodrick's TBN (Two-Note Base) constructs",
@@ -367,7 +391,11 @@
         "chapter_n": 1,
         "section_title": "TBN (Two-Note Base) Constructs",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "tbn-i",
+        "tbn-ii"
+      ]
     },
     {
       "rule_id": "goodrick-quartal-same-18-env-grid",
@@ -396,11 +424,9 @@
         "voicing.cycle_index": "locate entry at (cycle.id × scale.context) cell",
         "voicing.scale_context": "constrain analysis to parent scale"
       },
-      "preference": "mandatory",
+      "preference": 2,
       "quality_binding": [
-        "3part-quartal",
-        "4part-quartal",
-        "spread-cluster"
+        "any"
       ],
       "falsifier": "A quartal or cluster entry outside the 18-environment grid",
       "anchor": "six cycles (cycles 2-7) and three parent scales (C Major, C Melodic Minor, and C Harmonic Minor)",
@@ -409,7 +435,12 @@
         "chapter_n": 2,
         "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "3part-quartal",
+        "4part-quartal",
+        "spread-cluster"
+      ]
     },
     {
       "rule_id": "goodrick-quartal-three-analytical-layers",
@@ -426,11 +457,9 @@
         "voicing.functional_class": "apply functional layer",
         "voicing.msrp": "read M.S.R.P. string"
       },
-      "preference": "mandatory",
+      "preference": 2,
       "quality_binding": [
-        "3part-quartal",
-        "4part-quartal",
-        "spread-cluster"
+        "any"
       ],
       "falsifier": "A quartal or cluster entry that lacks one of the three layers",
       "anchor": "Intervallic Voice-Leading (pitch relationships), Functional Voice-Leading (harmonic context)",
@@ -439,7 +468,12 @@
         "chapter_n": 2,
         "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "3part-quartal",
+        "4part-quartal",
+        "spread-cluster"
+      ]
     },
     {
       "rule_id": "goodrick-quartal-nct-resist-naming",
@@ -456,8 +490,10 @@
         "voicing.functional_class": "do not force a tertian chord-quality label",
         "voicing.shape": "select using (cycle, scale, position) tuple"
       },
-      "preference": "required when chord_quality cannot be resolved",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A quartal or cluster entry defined only in relation to an underlying tertian chord name",
       "anchor": "the volume's strategic shift away from tertian harmony toward quartal and cluster sonorities that resist conventional chord naming",
       "source_page": 190,
@@ -476,9 +512,9 @@
       "then": {
         "voicing.shape": "select one of six 4-part quartal voicing types"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "4part-quartal"
+        "any"
       ],
       "falsifier": "Fewer than or more than six distinct 4-part quartal voicing types",
       "anchor": "4-part quartal voicings across six distinct voicing types",
@@ -487,7 +523,10 @@
         "chapter_n": 2,
         "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "4part-quartal"
+      ]
     },
     {
       "rule_id": "goodrick-spread-cluster-six-types",
@@ -498,9 +537,9 @@
       "then": {
         "voicing.shape": "select one of six Spread Cluster voicing types"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "spread-cluster"
+        "any"
       ],
       "falsifier": "Fewer than or more than six distinct Spread Cluster voicing types",
       "anchor": "Spread Cluster voicings across six further types",
@@ -509,7 +548,10 @@
         "chapter_n": 2,
         "section_title": "Quartal / Cluster Catalog — Same Grid, Different Primitives",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "spread-cluster"
+      ]
     },
     {
       "rule_id": "goodrick-family-agnostic-vl-discipline",
@@ -529,8 +571,10 @@
         "voicing.cycle_index": "apply same motion-budget analysis regardless of family",
         "voicing.functional_class": "track scale-degree or quartal-equivalent function using same logic"
       },
-      "preference": "invariant",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A voicing family requiring a fourth analytical layer or different grid",
       "anchor": "quartal and cluster harmony is not a special case requiring special treatment. It obeys the same voice-leading discipline as tertian harmony",
       "source_page": 190,
@@ -549,8 +593,10 @@
       "then": {
         "voicing.cycle_index": "read intervallic layer using same procedure regardless of family"
       },
-      "preference": "required",
-      "quality_binding": [],
+      "preference": 2,
+      "quality_binding": [
+        "any"
+      ],
       "falsifier": "A quartal or cluster entry where interval 0 cannot be identified using the same procedure",
       "anchor": "By running 4-part fourths and spread cluster voicings through the same 18-environment grid, with the same three analytical layers, Goodrick enforces the insight that the guitarist's contrapuntal obligation does not change when the harmonic language does",
       "source_page": 190,
@@ -574,11 +620,9 @@
         "voicing.cycle_index": "expect larger or more frequent intervallic leaps",
         "voicing.msrp": "M.S.R.P. reflects wider top-voice range"
       },
-      "preference": "descriptive",
+      "preference": 0,
       "quality_binding": [
-        "3part-quartal",
-        "4part-quartal",
-        "spread-cluster"
+        "any"
       ],
       "falsifier": null,
       "anchor": "What changes across families is which voice carries the common tone, which voice steps by a second or third, and how large the remaining leaps must be",
@@ -587,7 +631,12 @@
         "chapter_n": 2,
         "section_title": "Unity of Voice-Leading Across Families",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "3part-quartal",
+        "4part-quartal",
+        "spread-cluster"
+      ]
     },
     {
       "rule_id": "goodrick-msrp-quartal-top-voice-benchmark",
@@ -602,11 +651,9 @@
       "then": {
         "voicing.msrp": "use M.S.R.P. string as compact melodic handle on multi-voice contrapuntal event"
       },
-      "preference": "tie-breaker",
+      "preference": 0,
       "quality_binding": [
-        "3part-quartal",
-        "4part-quartal",
-        "spread-cluster"
+        "any"
       ],
       "falsifier": "A quartal or cluster entry where M.S.R.P. string is absent while equivalent tertian entry at same address has valid M.S.R.P.",
       "anchor": "M.S.R.P. string indicating the Most Stepwise Resolution Pattern",
@@ -615,7 +662,12 @@
         "chapter_n": 2,
         "section_title": "Unity of Voice-Leading Across Families",
         "level": "section"
-      }
+      },
+      "applicability_reasons": [
+        "3part-quartal",
+        "4part-quartal",
+        "spread-cluster"
+      ]
     }
   ]
 }

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-2/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-2/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-17T09:44:55-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -29,7 +29,7 @@
           "6th"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -50,7 +50,7 @@
           "6th"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -69,7 +69,7 @@
         "voicing.action": "exclude",
         "voicing.reason": "enharmonic-collapse-to-major-3rd"
       },
-      "preference": "avoid",
+      "preference": -1,
       "quality_binding": [
         "any"
       ],
@@ -89,7 +89,7 @@
         "voicing.technique": "drop-D-pedal",
         "tuning.low_string": "D"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -108,7 +108,7 @@
         "voicing.avoid_note_count": 0,
         "arrangement.style": "unrestricted-cycle-traversal"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -127,7 +127,7 @@
         "voicing.arpeggio_direction": "alternating-up-down",
         "voice_leading.constraint": "ascend-odd-descend-even"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -157,7 +157,7 @@
           "4-part-chords"
         ]
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -180,7 +180,7 @@
         "voice_leading.constraint": "stepwise-or-common-tone",
         "voice_leading.max_motion": "3rd"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -198,7 +198,7 @@
         "voice_leading.static_voice_label": "c.t.",
         "voice_leading.c.t._is_distinct_category": true
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -224,7 +224,7 @@
         "analysis.intervallic_cell": "motion-interval-per-voice",
         "analysis.functional_cell": "scale-degree-destination-per-voice"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -245,7 +245,7 @@
         "voice_leading.variant_count": 2,
         "voice_leading.hazard": "voice-crossing-on-diatonic-5th"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -268,7 +268,7 @@
         "voicing.expansion_method": "octave-insertion",
         "voicing.insertion_positions": "any-adjacent-voice-pair"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -290,7 +290,7 @@
           "drop-3-and-4"
         ]
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -315,7 +315,7 @@
           "Drop-3-and-4"
         ]
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -335,7 +335,7 @@
       "then": {
         "arrangement.technique": "fingerstyle-only"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -358,7 +358,7 @@
           "3-part-spread-cluster"
         ]
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -376,7 +376,7 @@
         "voicing.non_chord_tone": "passing-tone",
         "nct.placement": "between-two-chord-tones-a-3rd-apart"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -395,7 +395,7 @@
         "voicing.non_chord_tone": "passing-tone",
         "nct.voice_count": 2
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -418,7 +418,7 @@
         "voicing.density": "4-way-close",
         "voicing.minimum_starting_density": "close"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -437,7 +437,7 @@
         "voicing.open_strings": "preferred",
         "voicing.playability": "maximize"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -460,7 +460,7 @@
         "scale.context": "C-Harmonic-Minor",
         "scale.priority": 1
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -478,7 +478,7 @@
         "voice_leading.chromatic_density": "maximum",
         "voicing.sonic_reward": "highest"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -497,7 +497,7 @@
         "voicing.arpeggio_sequence_count": 24,
         "voicing.permutation_method": "exhaustive-voice-ordering"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -516,7 +516,7 @@
         "voicing.2-voice-subset-count": 6,
         "practice.traversal": "exhaustive"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -535,7 +535,7 @@
         "voicing.3-voice-subset-count": 4,
         "practice.traversal": "exhaustive"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -558,7 +558,7 @@
         ],
         "voicing.alternation": "pair-based"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -577,7 +577,7 @@
         "arrangement.physical_demand": "high",
         "arrangement.caution": "required"
       },
-      "preference": "avoid",
+      "preference": -1,
       "quality_binding": [
         "any"
       ],
@@ -601,7 +601,7 @@
         "voicing.naming_convention": "omit",
         "harmonic.context": "function-agnostic"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -627,7 +627,7 @@
         "progression.type": "diatonic-cycle",
         "traversal.scope": "all-six-cycles"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -655,7 +655,7 @@
           "C-Harmonic-Minor"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -685,7 +685,7 @@
         "voicing.family_count": 5,
         "voicing.completeness": "exhaustive"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -714,7 +714,7 @@
         "voicing.3-part-chord-count_floor": 20,
         "voicing.4-part-chord-count_floor": 30
       },
-      "preference": null,
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -737,7 +737,7 @@
         ],
         "voicing.guitar_playability": "high"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -760,7 +760,7 @@
           "7th": 1
         }
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -780,7 +780,7 @@
         "practice.drill": "M.S.R.P.",
         "practice.method": "memorized-note-sequence-loop"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -800,7 +800,7 @@
         "practice.strip_count": 8,
         "practice.purpose": "voice-isolation-and-reduction"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -819,7 +819,7 @@
         "voicing.melodic_source": "arpeggio-of-quartal-shape",
         "voice_leading.constraint": "chord-tone-sequence"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -839,7 +839,7 @@
         "voice_leading.moving_voice_count": 1,
         "voice_leading.moving_voice_interval": "4th"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -864,7 +864,7 @@
         "voice_leading.constraint": "voice-leading-primary",
         "harmonic.context": "voice-leading-derived"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-3/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-3/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-17T09:44:43-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -22,15 +22,18 @@
         "voicing.naming_convention": "sus4_over_triad_root",
         "voicing.label_form": "<root> [sus4]"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "clarity",
-        "convention"
+        "any"
       ],
       "falsifier": "A 3-part stacked-fourth chord is labelled with cumbersome alterations (e.g., 'B Diminished triad [no b3rd] add b9') or C2 shorthand instead of the sus4 form.",
       "anchor": "My suggestion for a suitable name for this chord would be: G [sus4]. That means a G Major triad with 4 suspended for 3.",
       "source_page": 4,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "clarity",
+        "convention"
+      ]
     },
     {
       "rule_id": "goodrick-sus4-naming-4part",
@@ -42,15 +45,18 @@
       "then": {
         "voicing.naming_convention": "sus4_over_triad_root"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "clarity",
-        "convention"
+        "any"
       ],
       "falsifier": "A 4-part 4ths voicing is labelled as 'C Major 7th [no 5] substitute 4 for the missing 5th' rather than as a sus4 chord.",
       "anchor": "NAMES FOR 4-PART 4THS This is fairly simple: Sus 4 Chords...[I think it's the best way to go...]",
       "source_page": 4,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "clarity",
+        "convention"
+      ]
     },
     {
       "rule_id": "goodrick-event-vs-episode",
@@ -63,14 +69,17 @@
         "passage.category": "event_if_2to6_notes_else_episode",
         "passage.length_independence": true
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "analytic_precision"
+        "any"
       ],
       "falsifier": "A passage is classified as event vs. episode based on its temporal length rather than the count of distinct diatonic notes it contains.",
       "anchor": "EVENT involves 2-6 diatonic scale notes at least once each. EPISODE involves all 7 diatonic scale notes at least once each.",
       "source_page": 3,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "analytic_precision"
+      ]
     },
     {
       "rule_id": "goodrick-event-diatonic-transposition",
@@ -83,14 +92,17 @@
         "passage.transposition_yields": "up_to_6_other_events",
         "passage.intervallic_identity": "possible_collapse"
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "analytic_precision"
+        "any"
       ],
       "falsifier": "Two diatonic transpositions of an event are treated as distinct sonorities when their interval structures are identical.",
       "anchor": "an event can be diatonically transposed to create 6 other events, but some of them will be intervallically identical.",
       "source_page": 3,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "analytic_precision"
+      ]
     },
     {
       "rule_id": "goodrick-episode-diatonic-transposition",
@@ -102,14 +114,17 @@
       "then": {
         "passage.transposition_yields": "6_other_episodes_each_a_mode"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "analytic_precision"
+        "any"
       ],
       "falsifier": "An episode's transpositions are claimed to share the same mode rather than mapping one-to-one onto the seven diatonic modes.",
       "anchor": "an episode can be diatonically transposed to create 6 other episodes, where each corresponds to a different mode.",
       "source_page": 3,
-      "source_chapter": 2
+      "source_chapter": 2,
+      "applicability_reasons": [
+        "analytic_precision"
+      ]
     },
     {
       "rule_id": "goodrick-spread-cluster-literal-pitch-naming",
@@ -122,15 +137,18 @@
         "voicing.naming_convention": "literal_pitch_list",
         "voicing.label_form": "<P1> <P2> <P3>"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "clarity",
-        "convention"
+        "any"
       ],
       "falsifier": "A 3-part spread cluster (e.g., the set C D E) is forced into a chord symbol like 'C Major 9 (no 5, no 7)' rather than written as 'C D E'.",
       "anchor": "Here’s what I think...Just name it like itis! CallitC DE\"! [Daa!!!]",
       "source_page": 6,
-      "source_chapter": 3
+      "source_chapter": 3,
+      "applicability_reasons": [
+        "clarity",
+        "convention"
+      ]
     },
     {
       "rule_id": "goodrick-real-compleat-m-lode-pairing",
@@ -148,15 +166,18 @@
           "3-part-spread-clusters": "4-part-spread-clusters"
         }
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "family_coherence",
-        "completeness"
+        "any"
       ],
       "falsifier": "A 3-part family is mapped to a 4-part counterpart outside of the five canonical pairings (e.g., triads paired with TBN I).",
       "anchor": "So, the REAL, COMPLEAT M-LODE depiction is: 3-Part Structures 4-Part Structures Triads (VolumelI) — 7th Chords 7th (no 3rd) TBNI 7th (no 5th) TBN IE 3-Part 4ths (Volume II) 4-Part 4ths 3-part Spread Clusters| Spread Clusters",
       "source_page": 7,
-      "source_chapter": 3
+      "source_chapter": 3,
+      "applicability_reasons": [
+        "family_coherence",
+        "completeness"
+      ]
     },
     {
       "rule_id": "goodrick-triad-interval-content",
@@ -169,14 +190,17 @@
         "voicing.family": "triads",
         "voicing.interval_profile": "mostly_3rds_6ths_some_4ths_5ths_no_2nds_no_7ths"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "family_coherence"
+        "any"
       ],
       "falsifier": "A 3-part chord containing a 2nd or a 7th between any voice pair is classified as a triad in the M-Lode sense.",
       "anchor": "The triads primarily consist of 3rds and 6ths with some 4ths and 5ths, but contain no 2nds or 7ths.",
       "source_page": 8,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "family_coherence"
+      ]
     },
     {
       "rule_id": "goodrick-3part-4ths-interval-content",
@@ -189,14 +213,17 @@
         "voicing.family": "3-part-4ths",
         "voicing.interval_profile": "mostly_4ths_5ths_some_2nds_7ths_no_3rds_no_6ths"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "family_coherence"
+        "any"
       ],
       "falsifier": "A 3-part chord containing a 3rd or a 6th between any voice pair is classified as a 3-part 4ths voicing.",
       "anchor": "While the 3-part 4ths primar- ily consist of 4ths and 5ths with some 2nds and 7ths, but contain no 3rds or 6ths.",
       "source_page": 8,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "family_coherence"
+      ]
     },
     {
       "rule_id": "goodrick-omission-allowed-families",
@@ -212,14 +239,17 @@
           "3-part-spread-clusters"
         ]
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "family_coherence"
+        "any"
       ],
       "falsifier": "Interval omission is treated as defining a member of the 7th-no-3rd, 7th-no-5th, TBN I, or TBN II family rather than as a structural property of triads / 3-part 4ths / spread clusters.",
       "anchor": "the omission of interval types only occurs within particular 3-part chord families (triad; 3-part 4th; spread cluster).",
       "source_page": 8,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "family_coherence"
+      ]
     },
     {
       "rule_id": "goodrick-four-family-even-distribution",
@@ -237,14 +267,17 @@
         ],
         "voicing.symmetry_basis": "even_interval_distribution"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "symmetry"
+        "any"
       ],
       "falsifier": "When the goal is consistent interval distribution across 3- and 4-part voicings, a non-even-distribution family (triad, 3-part 4ths, or spread cluster) is selected over the four even-distribution families.",
       "anchor": "the four chord families with the most even distribution are found both in 3- and 4-part chords (7th, no3rd; 7th, no5th; TBN I; TBN ID).",
       "source_page": 8,
-      "source_chapter": 4
+      "source_chapter": 4,
+      "applicability_reasons": [
+        "symmetry"
+      ]
     },
     {
       "rule_id": "goodrick-derive-3part-from-4part-voice-omission",
@@ -258,14 +291,17 @@
         "voicing.derivation_path": "omit_one_voice_from_4part_parent",
         "voicing.family": "determined_by_omitted_voice"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "derivation"
+        "any"
       ],
       "falsifier": "A 3-part voicing in the M-Lode framework is generated by omitting two voices, by adding a voice to a 2-part structure, or by any method other than single-voice omission from a 4-part parent.",
       "anchor": "What follows is a brief, introductory study of how to arrive at different 3-part chords by leaving out one voice of a 4-part chord.",
       "source_page": 9,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "derivation"
+      ]
     },
     {
       "rule_id": "goodrick-7th-chord-generates-two-triads",
@@ -281,14 +317,17 @@
         ],
         "voicing.family": "one_of_the_two_products"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "derivation"
+        "any"
       ],
       "falsifier": "A 4-part 7th chord is claimed to derive a 3-part voicing other than 7th-no-3rd or 7th-no-5th by single-voice omission.",
       "anchor": "7th chord generates _ two different triads, 7th (no 3rd), 7th (no 5th)",
       "source_page": 9,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "derivation"
+      ]
     },
     {
       "rule_id": "goodrick-each-3part-in-four-4part-families",
@@ -301,15 +340,18 @@
         "voicing.parent_4part_candidates_count": 4,
         "voicing.reharmonization_lattice": "four_family_substitution"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "symmetry",
-        "reharmonization"
+        "any"
       ],
       "falsifier": "A 3-part chord is treated as embeddable in only one 4-part parent family, or in a number of parents other than four.",
       "anchor": "[Each 3-part chord appears four times...]",
       "source_page": 9,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "symmetry",
+        "reharmonization"
+      ]
     },
     {
       "rule_id": "goodrick-35-structure-roadmap",
@@ -330,14 +372,17 @@
         ],
         "voicing.remaining_to_explore": 30
       },
-      "preference": "advisory",
+      "preference": 1,
       "quality_binding": [
-        "completeness"
+        "any"
       ],
       "falsifier": "The five worked CMaj7 examples are claimed to exhaust the derivation taxonomy rather than to sample positions 1, 8, 15, 22, 29 of 35.",
       "anchor": "the five examples used in the present chapter (CMaj7, C, C, C, C ) correspond to numbers 1, 8, 15, 22 and 29. That means that there are only thirty more 4-part structures to explore in the present fashion!",
       "source_page": 9,
-      "source_chapter": 5
+      "source_chapter": 5,
+      "applicability_reasons": [
+        "completeness"
+      ]
     },
     {
       "rule_id": "goodrick-drop-toolkit-tbn",
@@ -356,14 +401,17 @@
           "Double Drop 2 Drop 3"
         ]
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "derivation"
+        "any"
       ],
       "falsifier": "A TBN I or TBN II parent is derived to 3-part children using a procedure outside the named drop toolkit (e.g., random voice transposition) without justification.",
       "anchor": "3-Part Chords Derived From a TBN I",
       "source_page": 10,
-      "source_chapter": 6
+      "source_chapter": 6,
+      "applicability_reasons": [
+        "derivation"
+      ]
     },
     {
       "rule_id": "goodrick-c-major-default-with-transposition-expectation",
@@ -379,14 +427,17 @@
         ],
         "voicing.student_obligation": "adjust_to_other_7_note_scales"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "coverage"
+        "any"
       ],
       "falsifier": "Material is treated as valid only in C Major, with no expectation that the student extend it to melodic or harmonic minor.",
       "anchor": "All of the material that follows in this next section will be presented in C Major (no accidentals). The assumption is that our readers will have (by now) developed the necessary skills to make the needed adjustments to change the material to other 7-note scales.",
       "source_page": 14,
-      "source_chapter": 10
+      "source_chapter": 10,
+      "applicability_reasons": [
+        "coverage"
+      ]
     },
     {
       "rule_id": "goodrick-generic-vl-six-pattern-space",
@@ -401,15 +452,18 @@
         "voicing.previously_used_in_vols_1_2": 3,
         "voicing.alternates_to_explore": 3
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "coverage",
-        "innovation"
+        "any"
       ],
       "falsifier": "Voice-leading exploration is restricted to the three patterns used in Volumes I and II without ever considering the three new alternates.",
       "anchor": "Note: Only 3 different generic voice-leadings were used out of 6!",
       "source_page": 56,
-      "source_chapter": 10
+      "source_chapter": 10,
+      "applicability_reasons": [
+        "coverage",
+        "innovation"
+      ]
     },
     {
       "rule_id": "goodrick-abc-label-key",
@@ -426,14 +480,17 @@
         },
         "voicing.analysis_mode": "cycle_independent"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "analytic_precision"
+        "any"
       ],
       "falsifier": "Generic voice-leading formulas are analyzed using scale-degree numbers rather than the abstract A/B/C strand labels, collapsing cycle independence.",
       "anchor": "Key: A= Ist note B = 2nd note C = 3rd note",
       "source_page": 55,
-      "source_chapter": 10
+      "source_chapter": 10,
+      "applicability_reasons": [
+        "analytic_precision"
+      ]
     },
     {
       "rule_id": "goodrick-intervallic-vs-functional-msrp",
@@ -449,14 +506,17 @@
         "voicing.functional_anchor": "M.S.R.P.",
         "voicing.cycle_voices_count": 2
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "analytic_precision"
+        "any"
       ],
       "falsifier": "Voice-leading is described only by interval distance per voice, without identifying which voices form the M.S.R.P. cycle and which carry the chord-tone strands.",
       "anchor": "Functional Voice-Leading 1 7 3 5 Ascends 2 different voicing alternate (drop 3; drop 2 & 4) 2 voices are the cycle M.S.R.P.",
       "source_page": 32,
-      "source_chapter": 10
+      "source_chapter": 10,
+      "applicability_reasons": [
+        "analytic_precision"
+      ]
     },
     {
       "rule_id": "goodrick-duet-texture-passing-tones",
@@ -473,15 +533,18 @@
         "voicing.embellishment": "add_passing_tones",
         "voicing.stylistic_preference": "harmonic_minor"
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "voice_leading",
-        "texture"
+        "any"
       ],
       "falsifier": "A 4-part voicing is elaborated by adding passing tones across all four voices simultaneously rather than via the top-2 / bottom-2 duet split.",
       "anchor": "4-part; no passing tones Duet (top 2, bottom 2); add p.t.. ¢ NICE in Harmonic minor!",
       "source_page": 43,
-      "source_chapter": 10
+      "source_chapter": 10,
+      "applicability_reasons": [
+        "voice_leading",
+        "texture"
+      ]
     },
     {
       "rule_id": "goodrick-twenty-3part-from-three-scales",
@@ -499,14 +562,17 @@
         ],
         "voicing.distinct_voicings_with_inversions": 120
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "completeness"
+        "any"
       ],
       "falsifier": "The twenty foundational 3-part chord types are sourced from any scale outside Major / Melodic Minor / Harmonic Minor, or the close+spread inversion expansion is reported as a count other than 120.",
       "anchor": "All of the following 3-part chords are derived from the Major scale, the Melodic Minor and the Harmonic Minor scales, but they are transposed to the root of C. (Twenty 3-part chords is perhaps misleading...3 close inversions plus 3 spread inversions for each gives us one hundred twenty 3-part chords you should know...)",
       "source_page": 71,
-      "source_chapter": 11
+      "source_chapter": 11,
+      "applicability_reasons": [
+        "completeness"
+      ]
     },
     {
       "rule_id": "goodrick-prefer-3part-on-guitar",
@@ -522,15 +588,18 @@
           "melodic_embellishment_space"
         ]
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "playability",
-        "voice_leading"
+        "any"
       ],
       "falsifier": "On guitar, 4-part voicings are recommended over 3-part voicings without acknowledging the reduced embellishment space and increased fingering difficulty.",
       "anchor": "As guitarists, we can see that 3-part chords are easier to play than 4-part chords. Also, they often afford more space between the voices for melodic embellishment.",
       "source_page": 71,
-      "source_chapter": 11
+      "source_chapter": 11,
+      "applicability_reasons": [
+        "playability",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "goodrick-grip-slipping-inversion-cycle",
@@ -547,15 +616,18 @@
           "Drop 2&4"
         ]
       },
-      "preference": "moderate",
+      "preference": 1,
       "quality_binding": [
-        "coverage",
-        "fluency"
+        "any"
       ],
       "falsifier": "Grip-Slipping is presented as using a voicing type other than Drop 3 by default, or it omits the six-tonic / whole-tone organizing system.",
       "anchor": "\"Grip-Slipping\" is a term I use to describe a series of exercises that I sometimes give to my guitar students to help them learn all the inversions of different chords. Without giving away too many \"secrets,\" I've included six examples incorporating seventh chords in a six tonic system (whole tone scale). The voicing type is Drop 3. (You might try Drop 2 and Drop 2 & 4 as well...)",
       "source_page": 161,
-      "source_chapter": 12
+      "source_chapter": 12,
+      "applicability_reasons": [
+        "coverage",
+        "fluency"
+      ]
     },
     {
       "rule_id": "goodrick-gdvl-vs-scvl-mode-switch",
@@ -571,14 +643,17 @@
           "FVL"
         ]
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "analytic_precision"
+        "any"
       ],
       "falsifier": "Volumes I and II are described as using SCVL, or Grip-Slipping IVL/FVL exercises are classified as GDVL.",
       "anchor": "P.S. The IVLs and the FVLs are all examples of SCVL (specific chromatic voice-leading), as opposed to GDVL (generic diatonic voice-leading), which is all of Volumes 1 & 2.",
       "source_page": 161,
-      "source_chapter": 12
+      "source_chapter": 12,
+      "applicability_reasons": [
+        "analytic_precision"
+      ]
     },
     {
       "rule_id": "goodrick-harmonic-major-b6-substitution",
@@ -591,14 +666,17 @@
         "voicing.scale_target": "C_harmonic_major_Ionian_b6",
         "voicing.pitch_substitution": "Ab_for_A"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "coverage"
+        "any"
       ],
       "falsifier": "Conversion from C Major to Harmonic Major is performed by altering a degree other than the 6th (e.g., flatting the 3rd).",
       "anchor": "Harmonic Major...a major scale with b6...(sometimes named Ionian b6.) Ail of the “red pages” in Volumes 1 & 2 can be used with this very interesting variation: just play Ab (b6) instead of A (6).",
       "source_page": 145,
-      "source_chapter": 12
+      "source_chapter": 12,
+      "applicability_reasons": [
+        "coverage"
+      ]
     },
     {
       "rule_id": "goodrick-hungarian-minor-sharp4-substitution",
@@ -611,14 +689,17 @@
         "voicing.scale_target": "C_hungarian_minor",
         "voicing.pitch_substitution": "F#_for_F"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "coverage"
+        "any"
       ],
       "falsifier": "Conversion from Harmonic Minor to Hungarian Minor is performed without raising the 4th, or by altering a different degree.",
       "anchor": "Hungarian Minor...a harmonic minor scale with #4..|C D E}FEG AbBC |.",
       "source_page": 145,
-      "source_chapter": 12
+      "source_chapter": 12,
+      "applicability_reasons": [
+        "coverage"
+      ]
     },
     {
       "rule_id": "goodrick-five-scale-framework",
@@ -636,14 +717,17 @@
           "C hungarian minor (harmonic minor #4)"
         ]
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "coverage"
+        "any"
       ],
       "falsifier": "Advanced M-Lode material is restricted to three scales (Major, Melodic Minor, Harmonic Minor) and never extended to Harmonic Major or Hungarian Minor.",
       "anchor": "We present it in 5 scales: 1. C Major 2. C Melodic Minor 3. C Harmonic Minor 4. C Harmonic Major (C Ionian b6) 5. C Hungarian Minor (C Harmonic Minor #4)",
       "source_page": 145,
-      "source_chapter": 12
+      "source_chapter": 12,
+      "applicability_reasons": [
+        "coverage"
+      ]
     },
     {
       "rule_id": "goodrick-melody-harmony-equality",
@@ -655,15 +739,18 @@
         "voicing.aesthetic_principle": "melody_and_harmony_equal",
         "voicing.subordination": "neither"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "aesthetic",
-        "voice_leading"
+        "any"
       ],
       "falsifier": null,
       "anchor": "I feel that excellent voice-leading treats both melody and harmony as equals.",
       "source_page": 188,
-      "source_chapter": 12
+      "source_chapter": 12,
+      "applicability_reasons": [
+        "aesthetic",
+        "voice_leading"
+      ]
     },
     {
       "rule_id": "goodrick-spread-clusters-close-the-taxonomy",
@@ -676,14 +763,17 @@
         "voicing.closing_family": "4-part-spread-clusters",
         "voicing.taxonomy_status": "finite_and_complete"
       },
-      "preference": "strong",
+      "preference": 2,
       "quality_binding": [
-        "completeness"
+        "any"
       ],
       "falsifier": "The 4-part chord taxonomy is treated as open-ended without recognizing 4-Part Spread Clusters as the closing family.",
       "anchor": "I had completely overlooked SPREAD CLUSTERS! I did some more musical math and real- ized that this was the missing link! It not only completed the set of 4-part chords, but it helped me to realize that this WORK was not only finite, but do-able!",
       "source_page": 189,
-      "source_chapter": 12
+      "source_chapter": 12,
+      "applicability_reasons": [
+        "completeness"
+      ]
     }
   ]
 }

--- a/plugin/data/masters-corpus/mick-goodrick/almanac-vol-4/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mick-goodrick/almanac-vol-4/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-17T09:44:47-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -20,7 +20,7 @@
       "then": {
         "chord.label_format": "sus4"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -42,7 +42,7 @@
       "then": {
         "chord.label_format": "sus4"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -60,7 +60,7 @@
         "voicing.density": "3-part",
         "voicing.density_priority": "prefer-lower"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -77,7 +77,7 @@
       "then": {
         "voicing.voice_count_max": 4
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -96,7 +96,7 @@
         "voicing.voices_removed": 1,
         "voicing.source_density": "4-part"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -114,7 +114,7 @@
       "then": {
         "voicing.occurrence_count": 4
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -135,7 +135,7 @@
         "chord.taxonomy_family": "m-lode-expanded",
         "chord.collapse_to_other": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -160,7 +160,7 @@
         "chord.taxonomy_family": "m-lode-expanded",
         "chord.collapse_to_other": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -183,7 +183,7 @@
         "chord.taxonomy_family": "m-lode-expanded",
         "chord.subordinate_to": null
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -204,7 +204,7 @@
           "3-part Spread Clusters"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -224,7 +224,7 @@
           "SCVL"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -244,7 +244,7 @@
       "then": {
         "voice_leading.parent_type": "SCVL"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -262,7 +262,7 @@
         "voice_leading.domain_weight.melody": 1.0,
         "voice_leading.domain_weight.harmony": 1.0
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -281,7 +281,7 @@
         "transposition.step_max": 6,
         "transposition.collapse_identical_intervals": true
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -301,7 +301,7 @@
         "transposition.retain_count": 1,
         "transposition.duplicates_discarded": true
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -321,7 +321,7 @@
         "transposition.modal_variants": 6,
         "transposition.collapse_identical_intervals": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -340,7 +340,7 @@
         "transposition.modal_mapping": "one-to-one",
         "transposition.shared_mode_assignments": 0
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -365,7 +365,7 @@
           "combination"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -382,7 +382,7 @@
       "then": {
         "unit.classification_criterion": "note_coverage"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -404,7 +404,7 @@
         "scale.context": "C_major",
         "scale.accidentals": 0
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -426,7 +426,7 @@
         "transposition.agent": "student",
         "transposition.target_scales": "all-7-note-scales"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -443,7 +443,7 @@
       "then": {
         "catalog.traversal_pattern": "cycle3-cycle4-alternation"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -462,7 +462,7 @@
         "catalog.chord_type_count": 35,
         "catalog.total_entries": 840
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -480,7 +480,7 @@
       "then": {
         "catalog.3pt_chapters_precede_4pt": true
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -498,7 +498,7 @@
         "voice_leading.replication_source": "melodic_strand",
         "voice_leading.replication_target": "all_voices"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -516,7 +516,7 @@
         "voicing.position_shift": "minimal",
         "voicing.continuity_constraint": "same-position-preferred"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -534,7 +534,7 @@
         "voice_leading.scope": "chromatic",
         "voice_leading.prerequisite": "GDVL"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -554,7 +554,7 @@
       "then": {
         "voice_leading.type": "GDVL"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -575,7 +575,7 @@
       "then": {
         "chord.label_format": "sus4"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -594,7 +594,7 @@
         "voicing.voice_removed": "5th",
         "voicing.source_quality": "7th-4-part"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -621,7 +621,7 @@
         ],
         "voicing.symmetry_verified": true
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -640,7 +640,7 @@
       "then": {
         "transposition.total_modal_forms": 7
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -661,7 +661,7 @@
       "then": {
         "unit.multi_domain_allowed": true
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -678,7 +678,7 @@
       "then": {
         "catalog.traversal_pattern": "cycle3-cycle4-alternation"
       },
-      "preference": "recommended",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -695,7 +695,7 @@
       "then": {
         "voicing.valid": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -714,7 +714,7 @@
         "chord.taxonomy_rank": "coordinate",
         "chord.taxonomy_parent": "m-lode-expanded"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -733,7 +733,7 @@
         "scale.context": "C_major",
         "exercise.next_stage": "student-transposed-7-note-scales"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -751,7 +751,7 @@
         "voice_leading.motion_criterion": "interval",
         "voice_leading.parent_type": "SCVL"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -769,7 +769,7 @@
         "voice_leading.motion_criterion": "harmonic_function",
         "voice_leading.parent_type": "SCVL"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],

--- a/plugin/data/masters-corpus/mickey-baker/complete-course-in-jazz-guitar/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/mickey-baker/complete-course-in-jazz-guitar/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": null,
     "extracted_at": "2026-06-16T23:00:55-05:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -22,7 +22,7 @@
         "voicing.shape": "adaptable_voicing_with_motion",
         "progression.cycle_id": "baker-numbered-catalog"
       },
-      "preference": "mandatory_replacement",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -50,7 +50,7 @@
         "voicing.shape": "baker_catalog_number",
         "progression.cycle_id": "baker-numbered-catalog"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -88,7 +88,7 @@
         "chord_symbol.substitute": "G_major_or_C_major_position",
         "progression.cycle_id": "baker-seed-key-gc"
       },
-      "preference": "required_for_beginners",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "maj7",
@@ -114,7 +114,7 @@
         "voicing.shape": "position_shifted_identical_fingering",
         "progression.cycle_id": "baker-transposition-mandate"
       },
-      "preference": "non_negotiable",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -152,7 +152,7 @@
         "voicing.shape": "same_fingering_position_shifted_chromatically",
         "progression.cycle_id": "baker-chromatic-drill"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -182,7 +182,7 @@
         "voicing.shape": "baker_catalog_number_1_to_6",
         "progression.cycle_id": "baker-rhythm-palette"
       },
-      "preference": "required_for_comping",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -211,7 +211,7 @@
         "progression.cycle_id": "baker-two-line-format",
         "chord_symbol.substitute": "new_changes_displayed_below_standard"
       },
-      "preference": "canonical_display",
+      "preference": 0,
       "quality_binding": [
         "dom7",
         "maj",
@@ -242,7 +242,7 @@
         "voicing.shape": "same_intro_fingering_shifted_chromatically",
         "progression.cycle_id": "baker-chromatic-drill"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "maj7",
@@ -271,7 +271,7 @@
         "voicing.shape": "root_then_chord_or_arpeggiated",
         "progression.cycle_id": "baker-intro-rhythmic-displacement"
       },
-      "preference": "primary_invention_method",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "maj7",
@@ -300,7 +300,7 @@
         "voicing.shape": "arpeggio_or_walking_stringbass",
         "progression.cycle_id": "baker-texture-elevation"
       },
-      "preference": "preferred_over_strum",
+      "preference": 1,
       "quality_binding": [
         "maj",
         "min",
@@ -338,7 +338,7 @@
         "chord_symbol.substitute": "Cma7_or_Cma6_or_Cma9",
         "progression.cycle_id": "baker-triad-expansion"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "maj"
       ],
@@ -362,7 +362,7 @@
         "voicing.shape": "adaptable_progression_voicings",
         "progression.cycle_id": "baker-color-motion"
       },
-      "preference": "mandatory_aesthetic",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -394,7 +394,7 @@
         "chord_symbol.substitute": "Dmi6_or_Dmi7_or_Dmi9",
         "progression.cycle_id": "baker-triad-expansion"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "min"
       ],
@@ -428,7 +428,7 @@
         "chord_symbol.substitute": "G13_G9_G7#5+9_G13#5+9_G7b5_G11_G13b9",
         "progression.cycle_id": "baker-dominant-extension-menu"
       },
-      "preference": "expanded_palette",
+      "preference": 0,
       "quality_binding": [
         "dom7",
         "dom9",
@@ -457,7 +457,7 @@
         "progression.cycle_id": "baker-voice-leading-gate",
         "chord_symbol.substitute": "contextually_justified_voicing"
       },
-      "preference": "constraint",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj",
@@ -494,7 +494,7 @@
         "voicing.shape": "baker_two_position_sets",
         "progression.cycle_id": "baker-two-positions-per-key"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -527,7 +527,7 @@
         "voicing.shape": "baker_relative_minor_sub",
         "progression.cycle_id": "baker-dom-relative-minor"
       },
-      "preference": "primary_substitution_move",
+      "preference": 2,
       "quality_binding": [
         "dom7"
       ],
@@ -551,7 +551,7 @@
         "progression.cycle_id": "baker-dom-relative-minor-chart",
         "chord_symbol.substitute": "twelve_row_dom_to_mi_chart"
       },
-      "preference": "required_reference_artifact",
+      "preference": 2,
       "quality_binding": [
         "dom7"
       ],
@@ -575,7 +575,7 @@
         "progression.cycle_id": "baker-vamp-seven-key",
         "chord_symbol.substitute": "identical_shape_in_Db_Eb_F_G_A_Bb"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -603,7 +603,7 @@
         "voicing.shape": "baker_catalog_27_to_30_open_string_root",
         "progression.cycle_id": "baker-horn-backing-vamps"
       },
-      "preference": "required_for_horn_backing",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "dom9",
@@ -631,7 +631,7 @@
         "progression.cycle_id": "baker-key-scoped-shape-exception",
         "chord_symbol.substitute": "key_specific_open_string_selection"
       },
-      "preference": "exception_to_transposition_mandate",
+      "preference": 0,
       "quality_binding": [
         "dom7",
         "maj7",
@@ -658,7 +658,7 @@
         "chord_symbol.substitute": "inserted_dominant_leading_chord",
         "progression.cycle_id": "baker-dominant-as-leading"
       },
-      "preference": "universal_connector",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "dom9",
@@ -687,7 +687,7 @@
         "progression.cycle_id": "baker-three-connection-taxonomy",
         "chord_symbol.substitute": "dom_to_dom_OR_dom_to_min_OR_dom_to_maj"
       },
-      "preference": "required_classification",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "dom9",
@@ -716,7 +716,7 @@
         "progression.cycle_id": "baker-real-repertoire-loop",
         "chord_symbol.substitute": "new_changes_applied_over_standard_song"
       },
-      "preference": "required_after_drill",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -746,7 +746,7 @@
         "progression.cycle_id": "baker-intro-ending-six-key",
         "chord_symbol.substitute": "same_shape_in_Db_Eb_F_G_Ab_Bb"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -774,7 +774,7 @@
       "then": {
         "progression.cycle_id": "baker-listen-and-fit-loop"
       },
-      "preference": "complementary_required_practice",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -805,7 +805,7 @@
         "voicing.shape": "same_voicing_two_names",
         "progression.cycle_id": "baker-two-names-principle"
       },
-      "preference": "primary_dual_function",
+      "preference": 2,
       "quality_binding": [
         "maj6",
         "min7"
@@ -836,7 +836,7 @@
         "chord_symbol.substitute": "Db9b5_for_G7#5_or_vice_versa",
         "progression.cycle_id": "baker-tritone-equiv"
       },
-      "preference": "required_for_b5_sub",
+      "preference": 2,
       "quality_binding": [
         "aug7",
         "dom7b9"
@@ -861,7 +861,7 @@
         "progression.cycle_id": "baker_canonical_cycle_matched",
         "chord_symbol.substitute": "baker_new_changes_for_cycle"
       },
-      "preference": "primary_repertoire_framework",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -894,7 +894,7 @@
         "voicing.shape": "baker_catalog_min7_min6_pair",
         "progression.cycle_id": "baker_cycle_1"
       },
-      "preference": "primary_cycle1_substitution",
+      "preference": 2,
       "quality_binding": [
         "dom7"
       ],
@@ -924,7 +924,7 @@
         ],
         "progression.cycle_id": "baker_cycle_1"
       },
-      "preference": "primary_cycle1_substitution",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "dom13"
@@ -949,7 +949,7 @@
         "progression.cycle_id": "baker_sequence_seven_key_transpose",
         "chord_symbol.substitute": "cycle_pattern_in_F_G_Ab_Bb_C_Db_Eb"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -978,7 +978,7 @@
       "then": {
         "progression.cycle_id": "baker-alternate-picking-foundation"
       },
-      "preference": "non_negotiable",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1015,7 +1015,7 @@
       "then": {
         "progression.cycle_id": "baker-relaxed-slow-first"
       },
-      "preference": "technique_acquisition_rule",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1052,7 +1052,7 @@
       "then": {
         "progression.cycle_id": "baker-hum-then-play-loop"
       },
-      "preference": "required_companion_practice",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1082,7 +1082,7 @@
         "voicing.shape": "same_fingering_position_shifted",
         "progression.cycle_id": "baker-invariant-fingering"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1115,7 +1115,7 @@
         "progression.cycle_id": "baker-blues-five-key",
         "chord_symbol.substitute": "transposed_to_F_G_Ab_Bb_C"
       },
-      "preference": "required_contraction_of_mandate",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1145,7 +1145,7 @@
         "progression.cycle_id": "baker-exercise-as-performance",
         "chord_symbol.substitute": "named_run_from_lessons_27_to_30"
       },
-      "preference": "primary_construction_method",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1174,7 +1174,7 @@
         "chord_symbol.substitute": "relative_min7_run",
         "progression.cycle_id": "baker-relative-run-substitution"
       },
-      "preference": "primary_improvisational_license",
+      "preference": 1,
       "quality_binding": [
         "maj",
         "maj6",
@@ -1201,7 +1201,7 @@
         "chord_symbol.substitute": "Ami7_for_D7_Gmi7_for_C7",
         "progression.cycle_id": "baker-blues-ii-for-v-bars-9-10"
       },
-      "preference": "workhorse_blues_ii_for_v",
+      "preference": 1,
       "quality_binding": [
         "dom7"
       ],
@@ -1233,7 +1233,7 @@
         "chord_symbol.substitute": "G7#5+9_or_G13b5+9",
         "progression.cycle_id": "baker-always-alter-v"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "aug7",
@@ -1261,7 +1261,7 @@
         "chord_symbol.substitute": "Ami7_run_then_Cmi7_run_then_Gmaj_run",
         "progression.cycle_id": "baker-ami7-cmi7-gmaj-recipe"
       },
-      "preference": "primary_v_to_i_run_template",
+      "preference": 2,
       "quality_binding": [
         "dom7"
       ],
@@ -1284,7 +1284,7 @@
       "then": {
         "progression.cycle_id": "baker-strum-hum-drill"
       },
-      "preference": "required_internalization_step",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1314,7 +1314,7 @@
         "progression.cycle_id": "baker-fill-in-run-type-dispatch",
         "chord_symbol.substitute": "run_matching_labeled_type"
       },
-      "preference": "primary_improvisation_scaffold",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1341,7 +1341,7 @@
       "then": {
         "progression.cycle_id": "baker-line-blending"
       },
-      "preference": "phrasing_aesthetic_required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1371,7 +1371,7 @@
         "progression.cycle_id": "baker-forced-riff",
         "chord_symbol.substitute": "riff_forced_non_diatonic_ok"
       },
-      "preference": "primary_vamp_melodic_unit",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1401,7 +1401,7 @@
         "progression.cycle_id": "baker-forced-riff",
         "chord_symbol.substitute": "riff_over_fast_vamp_changes"
       },
-      "preference": "required_for_fast_vamps",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1428,7 +1428,7 @@
       "then": {
         "progression.cycle_id": "baker-position-by-first-finger"
       },
-      "preference": "terminology_required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1465,7 +1465,7 @@
       "then": {
         "progression.cycle_id": "baker-solo-two-positions"
       },
-      "preference": "required_position_framework",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1496,7 +1496,7 @@
         "voicing.shape": "baker_8th_position_C_major",
         "progression.cycle_id": "baker-c-major-single-position"
       },
-      "preference": "exception_to_two_position_rule",
+      "preference": 0,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1523,7 +1523,7 @@
       "then": {
         "progression.cycle_id": "baker-sing-before-play"
       },
-      "preference": "required_internalization",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1551,7 +1551,7 @@
         "chord_symbol.substitute": "vamp_voicings_in_Bb_major",
         "progression.cycle_id": "baker-rhythm-changes"
       },
-      "preference": "convention_required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1580,7 +1580,7 @@
         "voicing.shape": "baker_additional_third_position_frets_3_to_6",
         "progression.cycle_id": "baker-additional-third-position"
       },
-      "preference": "key_scoped_position",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1608,7 +1608,7 @@
         "progression.cycle_id": "baker-groove-riff",
         "chord_symbol.substitute": "first_last_course_matching_riff"
       },
-      "preference": "required_groove_riff_structure",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1635,7 +1635,7 @@
       "then": {
         "progression.cycle_id": "baker-groove-riff-placement"
       },
-      "preference": "placement_and_scope_rule",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1661,7 +1661,7 @@
         "voicing.shape": "baker_third_position_frets_3_to_6_locked",
         "progression.cycle_id": "baker-groove-riff-position-lock"
       },
-      "preference": "non_negotiable_position_discipline",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1687,7 +1687,7 @@
       "then": {
         "progression.cycle_id": "baker-sing-against-chord-verification"
       },
-      "preference": "required_verification_step",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1713,7 +1713,7 @@
       "then": {
         "progression.cycle_id": "baker-implied-melody"
       },
-      "preference": "primary_aesthetic_goal",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -1740,7 +1740,7 @@
       "then": {
         "progression.cycle_id": "baker-chord-runs-around-melody"
       },
-      "preference": "primary_construction_method",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -1769,7 +1769,7 @@
         "voicing.shape": "baker_7th_position_frets_7_to_11_locked",
         "progression.cycle_id": "baker-melody-solo-7th-position-lock"
       },
-      "preference": "non_negotiable_position_discipline",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -1796,7 +1796,7 @@
       "then": {
         "progression.cycle_id": "baker-solo-pattern-rhythmic-frame"
       },
-      "preference": "primary_solo_construction_method",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1825,7 +1825,7 @@
       "then": {
         "progression.cycle_id": "baker-solo-pattern-same-timing"
       },
-      "preference": "required_pattern_discipline",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1852,7 +1852,7 @@
       "then": {
         "progression.cycle_id": "baker-groove-riff-sing-invention"
       },
-      "preference": "primary_invention_procedure",
+      "preference": 2,
       "quality_binding": [
         "dom7",
         "maj",
@@ -1878,7 +1878,7 @@
       "then": {
         "progression.cycle_id": "baker-review-loop"
       },
-      "preference": "meta_study_rule",
+      "preference": 1,
       "quality_binding": [
         "dom7",
         "maj",

--- a/plugin/data/masters-corpus/ted-greene/single-note-soloing-vol-1/derived/engine-rules.json
+++ b/plugin/data/masters-corpus/ted-greene/single-note-soloing-vol-1/derived/engine-rules.json
@@ -4,7 +4,7 @@
     "stage": "s6-engine-rules",
     "source_pdf": "Greene, Ted - Jazz Guitar Single Note Soloing, Vol 1 (1992).pdf",
     "extracted_at": "2026-06-16T00:00:00+00:00",
-    "schema_version": "0.1",
+    "schema_version": "0.2",
     "model": "claude-opus-4-7",
     "ticket": "#527"
   },
@@ -24,7 +24,7 @@
           "shape_notes_into_interesting_lines"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -43,7 +43,7 @@
       "then": {
         "reference.set": "major_scale_numeric_degrees"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -62,7 +62,7 @@
       "then": {
         "notation.set": "numeric_degree_relative_to_root_major_scale"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -81,7 +81,7 @@
       "then": {
         "chord.formula_basis": "numeric_degrees_of_root_major_scale_with_accidentals"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -100,7 +100,7 @@
       "then": {
         "notation.semantics": "half_step_offset_from_major_scale_degree"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -140,7 +140,7 @@
           ]
         }
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "min",
@@ -162,7 +162,7 @@
       "then": {
         "chord_scale_pairing.rule": "scale_sounds_good_over_chord"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -190,7 +190,7 @@
           "lydian"
         ]
       },
-      "preference": "either_acceptable",
+      "preference": 0,
       "quality_binding": [
         "maj",
         "maj7",
@@ -220,7 +220,7 @@
           7
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "maj",
         "maj7"
@@ -245,7 +245,7 @@
         "line.eighth_subdivision": "primary",
         "line.duration_default": "eighth"
       },
-      "preference": "default",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -265,7 +265,7 @@
         "line.eighth_subdivision": "triplet_pair_long_short",
         "line.swing_ratio": "triplet_based"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -287,7 +287,7 @@
           "straight"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -310,7 +310,7 @@
       "then": {
         "line.eighth_subdivision": "double_time_sixteenths"
       },
-      "preference": "optional",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -329,7 +329,7 @@
       "then": {
         "practice.gate": "clean_at_current_tempo"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -350,7 +350,7 @@
         "line.articulation": "hammer_on",
         "line.hammer_on_target_constraint": "active_scale_tone"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -372,7 +372,7 @@
           "hammer_on": "component_of_trill_only"
         }
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -392,7 +392,7 @@
         "line.trill_semantics": "decorate_held_note",
         "line.trill_primary_pitch": "preserved"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -411,7 +411,7 @@
       "then": {
         "line.trill_placement": "strong_beat_default"
       },
-      "preference": "default",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -438,11 +438,11 @@
           "b7"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
-        "9",
-        "13"
+        "dom9",
+        "dom13"
       ],
       "falsifier": "Defining the dominant 7th scale as Mixolydian-with-#11 (that's Lydian Dominant) or as a major scale with #4 (that's Lydian).",
       "anchor": "The Dominant 7th scale is simply a Major scale\nwith a lowered 7th tone",
@@ -461,12 +461,12 @@
           "dominant_7th"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
-        "9",
-        "11",
-        "13"
+        "dom9",
+        "dom11",
+        "dom13"
       ],
       "falsifier": "Applying the Dominant 7th scale to a dom7b9 chord (the b9 is not in the dominant 7th scale — that chord requires an altered dominant scale).",
       "anchor": "Any chord containing some combination of any of (but only) these chord tones, can take the Dominant\n7th scale.",
@@ -485,7 +485,7 @@
         "scale.reference_root": "chord_root",
         "scale.reframe_as_relative_major": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7"
       ],
@@ -517,12 +517,12 @@
           "either_group": "contains_both_or_neither"
         }
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7",
-        "9",
-        "11",
-        "13"
+        "dom9",
+        "dom11",
+        "dom13"
       ],
       "falsifier": "Playing a run with a prominent natural 3 over a 7sus4 (Group-2 dominant) — the 3 collides with the suspended 4/11.",
       "anchor": "if a run\ncontains the 3rd, use it over any of the group-1 dominants, and if it contains the 11th, use it over any of the\ngroup-2 dominants.",
@@ -543,11 +543,11 @@
       "then": {
         "voicing.register_target": "lower_mid_for_spicy_color"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "dom7",
-        "9",
-        "13"
+        "dom9",
+        "dom13"
       ],
       "falsifier": "Voicing the b7 and 9 of a dom9 in the lowest bass register and expecting the spicy mid-range color the book describes.",
       "anchor": "67 and 9 really start to come alive in this “higher” register",
@@ -565,7 +565,7 @@
         "position.set": "single_5_to_6_fret_area",
         "position.scale_combine": "across_chord_changes"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -585,7 +585,7 @@
         "practice.mode": "visualize_fingerboard",
         "practice.priority": "highest"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -612,7 +612,7 @@
           "b7"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "min7"
       ],
@@ -633,7 +633,7 @@
         "scale.reference_root": "chord_root",
         "scale.reframe_as_relative_major": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "min7"
       ],
@@ -653,7 +653,7 @@
       "then": {
         "practice.progression": "ii_V_I"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "min7"
       ],
@@ -680,17 +680,19 @@
           "b7"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "dom7#11",
-        "9#11",
-        "13#11"
+        "dom7#11"
       ],
       "falsifier": "Defining Overtone Dominant with both a #4 AND a b9 (those altered tones would push it into altered-dominant territory).",
       "anchor": "The Overtone Dominant scale is simply a Dominant 7th scale with a #4th tone instead of the regular 4th.",
       "source_page": 82,
       "chapter_n": 4,
-      "section_title": "Overtone Dominant scale & Jazz Waltz aside"
+      "section_title": "Overtone Dominant scale & Jazz Waltz aside",
+      "applicability_reasons": [
+        "9#11",
+        "13#11"
+      ]
     },
     {
       "rule_id": "greene-jazz-waltz-application",
@@ -702,7 +704,7 @@
         "line.meter": "3_4",
         "line.feel": "jazz_waltz"
       },
-      "preference": "optional",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -723,17 +725,19 @@
           "lydian_dominant"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "dom7#11",
-        "9#11",
-        "13#11"
+        "dom7#11"
       ],
       "falsifier": "Treating 'Lydian Dominant' and 'Overtone Dominant' as different scales — they are the same scale with two names.",
       "anchor": "the Overtone Dominant scale is also called the LYDIAN\nDominant scale.",
       "source_page": 83,
       "chapter_n": 5,
-      "section_title": "Lydian Dominant, upper-structure triad & polytonality"
+      "section_title": "Lydian Dominant, upper-structure triad & polytonality",
+      "applicability_reasons": [
+        "9#11",
+        "13#11"
+      ]
     },
     {
       "rule_id": "greene-upper-structure-triad",
@@ -753,7 +757,7 @@
           "13"
         ]
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "maj7",
         "dom7#11"
@@ -773,7 +777,7 @@
       "then": {
         "line.device": "polytonality_upper_structure"
       },
-      "preference": "optional",
+      "preference": 0,
       "quality_binding": [
         "maj7",
         "dom7#11"
@@ -798,19 +802,21 @@
           "#5_b13"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "dom7alt",
-        "7b9",
-        "7#9",
-        "7b5",
-        "7#5"
+        "dom7b9"
       ],
       "falsifier": "Calling a scale 'altered dominant' when its only modification of the dominant 7th scale is a #11 — that's Overtone Dominant, not altered.",
       "anchor": "What is an altered dominant scale? Simply, any dominant 7th scale with one or\nmore of the following tones: 59, #9, 65 or #5 (613).",
       "source_page": 94,
       "chapter_n": 5,
-      "section_title": "Altered dominant scales & Group 4 dominants"
+      "section_title": "Altered dominant scales & Group 4 dominants",
+      "applicability_reasons": [
+        "dom7alt",
+        "7#9",
+        "7b5",
+        "7#5"
+      ]
     },
     {
       "rule_id": "greene-group-4-dominants",
@@ -834,19 +840,21 @@
           "altered_dominant_type_3"
         ]
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "7b9",
-        "7#9",
-        "7b5",
-        "7#5",
-        "7alt"
+        "dom7b9",
+        "alt7"
       ],
       "falsifier": "Placing a 7#11 chord (no altered b9/#9/b5/#5) into Group 4 — it belongs in Group 3 (Overtone Dominant).",
       "anchor": "Any Dom. 7th type chord that contains any one or more of the four altered tones (69, #9, 65 and\n#5 or 613) will be considered as being part of what we call the GROUP 4 DOMINANT CHORDS.",
       "source_page": 94,
       "chapter_n": 5,
-      "section_title": "Altered dominant scales & Group 4 dominants"
+      "section_title": "Altered dominant scales & Group 4 dominants",
+      "applicability_reasons": [
+        "7#9",
+        "7b5",
+        "7#5"
+      ]
     },
     {
       "rule_id": "greene-overtone-not-altered",
@@ -858,7 +866,7 @@
         "scale.classification": "non_altered",
         "chord.group": "dominant_group_3"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "dom7#11"
       ],
@@ -877,9 +885,9 @@
       "then": {
         "practice.layout": "all_three_types_one_position_juxtaposed"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
-        "7alt"
+        "alt7"
       ],
       "falsifier": "Drilling Type 1 in position 1, then moving to a completely different position for Type 2 — denies comparative absorption.",
       "anchor": "the three types of A.D. scales are all so\nsimilar that your brain, while noting the differences, can absorb them all in a kind of ‘package deal’, one\nposition at a time.",
@@ -896,7 +904,7 @@
       "then": {
         "practice.remediation": "study_chord_forms_for_position"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -918,7 +926,7 @@
           "alternate_at_least_one"
         ]
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -937,7 +945,7 @@
       "then": {
         "arpeggio.string_choice": "flexible_within_position"
       },
-      "preference": "optional",
+      "preference": 0,
       "quality_binding": [
         "any"
       ],
@@ -956,7 +964,7 @@
       "then": {
         "technique.left_hand_contact": "finger_pad"
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
         "any"
       ],
@@ -978,9 +986,9 @@
           "D6/9": "D49"
         }
       },
-      "preference": "optional",
+      "preference": 0,
       "quality_binding": [
-        "7alt"
+        "alt7"
       ],
       "falsifier": "Refusing the A7+ → A7#9+ substitution in a Type 3 reading purely because the symbols don't match literally.",
       "anchor": "As before, and on all Type 3 altered dominant pages coming up, you may wish to try A7+ for A7#9+\nand D49 for D6/9.",
@@ -997,7 +1005,7 @@
       "then": {
         "practice.transposition": "octave_up_same_position"
       },
-      "preference": "preferred",
+      "preference": 1,
       "quality_binding": [
         "any"
       ],
@@ -1020,16 +1028,18 @@
       "then": {
         "chord.alteration_choice": "sharp9_in_lieu_of_or_in_addition_to_natural_9"
       },
-      "preference": "optional",
+      "preference": 0,
       "quality_binding": [
-        "7alt",
-        "7#9"
+        "alt7"
       ],
       "falsifier": "Treating natural 9 and #9 as mutually exclusive in altered-dominant voicings — book explicitly allows both together.",
       "anchor": "INSTEAD OF OR IN ADDITION TO THE #9",
       "source_page": 131,
       "chapter_n": 7,
-      "section_title": "Standing chord-substitution allowances & practice rules"
+      "section_title": "Standing chord-substitution allowances & practice rules",
+      "applicability_reasons": [
+        "7#9"
+      ]
     },
     {
       "rule_id": "greene-no-type3-area-4a",
@@ -1041,9 +1051,9 @@
       "then": {
         "scale.availability": false
       },
-      "preference": "required",
+      "preference": 2,
       "quality_binding": [
-        "7alt"
+        "alt7"
       ],
       "falsifier": "Filing a Type 3 fingering chart for area 4A as if it existed — book states instrument geometry forbids it.",
       "anchor": "There won't be any Type 3 - 4A",
@@ -1061,9 +1071,9 @@
       "then": {
         "arpeggio.set_for_quality": "higher_register_supplement"
       },
-      "preference": "optional",
+      "preference": 0,
       "quality_binding": [
-        "7alt"
+        "alt7"
       ],
       "falsifier": "Limiting altered-dominant arpeggios to the original written register only.",
       "anchor": "EXTRA ARPEGGIOS FOR HIGHER REGISTER",

--- a/scripts/migrate_engine_rules_v02.py
+++ b/scripts/migrate_engine_rules_v02.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Corpus migration #555 — normalize engine-rules.json to spec v0.2 shape.
+
+For each rule across all 14 books:
+  1. quality_binding: apply spec v0.2 alias table (§2.3); split canonical
+     tokens from non-canonical (applicability_reasons); ["any"] if empty.
+  2. preference: coerce freeform-prose values to signed Likert int [-2..+2]
+     via the three approved mapping sources:
+       (a) directly-mappable Likert dict (15 tokens, ~426 rules)
+       (b) D5 lookup table from #555 sign-off (74 distinct, ~78 rules)
+       (c) D4 LLM mapping over long-prose preferences (246 rules)
+  3. Bump _provenance.schema_version 0.1 → 0.2.
+
+Provenance: spec v0.2 (#549, #555 sign-off 2026-06-17), D5 lookup at
+#555 comment-4736793419, D4 LLM mapping at /tmp/555-llm-mapping-compact.json
+(authored 2026-06-17, sonnet model).
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MASTERS_CORPUS = REPO_ROOT / "plugin" / "data" / "masters-corpus"
+
+# ----- Spec v0.2 §2.1 Canonical token set --------------------------------
+
+FAMILY_PARENTS = {"maj", "min", "dom7", "dim", "aug", "sus", "any"}
+
+SPECIFIC_TOKENS = {
+    # MAJOR family
+    "maj", "maj6", "maj69", "maj7", "maj9", "maj13", "maj7#11", "maj7b5",
+    # MINOR family
+    "min", "min6", "min69", "min7", "min9", "min11", "min13", "minMaj7", "min7b5",
+    # DOMINANT family
+    "dom7", "dom9", "dom11", "dom13",
+    "dom7b5", "dom7#5", "dom7b9", "dom7#9", "dom7#11",
+    "dom7sus4", "alt7",
+    # DIMINISHED family
+    "dim", "dim7",
+    # AUGMENTED family
+    "aug", "aug7",
+    # SUS family
+    "sus2", "sus4",
+    # Wildcard
+    "any",
+}
+
+CANONICAL_TOKENS = FAMILY_PARENTS | SPECIFIC_TOKENS
+
+# ----- Spec v0.2 §2.3 Alias table ----------------------------------------
+
+ALIAS_TABLE = {
+    "seventh": "dom7",
+    "7": "dom7",
+    "major": "maj",
+    "major7": "maj7",
+    "minor": "min",
+    "minor7": "min7",
+    "dominant": "dom7",
+    "dominant7": "dom7",
+    "dominant_7": "dom7",
+    "dominant_7th": "dom7",
+    "half-diminished": "min7b5",
+    "diminished": "dim7",
+    "+": "aug",
+    "°": "dim",
+    "ø": "min7b5",
+    "m": "min",
+    "M": "maj",
+    "Δ": "maj7",
+    # Extensions previously stored as numeric shorthand
+    "9": "dom9",
+    "11": "dom11",
+    "13": "dom13",
+    "7b9": "dom7b9",
+    "7alt": "alt7",
+    "dom7#11": "dom7#11",  # already canonical
+    # Mickey Baker / Bruno variants
+    "major_6_diminished": "min7b5",
+    "minor_6_diminished": "dim7",
+}
+
+# ----- D4 LLM mapping (loaded from /tmp/555-llm-mapping-compact.json) ----
+
+LLM_MAPPING_PATH = Path("/tmp/555-llm-mapping-compact.json")
+
+# ----- D5 lookup (per #555 D5 sign-off, embedded inline for the PR) -----
+
+D5_LOOKUP = {
+    "required_plectrum": 2,
+    "required for fretboard fluency": 2,
+    "primary_cycle1_substitution": 2,
+    "primary_construction_method": 2,
+    "Practice both placements": 1,
+    "optional_advanced": 0,
+    "advanced_alternative": 0,
+    "valid_alternative": 0,
+    "advanced_optional": 0,
+    "preferred_fingerstyle": 1,
+    "advantage_of_plectrum": 1,
+    "caution": -1,
+    "recommended for interest": 1,
+    "recommended for variety": 1,
+    "required as orientation step": 2,
+    "standard construction method": 1,
+    "required by convention": 2,
+    "definitional": 0,
+    "first omission candidate": 1,
+    "available simplification": 0,
+    "exceptional use only": -1,
+    "required for accurate analysis": 2,
+    "preferred_for_inside_energy": 1,
+    "recommended_for_modern": 1,
+    "required_first_stage": 2,
+    "required_second_stage": 2,
+    "required_final_stage_for_jazz": 2,
+    "take your time with this one": 1,
+    "design invariant": 2,
+    "required first step": 2,
+    "required second step": 2,
+    "strong preference": 2,
+    "available": 0,
+    "mandatory_replacement": 2,
+    "required_for_beginners": 2,
+    "required_for_comping": 2,
+    "canonical_display": 0,
+    "primary_invention_method": 2,
+    "preferred_over_strum": 1,
+    "mandatory_aesthetic": 2,
+    "expanded_palette": 0,
+    "constraint": 1,
+    "primary_substitution_move": 2,
+    "required_reference_artifact": 2,
+    "required_for_horn_backing": 2,
+    "universal_connector": 1,
+    "required_classification": 2,
+    "required_after_drill": 2,
+    "primary_dual_function": 2,
+    "required_for_b5_sub": 2,
+    "primary_repertoire_framework": 2,
+    "technique_acquisition_rule": 1,
+    "required_companion_practice": 2,
+    "workhorse_blues_ii_for_v": 1,
+    "primary_v_to_i_run_template": 2,
+    "required_internalization_step": 2,
+    "primary_improvisation_scaffold": 2,
+    "phrasing_aesthetic_required": 2,
+    "primary_vamp_melodic_unit": 2,
+    "required_for_fast_vamps": 2,
+    "terminology_required": 2,
+    "required_position_framework": 2,
+    "exception_to_two_position_rule": 0,
+    "required_internalization": 2,
+    "convention_required": 2,
+    "key_scoped_position": 1,
+    "required_groove_riff_structure": 2,
+    "placement_and_scope_rule": 1,
+    "required_verification_step": 2,
+    "primary_aesthetic_goal": 2,
+    "required_pattern_discipline": 2,
+    "primary_invention_procedure": 2,
+    "meta_study_rule": 1,
+    "either_acceptable": 0,
+}
+
+# ----- Direct Likert dict (covers 426 rules) -----------------------------
+
+DIRECT_LIKERT = {
+    "required": 2, "mandatory": 2, "invariant": 2, "non_negotiable": 2,
+    "essential": 2, "must": 2, "strongly preferred": 2, "strong": 2,
+    "preferred": 1, "recommended": 1, "moderate": 1, "advisory": 1,
+    "default": 1, "standard": 1,
+    "avoid": -1, "discouraged": -1,
+    "optional": 0, "descriptive": 0, "tie-breaker": 0,
+    "informational": 0, "flexible": 0, "permissive": 0,
+}
+
+
+# ----- migration ---------------------------------------------------------
+
+
+def normalize_token(value: str) -> str:
+    """Apply alias table to a single value. Returns the value if no alias."""
+    return ALIAS_TABLE.get(value, value)
+
+
+def split_quality_binding(qb: list) -> tuple[list[str], list[str]]:
+    """Split a raw quality_binding list into (canonical_qb, applicability_reasons).
+
+    1. Apply aliases.
+    2. Canonical tokens stay in quality_binding.
+    3. Non-canonical values move to applicability_reasons (deduplicated).
+    4. If canonical_qb is empty after split, use ["any"].
+    """
+    if not isinstance(qb, list):
+        qb = [qb] if qb else []
+    canonical = []
+    reasons = []
+    for v in qb:
+        if not isinstance(v, str):
+            continue
+        normalized = normalize_token(v)
+        if normalized in CANONICAL_TOKENS:
+            if normalized not in canonical:
+                canonical.append(normalized)
+        else:
+            if v not in reasons:
+                reasons.append(v)
+    if not canonical:
+        canonical = ["any"]
+    return canonical, reasons
+
+
+def coerce_preference(p, rule_id: str, llm_map: dict[str, int]) -> tuple[int, bool, str]:
+    """Coerce preference to Likert int. Returns (value, mapped_ok, source)."""
+    if p is None:
+        return 0, True, "None→0"
+    if isinstance(p, int):
+        return max(-2, min(2, p)), True, "int passthrough"
+    if not isinstance(p, str):
+        return 0, False, f"non-str type:{type(p).__name__}"
+    if p in DIRECT_LIKERT:
+        return DIRECT_LIKERT[p], True, "direct"
+    if p in D5_LOOKUP:
+        return D5_LOOKUP[p], True, "D5"
+    if rule_id in llm_map:
+        return llm_map[rule_id], True, "D4-LLM"
+    if len(p) > 30:
+        # Long prose not in LLM map — shouldn't happen but fallback to 0
+        return 0, False, "long-prose-unmapped"
+    return 0, False, f"unmapped:{p[:30]!r}"
+
+
+def discover_files() -> list[Path]:
+    return sorted(MASTERS_CORPUS.glob("*/*/derived/engine-rules.json"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--llm-mapping",
+        type=Path,
+        default=LLM_MAPPING_PATH,
+        help="Path to D4 LLM mapping JSON {m: {rule_id: int}}.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print diff summary; do not write changes.",
+    )
+    args = parser.parse_args()
+
+    if not args.llm_mapping.exists():
+        print(f"error: LLM mapping not found at {args.llm_mapping}", file=sys.stderr)
+        return 1
+    llm_map = json.loads(args.llm_mapping.read_text())["m"]
+
+    files = discover_files()
+    print(f"discovered {len(files)} engine-rules.json files")
+
+    stats = collections.Counter()
+    preference_sources = collections.Counter()
+    likert_dist = collections.Counter()
+    qb_token_dist = collections.Counter()
+    unmapped_warnings: list[str] = []
+
+    for f in files:
+        with open(f) as fh:
+            d = json.load(fh, object_pairs_hook=OrderedDict)
+        engine_rules = d.get("engine_rules", [])
+
+        for r in engine_rules:
+            rule_id = r.get("rule_id", "")
+
+            # quality_binding split
+            qb_raw = r.get("quality_binding", [])
+            canonical_qb, reasons_split = split_quality_binding(qb_raw)
+            existing_reasons = r.get("applicability_reasons", []) or []
+            merged_reasons = list(existing_reasons)
+            for x in reasons_split:
+                if x not in merged_reasons:
+                    merged_reasons.append(x)
+            r["quality_binding"] = canonical_qb
+            if merged_reasons:
+                r["applicability_reasons"] = merged_reasons
+            for tok in canonical_qb:
+                qb_token_dist[tok] += 1
+
+            # preference coercion
+            p_in = r.get("preference")
+            p_int, mapped_ok, src = coerce_preference(p_in, rule_id, llm_map)
+            r["preference"] = p_int
+            preference_sources[src] += 1
+            likert_dist[p_int] += 1
+            if not mapped_ok:
+                unmapped_warnings.append(f"{f.relative_to(REPO_ROOT)}::{rule_id} preference={p_in!r}")
+
+            stats["rules_processed"] += 1
+
+        # bump schema_version
+        prov = d.get("_provenance", {})
+        prov["schema_version"] = "0.2"
+        d["_provenance"] = prov
+        stats["files_processed"] += 1
+
+        if not args.dry_run:
+            with open(f, "w") as fh:
+                json.dump(d, fh, indent=2, ensure_ascii=False)
+                fh.write("\n")
+
+    print(f"\n=== migration summary ===")
+    print(f"files: {stats['files_processed']}; rules: {stats['rules_processed']}")
+    print(f"\nLikert distribution:")
+    for k in sorted(likert_dist):
+        print(f"  {k:+d}: {likert_dist[k]}")
+    print(f"\npreference source breakdown:")
+    for k, v in preference_sources.most_common():
+        print(f"  {v:4d}  {k}")
+    print(f"\ntop 15 canonical quality_binding tokens:")
+    for tok, n in qb_token_dist.most_common(15):
+        print(f"  {n:4d}  {tok}")
+    print(f"\nunmapped warnings: {len(unmapped_warnings)}")
+    for w in unmapped_warnings[:5]:
+        print(f"  {w}")
+
+    if args.dry_run:
+        print("\n(dry-run; no files modified)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #555.

## Summary
Normalizes all 750 engine-rules across 14 books to spec v0.2 shape (#560). Three mapping sources combined per #555 D1-D5 sign-off:

| Source | Rules | Mechanism |
|---|---:|---|
| Direct Likert dict | 371 | 15 freeform tokens (required→+2, preferred→+1, …) |
| D5 lookup table | 78 | 74 distinct short unmapped strings (eyeball-approved) |
| D4 LLM mapping | 246 | sonnet model over long-prose preferences |
| None→0 | 55 | null values become neutral |
| **Total** | **750** | 0 unmapped warnings |

## Distribution after migration

```
Likert  Count
  -1      7   (avoid)
   0    107   (neutral)
  +1    308   (prefer)
  +2    328   (strong_prefer)
```

Skew toward +2 reflects the corpus character: master texts encode mostly non-negotiable structural rules, not soft preferences.

Zero −2 entries — no prose in the corpus carries the "never (prohibition)" / "hazardous" / "must not" signal. Reasonable for a chord-melody/voicing corpus (most rules are "do X" not "avoid Y"). If you spot a rule that should be −2 during review, flag the rule_id and I'll surgically adjust.

## quality_binding changes

Top 15 canonical tokens (per spec v0.2 §2.1):

```
any (559), dom7 (133), maj7 (85), min7 (81), maj (58), min (54),
dom9 (46), dom13 (45), dom7b9 (21), dim7 (18), maj6 (18),
dom11 (13), aug7 (12), maj9 (10), min6 (10)
```

`maj`, `min`, `dom7` as family-parent tokens light up alongside their specific members — per spec §2.2 family-hierarchical matching, those rules fire against any quality in their family.

Non-canonical authorial hints (`voice_leading`, `clarity`, `playability`, `chord_melody`, etc.) moved to `applicability_reasons`. Sample:

```json
{
  "rule_id": "laukens-pass-study-bar-by-bar",
  "quality_binding": ["any"],
  "applicability_reasons": ["solo_chord_melody"],
  "preference": 1
}
```

## Artifact added

`scripts/migrate_engine_rules_v02.py` — repeatable migration with all three mapping tables embedded. Future migrations / re-extractions can re-run for audit. The D4 LLM mapping is loaded from `/tmp/555-llm-mapping-compact.json` (transient artifact; the script's lookups are stable).

## Verification

| Gate | Result |
|---|---|
| All 14 files `_provenance.schema_version` == "0.2" | ✅ |
| Total `engine_rules` count | 750 (unchanged) |
| Every `preference` is int in [-2,2] | ✅ |
| Every `quality_binding` is non-empty list | ✅ |
| Unmapped preference warnings | 0 |

## Diff stats
15 files changed: 14 engine-rules.json (normalization) + 1 migration script. +3171 / −1838 (much of the insert/delete count is reformatting from JSON minification).

## Unblocks
Cut `engine-rules-v0.2.0` release after merge. Ellington PR 2 (firing engine) ready to consume.