### PR TITLE
fix(#573): backfill Roberts 1979 + allow null year for genuinely-unknown publications

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -26240,7 +26240,7 @@
         {
           "id": "jazz-guitar-technique-in-20-weeks",
           "title": "Jazz Guitar Technique in 20 Weeks",
-          "year": null,
+          "year": 1979,
           "instrument_scope": "6-string",
           "summary": "Howard Roberts's 20-week structured technique-development program for jazz guitar — alternate-picking, scale patterns, chord voicings, voice-leading.",
           "source_locator": {

--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -61,7 +61,7 @@
           "description": "Master-local kebab id (e.g. '1939-method', 'harmonic-mechanisms'). '_placeholder:' prefix marks a work whose interior is pending research; its systems[] may be empty or absent."
         },
         "title": { "type": "string", "minLength": 1 },
-        "year": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+        "year": { "anyOf": [{ "type": "string" }, { "type": "number" }, { "type": "null" }] },
         "instrument_scope": { "type": "string" },
         "summary": { "type": "string" },
         "systems": {


### PR DESCRIPTION
Closes #573.

## What this fixes
`tests/test_masters_schema.py::test_existing_masters_json_validates` (and the broader schema test suite) was failing on develop because two work entries had `year: null` but the schema only permitted string-or-number.

## Two cases

| Master / work | Was | Now | Why |
|---|---|---|---|
| howard-roberts / jazz-guitar-technique-in-20-weeks | null | 1979 | Book has a fixed publication year; I left null in #567 out of laziness. Backfilled. |
| greg-orourke / complete-chord-melody | null | null | eBook/course product with no clearly-stated publication year online. 'Unknown' is the honest state. |

## Schema change
`schema/masters.schema.json` — `year` field now permits `null` alongside string + number:

```diff
- "year": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+ "year": { "anyOf": [{ "type": "string" }, { "type": "number" }, { "type": "null" }] },
```

The relaxation is honest, not lazy: Roberts is fixed (the laziness case); O'Rourke remains null (the genuine-unknown case the schema now correctly admits).

## Verification
`tests/test_masters_schema.py` — 24/24 passes locally.

## Refs
External hostile review attached to 260528-neat-forest session 2026-06-21. P1 finding.