### PR TITLE
fix(#432): galbraith placeholder system-id needs 3-segment work-scoped form (final of 5)

### DIFF
--- a/plugin/data/masters.json
+++ b/plugin/data/masters.json
@@ -2478,7 +2478,7 @@
           ],
           "systems": [
             {
-              "id": "_placeholder:barry-galbraith:jazz-solo-guitar",
+              "id": "_placeholder:barry-galbraith:jazz-solo-guitar:implicit-chord-melody-arranging",
               "name": "Implicit Chord-Melody Arranging System (notation-only)",
               "summary": "Galbraith's 42 Chord Melody Arrangements for Solo Guitar is a notation-only anthology — no prose, no labeled rules, no stated taxonomy. The pedagogical system it teaches is entirely implicit in the written arrangements: voice-leading choices, voicing densities, chord substitutions, inner-voice motion, and bass-melody-harmony coordination across 42 standards. Members, traversal rules, and modification rules cannot be extracted from text alone; they require direct musical analysis of the notation, which is out of scope for the prose-driven distillation pipeline. This system is recorded as a placeholder so downstream review can decide whether to commission notation-level analysis or treat this work as an analytic corpus rather than a rule-bearing master text.",
               "members": [],


### PR DESCRIPTION
## Summary

Last of the 5 system-id validation failures #432 originally tracked. The other 4 were silently fixed during Stage A.1 cascades; this one was the lone surviving warning.

\`barry-galbraith.works[jazz-solo-guitar].systems[0].id\` was \`_placeholder:barry-galbraith:jazz-solo-guitar\` — only 2 segments after the \`_placeholder:\` prefix, violating the per-#220 rule that \`master.works[*].systems[]\` ids must be 3 segments (\`<master>:<work>:<slug>\`).

Added the missing slug \`implicit-chord-melody-arranging\` (drawn from the system's existing \`name\`).

## Test plan

- [x] \`python scripts/validate.py --target masters\` → \`Valid. 34 master(s) passed schema validation.\` with **zero warnings** (was 1 warning before)
- [x] \`pytest tests/test_masters_schema.py\` → 24/24 pass
- [x] Single 1-line data change, no semantic implications

Closes #432.