### PR TITLE
fix(#574): GP5 tests skip when pyguitarpro is not installed

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -302,6 +302,11 @@ class TestExports:
                  "--root", "C", "-o", tmpdir],
                 capture_output=True, text=True,
             )
+            # #574: skip if pyguitarpro is not installed (matches the
+            # macOS-pasteboard graceful-skip pattern elsewhere in the suite).
+            if result.returncode != 0 and "Missing dependency" in (result.stderr or ""):
+                import pytest
+                pytest.skip("pyguitarpro not installed; GP5 export unavailable")
             assert result.returncode == 0, f"GP5 export failed:\n{result.stderr}"
             files = list(Path(tmpdir).glob("*.gp5"))
             assert len(files) == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -242,7 +242,8 @@ class TestGP5Integration:
 
     def test_gp5_roundtrip(self):
         """Export to GP5 and read it back with PyGuitarPro."""
-        import guitarpro as gp
+        import pytest
+        gp = pytest.importorskip("guitarpro")  # #574: skip when optional dep absent
 
         with tempfile.TemporaryDirectory() as tmpdir:
             result = subprocess.run(
@@ -272,7 +273,8 @@ class TestGP5Integration:
 
     def test_gp5_chord_names_correct(self):
         """Verify chord names in GP5 match our voicing names."""
-        import guitarpro as gp
+        import pytest
+        gp = pytest.importorskip("guitarpro")  # #574: skip when optional dep absent
 
         with tempfile.TemporaryDirectory() as tmpdir:
             subprocess.run(


### PR DESCRIPTION
Closes #574.

Three GP5 tests previously failed hard when `pyguitarpro` was absent. Now they skip gracefully — matching the macOS-pasteboard skip pattern already in the suite.

| Test | Fix |
|---|---|
| `test_core.py::TestExports::test_gp5_export_runs` | Detects "Missing dependency" in subprocess stderr and `pytest.skip()`s rather than asserting returncode==0 |
| `test_integration.py::TestGP5Integration::test_gp5_roundtrip` | `pytest.importorskip('guitarpro')` at test entry |
| `test_integration.py::TestGP5Integration::test_gp5_chord_names_correct` | `pytest.importorskip('guitarpro')` at test entry |

## Behavior

| Host | Before | After |
|---|---|---|
| Without pyguitarpro | 3 failed | 3 skipped |
| With pyguitarpro | 3 passed | 3 passed |

## Why it matters
The hard failures masked the real P1 null-year bug ([#573](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/573)) in the test signal during the external review.

## Refs
External hostile review attached to 260528-neat-forest 2026-06-21.