### PR TITLE
feat(#586): voicing-suggestion explanation text — v1a Walkthrough surface

### DIFF
--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -970,6 +970,38 @@ MuseScore {
         return (_modesById && _modesById[activeMode]) ? _modesById[activeMode] : null
     }
 
+    // #586: persisted toggle for the "Why this voicing?" explanation surface
+    // (DataCache default true; settings-panel toggle is v1b follow-up).
+    property bool enableExplanationText: true
+
+    // #586: explanation-context accessor — produces the {mode, style, rule}
+    // shape ExplanationFormatter.format() consumes. v1 only populates mode/style;
+    // rule is always null (no plugin-runtime engine_rules consumption yet).
+    function currentExplanationContext() {
+        var modeCfg = currentModeConfig()
+        var mode = modeCfg ? {
+            id: activeMode,
+            name: modeCfg.name || activeMode,
+            description: modeCfg.description || ""
+        } : null
+
+        var style = null
+        if (_activeProfileId) {
+            for (var i = 0; i < _profileList.length; i++) {
+                var p = _profileList[i]
+                if (p.id === _activeProfileId) {
+                    style = {
+                        id: p.id,
+                        name: p.name || p.id,
+                        description: p.description || ""
+                    }
+                    break
+                }
+            }
+        }
+        return { mode: mode, style: style, rule: null }
+    }
+
     // Reset a built-in tuning's label + pitches to the factory defaults. Rereads
     // the bundled tuning JSON from the plugin's own tunings/ dir (the one deploy.sh
     // overwrites) and applies it.
@@ -1496,6 +1528,10 @@ MuseScore {
             if (typeof s.activeMasterId === "string") {
                 activeMasterId = s.activeMasterId
             }
+            // #586 — round-trip the explanation-text toggle
+            if (typeof s.enableExplanationText === "boolean") {
+                enableExplanationText = s.enableExplanationText
+            }
             refreshFilteredTunings()
             console.log("Settings loaded: placement=" + diagramPlacement + ", tuning=" + selectedTuning + ", context=" + filterContext + ", profile=" + (s.activeProfile || "default"))
         } catch (e) {
@@ -1523,6 +1559,7 @@ MuseScore {
             scoreSections: scoreSections,
             userVoicingOverrides: userVoicingOverrides,  // #210 Stage 2
             activeMasterId: activeMasterId,              // #222 Track 3
+            enableExplanationText: enableExplanationText, // #586
         }
         settingsFile.write(DataCache.serializeSettings(s))
         console.log("Settings saved")
@@ -3568,6 +3605,10 @@ MuseScore {
             activeMode: chordLibrary.activeMode
             modeIdList: ["chord-melody", "comping", "solo-guitar", "duo"]
             modeDisplayList: ["Chord Melody", "Comping", "Solo Guitar", "Duo"]
+            // #586 — explanation surface inputs
+            explanationContext: chordLibrary.currentExplanationContext()
+            enableExplanationText: chordLibrary.enableExplanationText
+            theme: chordLibrary.theme
             onSectionsChanged: function(sections) {
                 chordLibrary.scoreSections = sections
                 chordLibrary.saveSettings()

--- a/plugin/model/DataCache.js
+++ b/plugin/model/DataCache.js
@@ -39,7 +39,12 @@ function parseSettings(rawJson) {
         calcRootInBass: true,
         calcMinNotes: 3,
         calcMaxMuted: 3,
-        calcMaxPerQuality: 0
+        calcMaxPerQuality: 0,
+        // #586: surfaces a "Why this voicing?" explanation next to every voicing
+        // in Walkthrough + Library card. Default true honors the
+        // "lessons in everything" framing; the settings-panel toggle (v1b
+        // follow-up) lets expert users disable.
+        enableExplanationText: true
     }
     if (!rawJson || rawJson.length === 0) return defaults
     try {
@@ -56,7 +61,8 @@ function parseSettings(rawJson) {
             calcRootInBass: s.calcRootInBass !== undefined ? s.calcRootInBass : defaults.calcRootInBass,
             calcMinNotes: s.calcMinNotes !== undefined ? s.calcMinNotes : defaults.calcMinNotes,
             calcMaxMuted: s.calcMaxMuted !== undefined ? s.calcMaxMuted : defaults.calcMaxMuted,
-            calcMaxPerQuality: s.calcMaxPerQuality !== undefined ? s.calcMaxPerQuality : defaults.calcMaxPerQuality
+            calcMaxPerQuality: s.calcMaxPerQuality !== undefined ? s.calcMaxPerQuality : defaults.calcMaxPerQuality,
+            enableExplanationText: s.enableExplanationText !== undefined ? s.enableExplanationText : defaults.enableExplanationText
         }
     } catch (e) {
         return defaults

--- a/plugin/model/ExplanationFormatter.js
+++ b/plugin/model/ExplanationFormatter.js
@@ -1,0 +1,172 @@
+.pragma library
+
+// ExplanationFormatter — produces the "Why this voicing?" text block surfaced
+// next to every voicing in the Walkthrough panel and Library card (#586).
+//
+// Input contract:
+//   format(context) where context = {
+//     mode:  { id, name, description } | null,
+//     style: { id, name, description } | null,
+//     rule:  RuleObject | null,                  // v1 always null; reserved for v2 (#586 follow-up)
+//   }
+//
+// Output contract:
+//   {
+//     has_rule:        bool,                     // true if rule-driven; v1 always false
+//     title:           string,                   // short header, e.g. "Comping · Bebop"
+//     body_full:       string,                   // 1-3 sentence prose for Walkthrough
+//     body_compact:    string,                   // single-line summary for Library card (tap-to-expand)
+//     citation:        string | null,            // "Bergonzi, Melodic Rhythms vol.4, p.47" — null in v1
+//     polarity_phrase: string | null,            // "Strong preference (+2)" — null in v1
+//     falsifier:       string | null,            // when the rule would NOT fire — null in v1
+//     token:           { source, id, payload },  // structured token mirroring the locked v1→v2 contract
+//   }
+//
+// Returns null if both mode and style are null AND rule is null (caller renders nothing).
+//
+// Token contract (locked 2026-06-23 with Ellington; #586 ticket comment):
+//   { source: "style" | "mode" | "rule",
+//     id:     <slug>,
+//     payload: <see ticket — style/mode shape in v1; rule shape reserved for v2> }
+
+
+function format(context) {
+    if (!context) return null
+    var mode = context.mode || null
+    var style = context.style || null
+    var rule = context.rule || null
+
+    // v1: rule path is reserved but not yet wired in (no plugin-runtime engine_rules consumption).
+    // Defensive: if a caller passes rule, route to the rule-shape (lets v2 land without re-touching this file).
+    if (rule) {
+        return _formatRule(rule)
+    }
+
+    // Style/Mode v1 path. Need at least one of the two; both gives the richer rendering.
+    if (!mode && !style) return null
+    return _formatStyleMode(mode, style)
+}
+
+
+function _formatStyleMode(mode, style) {
+    // Title — both / mode-only / style-only forms.
+    var title
+    if (mode && style) {
+        title = mode.name + " · " + style.name
+    } else if (mode) {
+        title = mode.name
+    } else {
+        title = style.name
+    }
+
+    var modeText = (mode && mode.description) ? mode.description : ""
+    var styleText = (style && style.description) ? style.description : ""
+
+    var bodyFullParts = []
+    if (modeText) bodyFullParts.push(modeText)
+    if (styleText) bodyFullParts.push(styleText)
+    var bodyFull = bodyFullParts.join(" ")
+
+    // Compact: prefer mode, fall back to style. Library card tap-expand shows the full block.
+    var bodyCompact = modeText || styleText
+
+    // Token mirrors the locked v1→v2 contract. v1 carries the style/mode payload;
+    // v2 will use `source: "rule"` with the firing-spec field set.
+    var token
+    if (mode && style) {
+        // Prefer style as the "primary" source token when both are active —
+        // style is genre-specific and more informative than the role-mode.
+        token = {
+            source: "style",
+            id: style.id,
+            payload: { name: style.name, description: style.description || "" }
+        }
+    } else if (mode) {
+        token = {
+            source: "mode",
+            id: mode.id,
+            payload: { name: mode.name, description: mode.description || "" }
+        }
+    } else {
+        token = {
+            source: "style",
+            id: style.id,
+            payload: { name: style.name, description: style.description || "" }
+        }
+    }
+
+    return {
+        has_rule: false,
+        title: title,
+        body_full: bodyFull,
+        body_compact: bodyCompact,
+        citation: null,
+        polarity_phrase: null,
+        falsifier: null,
+        token: token,
+    }
+}
+
+
+function _formatRule(rule) {
+    // v2 path — reserved. v1 callers will never reach here.
+    // Renders against the firing-spec v0.2 contract (rule_id, master_id, work_id, name,
+    // anchor, source_page, chapter_n, section_title, preference, falsifier, applicability_reasons).
+    var title = rule.name || rule.rule_id || "Untitled rule"
+
+    var citation = null
+    if (rule.master_id && rule.work_id && rule.source_page) {
+        var sec = rule.section_title ? ", \"" + rule.section_title + "\"" : ""
+        citation = rule.master_id + " · " + rule.work_id + ", p." + rule.source_page + sec
+    }
+
+    var polarityPhrase = _polarityPhrase(rule.preference)
+
+    return {
+        has_rule: true,
+        title: title,
+        body_full: rule.anchor || "",
+        body_compact: rule.anchor ? _shorten(rule.anchor, 80) : "",
+        citation: citation,
+        polarity_phrase: polarityPhrase,
+        falsifier: rule.falsifier || null,
+        token: {
+            source: "rule",
+            id: rule.rule_id,
+            payload: {
+                rule_id: rule.rule_id,
+                master_id: rule.master_id,
+                work_id: rule.work_id,
+                name: rule.name,
+                anchor: rule.anchor,
+                source_page: rule.source_page,
+                chapter_n: rule.chapter_n,
+                section_title: rule.section_title,
+                preference: rule.preference,
+                falsifier: rule.falsifier,
+                applicability_reasons: rule.applicability_reasons || [],
+            }
+        }
+    }
+}
+
+
+function _polarityPhrase(preference) {
+    // Signed Likert [-2, 2] per firing-spec v0.2. Used in v2 rule rendering.
+    if (preference === null || preference === undefined) return null
+    var p = parseInt(preference, 10)
+    if (isNaN(p)) return null
+    if (p >= 2) return "Strong preference (+2)"
+    if (p === 1) return "Preference (+1)"
+    if (p === 0) return "Neutral"
+    if (p === -1) return "Avoid (-1)"
+    if (p <= -2) return "Strong avoidance (-2)"
+    return null
+}
+
+
+function _shorten(text, maxLen) {
+    if (!text) return ""
+    if (text.length <= maxLen) return text
+    return text.substring(0, maxLen - 1).replace(/\s+\S*$/, "") + "…"
+}

--- a/plugin/ui/Explanation.qml
+++ b/plugin/ui/Explanation.qml
@@ -1,0 +1,179 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+// Explanation block — "Why this voicing?" text surfaced next to every voicing
+// in the Walkthrough panel (full mode) and Library card (compact + tap-expand).
+//
+// #586. Renders the structured output of ExplanationFormatter.format(...).
+//
+// Properties:
+//   formatted     — output object from ExplanationFormatter.format(); null hides the component
+//   theme         — theme object with .textMuted, .textPrimary, .cardBackground, .cardBorder, .divider
+//   displayMode   — "full" (Walkthrough side-panel) or "compact" (Library card; tap-to-expand)
+//   enabled       — false hides the component (driven by DataCache.enableExplanationText setting)
+//
+// Compact mode: single-line elided summary + tap chevron; tap opens the Popup with the full block.
+// Full mode: title + body_full + citation/polarity/falsifier (where present).
+
+Item {
+    id: root
+
+    property var formatted: null
+    property var theme: null
+    property string displayMode: "full"  // "full" or "compact"
+    property bool enabledSurface: true
+
+    // Hide the component entirely when there's nothing to render OR the user disabled the setting.
+    visible: enabledSurface && formatted !== null && formatted !== undefined
+    height: visible ? (displayMode === "compact" ? compactRow.implicitHeight : fullCol.implicitHeight) : 0
+
+    // ---------- COMPACT (Library card) ----------
+    RowLayout {
+        id: compactRow
+        visible: root.displayMode === "compact" && root.visible
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: 4
+
+        Label {
+            Layout.fillWidth: true
+            text: root.formatted ? (root.formatted.title + " — " + (root.formatted.body_compact || "")) : ""
+            font.pixelSize: 9
+            font.italic: true
+            color: root.theme ? root.theme.textMuted : "#888"
+            elide: Text.ElideRight
+            maximumLineCount: 1
+        }
+
+        Label {
+            text: "▸"
+            font.pixelSize: 9
+            color: root.theme ? root.theme.textMuted : "#888"
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: expandPopup.open()
+            }
+        }
+    }
+
+    // ---------- FULL (Walkthrough) ----------
+    ColumnLayout {
+        id: fullCol
+        visible: root.displayMode === "full" && root.visible
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: 2
+
+        Label {
+            text: root.formatted ? ("Why this voicing? " + root.formatted.title) : ""
+            font.pixelSize: 10
+            font.bold: true
+            color: root.theme ? root.theme.textPrimary : "#222"
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+        }
+
+        Label {
+            text: root.formatted ? (root.formatted.body_full || "") : ""
+            font.pixelSize: 10
+            color: root.theme ? root.theme.textMuted : "#666"
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            visible: text.length > 0
+        }
+
+        Label {
+            text: root.formatted ? (root.formatted.citation || "") : ""
+            font.pixelSize: 9
+            font.italic: true
+            color: root.theme ? root.theme.textMuted : "#888"
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            visible: text.length > 0
+        }
+
+        Label {
+            text: root.formatted && root.formatted.polarity_phrase ? root.formatted.polarity_phrase : ""
+            font.pixelSize: 9
+            color: root.theme ? root.theme.textMuted : "#888"
+            visible: text.length > 0
+        }
+
+        Label {
+            text: root.formatted && root.formatted.falsifier ? ("Doesn't apply: " + root.formatted.falsifier) : ""
+            font.pixelSize: 9
+            font.italic: true
+            color: root.theme ? root.theme.textMuted : "#888"
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            visible: text.length > 0
+        }
+    }
+
+    // ---------- POPUP (tap-expand from compact) ----------
+    Popup {
+        id: expandPopup
+        modal: false
+        focus: true
+        width: Math.min(380, root.parent ? root.parent.width - 20 : 360)
+        // Reuse the FULL layout inside the popup.
+
+        background: Rectangle {
+            color: root.theme ? root.theme.cardBackground : "#fafafa"
+            border.color: root.theme ? root.theme.cardBorder : "#ccc"
+            border.width: 1
+            radius: 4
+        }
+
+        contentItem: ColumnLayout {
+            spacing: 4
+
+            Label {
+                text: root.formatted ? ("Why this voicing? " + root.formatted.title) : ""
+                font.pixelSize: 11
+                font.bold: true
+                color: root.theme ? root.theme.textPrimary : "#222"
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+            }
+
+            Label {
+                text: root.formatted ? (root.formatted.body_full || "") : ""
+                font.pixelSize: 10
+                color: root.theme ? root.theme.textMuted : "#666"
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                visible: text.length > 0
+            }
+
+            Label {
+                text: root.formatted ? (root.formatted.citation || "") : ""
+                font.pixelSize: 9
+                font.italic: true
+                color: root.theme ? root.theme.textMuted : "#888"
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                visible: text.length > 0
+            }
+
+            Label {
+                text: root.formatted && root.formatted.polarity_phrase ? root.formatted.polarity_phrase : ""
+                font.pixelSize: 9
+                color: root.theme ? root.theme.textMuted : "#888"
+                visible: text.length > 0
+            }
+
+            Label {
+                text: root.formatted && root.formatted.falsifier ? ("Doesn't apply: " + root.formatted.falsifier) : ""
+                font.pixelSize: 9
+                font.italic: true
+                color: root.theme ? root.theme.textMuted : "#888"
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                visible: text.length > 0
+            }
+        }
+    }
+}

--- a/plugin/ui/WalkthroughPanel.qml
+++ b/plugin/ui/WalkthroughPanel.qml
@@ -5,6 +5,7 @@ import "../model/MelodyEngine.js" as MelodyEngine
 import "../model/Transposer.js" as Transposer
 import "../model/ReharmonizationEngine.js" as Reharm
 import "../model/ChordScales.js" as ChordScales
+import "../model/ExplanationFormatter.js" as ExplanationFormatter
 
 // Voice Score walkthrough overlay panel.
 // Displays the guided per-chord voicing workflow with melody/category overrides.
@@ -75,6 +76,13 @@ ColumnLayout {
     property var modeDisplayList: ["Chord Melody", "Comping", "Solo Guitar", "Duo"]
     property string activeMode: "chord-melody"
     property bool sectionsEditorOpen: false
+
+    // #586 — explanation surface. Parent passes the {mode, style, rule} context
+    // (currentExplanationContext) + the user toggle. v1 ships Style/Mode-driven
+    // text; rule path is reserved for v2.
+    property var explanationContext: null  // {mode, style, rule} or null
+    property bool enableExplanationText: true
+    property var theme: null  // bound from parent so Explanation.qml inherits theming
 
     // Resolve which mode the given chord index sits in
     function _modeForChord(idx) {
@@ -531,6 +539,20 @@ ColumnLayout {
                 font.pixelSize: 10
                 font.family: "Menlo, Monaco, monospace"
                 color: "#aaa"
+            }
+
+            // #586 — "Why this voicing?" explanation block (Walkthrough surface).
+            // v1: Style/Mode-driven text from ExplanationFormatter. v2 will swap
+            // in rule-driven citations from engine_rules without changing this surface.
+            Explanation {
+                Layout.fillWidth: true
+                visible: currentItem !== null && walkthroughPanel.enableExplanationText
+                theme: walkthroughPanel.theme
+                displayMode: "full"
+                enabledSurface: walkthroughPanel.enableExplanationText
+                formatted: walkthroughPanel.explanationContext
+                    ? ExplanationFormatter.format(walkthroughPanel.explanationContext)
+                    : null
             }
 
             // Color legend for fretboard dot intervals

--- a/tests/test_js_modules.py
+++ b/tests/test_js_modules.py
@@ -2766,3 +2766,107 @@ class TestStyleProfiles:
                 for name in scale_names:
                     assert name in valid_names, \
                         f"Profile '{p['name']}' references unknown scale '{name}' for quality '{quality}'"
+
+
+# === ExplanationFormatter.js (#586) ===
+
+
+class TestExplanationFormatter:
+    """ExplanationFormatter — v1 surfaces Style/Mode descriptions via the
+    locked {source, id, payload} token contract. Rule-driven path (v2) is
+    reserved; tested defensively for return-shape correctness."""
+
+    def test_null_when_no_context(self):
+        assert_js("ExplanationFormatter.js", """
+            assertEqual(format(null), null, "format(null) → null");
+            assertEqual(format({mode: null, style: null, rule: null}), null,
+                "all-null context → null");
+        """)
+
+    def test_mode_only(self):
+        assert_js("ExplanationFormatter.js", """
+            var out = format({
+                mode: {id: "comping", name: "Comping", description: "accompaniment behind a melody"},
+                style: null, rule: null
+            });
+            assertEqual(out.has_rule, false, "v1 path");
+            assertEqual(out.title, "Comping", "mode-only title");
+            assertEqual(out.body_full, "accompaniment behind a melody", "body_full");
+            assertEqual(out.body_compact, "accompaniment behind a melody", "body_compact");
+            assertEqual(out.token.source, "mode", "token source=mode");
+            assertEqual(out.token.id, "comping", "token id");
+        """)
+
+    def test_style_only(self):
+        assert_js("ExplanationFormatter.js", """
+            var out = format({
+                mode: null,
+                style: {id: "bebop", name: "Bebop", description: "altered dominants"},
+                rule: null
+            });
+            assertEqual(out.title, "Bebop", "style-only title");
+            assertEqual(out.token.source, "style", "token source=style");
+            assertEqual(out.token.id, "bebop", "token id");
+        """)
+
+    def test_both_mode_and_style(self):
+        assert_js("ExplanationFormatter.js", """
+            var out = format({
+                mode: {id: "comping", name: "Comping", description: "mode text"},
+                style: {id: "bebop", name: "Bebop", description: "style text"},
+                rule: null
+            });
+            assertEqual(out.title, "Comping · Bebop", "title joins both");
+            assert(out.body_full.indexOf("mode text") >= 0, "body_full has mode");
+            assert(out.body_full.indexOf("style text") >= 0, "body_full has style");
+            assertEqual(out.body_compact, "mode text", "compact prefers mode");
+            assertEqual(out.token.source, "style", "token prefers style when both active");
+        """)
+
+    def test_missing_description_field_defensive(self):
+        assert_js("ExplanationFormatter.js", """
+            var out = format({
+                mode: {id: "duo", name: "Duo"},
+                style: null, rule: null
+            });
+            assert(out !== null, "still renders without description");
+            assertEqual(out.title, "Duo", "title still works");
+            assertEqual(out.body_full, "", "body_full empty when description missing");
+        """)
+
+    def test_v2_rule_path_token_shape(self):
+        """Defensive — v1 doesn't call this path, but the rule-shape must be
+        contract-correct so v2 lands cleanly."""
+        assert_js("ExplanationFormatter.js", """
+            var rule = {
+                rule_id: "bergonzi-vol4-triadic-pairs",
+                master_id: "jerry-bergonzi", work_id: "melodic-rhythms-vol-4",
+                name: "Triadic pairs over Dom7",
+                anchor: "Avoid the 5th in shell voicings under dominant; double the b7 instead.",
+                source_page: 47, chapter_n: 3, section_title: "Triadic Pairs",
+                preference: 2, falsifier: "Doesn't apply in pedal/drone contexts.",
+                applicability_reasons: []
+            };
+            var out = format({mode: null, style: null, rule: rule});
+            assertEqual(out.has_rule, true, "rule path triggers has_rule");
+            assertEqual(out.token.source, "rule", "rule token source");
+            assertEqual(out.token.id, "bergonzi-vol4-triadic-pairs", "rule id passthrough");
+            assertEqual(out.token.payload.preference, 2, "preference passthrough");
+            assertEqual(out.token.payload.source_page, 47, "source_page passthrough");
+            assertEqual(out.polarity_phrase, "Strong preference (+2)", "polarity phrase");
+            assert(out.citation.indexOf("p.47") >= 0, "citation has page");
+            assertEqual(out.falsifier, "Doesn't apply in pedal/drone contexts.", "falsifier passthrough");
+        """)
+
+    def test_polarity_phrase_likert_range(self):
+        assert_js("ExplanationFormatter.js", """
+            function check(pref, expected) {
+                var out = format({mode: null, style: null, rule: {rule_id: "x", name: "x", preference: pref}});
+                assertEqual(out.polarity_phrase, expected, "preference=" + pref);
+            }
+            check(2, "Strong preference (+2)");
+            check(1, "Preference (+1)");
+            check(0, "Neutral");
+            check(-1, "Avoid (-1)");
+            check(-2, "Strong avoidance (-2)");
+        """)


### PR DESCRIPTION
## Summary

Surfaces a "Why this voicing?" block next to every voicing in the Walkthrough panel, drawn from the active Mode + Style descriptions. Honors the "lessons in everything" framing established in the ticket.

This is **v1a of Proposal C** (per Step 6 sign-off [2026-06-23 23:09 CDT](https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/586#issuecomment-4785789364)): foundation + Walkthrough integration only. v1b follow-up will add the Library card compact surface + the SettingsPanel toggle UI. v2 extends ExplanationFormatter's reserved \`rule\` path to consume engine_rules and render Bergonzi-page-47-style citations.

## What ships

| File | Status | Purpose |
|---|---|---|
| \`plugin/model/ExplanationFormatter.js\` | **new** | Pure formatter producing the locked \`{source, id, payload}\` token contract |
| \`plugin/ui/Explanation.qml\` | **new** | Visual component (\`full\` + \`compact\` modes, tap-to-expand Popup) |
| \`plugin/model/DataCache.js\` | edit | \`enableExplanationText: true\` default + round-trip |
| \`plugin/ChordLibrary.qml\` | edit | \`enableExplanationText\` property + \`currentExplanationContext()\` accessor + load/save wired |
| \`plugin/ui/WalkthroughPanel.qml\` | edit | Explanation block inserted next to the mini fretboard preview |
| \`tests/test_js_modules.py\` | edit | 7 new ExplanationFormatter tests |

## Token contract (locked with Ellington 2026-06-23)

\`\`\`
{
  source: "style" | "mode" | "rule",
  id: <slug>,
  payload: {
    // v1 (style/mode): { name, description }
    // v2 (rule): { rule_id, master_id, work_id, name, anchor,
    //              source_page, chapter_n, section_title,
    //              preference, falsifier, applicability_reasons }
  }
}
\`\`\`

Schema-stable for v1→v2 transition. Ellington's \`rule_review\` UI will render against the same contract from Python templates so the field set never diverges between the plugin and the web app.

## Test plan

- [x] 7 new ExplanationFormatter tests pass (null/null, mode-only, style-only, both, missing-description fallback, v2 rule-path defensive, polarity_phrase across signed Likert)
- [x] Full suite green: **346/346** on develop's CI subset (\`test_js_modules.py\` + \`test_core.py\` + \`test_masters_schema.py\` + \`test_engine_rules_schema.py\` + \`test_no_bare_console_log_in_model.py\`)
- [ ] Manual smoke-test in MuseScore Studio (\`deploy.sh\` + Voice All on a test score) — pending maintainer if requested. The QML wiring follows existing patterns (properties-in / signals-out, theme passthrough); risk is low per pre-mortem Risk 5 (cosmetic only).

## Deferred to v1b follow-up (will file separate ticket)

- Library card compact integration (VoicingCard.qml fixed-height 80px constraint needs the tap-to-expand modal flow Explanation.qml already supports; just needs the surface wiring)
- SettingsPanel checkbox for the \`enableExplanationText\` toggle
- README "Master distillation layer" section update describing the explanation surface + the consumer-contract token

## Risk classification (from pre-mortem)

**Overall: LOW** (revised down from MEDIUM after deciding to ship the helper-function approach instead of extending the ranker return shape — zero caller migration required in v1a; the ranker return-shape change can land in v2 alongside the rule-consumption work).

Refs #586. Step 6 sign-off captured at https://github.com/siege-analytics/musescore4-chord-library-plugin/issues/586#issuecomment-4785789364