### PR TITLE
fix(#524): re-status 4 masters from pending-extraction to corpus_only (resurrect from stale branch)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -2626,7 +2626,7 @@
           }
         }
       ],
-      "status": "pending-extraction",
+      "status": "corpus_only",
       "usage_notes": [
         {
           "chord_quality": "dom7",
@@ -12937,7 +12937,7 @@
           }
         }
       ],
-      "status": "pending-extraction",
+      "status": "corpus_only",
       "usage_notes": [
         {
           "chord_quality": "min7",
@@ -26253,7 +26253,7 @@
           }
         }
       ],
-      "status": "pending-extraction",
+      "status": "corpus_only",
       "usage_notes": [
         {
           "chord_quality": "close-voicing",
@@ -49247,7 +49247,7 @@
           }
         }
       ],
-      "status": "pending-extraction",
+      "status": "corpus_only",
       "usage_notes": [
         {
           "chord_quality": "maj7",


### PR DESCRIPTION
## Summary

Resurrects #524 (June 16) on top of current develop. The original branch (`fix/524-restatus-4-masters-corpus-only`) had conflicts across 100+ lines of `masters.json` after a week of churn; the actual fix is 4/4 lines and trivial to re-apply.

**The fix:** Four masters (howard-roberts, mick-goodrick, barry-harris, bert-ligon) carry `status: pending-extraction` but the schema-check invariant requires `non-corpus_only → non-empty principles[]`. They have works[] with usage_notes but no curated principles — that's exactly `corpus_only`. Re-status fixes the test invariant and is semantically correct.

## Test plan

- [x] `tests/test_masters_schema.py` — all 24 pass after the change
- [x] Diff is exactly 4 lines added / 4 lines removed, all `status` field changes on the named 4 masters

Closes #524. Filed under #577 branch triage as the "land fix/524" sub-item.