### PR TITLE
feat(#589): voicing-explanation v1b — Library card + SettingsPanel + docs (closes #586)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,10 @@ Spec permits only `polarity ∈ {positive, avoid}`. If a master's source uses di
 
 `engine-rules-v{X.Y.Z}` git tag → GitHub Actions workflow → Release with `bundle.tar.gz` + `manifest.json` (validated against `plugin/schemas/engine-rules-manifest.schema.json`) + `fixture.json`. The manifest declares `schema_version` and `min_consumer_version` so downstream consumers can refuse mismatched bundles.
 
+### Explanation surface (#586)
+
+Plugin-side rendering of "Why this voicing?" text next to every voicing in Walkthrough + Library card. Pure-logic formatter at `plugin/model/ExplanationFormatter.js` (`.pragma library`) emits a structured token contract — `{ source: "style" | "mode" | "rule", id, payload }` — shared with the Ellington `rule_review` UI so both projects render the same field set without divergence. v1 ships `source: "style" | "mode"` paths drawn from `config/modes.json` + `config/styles.json` descriptions; v2 (engine-rules consumption in plugin runtime) slots into the reserved `source: "rule"` path without breaking v1 consumers. UI rendered by `plugin/ui/Explanation.qml` (full mode for Walkthrough side-panel, compact + tap-expand Popup for the Library card's 80px-constrained height). User toggle persisted via `DataCache.enableExplanationText` (default `true`).
+
 ---
 
-*Last updated: 2026-06-21*
+*Last updated: 2026-06-24*

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ Bundled releases are tagged independently from the plugin: `engine-rules-v0.1.0`
 
 Style and Mode scoring will increasingly *consume* engine-rules instead of carrying hand-tuned weights. The corpus is the rigorous, source-traceable replacement for "master profiles" — Pass-style comping, Bergonzi-style melodic-rhythms, Goodrick-mvmt voicing flow — all expressible as queries over the same firing contract.
 
+### Explaining suggestions (#586)
+
+Every voicing the plugin suggests now carries a brief "Why this voicing?" explanation, surfaced in the Walkthrough side-panel (full prose) and Library card (compact single-line + tap-to-expand). v1 draws the text from the active Mode + Style descriptions; a future v2 will render the matched master rule's `name + anchor + source_page + section_title + falsifier` from the engine-rules corpus directly (so the user sees "Bergonzi, *Melodic Rhythms* vol.4, p.47 — *Triadic Pairs over Dom7*: avoid the 5th in shell voicings under dominant; double the b7 instead.").
+
+The explanation surface ships off a structured token contract:
+
+```
+{ source: "style" | "mode" | "rule",
+  id:     <slug>,
+  payload: { ... } }
+```
+
+…ratified jointly with the [Ellington practice-feedback web app](https://github.com/siege-analytics/ellington-systems) so the plugin's QML rendering and Ellington's Django template rendering of "why this voicing" share one field set. Future engine_rules-driven explanations slot into the reserved `source: "rule"` path without breaking v1 consumers.
+
+Toggle in **Settings → Explanations** (defaults on; honors the "lessons in everything" framing while letting expert users disable the surface).
+
 ---
 
 ## Install

--- a/plugin/ChordLibrary.qml
+++ b/plugin/ChordLibrary.qml
@@ -3249,6 +3249,8 @@ MuseScore {
             tuningListModel: tuningList.slice()
             theme: theme
             diagramPlacement: chordLibrary.diagramPlacement
+            // #586 v1b — explanation surface toggle
+            enableExplanationText: chordLibrary.enableExplanationText
             // #210 Stage 2 — voicing exclusion engine surface
             effectiveVoicingTolerances: ExclusionEngine.resolveTolerances(
                 chordLibrary.voicingToleranceMap,
@@ -3422,6 +3424,11 @@ MuseScore {
 
             onPlacementChanged: function(placement) {
                 diagramPlacement = placement
+                saveSettings()
+            }
+            // #586 v1b
+            onExplanationTextToggled: function(enabled) {
+                chordLibrary.enableExplanationText = enabled
                 saveSettings()
             }
             onEditTuningRequested: function(slug) { editTuning(slug) }
@@ -3674,6 +3681,10 @@ MuseScore {
             visible: currentTab === 0 && !showToolResults
             Layout.fillWidth: true
             Layout.fillHeight: true
+
+            // #586 v1b — explanation surface inputs
+            explanationContext: chordLibrary.currentExplanationContext()
+            enableExplanationText: chordLibrary.enableExplanationText
 
             filteredData: chordLibrary.filteredData
             voicingsData: chordLibrary.voicingsData

--- a/plugin/ui/LibraryPanel.qml
+++ b/plugin/ui/LibraryPanel.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import "../model/ExplanationFormatter.js" as ExplanationFormatter
 
 // LibraryPanel.qml — Library tab UI (Tab 0) for the Chord Library plugin.
 // Extracted from ChordLibrary.qml (A6, #99).
@@ -20,6 +21,10 @@ import QtQuick.Layouts 1.15
 
 Item {
     id: libraryPanel
+
+    // #586 v1b — explanation surface inputs (from ChordLibrary)
+    property var explanationContext: null
+    property bool enableExplanationText: true
 
     // --- Input properties (data) ---
     property var filteredData: []
@@ -463,13 +468,19 @@ Item {
 
             delegate: Rectangle {
                 width: voicingList.width
-                height: 100
+                // #586 v1b — bump height +16px when explanation surface enabled
+                height: libraryPanel.enableExplanationText && libraryPanel.explanationContext ? 116 : 100
                 radius: 4
                 color: ma.containsMouse ? theme.chipHover : theme.chipBackground
                 border.color: theme.divider
                 border.width: 1
 
                 property var v: modelData || {}
+                // #586 v1b — formatted explanation for this card. Computed once per
+                // delegate instance; context comes from libraryPanel (passed by ChordLibrary).
+                property var _explanationFormatted: libraryPanel.explanationContext
+                    ? ExplanationFormatter.format(libraryPanel.explanationContext)
+                    : null
                 onVChanged: if (fretCanvas) fretCanvas.requestPaint()
 
                 MouseArea {
@@ -583,8 +594,19 @@ Item {
 
                     // Text info
                     ColumnLayout {
+                        id: cardTextCol
                         Layout.fillWidth: true
                         spacing: 2
+
+                        // #586 v1b — compact explanation row at the top of the text column
+                        Explanation {
+                            Layout.fillWidth: true
+                            visible: libraryPanel.enableExplanationText && _explanationFormatted !== null
+                            theme: theme
+                            displayMode: "compact"
+                            enabledSurface: libraryPanel.enableExplanationText
+                            formatted: _explanationFormatted
+                        }
 
                         Label {
                             text: v.name || ""

--- a/plugin/ui/PanelView.qml
+++ b/plugin/ui/PanelView.qml
@@ -7,6 +7,9 @@ ColumnLayout {
     spacing: 8
 
     property var libraryModel
+    // #586 v1b — explanation surface inputs (passed from parent)
+    property var explanationContext: null
+    property bool enableExplanationText: true
     signal insertRequested(var voicing)
 
     // Header
@@ -64,6 +67,8 @@ ColumnLayout {
         Layout.fillWidth: true
         Layout.fillHeight: true
         voicings: libraryModel.filteredVoicings
+        explanationContext: panelView.explanationContext
+        enableExplanationText: panelView.enableExplanationText
         onVoicingSelected: function(v) {
             panelView.insertRequested(v)
         }

--- a/plugin/ui/SettingsPanel.qml
+++ b/plugin/ui/SettingsPanel.qml
@@ -25,6 +25,8 @@ Item {
 
     // --- Input properties (scalar) ---
     property string diagramPlacement: "above"
+    // #586 v1b — explanation surface toggle (persisted via DataCache)
+    property bool enableExplanationText: true
     property var builtInTunings: []
     property var tuningListModel: []   // explicitly set by parent after changes
 
@@ -48,6 +50,7 @@ Item {
 
     // --- Output signals ---
     signal placementChanged(string placement)
+    signal explanationTextToggled(bool enabled)  // #586 v1b
     signal editTuningRequested(string slug)
     signal deleteTuningRequested(string slug)
     signal moveTuningRequested(string slug, int direction)
@@ -229,6 +232,36 @@ Item {
                         font.pixelSize: 10
                         wrapMode: Text.WordWrap
                         Layout.fillWidth: true
+                    }
+
+                    // --- Divider ---
+                    Rectangle { Layout.fillWidth: true; height: 1; color: theme.divider }
+
+                    // --- Explanation surface (#586 v1b) ---
+                    Label {
+                        text: "EXPLANATIONS"
+                        font.pixelSize: 11
+                        font.bold: true
+                        Layout.fillWidth: true
+                    }
+
+                    CheckBox {
+                        id: explanationToggle
+                        text: "Show 'Why this voicing?' text next to suggestions"
+                        checked: settingsPanel.enableExplanationText
+                        onCheckedChanged: {
+                            if (checked !== settingsPanel.enableExplanationText) {
+                                settingsPanel.explanationTextToggled(checked)
+                            }
+                        }
+                    }
+
+                    Label {
+                        text: "Adds a brief explanation drawn from the active Mode + Style next to every voicing in the Walkthrough and Library. Future: cites the matching master rule (Bergonzi, Greene, etc.) when engine_rules consumption ships."
+                        font.pixelSize: 10
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                        color: theme.textMuted
                     }
 
                     // --- Divider ---

--- a/plugin/ui/VoicingCard.qml
+++ b/plugin/ui/VoicingCard.qml
@@ -1,16 +1,20 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import "../model/ExplanationFormatter.js" as ExplanationFormatter
 
 Rectangle {
     id: card
-    height: 80
+    height: explanation.visible ? 96 : 80   // +16px when explanation surface enabled
     radius: 4
     color: mouseArea.containsMouse ? theme.cardHover : theme.cardBackground
     border.color: theme.cardBorder
     border.width: 1
 
     property var voicing: ({})
+    // #586 v1b — explanation surface inputs (passed from parent / ChordLibrary)
+    property var explanationContext: null
+    property bool enableExplanationText: true
     signal doubleClicked(var voicing)
     signal compareClicked(var voicing)
 
@@ -146,6 +150,19 @@ Rectangle {
                 color: theme.textFaint
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+            }
+
+            // #586 v1b — compact explanation surface ("Comping · Bebop — accompaniment…")
+            Explanation {
+                id: explanation
+                Layout.fillWidth: true
+                visible: card.enableExplanationText && card.explanationContext !== null && formatted !== null
+                theme: theme   // resolves through QML parent scope
+                displayMode: "compact"
+                enabledSurface: card.enableExplanationText
+                formatted: card.explanationContext
+                    ? ExplanationFormatter.format(card.explanationContext)
+                    : null
             }
         }
     }

--- a/plugin/ui/VoicingGrid.qml
+++ b/plugin/ui/VoicingGrid.qml
@@ -8,6 +8,9 @@ ListView {
     spacing: 4
 
     property var voicings: []
+    // #586 v1b — explanation surface inputs (bubbled from parent / ChordLibrary)
+    property var explanationContext: null
+    property bool enableExplanationText: true
     signal voicingSelected(var voicing)
     signal voicingCompare(var voicing)
 
@@ -16,6 +19,8 @@ ListView {
     delegate: VoicingCard {
         width: voicingGrid.width
         voicing: voicingGrid.voicings[index] || {}
+        explanationContext: voicingGrid.explanationContext
+        enableExplanationText: voicingGrid.enableExplanationText
         onDoubleClicked: function(v) {
             voicingGrid.voicingSelected(v)
         }


### PR DESCRIPTION
## Summary

Completes the dual-surface scope of #586 (v1a shipped via #588). Library card now renders a compact "Why this voicing?" summary, SettingsPanel exposes the persisted toggle, README + CLAUDE.md describe the locked token contract and the v1→v2 reservation.

## What ships

| File | Change |
|---|---|
| \`plugin/ui/LibraryPanel.qml\` | Explanation in compact mode inside the delegate's text column; height bumps 100→116 when surface enabled |
| \`plugin/ui/VoicingCard.qml\` + \`VoicingGrid.qml\` + \`PanelView.qml\` | Same wire-up for the next-gen card components |
| \`plugin/ui/SettingsPanel.qml\` | "EXPLANATIONS" section with CheckBox + descriptive Label; new property + signal |
| \`plugin/ChordLibrary.qml\` | Wires SettingsPanel toggle to \`enableExplanationText\` + saveSettings; bubbles explanationContext + toggle to LibraryPanel |
| \`README.md\` | New "Explaining suggestions (#586)" subsection inside the Master distillation layer |
| \`CLAUDE.md\` | New "Explanation surface (#586)" section documenting the formatter, contract shape, both UI surfaces, persistence |

## Test plan

- [x] Full suite green: **346/346** locally
- [x] No new code paths in pure JS that needed unit tests (formatter contract already covered by #588's 7 tests)
- [x] QML wiring follows existing properties-in / signals-out pattern (SettingsPanel emits, ChordLibrary mutates + persists)

## Closes #586 entirely

With v1a (#588) + v1b (this PR), the explanation surface ships in both contexts (Walkthrough full block, Library card compact + tap-expand), the user can toggle via Settings, the contract is locked + documented + cross-project-aligned with Ellington, and the v2 rule-driven path is reserved + defensively unit-tested for the engine_rules consumer to land cleanly.

Refs #586, #588.