### PR TITLE
fix(#555): build script supports schema 0.2 with bumped min_consumer_version

### DIFF
--- a/scripts/build_engine_rules_bundle.py
+++ b/scripts/build_engine_rules_bundle.py
@@ -31,8 +31,14 @@ MASTERS_CORPUS = REPO_ROOT / "plugin" / "data" / "masters-corpus"
 SCHEMA_PATH = REPO_ROOT / "plugin" / "schemas" / "engine-rules-manifest.schema.json"
 
 REQUIRED_PROVENANCE_FIELDS = ["schema_version", "extracted_at"]
-SUPPORTED_SCHEMA_VERSIONS = {"0.1"}
-MIN_CONSUMER_VERSION_DEFAULT = "0.1.0"
+SUPPORTED_SCHEMA_VERSIONS = {"0.1", "0.2"}
+# v0.2 introduces family-hierarchical matching (spec #549 §2.2) that
+# consumers running v0.1 do NOT understand; force them to upgrade
+# before ingesting v0.2 bundles.
+MIN_CONSUMER_VERSION_BY_SCHEMA = {
+    "0.1": "0.1.0",
+    "0.2": "0.2.0",
+}
 REQUIRED_TOP_LEVEL_FIELDS = ["_provenance", "master_id", "work_id", "engine_rules"]
 
 
@@ -99,7 +105,7 @@ def build_manifest(
         [
             ("schema_version", schema_version),
             ("bundle_version", bundle_version),
-            ("min_consumer_version", MIN_CONSUMER_VERSION_DEFAULT),
+            ("min_consumer_version", MIN_CONSUMER_VERSION_BY_SCHEMA[schema_version]),
             ("plugin_commit_sha", git_head_sha()),
             (
                 "built_at",


### PR DESCRIPTION
Closes the v0.2.0 release blocker surfaced when tag push triggered workflow failure.

## What happened
After #561 (corpus migration to spec v0.2) landed, I cut `engine-rules-v0.2.0`. The release workflow ran `build_engine_rules_bundle.py` against the migrated corpus and failed:

```
validation error: ...engine-rules.json: schema_version '0.2' not in supported set {'0.1'}
```

## Fix
1. `SUPPORTED_SCHEMA_VERSIONS` extended from `{'0.1'}` to `{'0.1', '0.2'}`.
2. `min_consumer_version` now derived from the bundle's `schema_version` via a new `MIN_CONSUMER_VERSION_BY_SCHEMA` map:
   - schema 0.1 → min_consumer_version 0.1.0
   - schema 0.2 → min_consumer_version 0.2.0

## Why the min_consumer_version bump matters
v0.2 introduces family-hierarchical matching (spec §2.2). A consumer running v0.1 sync code would silently mis-parse v0.2 family-parent tokens (`maj`, `min`, `dom7`). The min_consumer_version field is precisely the Hyrum's-law guard for this — bumping it makes the older consumer hard-refuse the bundle instead of silently producing wrong results.

## Verification
```
$ python3 scripts/build_engine_rules_bundle.py --bundle-version 0.2.0 --out-dir /tmp/bundle-v02
discovered 14 engine-rules files
validated: all files have canonical shape + _provenance.schema_version in {'0.2', '0.1'}
wrote /tmp/bundle-v02/manifest.json (750 rules across 10 masters)

manifest contents:
  schema_version: 0.2
  bundle_version: 0.2.0
  min_consumer_version: 0.2.0
  total_rules: 750
```

## After merge
Re-cut `engine-rules-v0.2.0` tag → release workflow publishes the bundle.