### PR TITLE
feat(#563): lineage DAG v0.1 — studied_with/influenced fields on Master

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -3771,7 +3771,9 @@
             "dom7/chameleon-chord-recognition"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "ted-greene",
@@ -9787,7 +9789,9 @@
           "provenance": "extracted",
           "polarity": "proscriptive"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "joe-pass",
@@ -12069,7 +12073,9 @@
           ],
           "provenance": "extracted"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "martin-taylor",
@@ -12353,7 +12359,14 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "studied_with": [],
+      "influenced": [
+        {
+          "master_id": "joe-pass",
+          "source_phrase": "extends the Django Reinhardt and Joe Pass traditions"
+        }
+      ]
     },
     {
       "id": "wes-montgomery",
@@ -12750,7 +12763,9 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "lenny-breau",
@@ -13036,7 +13051,9 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "jim-hall",
@@ -13360,7 +13377,9 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "johnny-smith",
@@ -13601,7 +13620,9 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "jody-fisher",
@@ -19719,7 +19740,9 @@
             "major/chord-family-interchangeability"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "jens-larsen",
@@ -21328,7 +21351,9 @@
             "m7/ii-chord-chord-tone-omission"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "jerry-bergonzi",
@@ -23151,7 +23176,9 @@
           ],
           "provenance": "extracted"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "greg-orourke",
@@ -25539,7 +25566,9 @@
             "maj7/passing-tone-escape-hatch"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "nelson-faria",
@@ -27644,7 +27673,9 @@
             "dom7/choro-16th-note-melodic-phrasing"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "pat-martino",
@@ -29217,7 +29248,9 @@
             "minor7/twelve-key-prerequisite"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "ted-dunbar",
@@ -31044,7 +31077,9 @@
             "dominant-seventh/circle-of-gravities-navigation"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "brent-vaartstra",
@@ -33375,7 +33410,9 @@
             "dominant-7/relational-analysis-required"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "alan-de-mause",
@@ -35767,7 +35804,9 @@
             }
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "barry-galbraith",
@@ -35861,7 +35900,9 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "gene-bertoncini",
@@ -36087,7 +36128,9 @@
           ]
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "matt-warnock",
@@ -37795,7 +37838,9 @@
             "dom7/v-chord-picking-hand-as-primary-variable"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "jerry-coker",
@@ -41371,7 +41416,9 @@
             }
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "jamey-aebersold",
@@ -43529,7 +43576,9 @@
             }
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "dirk-laukens",
@@ -48706,7 +48755,9 @@
           "provenance": "extracted"
         }
       ],
-      "status": "promoted"
+      "status": "promoted",
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "randy-felts",
@@ -51696,7 +51747,9 @@
             "minor-seventh/modal-interchange-i-minor"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "heussenstamm-silbergleit",
@@ -54217,7 +54270,9 @@
             }
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "benson",
@@ -64001,7 +64056,9 @@
             "dom7/rhythmic-positioning-slow-tempo"
           ]
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "jimmy-bruno",
@@ -65374,7 +65431,9 @@
           ],
           "provenance": "extracted"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "peter-bernstein",
@@ -68100,6 +68159,17 @@
             "dominant7/flexible-vocabulary-delivery",
             "dominant7/single-target-variation"
           ]
+        }
+      ],
+      "studied_with": [],
+      "influenced": [
+        {
+          "master_id": "wes-montgomery",
+          "source_phrase": "extend the post-bop lineage of Wes Montgomery, Grant Green, and Jim Hall"
+        },
+        {
+          "master_id": "jim-hall",
+          "source_phrase": "extend the post-bop lineage of Wes Montgomery, Grant Green, and Jim Hall"
         }
       ]
     },
@@ -71100,7 +71170,9 @@
           ],
           "provenance": "extracted"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "howard-roberts",
@@ -72151,7 +72223,9 @@
           "provenance": "extracted",
           "polarity": "prescriptive"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "mick-goodrick",
@@ -73427,7 +73501,9 @@
           ],
           "provenance": "extracted"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "barry-harris",
@@ -73914,7 +73990,9 @@
           ],
           "provenance": "extracted"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     },
     {
       "id": "bert-ligon",
@@ -74517,7 +74595,9 @@
           ],
           "provenance": "extracted"
         }
-      ]
+      ],
+      "studied_with": [],
+      "influenced": []
     }
   ]
 }


### PR DESCRIPTION
Closes #563.

## Summary
Adds two array fields to every `Master` in `plugin/data/masters.json`:

```json
"studied_with": [{"master_id": "...", "source_phrase": "..."}],
"influenced":   [{"master_id": "...", "source_phrase": "..."}]
```

Per [#563 sign-off](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/563#issuecomment-4738189309) (Option A): schema fields land now to preserve forward compatibility for v1.2 trust model; richer curated extraction queued as a separate follow-up if v1.2 demonstrates lineage weighting is load-bearing.

## Edges populated

Conservative LLM extraction (sonnet model) over `Master.biography` prose with strict target-in-corpus filter:

| source | relation | target | source_phrase |
|---|---|---|---|
| martin-taylor | influenced | joe-pass | "extends the Django Reinhardt and Joe Pass traditions" |
| peter-bernstein | influenced | wes-montgomery | "extend the post-bop lineage of Wes Montgomery, Grant Green, and Jim Hall" |
| peter-bernstein | influenced | jim-hall | (same phrase) |

3 total edges across 33 masters. Sparse because biographies overwhelmingly reference off-corpus figures (Django, Christian, Coltrane).

## Verification

| Gate | Result |
|---|---|
| All 33 masters have `studied_with` field | ✅ |
| All 33 masters have `influenced` field | ✅ |
| Every cited `master_id` resolves to a corpus entry | ✅ |
| Total `engine_rules` count (unrelated) | unchanged |

## Refs
- Joint pedagogue methodology proposal: [ellington-web#96 comment](https://github.com/siege-analytics/ellington-web/issues/96#issuecomment-4738028129)
- Ellington v1.2 trust model uses this DAG joined with calibrated-pedagogue × claimed-affinity