### PR TITLE
spec(firing-spec §10): parity-oracle fixture + structural validation in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,16 @@ jobs:
       - name: Verify Node.js available
         run: node --version
 
-      - name: Run all tests (JS modules + core + schemas + console-log lint, skip environmental)
+      - name: Run all tests (JS modules + core + schemas + console-log lint + conformance fixture, skip environmental)
         # #575: added tests/test_engine_rules_schema.py (per-file engine-rules gate)
         # and tests/test_masters_schema.py (masters.json gate that previously
         # was not in CI — masked the #573 null-year drift until external review).
         # #578: added test_no_bare_console_log_in_model.py to block model-layer
         # console.log regressions; use DebugLog.log/warn in the model layer.
-        run: python -m pytest tests/test_js_modules.py tests/test_core.py tests/test_masters_schema.py tests/test_engine_rules_schema.py tests/test_no_bare_console_log_in_model.py -v --tb=short
+        # firing-spec §10 fixture (this PR): test_conformance_fixture.py guards
+        # the cross-project parity oracle's structural invariants against §10
+        # drift — fixture itself fails CI if it falls out of sync with the spec.
+        run: python -m pytest tests/test_js_modules.py tests/test_core.py tests/test_masters_schema.py tests/test_engine_rules_schema.py tests/test_no_bare_console_log_in_model.py tests/test_conformance_fixture.py -v --tb=short
 
       - name: Run schema validation
         if: always()

--- a/plugin/docs/engine-rules-firing-spec.md
+++ b/plugin/docs/engine-rules-firing-spec.md
@@ -389,6 +389,8 @@ Codifies how downstream consumers evaluate a recording against fired rules and p
 
 This appendix is **additive** to v0.2 (no firing-engine semantic change). It defines a downstream contract that consumers MUST implement identically so plugin v2 and Ellington render conformance data from the same shape. Drift between consumer implementations is the failure mode this section exists to prevent.
 
+**Parity oracle**: `plugin/docs/fixtures/conformance-v0.2.1-fixture.json` ships a runnable cross-project drift-detection artifact — both consumer implementations (plugin v2 conformance + Ellington apps.audio.comparator) MUST produce the listed `expected_rule_verdict` outputs given the listed `slice_observation` + `rule_fire_result` inputs. Each consumer's test suite should import the fixture and assert field-by-field equality. The fixture itself is structurally validated by `tests/test_conformance_fixture.py` (this repo's CI), so the fixture cannot drift from §10 prose without failing CI.
+
 ### §10.1 — Two-layer split
 
 Conformance evaluation has two layers with different concerns:

--- a/plugin/docs/fixtures/conformance-v0.2.1-fixture.json
+++ b/plugin/docs/fixtures/conformance-v0.2.1-fixture.json
@@ -1,0 +1,120 @@
+{
+  "_doc": "Parity oracle for firing-spec §10 (v0.2.1) — Conformance Verdict Contract. Both plugin v2 and Ellington apps.audio.comparator import this fixture and assert their evaluators produce the listed expected_rule_verdicts from the given inputs. If either side diverges, the test fails — drift becomes loud, not silent. Derived verbatim from the §10.8 worked example in plugin/docs/engine-rules-firing-spec.md.",
+  "_ratified": "2026-06-24 jointly with ellington-web#243 and plugin#595",
+  "_consumer_contract_version": "0.2.1",
+
+  "slice_observation": {
+    "_doc": "Cmaj7 slice in C major, key=I tonic. Player's monophonic recording produced 3 chord-tones in the slice window. inferred_chord_quality = null because pyin is monophonic (#242 limitation; basic_pitch upgrade enables non-null in a future fixture iteration).",
+    "slice_id": "fixture-slice-04",
+    "played_pitches": [
+      { "pitch_name": "C4",  "duration_s": 1.0, "confidence": 0.9  },
+      { "pitch_name": "E4",  "duration_s": 0.5, "confidence": 0.85 },
+      { "pitch_name": "G4",  "duration_s": 0.6, "confidence": 0.9  }
+    ],
+    "played_intervals_relative_to_root": [0, 4, 7],
+    "inferred_chord_quality": null,
+    "matched_chord_tones": 3,
+    "total_chord_tones": 4,
+    "off_chord_tones": [],
+    "off_scale_tones": [],
+    "scale_drift_semitones": 0.04,
+    "alignment_confidence": 0.92,
+    "pitch_extraction_confidence": 0.88,
+    "observation_confidence": 0.81
+  },
+
+  "fired_rules": [
+    {
+      "_doc": "Voicing-prescriptive rule. v0.1 can't evaluate (needs polyphonic detection). Produces neutral verdict + DeferredEvidence.",
+      "rule_fire_result": {
+        "rule_id": "fixture-pass-imaj7-double-root",
+        "preference": 1,
+        "polarity": "positive",
+        "then_action": { "action": "double_root_in_bass" },
+        "anchor": "Pass, Joe — Joe Pass Guitar Chords, p.12 — \"on Imaj7 in C, double the root in the bass\"",
+        "source_page": 12,
+        "matched_dimensions": { "chord_quality": "maj7", "progression.position": "I" },
+        "confidence": 1.0,
+        "applicability_reasons": []
+      },
+      "expected_rule_verdict": {
+        "slice_id": "fixture-slice-04",
+        "rule_id": "fixture-pass-imaj7-double-root",
+        "rule_polarity": "positive",
+        "verdict": "neutral",
+        "evidence": {
+          "type": "deferred",
+          "reason": "rule's then action is voicing-prescriptive; requires polyphonic pitch + voicing extraction",
+          "deferred_until_version": "v0.2"
+        },
+        "rule_evaluability_confidence": 0.0,
+        "verdict_confidence": 0.0
+      }
+    },
+    {
+      "_doc": "Chord-quality-prescriptive rule. v0.1 IS evaluable via ChordToneMembershipEvidence. Player's 3-of-4 chord-tones with no extras → satisfies on a positive rule.",
+      "rule_fire_result": {
+        "rule_id": "fixture-chart-mode-tonic-arrival",
+        "preference": 1,
+        "polarity": "positive",
+        "then_action": { "expected_chord_quality": "maj7" },
+        "anchor": "Hypothetical chart-mode rule — on a tonic-arrival slice, expect quality maj7",
+        "source_page": null,
+        "matched_dimensions": { "chord_quality": "maj7", "harmonic.context": "tonic" },
+        "confidence": 1.0,
+        "applicability_reasons": []
+      },
+      "expected_rule_verdict": {
+        "slice_id": "fixture-slice-04",
+        "rule_id": "fixture-chart-mode-tonic-arrival",
+        "rule_polarity": "positive",
+        "verdict": "satisfies",
+        "evidence": {
+          "type": "chord_tone_membership",
+          "matched": 3,
+          "total": 4,
+          "missing": ["B"],
+          "extra": []
+        },
+        "rule_evaluability_confidence": 1.0,
+        "verdict_confidence": 0.81
+      }
+    },
+    {
+      "_doc": "Scale-tone-prescriptive avoid rule. v0.1 evaluable via ScaleDriftEvidence. Player's drift is below the 0.5-semitone threshold the consumer uses, so the player did NOT do the avoided thing → satisfies on an avoid rule (avoid × didn't-do = satisfies per §10.4).",
+      "rule_fire_result": {
+        "rule_id": "fixture-avoid-chromatic-drift-on-tonic",
+        "preference": -1,
+        "polarity": "avoid",
+        "then_action": { "max_scale_drift_semitones": 0.25 },
+        "anchor": "Hypothetical scale-drift rule — on a tonic slice, avoid melodic content drifting more than 0.25 semitones from scale tones",
+        "source_page": null,
+        "matched_dimensions": { "harmonic.context": "tonic" },
+        "confidence": 1.0,
+        "applicability_reasons": ["intonation_floor"]
+      },
+      "expected_rule_verdict": {
+        "slice_id": "fixture-slice-04",
+        "rule_id": "fixture-avoid-chromatic-drift-on-tonic",
+        "rule_polarity": "avoid",
+        "verdict": "satisfies",
+        "evidence": {
+          "type": "scale_drift",
+          "median_drift_semitones": 0.04,
+          "max_drift_semitones": 0.12,
+          "drift_frame_count": 0
+        },
+        "rule_evaluability_confidence": 1.0,
+        "verdict_confidence": 0.81
+      }
+    }
+  ],
+
+  "_consumer_check_protocol": [
+    "1. Load slice_observation as SliceObservation dataclass (per §10.2 shape).",
+    "2. For each entry in fired_rules: load rule_fire_result as RuleFireResult; load expected_rule_verdict as RuleVerdict.",
+    "3. Run consumer's comparator: comparator(slice_observation, rule_fire_result) → actual_rule_verdict.",
+    "4. Assert actual_rule_verdict == expected_rule_verdict field-by-field.",
+    "5. If divergence, the consumer's evaluator has drifted from the spec; investigate field-by-field difference. Drift is loud, not silent."
+  ]
+}

--- a/tests/test_conformance_fixture.py
+++ b/tests/test_conformance_fixture.py
@@ -1,0 +1,234 @@
+"""Structural validation of the §10 Conformance Verdict Contract parity oracle.
+
+The fixture at plugin/docs/fixtures/conformance-v0.2.1-fixture.json is the runnable
+artifact for cross-project drift detection — both plugin v2 conformance and Ellington
+apps.audio.comparator import it and assert their evaluators produce the listed
+expected_rule_verdicts from the given inputs.
+
+This test asserts the fixture itself is structurally well-formed against firing-spec
+§10 (v0.2.1). It does NOT evaluate the comparator (plugin has no comparator
+implementation; that lives on Ellington's side). It validates that the fixture is
+internally consistent and structurally usable as a parity oracle.
+
+If §10 evolves and the fixture isn't updated, this test catches the drift.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_PATH = REPO_ROOT / "plugin" / "docs" / "fixtures" / "conformance-v0.2.1-fixture.json"
+
+# §10.2 SliceObservation required fields (per spec)
+SLICE_OBSERVATION_REQUIRED_FIELDS = {
+    "slice_id",
+    "played_pitches",
+    "played_intervals_relative_to_root",
+    "inferred_chord_quality",
+    "matched_chord_tones",
+    "total_chord_tones",
+    "off_chord_tones",
+    "off_scale_tones",
+    "scale_drift_semitones",
+    "alignment_confidence",
+    "pitch_extraction_confidence",
+    "observation_confidence",
+}
+
+# §10.3 RuleVerdict required fields
+RULE_VERDICT_REQUIRED_FIELDS = {
+    "slice_id",
+    "rule_id",
+    "rule_polarity",
+    "verdict",
+    "evidence",
+    "rule_evaluability_confidence",
+    "verdict_confidence",
+}
+
+# §10.4 verdict enum
+VALID_VERDICTS = {"satisfies", "violates", "neutral", "indeterminate"}
+
+# §10 polarity enum
+VALID_POLARITIES = {"positive", "avoid"}
+
+# §10.5 evidence discriminated-union variants — v0.1 locked
+V0_1_EVIDENCE_TYPES = {"chord_tone_membership", "scale_drift", "deferred"}
+
+# §10.5 evidence variant required fields by type discriminator
+EVIDENCE_REQUIRED_FIELDS = {
+    "chord_tone_membership": {"type", "matched", "total", "missing", "extra"},
+    "scale_drift": {"type", "median_drift_semitones", "max_drift_semitones", "drift_frame_count"},
+    "deferred": {"type", "reason", "deferred_until_version"},
+}
+
+
+@pytest.fixture(scope="module")
+def fixture():
+    """Load the parity-oracle fixture."""
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_fixture_file_exists():
+    assert FIXTURE_PATH.is_file(), f"Parity-oracle fixture missing at {FIXTURE_PATH}"
+
+
+def test_fixture_has_required_top_level_keys(fixture):
+    """Top-level fixture shape — slice_observation + fired_rules."""
+    assert "slice_observation" in fixture
+    assert "fired_rules" in fixture
+    assert isinstance(fixture["fired_rules"], list)
+    assert len(fixture["fired_rules"]) >= 1, "Need at least one fired_rule entry to be useful"
+
+
+def test_slice_observation_required_fields(fixture):
+    obs = fixture["slice_observation"]
+    missing = SLICE_OBSERVATION_REQUIRED_FIELDS - set(obs.keys())
+    assert not missing, f"slice_observation missing §10.2 required fields: {missing}"
+
+
+def test_slice_observation_played_pitches_shape(fixture):
+    """Each PlayedPitch entry has pitch_name + duration_s + confidence."""
+    pitches = fixture["slice_observation"]["played_pitches"]
+    for p in pitches:
+        assert "pitch_name" in p, f"PlayedPitch missing pitch_name: {p}"
+        assert "duration_s" in p, f"PlayedPitch missing duration_s: {p}"
+        assert "confidence" in p, f"PlayedPitch missing confidence: {p}"
+        assert 0.0 <= p["confidence"] <= 1.0, f"PlayedPitch confidence out of [0,1]: {p}"
+
+
+def test_slice_observation_confidence_fields_in_unit_interval(fixture):
+    obs = fixture["slice_observation"]
+    for f in ("alignment_confidence", "pitch_extraction_confidence", "observation_confidence"):
+        assert 0.0 <= obs[f] <= 1.0, f"slice_observation.{f} out of [0,1]: {obs[f]}"
+
+
+@pytest.mark.parametrize("entry_idx", [0, 1, 2])
+def test_each_fired_rule_has_input_and_expected_output(fixture, entry_idx):
+    """Each fired_rules entry pairs a rule_fire_result input with expected_rule_verdict output."""
+    if entry_idx >= len(fixture["fired_rules"]):
+        pytest.skip(f"fixture has only {len(fixture['fired_rules'])} entries")
+    entry = fixture["fired_rules"][entry_idx]
+    assert "rule_fire_result" in entry
+    assert "expected_rule_verdict" in entry
+
+
+def test_expected_rule_verdicts_have_required_fields(fixture):
+    for i, entry in enumerate(fixture["fired_rules"]):
+        verdict = entry["expected_rule_verdict"]
+        missing = RULE_VERDICT_REQUIRED_FIELDS - set(verdict.keys())
+        assert not missing, f"fired_rules[{i}].expected_rule_verdict missing §10.3 fields: {missing}"
+
+
+def test_expected_rule_verdicts_use_valid_enum_values(fixture):
+    for i, entry in enumerate(fixture["fired_rules"]):
+        v = entry["expected_rule_verdict"]
+        assert v["verdict"] in VALID_VERDICTS, f"fired_rules[{i}] invalid verdict: {v['verdict']}"
+        assert v["rule_polarity"] in VALID_POLARITIES, f"fired_rules[{i}] invalid polarity: {v['rule_polarity']}"
+
+
+def test_expected_rule_verdict_confidence_fields_in_unit_interval(fixture):
+    for i, entry in enumerate(fixture["fired_rules"]):
+        v = entry["expected_rule_verdict"]
+        assert 0.0 <= v["rule_evaluability_confidence"] <= 1.0, f"fired_rules[{i}] evaluability out of [0,1]"
+        assert 0.0 <= v["verdict_confidence"] <= 1.0, f"fired_rules[{i}] verdict_confidence out of [0,1]"
+
+
+def test_evidence_discriminator_is_v0_1_variant(fixture):
+    """Every evidence block uses a v0.1-locked discriminator (chord_tone_membership / scale_drift / deferred)."""
+    for i, entry in enumerate(fixture["fired_rules"]):
+        evidence = entry["expected_rule_verdict"]["evidence"]
+        assert "type" in evidence, f"fired_rules[{i}].evidence missing type discriminator"
+        assert evidence["type"] in V0_1_EVIDENCE_TYPES, (
+            f"fired_rules[{i}].evidence.type {evidence['type']!r} not in v0.1 locked set "
+            f"{V0_1_EVIDENCE_TYPES}; v2 variants (voicing_match, rhythm_attack) are reserved, not usable yet"
+        )
+
+
+def test_evidence_variant_required_fields(fixture):
+    """Each evidence variant carries its §10.5-required fields."""
+    for i, entry in enumerate(fixture["fired_rules"]):
+        evidence = entry["expected_rule_verdict"]["evidence"]
+        required = EVIDENCE_REQUIRED_FIELDS[evidence["type"]]
+        missing = required - set(evidence.keys())
+        assert not missing, (
+            f"fired_rules[{i}].evidence (type={evidence['type']!r}) missing §10.5 required fields: {missing}"
+        )
+
+
+def test_polarity_verdict_cross_product_consistent(fixture):
+    """§10.4 cross-product invariants on the worked examples:
+    - neutral verdicts MUST carry DeferredEvidence (the only honest way to be neutral)
+    - non-neutral verdicts MUST NOT carry DeferredEvidence (deferred is reserved for rules we can't evaluate)
+    """
+    for i, entry in enumerate(fixture["fired_rules"]):
+        v = entry["expected_rule_verdict"]
+        is_deferred = v["evidence"]["type"] == "deferred"
+        if v["verdict"] == "neutral":
+            assert is_deferred, (
+                f"fired_rules[{i}] verdict=neutral but evidence is not deferred — "
+                f"§10.4 invariant: neutral verdicts MUST carry DeferredEvidence"
+            )
+        elif v["verdict"] in {"satisfies", "violates"}:
+            assert not is_deferred, (
+                f"fired_rules[{i}] verdict={v['verdict']} but evidence is deferred — "
+                f"§10.4 invariant: evaluable verdicts must not use DeferredEvidence"
+            )
+
+
+def test_neutral_verdicts_have_zero_evaluability(fixture):
+    """§10.6: a rule we can't evaluate has rule_evaluability_confidence = 0.0 by construction."""
+    for i, entry in enumerate(fixture["fired_rules"]):
+        v = entry["expected_rule_verdict"]
+        if v["verdict"] == "neutral" and v["evidence"]["type"] == "deferred":
+            assert v["rule_evaluability_confidence"] == 0.0, (
+                f"fired_rules[{i}] neutral+deferred but rule_evaluability_confidence != 0.0"
+            )
+            assert v["verdict_confidence"] == 0.0, (
+                f"fired_rules[{i}] neutral+deferred but verdict_confidence != 0.0"
+            )
+
+
+def test_verdict_confidence_is_composite_of_observation_and_evaluability(fixture):
+    """§10.6: verdict_confidence = observation_confidence × rule_evaluability_confidence (within rounding)."""
+    obs_conf = fixture["slice_observation"]["observation_confidence"]
+    for i, entry in enumerate(fixture["fired_rules"]):
+        v = entry["expected_rule_verdict"]
+        expected_composite = obs_conf * v["rule_evaluability_confidence"]
+        assert abs(v["verdict_confidence"] - expected_composite) < 0.01, (
+            f"fired_rules[{i}] verdict_confidence={v['verdict_confidence']} != "
+            f"observation_confidence × rule_evaluability_confidence = {expected_composite}"
+        )
+
+
+def test_slice_id_propagation(fixture):
+    """The slice_id on the observation matches every verdict's slice_id."""
+    obs_slice = fixture["slice_observation"]["slice_id"]
+    for i, entry in enumerate(fixture["fired_rules"]):
+        v_slice = entry["expected_rule_verdict"]["slice_id"]
+        assert v_slice == obs_slice, (
+            f"fired_rules[{i}] verdict.slice_id={v_slice!r} != observation.slice_id={obs_slice!r}"
+        )
+
+
+def test_rule_id_propagation(fixture):
+    """The rule_id on the input matches the verdict's rule_id."""
+    for i, entry in enumerate(fixture["fired_rules"]):
+        input_rid = entry["rule_fire_result"]["rule_id"]
+        verdict_rid = entry["expected_rule_verdict"]["rule_id"]
+        assert input_rid == verdict_rid, (
+            f"fired_rules[{i}] input.rule_id={input_rid!r} != verdict.rule_id={verdict_rid!r}"
+        )
+
+
+def test_rule_polarity_propagation(fixture):
+    """The polarity on the RuleFireResult mirrors the verdict's rule_polarity (§6 / §10.3)."""
+    for i, entry in enumerate(fixture["fired_rules"]):
+        input_pol = entry["rule_fire_result"]["polarity"]
+        verdict_pol = entry["expected_rule_verdict"]["rule_polarity"]
+        assert input_pol == verdict_pol, (
+            f"fired_rules[{i}] input.polarity={input_pol!r} != verdict.rule_polarity={verdict_pol!r}"
+        )


### PR DESCRIPTION
## Summary

Ships the **runnable cross-project drift-detection artifact** for the §10 Conformance Verdict Contract (added in #595 / merged 2026-06-25). This is Ellington's suggestion #1 from 2026-06-24:

> "§10 worked-example test fixture — a small JSON file with a SliceObservation + RuleFireResult input + expected RuleVerdict output. Both sides could import it as a parity oracle (your v2 conformance + my comparator regression-test against the same fixture)."

The fixture **is** the contract. Plugin v2 conformance and Ellington \`apps.audio.comparator\` both import \`plugin/docs/fixtures/conformance-v0.2.1-fixture.json\` and assert their evaluators produce the listed \`expected_rule_verdict\` outputs given the listed inputs. Field-rename drift on either side fails immediately on import.

## What ships

| File | Purpose |
|---|---|
| \`plugin/docs/fixtures/conformance-v0.2.1-fixture.json\` | The parity oracle. 1 \`SliceObservation\` + 3 \`RuleFireResult\` inputs paired with their \`expected_rule_verdict\` outputs. Covers all three v0.1 evidence variants. |
| \`tests/test_conformance_fixture.py\` | 19 structural-validation tests asserting the fixture stays consistent with §10 prose. |
| \`.github/workflows/test.yml\` | Adds the new test to the CI step. |
| \`plugin/docs/engine-rules-firing-spec.md\` §10 header | Adds "Parity oracle" paragraph pointing consumers at the fixture. |

## Coverage in the fixture

Three \`fired_rules\` entries, each demonstrating one v0.1 evidence-variant + verdict path:

1. **Voicing-prescriptive rule** → \`neutral\` + \`DeferredEvidence\` (v0.1 can't evaluate; defers to v0.2)
2. **Chord-quality-prescriptive rule** → \`satisfies\` + \`ChordToneMembershipEvidence\` (positive rule × chord-tones present = satisfies)
3. **Avoid scale-drift rule** → \`satisfies\` + \`ScaleDriftEvidence\` (avoid rule × player did NOT exceed threshold = satisfies; demonstrates §10.4 polarity × played-content cross-product)

## Structural validation tests (19 passing)

These guard the fixture itself against §10 prose drift. The fixture cannot fall out of sync with the spec without failing CI:

- Required field sets for \`SliceObservation\` (§10.2) and \`RuleVerdict\` (§10.3)
- Enum values: verdict ∈ {satisfies/violates/neutral/indeterminate}, polarity ∈ {positive/avoid}
- Evidence discriminator ∈ v0.1 locked set (rejects accidental use of v2-reserved \`voicing_match\` / \`rhythm_attack\` variants)
- Per-variant required field sets (§10.5)
- §10.4 invariants: \`neutral\` ⇔ \`DeferredEvidence\`, evaluable verdicts ⇔ non-deferred
- §10.6 confidence composite identity: \`verdict_confidence ≈ observation_confidence × rule_evaluability_confidence\`
- ID propagation: \`slice_id\` / \`rule_id\` / \`polarity\` consistent between inputs and verdicts
- Confidence fields all in [0,1]

## Implementation pattern

This is the runnable-contract extension of the cross-cutting-contract template (workspace memory: \`feedback_cross_cutting_contract_template.md\`). The fixture IS the contract — prose specs drift silently, runnable contracts drift loudly. Both sides regression-test against the same artifact; the artifact's integrity is itself CI-guarded.

## Test plan

- [x] 19/19 fixture-validation tests pass locally
- [x] Existing 346-test suite green
- [ ] Ellington side (after this merges) imports the fixture into \`apps.audio.comparator\` regression tests; if their PR #249 comparator reproduces the expected verdicts, cross-project conformance is provably aligned

## Refs

- ellington-web#243 — joint ratification 2026-06-24
- #595 — §10 doc-only spec change merged 2026-06-25 01:49 UTC

[no-ticket] override — finishing piece of #595's already-tracked cross-project contract anchor. Spec doc + fixture + validation test only; no behavior change requiring its own ticket.