### PR TITLE
feat(#550): source_locator schema v0.1 on 14 distilled works

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -6704,7 +6704,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": "Greene, Ted - Jazz Guitar Single Note Soloing, Vol 1 (1992).pdf",
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         }
       ],
       "usage_notes": [
@@ -11301,7 +11309,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         }
       ],
       "usage_notes": [
@@ -22342,7 +22358,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         }
       ],
       "status": "promoted",
@@ -45029,7 +45053,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         },
         {
           "id": "jazz-guitar-chord-dictionary",
@@ -64903,7 +64935,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         }
       ],
       "status": "promoted",
@@ -69037,7 +69077,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         },
         {
           "id": "complete-course-vol-2",
@@ -71346,13 +71394,36 @@
           "id": "chord-melody",
           "title": "Chord Melody",
           "year": 1971,
-          "instrument_scope": "6-string"
+          "instrument_scope": "6-string",
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         },
         {
           "id": "jazz-guitar-technique-20-weeks",
           "title": "Jazz Guitar Technique in 20 Weeks",
           "year": 1971,
           "instrument_scope": "6-string"
+        },
+        {
+          "id": "jazz-guitar-technique-in-20-weeks",
+          "title": "Jazz Guitar Technique in 20 Weeks",
+          "year": null,
+          "instrument_scope": "6-string",
+          "summary": "Howard Roberts's 20-week structured technique-development program for jazz guitar — alternate-picking, scale patterns, chord voicings, voice-leading.",
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         }
       ],
       "status": "pending-extraction",
@@ -72461,25 +72532,57 @@
           "id": "almanac-vol-1",
           "title": "Almanac of Guitar Voice Leading, Vol 1",
           "year": 2001,
-          "instrument_scope": "6-string"
+          "instrument_scope": "6-string",
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         },
         {
           "id": "almanac-vol-2",
           "title": "Almanac of Guitar Voice Leading, Vol 2",
           "year": 2002,
-          "instrument_scope": "6-string"
+          "instrument_scope": "6-string",
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         },
         {
           "id": "almanac-vol-3",
           "title": "Almanac of Guitar Voice Leading, Vol 3",
           "year": 2003,
-          "instrument_scope": "6-string"
+          "instrument_scope": "6-string",
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         },
         {
           "id": "almanac-vol-4",
           "title": "Almanac of Guitar Voice Leading, Vol 4",
           "year": 2005,
-          "instrument_scope": "6-string"
+          "instrument_scope": "6-string",
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         }
       ],
       "status": "pending-extraction",
@@ -73628,7 +73731,15 @@
           "id": "jazz-workshop",
           "title": "Jazz Workshop",
           "year": 1986,
-          "instrument_scope": "piano-translatable-to-guitar"
+          "instrument_scope": "piano-translatable-to-guitar",
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         }
       ],
       "status": "pending-extraction",
@@ -74145,7 +74256,15 @@
           "id": "connecting-chords-with-linear-harmony",
           "title": "Connecting Chords with Linear Harmony",
           "year": 1996,
-          "instrument_scope": "concert-pitch-translatable-to-guitar"
+          "instrument_scope": "concert-pitch-translatable-to-guitar",
+          "source_locator": {
+            "type": "pdf",
+            "access_tier": "trusted_contributor",
+            "pdf_filename": null,
+            "total_pages": null,
+            "first_indexed_page_offset": null,
+            "internal_path": null
+          }
         }
       ],
       "status": "pending-extraction",


### PR DESCRIPTION
Implements v0.1 of #550 per [maintainer disposition](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/550#issuecomment-4742614388).

## Summary
Adds `source_locator` field to all 14 works that have engine-rules. Schema fields:

```json
"source_locator": {
  "type": "pdf",
  "access_tier": "trusted_contributor",   // pedagogue role per ellington-web#96
  "pdf_filename": <known or null>,
  "total_pages": null,
  "first_indexed_page_offset": null,
  "internal_path": null
}
```

`access_tier` is uniform: full-PDF access gated behind the pedagogue role. General users get the existing `anchor` quote + `source_page` text label only.

## Also fixes
Adds the previously-orphaned Roberts 'Jazz Guitar Technique in 20 Weeks' work entry to masters.json (its engine-rules existed in develop but the work entry was missing from the catalog).

## Deferred to follow-up tickets
- `pdf_filename` for 13 books (Greene's is known from existing provenance; rest need maintainer-canonical filenames or a storage-pipeline decision)
- `total_pages`, `first_indexed_page_offset` (need touching the actual PDFs)
- `internal_path` (depends on hosting infrastructure — cyberpower volume layout, Authentik gate, page-rendering pipeline)
- `watermark_template` (open question on #550 — recommend yes for pedagogue traceability)

## Verification
| Gate | Result |
|---|---|
| All 14 engine-rules works have `source_locator` | ✅ |
| Greene's known PDF filename populated | ✅ |
| Roberts 20-weeks work entry added (was orphaned) | ✅ |

## Forward compatibility
Ellington v2 review UI's "show source text" feature consumes whatever locator fields are populated. v1 review UI doesn't depend on this at all (just shows "Page N of Book" text + the anchor quote).