### PR TITLE
feat(#554): Slonimsky distillation s1-s3 (chapters, summaries, systems-draft)

### DIFF
--- a/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/chapters/ch01-introduction.md
+++ b/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/chapters/ch01-introduction.md
@@ -1,0 +1,410 @@
+# Chapter 1 — Introduction
+
+_Slonimsky's prose introduction to the Thesaurus. Source: page numbers in the original 1947 edition; OCR text from Internet Archive._
+
+INTRODUCTION 
+
+
+T he present Thesaurus is a reference book of scales and melodic patterns 
+analogous in function with phrase books and dictionaries of idiomatic expres- 
+sions. But while phrase books are limited to locutions consecrated by usage the 
+Thesaurus includes a great number of melodically plausible patterns that are iiew 
+
+In fact, many compositions appearing in recent years contain thematic figures identical 
+with those found in the Thesaurus. 
+
+From time to time musical theorists have suggested the possibility of forming en- 
+tirely new scales based on the division of the octave into several equal parts. As early 
+as 1911 the Italian musician Domenico Alaleona proposed such new scales Alois Haba 
+m his Neue Harmonielehre (1927), classifies a great number of scales based on equal 
+intervals and suggests harmonizations of these new scales. Joseph Schillinger in his 
+posthumously published Schillinger System of Musical Composition classifies new 
+tonal progressions in the chapter Theory of Pitch-Scales. 
+
+The scales and melodic patterns in the Thesaurus are systematized in a manner 
+convenient to composers in search of new materials. The title Thesaurus of scales 
+and MELODIC patterns is chosen advisedly. The term scale, as here used, means a 
+progression, either diatonic or chromatic, that proceeds uniformly in one direction 
+ascending or descending, until the terminal point is reached. A melodic pattern, on the 
+other hand, may be formed by any group of notes that has melodic plausibility. There 
+are scales of 4 notes only; and there are scales and patterns of 12 different notes But 
+counting repeated notes appearing in different octaves, a scale may have as many as 
+48 functionally different notes, as in the Disjunct Major Polytetrachord (No 958) 
+As to melodic patterns, there is virtually no limit to the number of such tones. 
+
+The Thesaurus is arranged in the form of piano scales and melodic studies No 
+fmgermg is given, for the pianist will readily find the type of digitation best suited to 
+the hand. Other instrumentalists, too, will find most of the scales and melodic patterns 
+in the Thesaurus adaptable to their instruments. The notation throughout is enhar¬ 
+monic, and accidentals are used according to convenience. Double sharps and double 
+flats are avoided entirely. Precautionary natural signs are placed here and there when 
+- 1 melodlc mterval -urs. All accidentals affect only the note immediately 
+
+The scales and patterns in the Thesaurus are arranged according to the principal 
+interval of each particular section. In order to avoid association with a definite tonality 
+these basic intervals are here referred to by Latin and Greek names derived from old 
+usage. In addition, new terms had to be coined for intervals not in the system of historic 
+scales In these new terms the prefix sesqui stands for the addition of one-half of a 
+tone. Thus, Sesquitone is 1 V 2 tones, or a minor third; Sesquiquadritone is 4 V 2 tones or 
+a major sixth; and Sesquiquinquetone is 5 V 2 tones, or a major seventh. 
+
+
+1 
+
+
+The table of intervals from the semitone to the major seventh appears as follows: 
+
+Semitone .Minor Second Tritone .Augmented Fourth 
+
+Whole Tone .Major Second Diapente .Perfect Fifth 
+
+Sesquitone .Minor Third Quadritone .Minor Sixth 
+
+Ditone .Major Third Sesquiquadritone .Major Sixth 
+
+Diatessaron .Perfect Fourth Quinquetone .Minor Seventh 
+
+Sesquiquinquetone .Major Seventh 
+
+The interval of a major ninth is called Septitone, to indicate that it contains 7 whole 
+tones. 
+
+These basic intervals are regarded as fractions of one or more octaves. Thus, the 
+Tritone Progression represents the division of the octave into 2 equal parts, and it 
+produces sequential scales and patterns. The Ditone Progression is the division of the 
+octave into 3 equal parts, and is intervallically identical with the augmented triad. 
+The Sesquitone Progression is the division of the octave into 4 equal parts, and is iden¬ 
+tical with the familiar diminished-seventh chord. The Whole-Tone scale represents 
+the equal division of the octave into 6 parts. The Semitone Progression is equivalent 
+to the chromatic scale. By the process of permutation the chromatic scale is productive 
+of characteristic patterns of the 12-tone technique. 
+
+By dividing 2 octaves into 3 equal parts we obtain the Quadritone Progression, 
+which is closely related to the Ditone Progression, being in fact a spread-out augmented 
+triad. By dividing 3 octaves into 4 equal parts we obtain the interval of the major sixth. 
+This is the Sesquiquadritone Progression, which is an unfolded Sesquitone Progres¬ 
+sion, productive of patterns related to diminished-seventh harmonies. 
+
+In the cycle of scales the interval of a perfect fifth is one-twelfth part of 7 octaves, 
+and it is so represented in the Diapente Progression. A perfect fourth is one-twelfth 
+part of 5 octaves, and is classified as such in the section Diatessaron Progression. 
+
+Pursuing a similar process, we find that the Sesquiquinquetone Progression, or the 
+progression of major sevenths, is the result of the equal division of 11 octaves into 12 
+parts. Finally, the Septitone Progression is the equal division of 7 octaves into 6 parts, 
+with the basic interval of a major ninth. 
+
+Scales and melodic patterns are formed by the processes of Interpolation, Infra- 
+polation, and Ultrapolation. The word Interpolation is in common usage; here it 
+signifies the insertion of one or several notes between the principal tones. Infrapolation 
+and Ultrapolation are coined words. Infrapolation indicates the addition of a note 
+below a principal tone; Ultrapolation is the addition of a note above the next principal 
+tone. Infrapolation and Ultrapolation result in the shift of direction, with the melodic 
+line progressing in zigzags. Infrapolation, Interpolation and Ultrapolation may be 
+freely combined, resulting in hyphenated forms: Infra-Interpolation, Infra-Ultrapola- 
+tion, and Infra-Inter-Ultrapolation. 
+
+
+Principal Tones Interpolation Ultrapolation Infrapolation 
+
+
+
+Infra-Interpolation Infra-Ultrapolation Infra-Inter-Ultrapolation 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Progressions and patterns based on unequal division of the octave are exemplified 
+h Y Heptatonic scales and Pentatonic scales. Among Heptatonic scales, or 7-tone scales, 
+are our familiar major and minor scales as well as the church modes. In the section 
+Heptatonic Arpeggios the scales are spread out in thirds. In the section Bitonal Arpeg¬ 
+gios the C major arpeggio is combined with arpeggios in all other 23 major ami 
+minor keys. 
+
+Busoni, who had earnestly explored new musical resources, found 113 different 
+scales of 7 notes. Mentioning as an example the scale: C, Db, Eb, Fb, Gb, Ab, Bb, C 
+(it is No. 1035 in the Thesaurus), he writes in his Entwurf einer neuen Aesthetik 
+der Tonkunst: “There is a significant difference between the sound of this new scale 
+when C is taken as the tonic and when it is taken as the leading tone of the scale of 
+Db minor. By harmonizing the tonic with the customary C major triad as a fundamental 
+chord, a novel harmonic sensation is obtained.” 
+
+In his Chronicle of My Musical Life Rimsky-Korsakov mentions the use he made 
+of an 8-tone scale, formed by alternating major and minor seconds. This is Scale No. 
+393 in the Thesaurus. Sporadic uses of the Whole-Tone scale are found in Glinka 
+and even in Mozart (as a jest to mock the inept Dorfmusikanten) , but it did not 
+become a deliberate device before Debussy. In Debussy’s piano piece Voiles the prin¬ 
+cipal melodic structure is in the ^OCHhole-Tone scale, but the middle part is written 
+exclusively on the black keys, exemplifying the Pentatonic scale. 
+
+The Whole-Tone scale has 6 notes to the octave; the Pentatonic scale has five. The 
+Whole-Tone scale is possible in only one form on a given note, but there can be many 
+Pentatonic scales. There are 49 Pentatonic scales in the Thesaurus. 
+
+The 12-Tone Technique of composition promulgated by Schoenberg is based on 
+permutations of the Semitone scale. Various 12-tone patterns are found in the The¬ 
+saurus in examples No. 1214 to No. 1318. For example, it is possible to arrange the 
+12 chromatic tones in 2 major and 2 minor triads without repeating a note. It is also 
+possible to form 4 mutually exclusive augmented triads using all 12 chromatic tones. 
+The theme of Liszt s Faust Symphony is composed of 4 augmented triads. It is further 
+possible to split the chromatic scale into a diminished triad, a minor triad, a major 
+triad, and an augmented triad. These mutually exclusive triads can be arranged in the 
+form of Quadritonal Arpeggios. 
+
+A recent development of the 12-Tone Technique is the n-interval technique, which 
+prescribes the formation of progressions containing 11 different intervals. The idea was 
+first introduced by the Austrian musician Fritz Klein in 1921 in a curious composition 
+entitled Die Maschine, with the sub-title Ex-Tonal Self-Satire. The name of the com¬ 
+poser was concealed behind a characteristic nom de plume Heautontimorumenus which 
+means Self-Torturer. In this piece Klein introduced a Mother Chord which contains 
+not only all 11 different intervals, but 12 different notes as well. 
+
+A further elaboration on the Mother Chord is an invertible 11-interval, 12-tone 
+chord introduced by the author and appropriately christened Grandmother Chord. It 
+has all the intervallic properties of the Mother Chord plus an especial order of inter¬ 
+vals so arranged that they are alternately odd-numbered and even-numbered when 
+counted in semitones, with the row of odd-numbered intervals forming a decreasing 
+arithmetical progression and the row of even-numbered intervals forming an increas¬ 
+es arithmetical progression. The order of notes in the Grandmother Chord is identical 
+with the 12-tone Spiral Pattern No. 1232a. 
+
+iii 
+
+
+
+
+
+All chords composed of u different intervals add up to the interval of 66 semi¬ 
+tones, which is the sum of the arithmetical progression from i to ir. The interval of 
+66 semitones equals 5 V2 octaves, and so forms a Tritone between the lowest and the 
+highest tones in the Pyramid Chord, Mother Chord, Grandmother Chord, and other 
+11-interval structures. 
+
+Scales and patterns listed in the main body of the Thesaurus readily lend them¬ 
+selves to new melodic possibilities. For instance, a descending scale may be played in 
+the form of the melodic inversion of the ascending scale, as suggested in the section 
+Mirror Interval Progressions. It is possible to form complementary scales in the range 
+of 2 octaves, by using in the second octave the notes not used in the first. Other possi¬ 
+bilities for the formation of new patterns are demonstrated in the section on Permu¬ 
+tations. 
+
+A Diatonic counterpart of the 12-Tone Technique is the system of Pandiatonic 
+composition. The term Pandiatonic, first introduced by this writer in 1937, denotes the 
+free use of all 7 tones of the diatonic scale, both melodically and harmonically. In 
+one-part Pandiatonic Progressions, the melody is made up of 7 different notes of the 
+diatonic scale. Such a progression may then be melodically inverted, read backward, or 
+both, resulting in 4 different forms. Pandiatonic Counterpoint in strict style uses 
+progressions of 7 different notes in each voice, with no vertical duplication. 
+
+Pandiatonic Harmony is the twentieth century counterpart of classical harmony. 
+Modern composers of such varied backgrounds and musical persuasions as Ravel, 
+Stravinsky, Hindemith, Milhaud, Copland and Roy Harris make use of this technique, 
+arriving at it by different creative processes. Jazz composers, too, have found, by sheer 
+experimentation, effective application for the enriched chords of Pandiatonic forma¬ 
+tions. It is a common practice to end an orchestral arrangement of a popular song by 
+the enriched major triad with an added sixth, seventh, or ninth. 
+
+The concluding sections of the Thesaurus demonstrate the various methods by 
+which tonal materials may be used to best advantage. The section Double Notes shows 
+the combinations derived from corresponding scales and patterns. Plural Scales and 
+Arpeggios give examples of common major and minor progressions arranged consecu¬ 
+tively in chromatic transposition. Polytonal Scales are simultaneous progressions in 
+different keys. Polyrhythmic Scales are progressions in different rhythms. Polytonal 
+Polyrhythmic Scales combine different rhythms in different tonalities. 
+
+A special word is to be said about Palindromic Canons. Palindromes are words or 
+sentences that read the same forward or backward, as the sentence Able Was l Ere I 
+Saw Elba (applied to Napoleon). Similarly, Palindromic Canons read the same back¬ 
+ward or forward. The two Palindromic Canons based on Pattern No. 72 are particularly 
+interesting. They result in a progression of enharmonic triads or their inversions, alter¬ 
+nating in major and minor keys. 
+
+Fragments of the scales and patterns in the Thesaurus may be used as motives 
+and themes. The rhythmical elaboration is left to the imagination of the composer. By 
+using a portion of a pattern in forward and retrograde motion, in varied rhythms 
+within a given meter, it is possible to form an unlimited number of melodic figures. 
+
+
+Pattern N2194 
+
+
+Rhythmic Development 
+
+11 retrograde 
+
+
+
+IV 
+
+
+
+Two formulas are used in the harmonization of the scales and patterns: one by com- 
+triads, and one by seventh-chords. In the harmonization by common triads only 
+root positions of major triads in close harmony are applied. Either the root, the third 
+or the fifth may appear in the melody. These positions are referred to as Octave, Ter¬ 
+tian, and Quintan, or in figures, 8, 3, and 5. When the melody ascends, diatonically or 
+chromatically, the positions change from the Octave to the Tertian to the Quintan 
+to the Octave. When the melody descends, the order of the positions is reversed. 
+Furthermore, the order of positions may be reversed at the end of a cadence even in 
+ascending motion. When the melody is stationary, the order of positions is free. The re¬ 
+sulting harmony traverses several tonalities in an alternation of successive major chords. 
+
+
+Harmonization in Major Triads 
+(Figures Indicate Intervals Between the Melody and the Bass) 
+
+
+
+8 3 5 3 8 8 5 8 5 “ 8 3 8 5 
+
+
+The harmonization in major triads is found in the music of Debussy, Moussorgsky, 
+and other composers of the French and Russian schools. A classical example is the 
+scene in the monk’s cell in Moussorgsky’s opera Boris Godunov. In the second act of 
+Puccini s opera Tosca the Whole-Tone scale in the bass is harmonized by a row of 
+major triads with the positions following the Octave-Tertian-Quintan (8-3-5) formula. 
+
+
+Moussorgsky: Boris Godunov Puccini: Tosca (Whole-Tone Scale in the Bass) 
+
+
+
+The second type of harmonization is effected by means of Master Chords. These 
+Master Chords are dominant-seventh chords with the fifth omitted. In combination 
+with melodic elements of a given scale or pattern, these chords form harmonic struc¬ 
+tures of the type of seventh-chords, ninth-chords, or whole-tone chords. The Master 
+Chords are indicated for ascending scales and patterns in the sections Tritone Pro¬ 
+gression, Ditone Progression and Sesquitone Progression by figures within circles, as ©, 
+and are used to harmonize an entire rhythmic group in a given progression. In the 
+Tritone and Sesquitone Progressions it is also possible to harmonize the entire octave 
+range with a single Master Chord. Furthermore, any Master Chord suitable for harmo¬ 
+nization of a given progression may be transposed a tritone up or down with satisfactory 
+results. 
+
+
+Harmonization with Master Chords 
+
+
+
+v 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Harmonization of both types is given in the tables on pp.240-241. To harmonize in 
+major triads, it is necessary to alternate the Octave, Tertian, and Quintan positions given 
+in the table. In harmonizing by seventh-chords, ninth-chords, and whole-tone chords, 
+any chord under a given melody note will furnish a workable harmony. 
+
+The patterns in the Diatessaron and Diapente Progressions lend themselves to har¬ 
+monization characteristic of the Dominant-Tonic cycle. When harmonized in consecutive 
+seventh-chords, such patterns acquire a Schumannesque quality. 
+
+Harmonization in Seventh-Chords 
+
+
+'hJOQR.C 
+
+
+
+
+Traditional harmonization in major and minor keys uses chords formed by the dia¬ 
+tonic scale. Similarly, new scales may be harmonized with the aid of chords formed by 
+the notes of the scale itself. Examples of such Autochordal Harmonization are given in a 
+special table. There are scales that admit of only 2 different triads, as Scale No. 7, which 
+can be harmonized with C major and F# major triads. The 8-tone scale No. 393 is capable- 
+of forming 8 different triads, while other scales, such as No. 5, do not yield a single triad. 
+
+All scales and patterns in the Thesaurus are centered on C as the initial and con¬ 
+cluding tone. It goes without saying that these progressions can be transposed to any 
+tonal center according to a composer’s requirements. 
+
+John Stuart Mill once wrote: "I was seriously tormented by the thought of the ex- 
+haustibility of musical combinations. The octave consists only of five tones and two 
+semitones, which can be put together in only a limited number of ways of which but a 
+small proportion are beautiful: most of these, it seemed to me, must have been already 
+discovered, and there could not be room for a long succession of Mozarts and Webers 
+to strike out, as these have done, entirely new surpassing rich veins of musical beauty. 
+This sort of anxiety, may, perhaps, be thought to resemble that of the philosophers of 
+Laputa, who feared lest the sun be burnt out.” 
+
+The fears of John Stuart Mill are unjustified. There are 479,001,600 possible com¬ 
+binations of the 12 tones of the chromatic scale. With rhythmic variety added to the 
+unbounded universe of melodic patterns, there is no likelihood that new music will die 
+of internal starvation in the next 1000 years. Nicolas Slonimsky 
+
+1 January 1947 Boston, Massachusetts 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/chapters/ch02-explanation-of-terms.md
+++ b/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/chapters/ch02-explanation-of-terms.md
@@ -1,0 +1,288 @@
+# Chapter 2 — Explanation of Terms
+
+_Slonimsky's glossary defining the operational vocabulary (autochordal harmonization, bitonal arpeggios, infrapolation, interpolation, ultrapolation, sesquiquadritone, etc.). The taxonomic dictionary that downstream patterns reference._
+
+EXPLANATION OF TERMS 
+
+
+Autochordal harmonization. Application of 
+chords derived from the tones of a given scale 
+(Example, Scale No. 12: C, DJ, F, FJ, A, B, C, 
+harmonized in 2 triads, F major and B major). 
+
+Bitonal arpeggios. [Nos. 1191-1213]. Melodic 
+progressions formed of alternating arpeggios in 
+2 different keys. 
+
+Bitonal palindromic canons. Canons that re¬ 
+sult in the formation of 6-tone chords composed 
+of 2 triads (Example, Scale No. 7: C, C$, E, FJ, 
+G, A#, C, developed canonically, forming bitonal 
+chords of C major and F# major). 
+
+Chord of the minor 23RD. Chord consisting of 
+12 different notes, arranged in thirds, and forming 
+4 mutually exclusive triads. 
+
+Complementary scales. Melodic progressions of 
+two octaves in range, comprising all 12 tones 
+of the chromatic scale (Example, C major scale 
+plus the pentatonic scale on black keys). 
+
+Conjunct polytetrachord. Progression of 12 
+tetrachords traversing all 12 keys, with the ter¬ 
+minal tone of one tetrachord being the initial tone 
+of the next (Examples, Phrygian Polytetrachord, 
+No. 830 ; Minor Polytetrachord, No. 832 ; Major 
+Polytetrachord, No. 833). 
+
+Crossing intervals. [Nos. 1243-1250}. Two 
+overlapping 6-tone rows comprising all 12 dif¬ 
+ferent tones, each row forming a progression of 
+major or minor seconds, thirds, fourths, fifths 
+and sixths. 
+
+Diapente. Interval of 3% tones; a perfect fifth. 
+
+Diatessaron. Interval of 2]/ 2 tones; a perfect 
+fourth. 
+
+Disjunct polytetrachord. Progression of 12 
+tetrachords traversing all 12 keys, with adjacent 
+tetrachords separated by one diatonic degree (Ex¬ 
+amples, Disjunct Phrygian Polytetrachord, No. 
+951; Disjunct Minor Polytetrachord, No. 956; 
+Disjunct Major Polytetrachord, No. 958; Disjunct 
+Lydian Polytetrachord, No. 959). 
+
+Ditone. Interval of 2 whole tones; a major third. 
+
+Grandmother chord. Chord, invented by Nico¬ 
+las Slonimsky on February 13, 1938, containing 
+all 12 different tones and different intervals sym¬ 
+metrically invertible in relation to the central 
+interval, the tritone, which is the inversion of it¬ 
+self ; the intervallic structure being a row of alter¬ 
+
+
+natingly odd and even intervals (counted in semi¬ 
+tones), the odd-numbered series forming a dimin¬ 
+ishing arithmetical progression, and the even- 
+numbered series an increasing progression. 
+
+Heptatonic arpeggios. [Nos. 1088-1141]. Me¬ 
+lodic progressions by thirds derived from Hepta¬ 
+tonic scales. 
+
+Heptatonic scales. [Nos. 1034-1087]. Diatonic 
+progressions of 7 degrees, such as major and 
+minor scales and church modes, and also scales 
+containing 1 or 2 augmented seconds. 
+
+Infra-inter-ultrapolation. Pattern formed by 
+the insertion of notes below, between, and above 
+the principal tones of a progression (Example, 
+Pattern No. 341). 
+
+Infrapolation. Insertion of a note below the 
+principal tones of a progression (Example, Pat¬ 
+tern 231). 
+
+Interpolation. Insertion of one or more notes 
+between the principal tones of a progression (Ex¬ 
+ample, Scale No. 21). 
+
+Inter-ultrapolation. Insertion of 2 notes, one 
+between the principal tones of a given progression, 
+the other above the principal tone (Example, Pat¬ 
+tern No. 123). 
+
+Major bitonal chord. Chord of 2 major triads 
+usually in keys whose tonics are at the interval 
+of a tritone, as C major and Fj major. 
+
+Major polytetrachord. A series of major tetra¬ 
+chords, conjunct or disjunct, covering all 12 
+major keys (Examples, No. 833 and No. 958). 
+
+Master chords. Dominant-seventh chords with 
+the fifth omitted, tabulated chromatically in 12 
+different keys, to be used in harmonizing scales 
+and melodic patterns, and indicated by figures, 
+enclosed in circles, from 1 to 12. 
+
+Minor bitonal chord. Chord consisting of 2 
+minor chords, usually with tonics at the interval 
+of a tritone, as C minor and F jjf minor. 
+
+Minor polytetrachord. A series of minor tetra¬ 
+chords, conjunct or disjunct, covering all 12 
+minor keys (Examples, No. 832 and No. 956). 
+
+Mirror interval progressions. Scales and pat¬ 
+terns in which the descending figure is the me¬ 
+lodic inversion of the ascending figure (Exam¬ 
+ple, Scale No. 1 ascending is the mirror inversion 
+of Scale No. 4 descending). 
+
+
+Vll 
+
+
+
+Mother chord. Chord, introduced by Fritz Klein 
+in 1921, containing all 12 tones and 11 different 
+intervals. 
+
+Mutually exclusive triads. Four triads (major, 
+minor, diminished or augmented) comprising all 
+12 different tones (Example, C major, F# major, 
+
+D minor, and G# minor). 
+
+Non-symmetric interpolation. Free insertion 
+of additional notes between the principal tones. 
+
+Octave position. In four-part harmony, a triad 
+with the root both in the melody and in the bass. 
+
+Palindromic canons. Canons that read the same 
+backward or forward. 
+
+Pandiatonic harmony. Part-writing in chords 
+freely combined from the 7 tones of the diatonic 
+scale. 
+
+Pandiatonic progressions. Tonal rows com¬ 
+posed of all 7 different tones of the diatonic scale. 
+
+Pattern. Melodic figure in which the direction 
+changes from ascending to descending, or vice 
+versa, before arriving at the terminal point (All 
+infrapolated and ultrapolated progressions are 
+patterns). 
+
+Pentatonic scales. [Nos. 1142-1190]. Scales of 
+5 notes. 
+
+Permutation. Distribution of notes of a given 
+melodic pattern in different orders of succession. 
+
+Phrygian polytetrachord. Polytetrachord com¬ 
+posed of 12 conjunct or disjunct Phrygian tetra- 
+chords (1 semitone plus 2 whole tones), (Exam¬ 
+ples, No. 830 and No. 931). 
+
+Plural scales. Progressions formed by disjunct 
+scales, as C major, major, D major, and Efc> 
+major. 
+
+Polyrhythmic scales. Simultaneous progressions 
+in different rhythms. 
+
+Polytetrachord. Progression of 12 tetrachords 
+passing through all 12 keys conjunctly (with the 
+last tone of one tetrachord coinciding with the 
+first tone of the next), or disjunctly (with the 
+terminal tone of the first tetrachord separated by 
+a diatonic degree from the initial tone of the 
+next). 
+
+Polytonal polyrhythmic scales. Simultaneous 
+progressions in different keys and in different 
+rhythms. 
+
+Polytonal scales. Scales in different tonalities 
+played simultaneously. 
+
+Progression. General term for any scale or me¬ 
+lodic pattern. 
+
+Prometheus scale. [No. 50}. The 6-tone scale 
+(C, D, E, FJ, A, Bfe>) used by Scriabin in his 
+symphonic poem Prometheus. 
+
+
+Pyramid chord. Chord, introduced by Fritz Klein 
+in 1921, composed of a series of diminishing in¬ 
+tervals from an octave to a semitone. 
+
+Quadritone. Interval of 4 whole tones; a minor 
+sixth. 
+
+Quadritonal arpeggios. [Nos. 1251-1291]. 
+Melodic progressions formed by 4 mutually ex¬ 
+clusive triads, as C major, D minor, F$ major, 
+and Gf minor. 
+
+Quartal chord. 12-tone chord arranged in per¬ 
+fect fourths. 
+
+Quinquetone. Interval of 5 whole tones; a 
+minor seventh. 
+
+Quintan position. In four-part harmony, a 
+triad with the root in the bass and the fifth in 
+the melody. 
+
+Scale. Progression of tones changing its direction 
+only at terminal points (All interpolated pro¬ 
+gressions are scales). 
+
+Semitone progression. Scale consisting of con¬ 
+secutive semitones; a chromatic scale. 
+
+Septitone. Interval of 7 whole tones; a major 
+ninth. 
+
+Sesqui. Prefix signifying the addition of a semi¬ 
+tone to a given interval (Sesquitone — iy 2 tones; 
+Sesquiquadritone = 4^ tones). 
+Sesquiquadritone. Interval of 4^2 tones; a 
+major sixth. 
+
+Sesquiquinquetone. Interval of 5^ tones; a 
+major seventh. 
+
+Sesquitone. Interval of 1 y 2 tones; a minor third. 
+Spiral patterns. Melodic progressions converg¬ 
+ing toward a central tone. 
+
+Symmetric interpolation. Insertion of notes at 
+equal intervals from respective pivotal points, 
+resulting in invertible progressions (Example, 
+Scale No. 37: C, D, F, Ffl, G, Bb, C, in which 
+the intervals are the same from C upward and 
+from the upper C downward). 
+
+Tertian position. In four-part harmony, a triad 
+with the root in the bass and the third in the 
+melody. 
+
+Tone-cluster. Term, introduced by Henry Cow¬ 
+ell, signifying a complex of notes filling one or 
+more octaves, diatonically, chromatically, or pen- 
+tatonically. 
+
+Tritone. Interval of 3 whole tones; an augmented 
+fourth, or a diminished fifth. 
+
+Twelve-tone progressions. Melodic figures of 
+12 different tones. 
+
+Ultrapolation. Insertion of one or more notes 
+above a principal tone of a scale (Example, Pat¬ 
+tern No. 53, in which G is inserted above Fjf). 
+
+Whole-tone chords. Chords composed of in¬ 
+tervals of one or several whole tones each. 
+
+
+
+Tritone Progression 
+
+Equal Division of One Octave into Two Parts 
+
+
+
+®©©indicateMaster Chords, 

--- a/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/derived/systems-draft.json
+++ b/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/derived/systems-draft.json
@@ -1,0 +1,212 @@
+{
+  "_provenance": {
+    "run_id": "2026-06-18T15-45-00-slonimsky-thesaurus-s3",
+    "stage": "s3-systems-draft",
+    "source_pdf": "Nicolas Slonimsky - Thesaurus OfScales And Melodic Patterns.pdf",
+    "extracted_at": "2026-06-18T15:45:00+00:00",
+    "schema_version": "0.1",
+    "model": "claude-sonnet+human-curated",
+    "ticket": "#554"
+  },
+  "master_id": "nicolas-slonimsky",
+  "work_id": "thesaurus-of-scales-and-melodic-patterns",
+  "systems": {
+    "polation_operations": {
+      "_description": "Three coined operations Slonimsky applies to principal tones of an equal-division progression. Each yields a different decorated shape, and they compose freely. Categorical primitives for the melodic engine's then-action vocabulary.",
+      "operations": [
+        {
+          "id": "interpolation",
+          "definition": "Insertion of one or more notes BETWEEN principal tones.",
+          "preserves_direction": true,
+          "produces_taxonomy_class": "scale",
+          "example_pattern_number": 21
+        },
+        {
+          "id": "infrapolation",
+          "definition": "Insertion of a note BELOW a principal tone.",
+          "preserves_direction": false,
+          "produces_taxonomy_class": "pattern",
+          "example_pattern_number": 231
+        },
+        {
+          "id": "ultrapolation",
+          "definition": "Insertion of a note ABOVE the next principal tone.",
+          "preserves_direction": false,
+          "produces_taxonomy_class": "pattern",
+          "example_pattern_number": 53
+        },
+        {
+          "id": "inter-ultrapolation",
+          "definition": "Compound: interpolation + ultrapolation in the same figure.",
+          "preserves_direction": false,
+          "produces_taxonomy_class": "pattern",
+          "example_pattern_number": 123
+        },
+        {
+          "id": "infra-inter-ultrapolation",
+          "definition": "Compound: all three operations in the same figure.",
+          "preserves_direction": false,
+          "produces_taxonomy_class": "pattern",
+          "example_pattern_number": 341
+        },
+        {
+          "id": "symmetric-interpolation",
+          "definition": "Interpolation at equal intervals from pivotal points; produces palindromic interval structure.",
+          "preserves_direction": true,
+          "produces_taxonomy_class": "scale",
+          "example_pattern_number": 37
+        },
+        {
+          "id": "non-symmetric-interpolation",
+          "definition": "Free interpolation (no equal-interval constraint).",
+          "preserves_direction": true,
+          "produces_taxonomy_class": "scale",
+          "example_pattern_number": null
+        }
+      ]
+    },
+    "equal_division_progressions": {
+      "_description": "The structural backbone of the Thesaurus. Each progression divides one or more octaves into equal parts; principal tones of that division are then decorated via polation operations.",
+      "progressions": [
+        {"id": "tritone", "interval_name": "tritone", "interval_semitones": 6, "octaves_divided": 1, "parts": 2, "alias": "augmented fourth iterated", "first_indexed_scale_number": null},
+        {"id": "ditone", "interval_name": "ditone", "interval_semitones": 4, "octaves_divided": 1, "parts": 3, "alias": "augmented triad", "first_indexed_scale_number": null},
+        {"id": "sesquitone", "interval_name": "sesquitone", "interval_semitones": 3, "octaves_divided": 1, "parts": 4, "alias": "diminished-seventh chord", "first_indexed_scale_number": null},
+        {"id": "whole-tone", "interval_name": "whole tone", "interval_semitones": 2, "octaves_divided": 1, "parts": 6, "alias": "whole-tone scale", "first_indexed_scale_number": null},
+        {"id": "semitone", "interval_name": "semitone", "interval_semitones": 1, "octaves_divided": 1, "parts": 12, "alias": "chromatic scale; 12-tone technique source", "first_indexed_scale_number": null},
+        {"id": "quadritone", "interval_name": "quadritone", "interval_semitones": 8, "octaves_divided": 2, "parts": 3, "alias": "minor sixth; spread-out augmented triad", "first_indexed_scale_number": null},
+        {"id": "sesquiquadritone", "interval_name": "sesquiquadritone", "interval_semitones": 9, "octaves_divided": 3, "parts": 4, "alias": "major sixth; unfolded sesquitone", "first_indexed_scale_number": null},
+        {"id": "diatessaron", "interval_name": "diatessaron", "interval_semitones": 5, "octaves_divided": 5, "parts": 12, "alias": "perfect fourth", "first_indexed_scale_number": null},
+        {"id": "diapente", "interval_name": "diapente", "interval_semitones": 7, "octaves_divided": 7, "parts": 12, "alias": "perfect fifth", "first_indexed_scale_number": null},
+        {"id": "sesquiquinquetone", "interval_name": "sesquiquinquetone", "interval_semitones": 11, "octaves_divided": 11, "parts": 12, "alias": "major seventh", "first_indexed_scale_number": null},
+        {"id": "septitone", "interval_name": "septitone", "interval_semitones": 14, "octaves_divided": 7, "parts": 6, "alias": "major ninth", "first_indexed_scale_number": null}
+      ]
+    },
+    "interval_taxonomy": {
+      "_description": "Slonimsky's tone-distance vocabulary. The 'sesqui-' prefix uniformly adds a semitone. Coined names for intervals where common practice uses tonal-functional labels.",
+      "intervals": [
+        {"name": "semitone", "tones": 0.5, "semitones": 1, "common_name": "minor second"},
+        {"name": "whole tone", "tones": 1.0, "semitones": 2, "common_name": "major second"},
+        {"name": "sesquitone", "tones": 1.5, "semitones": 3, "common_name": "minor third"},
+        {"name": "ditone", "tones": 2.0, "semitones": 4, "common_name": "major third"},
+        {"name": "diatessaron", "tones": 2.5, "semitones": 5, "common_name": "perfect fourth"},
+        {"name": "tritone", "tones": 3.0, "semitones": 6, "common_name": "augmented fourth / diminished fifth"},
+        {"name": "diapente", "tones": 3.5, "semitones": 7, "common_name": "perfect fifth"},
+        {"name": "quadritone", "tones": 4.0, "semitones": 8, "common_name": "minor sixth"},
+        {"name": "sesquiquadritone", "tones": 4.5, "semitones": 9, "common_name": "major sixth"},
+        {"name": "quinquetone", "tones": 5.0, "semitones": 10, "common_name": "minor seventh"},
+        {"name": "sesquiquinquetone", "tones": 5.5, "semitones": 11, "common_name": "major seventh"},
+        {"name": "septitone", "tones": 7.0, "semitones": 14, "common_name": "major ninth"}
+      ]
+    },
+    "progression_taxonomy": {
+      "_description": "Slonimsky's structural categories for distinguishing types of melodic lines. The Scale-vs-Pattern distinction is fundamental: it determines whether polation operations preserve or reverse direction.",
+      "categories": [
+        {"id": "scale", "definition": "A progression that changes direction only at terminal points. All interpolated progressions are Scales."},
+        {"id": "pattern", "definition": "A melodic figure in which direction changes before terminal point. All infrapolated and ultrapolated progressions are Patterns."},
+        {"id": "progression", "definition": "Umbrella term for any scale or pattern."},
+        {"id": "permutation", "definition": "Reordering of an existing pattern's notes."},
+        {"id": "complementary-scales", "definition": "Two-octave progressions whose pitch content together exhausts the chromatic aggregate."},
+        {"id": "plural-scales", "definition": "Disjunct scales concatenated (e.g., C major + C# major + D major + Eb major)."},
+        {"id": "polytonal-scales", "definition": "Scales in different tonalities played simultaneously."},
+        {"id": "polyrhythmic-scales", "definition": "Simultaneous progressions in different rhythms."},
+        {"id": "polytonal-polyrhythmic-scales", "definition": "Simultaneous progressions in different keys AND different rhythms."},
+        {"id": "spiral-patterns", "definition": "Progressions converging toward a central tone."},
+        {"id": "pandiatonic-progressions", "definition": "Rows composed of all 7 different diatonic tones."},
+        {"id": "twelve-tone-progressions", "definition": "Melodic figures using all 12 different tones."}
+      ]
+    },
+    "named_chord_constructs": {
+      "_description": "Specific chord constructs Slonimsky names. Some are his own coinages; some are attributed to other theorists (Klein, Cowell, Scriabin).",
+      "constructs": [
+        {"id": "master-chord", "definition": "Dominant-seventh with fifth omitted; chromatically tabulated in 12 keys.", "attribution": "Slonimsky"},
+        {"id": "grandmother-chord", "definition": "12-tone chord, intervals symmetrically invertible around the tritone axis; odd-indexed intervals form a decreasing arithmetic sequence, even-indexed an increasing one.", "attribution": "Slonimsky 1938-02-13"},
+        {"id": "mother-chord", "definition": "12-tone chord with all 11 different intervals.", "attribution": "Fritz Klein 1921"},
+        {"id": "pyramid-chord", "definition": "Series of diminishing intervals from octave to semitone.", "attribution": "Fritz Klein 1921"},
+        {"id": "chord-of-the-minor-23rd", "definition": "12 different notes arranged in thirds, forming 4 mutually exclusive triads.", "attribution": "Slonimsky"},
+        {"id": "quartal-chord", "definition": "12-tone chord arranged in perfect fourths.", "attribution": "Slonimsky"},
+        {"id": "major-bitonal-chord", "definition": "Two major triads, usually at tritone distance.", "attribution": "Slonimsky"},
+        {"id": "minor-bitonal-chord", "definition": "Two minor triads, usually at tritone distance.", "attribution": "Slonimsky"},
+        {"id": "mutually-exclusive-triads", "definition": "Four triads (major/minor/dim/aug) comprising all 12 tones.", "attribution": "Slonimsky"},
+        {"id": "whole-tone-chords", "definition": "Chords composed of intervals of whole tones each.", "attribution": "Slonimsky"},
+        {"id": "tone-cluster", "definition": "Complex of adjacent notes filling one or more octaves.", "attribution": "Henry Cowell"},
+        {"id": "prometheus-scale", "definition": "6-tone scale C-D-E-F#-A-Bb used by Scriabin in Prometheus.", "attribution": "Scriabin (cataloged by Slonimsky)"}
+      ]
+    },
+    "harmonization_methods": {
+      "_description": "Methods Slonimsky catalogs for harmonizing a given scale or pattern.",
+      "methods": [
+        {"id": "autochordal", "definition": "Harmonize using only chords derivable from the scale's own pitch content.", "example": "Scale No. 12 (C, D#, F, F#, A, B, C) harmonized in F major + B major triads."},
+        {"id": "common-triads-positional", "definition": "Cycle Octave → Tertian → Quintan → Octave bass position as melody ascends (reverse on descent); produces parallel major triads across tonalities.", "example": "Tosca Act II whole-tone bass under parallel majors."},
+        {"id": "master-chord", "definition": "Apply Master Chords (dom7 minus 5th); transposable a tritone with satisfactory results.", "example": null},
+        {"id": "pandiatonic-counterpoint", "definition": "Each voice uses all 7 diatonic notes with no vertical duplication.", "example": null}
+      ]
+    },
+    "arpeggiation_systems": {
+      "_description": "Specific arpeggiation pattern families with their catalog ranges.",
+      "families": [
+        {"id": "heptatonic-arpeggios", "scale_number_range": [1088, 1141], "definition": "Arpeggiation by thirds from heptatonic scales."},
+        {"id": "bitonal-arpeggios", "scale_number_range": [1191, 1213], "definition": "Alternating arpeggios in 2 different keys."},
+        {"id": "quadritonal-arpeggios", "scale_number_range": [1251, 1291], "definition": "Arpeggios cycling 4 mutually exclusive triads (e.g., C major, D minor, F# major, G# minor)."},
+        {"id": "crossing-intervals", "scale_number_range": [1243, 1250], "definition": "Two overlapping 6-tone rows comprising all 12 different tones."}
+      ]
+    },
+    "canon_types": {
+      "_description": "Self-referential melodic structures.",
+      "types": [
+        {"id": "palindromic-canon", "definition": "Reads the same backward or forward."},
+        {"id": "bitonal-palindromic-canon", "definition": "Palindromic canon producing 6-tone chords composed of 2 triads.", "example": "Scale No. 7 canonically developed → C major + F# major bitonal chord."}
+      ]
+    },
+    "tetrachord_systems": {
+      "_description": "12-tetrachord chains covering all 12 keys.",
+      "systems": [
+        {"id": "phrygian-conjunct", "scale_number": 830, "definition": "Phrygian tetrachords, terminal-to-initial connected."},
+        {"id": "minor-conjunct", "scale_number": 832, "definition": "Minor tetrachords, terminal-to-initial connected."},
+        {"id": "major-conjunct", "scale_number": 833, "definition": "Major tetrachords, terminal-to-initial connected."},
+        {"id": "phrygian-disjunct", "scale_number": 951, "definition": "Phrygian tetrachords with diatonic-step gap."},
+        {"id": "minor-disjunct", "scale_number": 956, "definition": "Minor tetrachords with diatonic-step gap."},
+        {"id": "major-disjunct", "scale_number": 958, "definition": "Major tetrachords with diatonic-step gap. Has 48 functionally different notes."},
+        {"id": "lydian-disjunct", "scale_number": 959, "definition": "Lydian tetrachords with diatonic-step gap."}
+      ]
+    },
+    "voice_leading_positions": {
+      "_description": "Slonimsky's named soprano-voice positions in four-part triad writing.",
+      "positions": [
+        {"id": "octave-position", "definition": "Root in both melody and bass."},
+        {"id": "tertian-position", "definition": "Root in bass, third in melody."},
+        {"id": "quintan-position", "definition": "Root in bass, fifth in melody."}
+      ]
+    }
+  },
+  "theoretical_lineage_cited": [
+    {"name": "Domenico Alaleona", "year": 1911, "contribution": "Early proposal of new scales by equal division of octave."},
+    {"name": "Alois Hába", "work": "Neue Harmonielehre", "year": 1927, "contribution": "Classified equal-interval scales with proposed harmonizations."},
+    {"name": "Joseph Schillinger", "work": "Schillinger System of Musical Composition", "contribution": "Classified new tonal progressions in Theory of Pitch-Scales chapter."},
+    {"name": "Ferruccio Busoni", "work": "Entwurf einer neuen Aesthetik der Tonkunst", "contribution": "Identified 113 distinct 7-note scales; Thesaurus #1035 attributed."},
+    {"name": "Fritz Klein", "year": 1921, "contribution": "Introduced n-interval technique; coined Mother Chord and Pyramid Chord in Die Maschine (under pseudonym Heautontimorumenus)."},
+    {"name": "Rimsky-Korsakov", "contribution": "Deliberate use of 8-tone scale alternating major/minor seconds (Scale No. 393)."},
+    {"name": "Debussy", "contribution": "First deliberate use of whole-tone scale as a device; Voiles combines whole-tone with pentatonic."},
+    {"name": "Henry Cowell", "contribution": "Coined tone-cluster."},
+    {"name": "Schoenberg", "contribution": "12-tone technique, treated by Slonimsky as a permutation case of the semitone progression."},
+    {"name": "Scriabin", "contribution": "Prometheus scale (C-D-E-F#-A-Bb) used in his symphonic poem."}
+  ],
+  "applications_to_jazz_lineage": {
+    "_description": "How the Thesaurus connects to the jazz masters distilled elsewhere in this corpus. For the eventual melodic engine: these are the rule_id prefixes downstream consumers will key off when classifying patterns by playing tradition.",
+    "connections": [
+      {"player": "John Coltrane", "thesaurus_application": "Equal Division of Octave into Three Parts (Ditone Progression) is the Giant Steps cycle. Multiple Coltrane practice routines documented as Thesaurus-derived."},
+      {"player": "Pat Martino", "thesaurus_application": "Linear concept uses Slonimsky-style equal-division pivots extensively; diminished and augmented symmetric divisions central to his vocabulary."},
+      {"player": "John McLaughlin", "thesaurus_application": "Symmetric-diminished scales and polation patterns visible across his Mahavishnu Orchestra and acoustic output."},
+      {"player": "Allan Holdsworth", "thesaurus_application": "Wide-interval polations and chromatic infra-inter-ultrapolation shape his improvisational vocabulary."}
+    ],
+    "_distillation_note": "These connections are MAINTAINER-attested per session memory + general jazz scholarship. Codifying them as engine rules requires a separate Phase 7 pass that maps Coltrane/Martino/McLaughlin documented practice routines onto specific Thesaurus patterns. v0.1 systems-draft establishes the taxonomy only; the player-to-pattern bindings come in v0.2."
+  },
+  "v01_distillation_completeness": {
+    "front_matter_distilled": true,
+    "operational_vocabulary_distilled": true,
+    "theoretical_lineage_captured": true,
+    "specific_pattern_catalog_distilled": false,
+    "scale_pattern_count_distilled": 0,
+    "scale_pattern_count_target": 1500,
+    "next_phase": "Pattern catalog distillation requires notation-OCR (Audiveris) or manual transcription. v0.1 melodic_rules can fire on TAXONOMY (polation operation + equal-division family + progression category) without specific pattern bindings. v0.2 adds the 1500+ pattern catalog."
+  }
+}

--- a/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/summaries/ch01-summary.md
+++ b/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/summaries/ch01-summary.md
@@ -1,0 +1,126 @@
+---
+run_id: 2026-06-18T15-35-00-slonimsky-thesaurus-s2
+stage: s2
+source_chapter: ch01-introduction.md
+model: claude-sonnet
+extracted_at: 2026-06-18T15:35:00+00:00
+schema_version: 0.1
+---
+
+# Slonimsky's Introduction to the *Thesaurus of Scales and Melodic Patterns* (1947): A Summary
+
+---
+
+## 1. Purpose of the Thesaurus
+
+Slonimsky opens by positioning the *Thesaurus* as a **reference book**—explicitly analogous to "phrase books and dictionaries of idiomatic expressions"—but with a crucial distinction: where phrase books are "limited to locutions consecrated by usage," the *Thesaurus* deliberately encompasses patterns that are *new*. The work is not a harmony treatise, not a pedagogy of style, and not a historical catalogue of what composers have done. It is a systematic enumeration of what is *melodically plausible*, whether or not any composer has yet discovered it.
+
+That framing carries a self-fulfilling prophecy Slonimsky notes with quiet satisfaction: "many compositions appearing in recent years contain thematic figures identical with those found in the Thesaurus." The implication is that the *Thesaurus* does not follow practice—it anticipates and maps it.
+
+Two terms receive careful definition at the outset, because the book's organization depends on them. A **scale** is "a progression, either diatonic or chromatic, that proceeds uniformly in one direction—ascending or descending—until the terminal point is reached." A **melodic pattern**, by contrast, "may be formed by any group of notes that has melodic plausibility." The distinction matters: scales are directionally constrained; patterns are not. Both are centered throughout on C as "the initial and concluding tone," with the understanding that transposition to any tonal center is left to the composer.
+
+The scope is deliberately extreme. Scales may have as few as 4 notes or as many as 48 "functionally different notes" (as in the Disjunct Major Polytetrachord, No. 958). As for melodic patterns, Slonimsky remarks that "there is virtually no limit to the number of such tones."
+
+---
+
+## 2. Operational Vocabulary
+
+### The Interval Naming System
+
+Slonimsky adopts Latin and Greek names for basic intervals, deliberately stripped of tonal association, supplementing traditional terms with coinages where gaps exist. The full table he provides reads:
+
+| Name | Interval |
+|---|---|
+| Semitone | Minor Second |
+| Whole Tone | Major Second |
+| Sesquitone | Minor Third |
+| Ditone | Major Third |
+| Diatessaron | Perfect Fourth |
+| Tritone | Augmented Fourth |
+| Diapente | Perfect Fifth |
+| Quadritone | Minor Sixth |
+| Sesquiquadritone | Major Sixth |
+| Quinquetone | Minor Seventh |
+| Sesquiquinquetone | Major Seventh |
+| Septitone | Major Ninth |
+
+The prefix **sesqui** means "the addition of one-half of a tone," so Sesquitone = 1½ tones (minor third), Sesquiquadritone = 4½ tones (major sixth), Sesquiquinquetone = 5½ tones (major seventh). **Septitone** is coined separately to indicate "7 whole tones," i.e., the major ninth.
+
+### Equal Division of the Octave: The Progression System
+
+The organizing backbone of the *Thesaurus* is the idea that each basic interval represents a **fraction of one or more octaves**, producing a "progression" when iterated:
+
+- **Tritone Progression** — divides the octave into **2 equal parts**; intervallically identical with the augmented fourth iterated.
+- **Ditone Progression** — divides the octave into **3 equal parts**; identical with the augmented triad.
+- **Sesquitone Progression** — divides the octave into **4 equal parts**; identical with the diminished-seventh chord.
+- **Whole-Tone scale** — divides the octave into **6 equal parts**.
+- **Semitone Progression** — the chromatic scale; equivalent to 12 equal parts of the octave, and "productive of characteristic patterns of the 12-tone technique."
+
+Beyond the single octave, Slonimsky extends the scheme across multiple octaves:
+
+- **Quadritone Progression** — 2 octaves divided into 3 equal parts (yielding the minor sixth); "closely related to the Ditone Progression, being in fact a spread-out augmented triad."
+- **Sesquiquadritone Progression** — 3 octaves divided into 4 equal parts (major sixth); "an unfolded Sesquitone Progression, productive of patterns related to diminished-seventh harmonies."
+- **Diapente Progression** — the perfect fifth as "one-twelfth part of 7 octaves."
+- **Diatessaron Progression** — the perfect fourth as "one-twelfth part of 5 octaves."
+- **Sesquiquinquetone Progression** — the major seventh as "the equal division of 11 octaves into 12 parts."
+- **Septitone Progression** — the major ninth as "the equal division of 7 octaves into 6 parts."
+
+The elegance here is architectural: every interval in Western music is recuperated as a rational fraction of some span of octaves, binding the entire chromatic universe into a single generative scheme.
+
+### Interpolation, Infrapolation, Ultrapolation
+
+Scales and patterns are generated not only by iterating an interval but by **ornamenting** the principal tones through three coined processes:
+
+- **Interpolation** (common usage, repurposed): "the insertion of one or several notes *between* the principal tones." The melodic line remains directionally smooth.
+- **Infrapolation** (coined): "the addition of a note *below* a principal tone," producing a downward jog before continuing upward—a "shift of direction, with the melodic line progressing in zigzags."
+- **Ultrapolation** (coined): "the addition of a note *above* the next principal tone," producing a corresponding upward jog in an otherwise descending motion.
+
+These three operations may be compounded freely, yielding hyphenated forms: **Infra-Interpolation**, **Infra-Ultrapolation**, and **Infra-Inter-Ultrapolation**. The result is a combinatorial grammar that converts any progression of principal tones into a family of derived melodic figures.
+
+---
+
+## 3. Predecessors Cited
+
+Slonimsky places himself in an explicit lineage of theorists who sought to move beyond received scale theory:
+
+- **Domenico Alaleona** (Italian, 1911): cited as proposing "entirely new scales based on the division of the octave into several equal parts"—among the earliest such proposals.
+- **Alois Hába**, *Neue Harmonielehre* (1927): "classifies a great number of scales based on equal intervals and suggests harmonizations of these new scales."
+- **Joseph Schillinger**, *Schillinger System of Musical Composition* (posthumous): classified "new tonal progressions in the chapter Theory of Pitch-Scales."
+- **Ferruccio Busoni**, *Entwurf einer neuen Aesthetik der Tonkunst*: "found 113 different scales of 7 notes." Slonimsky quotes Busoni directly on the scale C–D♭–E♭–F♭–G♭–A♭–B♭–C (No. 1035 in the *Thesaurus*): "There is a significant difference between the sound of this new scale when C is taken as the tonic and when it is taken as the leading tone of the scale of D♭ minor."
+- **Rimsky-Korsakov**, *Chronicle of My Musical Life*: credited with deliberate use of "an 8-tone scale, formed by alternating major and minor seconds" (Scale No. 393).
+- **Glinka** and **Mozart**: noted for "sporadic uses of the Whole-Tone scale," with Mozart's instance described as "a jest to mock the inept Dorfmusikanten."
+- **Debussy**: identified as the first to make the Whole-Tone scale "a deliberate device." Slonimsky analyzes *Voiles* as combining the Whole-Tone scale in its principal section with the Pentatonic scale (black keys only) in the middle.
+- **Fritz Klein** (Austrian, 1921): introduced the **n-interval technique** in *Die Maschine* (subtitled *Ex-Tonal Self-Satire*), published under the pseudonym "Heautontimorumenus" (Self-Torturer). Klein's **Mother Chord** contains "all 11 different intervals" and "12 different notes."
+- **Schoenberg**: credited with promulgating the 12-Tone Technique, treated here as a special case of permutations of the Semitone Progression.
+- **Moussorgsky** (*Boris Godunov*) and **Puccini** (*Tosca*): cited as practitioners of Octave-Tertian-Quintan harmonization in consecutive major triads.
+- **Ravel, Stravinsky, Hindemith, Milhaud, Copland, Roy Harris**: grouped as modern composers who, "arriving at it by different creative processes," all employ Pandiatonic technique.
+
+---
+
+## 4. Compositional Applications Highlighted
+
+Slonimsky illustrates several specific applications:
+
+**Harmonization by common triads** follows a strict positional formula: as the melody ascends, the bass position cycles Octave → Tertian → Quintan → Octave (notated as 8–3–5); descent reverses the order. The system deliberately produces parallel major chords traversing multiple tonalities—a technique he identifies in Moussorgsky and in the second act of *Tosca*, where a Whole-Tone scale in the bass is harmonized by exactly this row of major triads.
+
+**Master Chord harmonization** employs dominant-seventh chords with the fifth omitted, which in combination with melodic elements produce seventh-chords, ninth-chords, or whole-tone chords. Any Master Chord may also be transposed a tritone "up or down with satisfactory results"—exploiting the symmetry of the Tritone Progression.
+
+**Palindromic Canons** are progressions "that read the same backward or forward." The two based on Pattern No. 72 "result in a progression of enharmonic triads or their inversions, alternating in major and minor keys."
+
+**Grandmother Chord** (Slonimsky's own invention, an elaboration of Klein's Mother Chord): an invertible 11-interval, 12-tone chord whose intervals are arranged "alternately odd-numbered and even-numbered when counted in semitones," with odd-numbered intervals forming a decreasing arithmetic progression and even-numbered intervals an increasing one. It is identical with the 12-tone Spiral Pattern No. 1232a. All 11-interval structures share the property that their intervals sum to 66 semitones (the arithmetic series 1–11), equal to 5½ octaves—placing a Tritone between lowest and highest note in every such structure.
+
+**Pandiatonic technique**: Slonimsky coined the term *Pandiatonic* in 1937 to denote "the free use of all 7 tones of the diatonic scale, both melodically and harmonically." In strict Pandiatonic Counterpoint, each voice uses all 7 different diatonic notes with no vertical duplication. He notes that jazz composers arrived at Pandiatonic formations "by sheer experimentation," particularly in the enriched final chords of popular-song arrangements.
+
+**Rhythmic development** of melodic cells is gestured toward: Pattern No. 194 is shown generating multiple rhythmic variants through forward and retrograde motion, illustrating that "with rhythmic variety added to the unbounded universe of melodic patterns," compositional material is effectively inexhaustible.
+
+---
+
+## 5. Slonimsky's Epistemology of Melodic Exhaustion
+
+The Introduction closes with a pointed philosophical rejoinder to John Stuart Mill, who confessed to being "seriously tormented by the thought of the exhaustibility of musical combinations," fearing that "most of these, it seemed to me, must have been already discovered." Slonimsky dismisses this anxiety directly: "The fears of John Stuart Mill are unjustified. There are 479,001,600 possible combinations of the 12 tones of the chromatic scale."
+
+That figure (12 factorial) is itself a rhetorical gesture rather than a rigorous combinatorial argument—Slonimsky is not claiming every permutation is musically useful—but the point is epistemological: the *Thesaurus* exists to demonstrate that the available space is orders of magnitude larger than common practice has explored. Systematic enumeration, not stylistic tradition, is the proper guide to that space.
+
+This stance places Slonimsky in deliberate opposition to harmony pedagogy grounded in historical usage. Traditional theory teaches what has been done; the *Thesaurus* maps what *can* be done. The distinction is not merely organizational—it reflects a belief that melodic possibility is a mathematical object to be surveyed, not a canon to be transmitted. Infrapolation, Ultrapolation, and the equal-division scheme are not analytical tools applied retroactively to existing music; they are *generative* formalisms that produce new material by systematic operation on an abstract interval grammar.
+
+The result is a work that sits at an unusual intersection: it is at once a composer's reference (no fingerings, immediate transposability, practical layout for piano), a theorist's taxonomy (every term defined, every progression rationalized as an octave-fraction), and an implicit argument that the boundary between "discovered" and "discoverable" in music is an artifact of insufficient method—not of nature.

--- a/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/summaries/ch02-summary.md
+++ b/plugin/data/masters-corpus/nicolas-slonimsky/thesaurus-of-scales-and-melodic-patterns/summaries/ch02-summary.md
@@ -1,0 +1,257 @@
+---
+run_id: 2026-06-18T15-35-00-slonimsky-thesaurus-s2
+stage: s2
+source_chapter: ch02-explanation-of-terms.md
+model: claude-sonnet
+extracted_at: 2026-06-18T15:35:00+00:00
+schema_version: 0.1
+---
+
+# Slonimsky's Explanation of Terms — Structured Glossary
+
+---
+
+## 1. Polation Operations
+*Techniques for inserting notes relative to principal tones of a progression*
+
+**Infrapolation**
+: Insertion of a note **below** the principal tones of a progression.
+- *What it does:* Decorates each principal tone by approaching it from below, causing direction changes that make the result a Pattern (not a Scale).
+- *Example:* Pattern No. 231
+
+**Interpolation**
+: Insertion of one or more notes **between** the principal tones of a progression.
+- *What it does:* Fills the space between structural tones with passing material; progressions that only interpolate remain Scales (direction does not reverse).
+- *Example:* Scale No. 21
+
+**Ultrapolation**
+: Insertion of one or more notes **above** a principal tone of a scale.
+- *What it does:* Decorates each principal tone by overshooting it, again producing direction changes and therefore Patterns.
+- *Example:* Pattern No. 53 (G inserted above F♯)
+
+**Inter-ultrapolation**
+: Insertion of 2 notes — one **between** the principal tones of a given progression, the other **above** the principal tone.
+- *What it does:* Combines interpolation and ultrapolation in a single figure, producing a compound decorated Pattern.
+- *Example:* Pattern No. 123
+
+**Infra-inter-ultrapolation**
+: Pattern formed by insertion of notes **below, between, and above** the principal tones of a progression.
+- *What it does:* Applies all three polation types simultaneously; the most elaborate single-figure decoration in the system.
+- *Example:* Pattern No. 341
+
+**Non-symmetric interpolation**
+: **Free** insertion of additional notes between the principal tones (no constraint of equal interval spacing).
+- *What it does:* Relaxes the symmetry requirement of symmetric interpolation, permitting irregular decorative filling.
+
+**Symmetric interpolation**
+: Insertion of notes at **equal intervals** from respective pivotal points, resulting in invertible progressions.
+- *What it does:* Guarantees that the interval sequence read upward from the bottom mirrors the interval sequence read downward from the top, making the progression palindromic in interval structure.
+- *Example:* Scale No. 37 (C, D, F, F♯, G, B♭, C)
+
+---
+
+## 2. Scale / Progression Taxonomy
+*Structural categories defining the shape of a melodic line*
+
+**Scale**
+: A progression of tones that changes its direction **only at terminal points** (all interpolated progressions are Scales).
+
+**Pattern**
+: A melodic figure in which the direction changes **from ascending to descending, or vice versa, before arriving at the terminal point** (all infrapolated and ultrapolated progressions are Patterns).
+
+**Progression**
+: General term for **any** scale or melodic pattern.
+
+**Permutation**
+: Distribution of notes of a given melodic pattern in **different orders of succession**.
+
+**Semitone progression**
+: A scale consisting of consecutive semitones — a chromatic scale.
+
+**Complementary scales**
+: Melodic progressions of **two octaves** in range, comprising all 12 tones of the chromatic scale.
+
+**Plural scales**
+: Progressions formed by **disjunct scales** (e.g., C major, C♯ major, D major, E♭ major).
+
+**Polytonal scales**
+: Scales in **different tonalities played simultaneously**.
+
+**Polyrhythmic scales**
+: **Simultaneous progressions in different rhythms**.
+
+**Polytonal polyrhythmic scales**
+: Simultaneous progressions in **different keys and in different rhythms**.
+
+**Spiral patterns**
+: Melodic progressions **converging toward a central tone**.
+
+**Heptatonic scales** *(Nos. 1034–1087)*
+: Diatonic progressions of **7 degrees** — major, minor, church modes, and scales containing 1 or 2 augmented seconds.
+
+**Pentatonic scales** *(Nos. 1142–1190)*
+: Scales of **5 notes**.
+
+**Pandiatonic progressions**
+: Tonal rows composed of **all 7 different tones of the diatonic scale**.
+
+**Twelve-tone progressions**
+: Melodic figures of **12 different tones**.
+
+**Prometheus scale** *(No. 50)*
+: The 6-tone scale **C, D, E, F♯, A, B♭** used by Scriabin in his symphonic poem *Prometheus*.
+
+---
+
+## 3. Interval Distance Terms (Tone-Distance Vocabulary)
+
+| Term | Distance | Common Name |
+|---|---|---|
+| **Sesqui-** (prefix) | adds ½ tone | — |
+| **Sesquitone** | 1½ tones | minor third |
+| **Ditone** | 2 tones | major third |
+| **Diatessaron** | 2½ tones | perfect fourth |
+| **Diapente** | 3½ tones | perfect fifth |
+| **Tritone** | 3 tones | augmented fourth / diminished fifth |
+| **Quadritone** | 4 tones | minor sixth |
+| **Sesquiquadritone** | 4½ tones | major sixth |
+| **Quinquetone** | 5 tones | minor seventh |
+| **Sesquiquinquetone** | 5½ tones | major seventh |
+| **Septitone** | 7 tones | major ninth |
+
+---
+
+## 4. Chord Types and Harmonization
+
+**Autochordal harmonization**
+: Application of chords **derived from the tones of a given scale**.
+- *Example:* Scale No. 12 (C, D♯, F, F♯, A, B, C) harmonized in 2 triads, F major and B major.
+
+**Master chords**
+: Dominant-seventh chords with the **fifth omitted**, tabulated chromatically in 12 keys, used to harmonize scales and melodic patterns.
+
+**Chord of the minor 23rd**
+: A chord consisting of **12 different notes arranged in thirds**, forming 4 mutually exclusive triads.
+
+**Mother chord**
+: Chord introduced by Fritz Klein in 1921, containing **all 12 tones and 11 different intervals**.
+
+**Grandmother chord**
+: Chord invented by Nicolas Slonimsky on February 13, 1938, containing **all 12 different tones and different intervals symmetrically invertible in relation to the central interval (the tritone)**.
+
+**Pyramid chord**
+: Chord introduced by Fritz Klein in 1921, composed of a **series of diminishing intervals from an octave to a semitone**.
+
+**Quartal chord**
+: A 12-tone chord arranged in **perfect fourths**.
+
+**Major bitonal chord**
+: A chord of **2 major triads**, usually in keys whose tonics are at the interval of a tritone (e.g., C major and F♯ major).
+
+**Minor bitonal chord**
+: A chord consisting of **2 minor triads**, usually with tonics at the interval of a tritone (e.g., C minor and F♯ minor).
+
+**Mutually exclusive triads**
+: Four triads (major, minor, diminished, or augmented) comprising **all 12 different tones** (e.g., C major, F♯ major, D minor, G♯ minor).
+
+**Whole-tone chords**
+: Chords composed of intervals of **one or several whole tones each**.
+
+**Tone-cluster**
+: Term introduced by Henry Cowell, signifying **a complex of notes filling one or more octaves, diatonically, chromatically, or pentatonically**.
+
+---
+
+## 5. Harmony Part-Writing Positions
+
+**Octave position**
+: In four-part harmony, a triad with the **root both in the melody and in the bass**.
+
+**Quintan position**
+: In four-part harmony, a triad with the **root in the bass and the fifth in the melody**.
+
+**Tertian position**
+: In four-part harmony, a triad with the **root in the bass and the third in the melody**.
+
+**Pandiatonic harmony**
+: Part-writing in chords **freely combined from the 7 tones of the diatonic scale**.
+
+---
+
+## 6. Bitonal and Polytonal Arpeggiation Patterns
+
+**Bitonal arpeggios** *(Nos. 1191–1213)*
+: Melodic progressions formed of **alternating arpeggios in 2 different keys**.
+
+**Heptatonic arpeggios** *(Nos. 1088–1141)*
+: Melodic progressions by **thirds derived from heptatonic scales**.
+
+**Quadritonal arpeggios** *(Nos. 1251–1291)*
+: Melodic progressions formed by **4 mutually exclusive triads** (e.g., C major, D minor, F♯ major, G♯ minor).
+
+**Crossing intervals** *(Nos. 1243–1250)*
+: Two **overlapping 6-tone rows** comprising all 12 different tones.
+
+---
+
+## 7. Canon Types
+
+**Palindromic canons**
+: Canons that **read the same backward or forward**.
+
+**Bitonal palindromic canons**
+: Canons that result in the formation of **6-tone chords composed of 2 triads**.
+- *Example:* Scale No. 7 (C, C♯, E, F♯, G, A♯, C) developed canonically, forming bitonal chords of C major and F♯ major.
+
+---
+
+## 8. Tetrachord Systems (Polytetrachords)
+
+**Polytetrachord**
+: Progression of **12 tetrachords passing through all 12 keys**, either conjunctly (last tone of one = first tone of next) or disjunctly (terminal tone separated by a diatonic degree from the initial tone of the next).
+
+**Conjunct polytetrachord**
+: Polytetrachord with **terminal tone of one tetrachord = initial tone of the next**.
+- *Examples:* Phrygian No. 830; Minor No. 832; Major No. 833.
+
+**Disjunct polytetrachord**
+: Polytetrachord with **adjacent tetrachords separated by one diatonic degree**.
+- *Examples:* Phrygian No. 951; Minor No. 956; Major No. 958; Lydian No. 959.
+
+---
+
+## 9. Mirror and Inversion Structures
+
+**Mirror interval progressions**
+: Scales and patterns in which the **descending figure is the melodic inversion of the ascending figure**.
+- *Example:* Scale No. 1 ascending = melodic inversion of Scale No. 4 descending.
+
+---
+
+## Quick Reference: Example Numbers Cited
+
+| Term | Pattern / Scale Numbers |
+|---|---|
+| Infrapolation | Pattern No. 231 |
+| Inter-ultrapolation | Pattern No. 123 |
+| Infra-inter-ultrapolation | Pattern No. 341 |
+| Ultrapolation | Pattern No. 53 |
+| Interpolation | Scale No. 21 |
+| Symmetric interpolation | Scale No. 37 |
+| Autochordal harmonization | Scale No. 12 |
+| Bitonal palindromic canons | Scale No. 7 |
+| Mirror interval progressions | Scale No. 1 / Scale No. 4 |
+| Prometheus scale | No. 50 |
+| Heptatonic scales | Nos. 1034–1087 |
+| Heptatonic arpeggios | Nos. 1088–1141 |
+| Pentatonic scales | Nos. 1142–1190 |
+| Bitonal arpeggios | Nos. 1191–1213 |
+| Crossing intervals | Nos. 1243–1250 |
+| Quadritonal arpeggios | Nos. 1251–1291 |
+| Phrygian polytetrachord (conjunct) | No. 830 |
+| Minor polytetrachord (conjunct) | No. 832 |
+| Major polytetrachord (conjunct) | No. 833 |
+| Phrygian polytetrachord (disjunct) | No. 951 |
+| Disjunct minor polytetrachord | No. 956 |
+| Disjunct major polytetrachord | No. 958 |
+| Disjunct Lydian polytetrachord | No. 959 |


### PR DESCRIPTION
Continues [#554](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/554). Builds on [#569 setup](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/569).

## What lands

### s1 — Chapters
- `ch01-introduction.md` (18KB) — Slonimsky's own theory exposition
- `ch02-explanation-of-terms.md` (9KB) — the glossary

### s2 — Per-chapter summaries
- `ch01-summary.md` — structured summary of the Introduction covering purpose, operational vocabulary, predecessors, applications, and epistemology
- `ch02-summary.md` — structured glossary across 9 categories (polation operations, scale taxonomy, interval distance terms, chord constructs, harmonization methods, voice-leading positions, bitonal arpeggios, canon types, tetrachord systems)

### s3 — systems-draft.json (17KB structured taxonomy)
Twelve top-level systems captured as structured JSON the eventual melodic firing engine will key off:

| System | Item count | Notes |
|---|---:|---|
| polation_operations | 7 | Interpolation, infrapolation, ultrapolation + compounds + symmetric/non-symmetric variants. Each with direction-preservation flag. |
| equal_division_progressions | 11 | Octave division taxonomies across 1–11 octaves. Tritone, ditone, sesquitone, whole-tone, semitone, quadritone, sesquiquadritone, diatessaron, diapente, sesquiquinquetone, septitone. |
| interval_taxonomy | 12 | Slonimsky's tone-distance vocabulary (semitone → septitone). |
| progression_taxonomy | 12 | Scale vs Pattern taxonomic categories + complementary/plural/polytonal/etc. |
| named_chord_constructs | 12 | Master, Grandmother, Mother, Pyramid, Quartal, Major/Minor Bitonal, Mutually Exclusive Triads, Whole-tone, Tone-cluster, Prometheus, Chord of Minor 23rd. |
| harmonization_methods | 4 | Autochordal, common-triads positional, master-chord, pandiatonic counterpoint. |
| arpeggiation_systems | 4 | Catalog ranges for heptatonic, bitonal, quadritonal arpeggios + crossing intervals. |
| canon_types | 2 | Palindromic + bitonal palindromic. |
| tetrachord_systems | 7 | Polytetrachord chains for Phrygian/Minor/Major/Lydian × conjunct/disjunct. |
| voice_leading_positions | 3 | Octave/Tertian/Quintan. |
| theoretical_lineage_cited | 10 | Alaleona, Hába, Schillinger, Busoni, Klein, Rimsky-Korsakov, Debussy, Cowell, Schoenberg, Scriabin. |
| applications_to_jazz_lineage | 4 | Coltrane/Martino/McLaughlin/Holdsworth connections (maintainer-attested; codification deferred to v0.2). |

## What's NOT in this PR (deferred to v0.2)
- The 1500+ specific scale/pattern catalog (notation, not prose — needs Audiveris pipeline or manual transcription)
- Per-pattern `melodic_rules` artifact (depends on pattern catalog)
- Codified player-to-pattern bindings (depends on pattern catalog)

## Model usage
- Sonnet for s1 chapter extraction (ch01 + ch02 from source OCR)
- Sonnet for s2 summaries
- Hand-curated for s3 systems-draft to ensure structural fidelity

## Refs
- #554 Phase 7 melodic_rules workstream
- #569 Slonimsky corpus setup (merged)