### PR TITLE
feat(#563): lineage DAG schema + graph-validation tests

### DIFF
--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -41,6 +41,16 @@
           "type": "array",
           "description": "Per-master × per-chord-quality pedagogical notes. Each entry says how this master uses or teaches voicings of the named chord quality — function role, idiom, common substitution, voice-leading context. Consumed by reviewer-facing surfaces (the #395 review form, the docs glossary) so reviewers can confirm 'is this how the master would use this chord in a lesson' rather than just 'is this a master-X voicing'. Optional; populated incrementally per #415 and follow-up tickets.",
           "items": { "$ref": "#/$defs/usage_note" }
+        },
+        "studied_with": {
+          "type": "array",
+          "description": "Lineage DAG edges (#563): masters who served as formal teacher or sustained study source for this master. Each edge cites the biography source phrase that justifies the edge. Conservative — only edges where both endpoints are in the corpus get encoded. Consumed by Ellington v1.2 pedagogue trust model (ellington-web#96) for per-Master expertise weighting. Empty array means no studied-with edges have been extracted yet (default state); missing entries get treated identically to empty.",
+          "items": { "$ref": "#/$defs/lineage_edge" }
+        },
+        "influenced": {
+          "type": "array",
+          "description": "Lineage DAG edges (#563): masters who exerted stylistic / lineage influence on this master without direct study. Same edge shape and consumer contract as studied_with; semantic distinction is teacher-vs-influencer.",
+          "items": { "$ref": "#/$defs/lineage_edge" }
         }
       },
       "anyOf": [
@@ -263,6 +273,23 @@
         },
         "additionalProperties": true
       }
+    },
+    "lineage_edge": {
+      "description": "A single lineage edge (#563) — directed from the master that owns the studied_with/influenced array, to the master named by master_id. master_id MUST reference an existing master entry's id (graph-validation enforced by tests/test_masters_schema.py). source_phrase carries the biography quote that justifies the edge so the extraction is auditable.",
+      "type": "object",
+      "required": ["master_id"],
+      "properties": {
+        "master_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+$",
+          "description": "id of the target master — must resolve to a real entry in masters[]."
+        },
+        "source_phrase": {
+          "type": "string",
+          "description": "Verbatim quote from the source master's biography that justifies the edge. Optional but strongly recommended for audit / reviewer trust."
+        }
+      },
+      "additionalProperties": true
     }
   }
 }

--- a/tests/test_masters_schema.py
+++ b/tests/test_masters_schema.py
@@ -499,3 +499,85 @@ def test_consistency_flags_2segment_system_inside_work():
     }])
     warnings = mod._check_masters_consistency(data)
     assert any("expected 3 colon-separated segments" in w for w in warnings), warnings
+
+
+# === #563 Lineage DAG graph-validation ===
+
+
+class TestLineageDagIntegrity:
+    """Graph-validation for the studied_with / influenced lineage edges (#563).
+
+    Every edge's master_id MUST resolve to a real entry in masters[]. Catches
+    typos and stale references (e.g. if a master is renamed).
+    """
+
+    @pytest.fixture(scope="class")
+    def masters_data(self):
+        return json.loads(DATA_PATH.read_text(encoding="utf-8"))["masters"]
+
+    def test_studied_with_present_on_all_masters(self, masters_data):
+        # Acceptance criterion: every master carries the field (possibly empty).
+        for master in masters_data:
+            assert "studied_with" in master, (
+                f"master {master.get('id', '<unknown>')!r} missing studied_with field "
+                f"— must be present as at least an empty array"
+            )
+            assert isinstance(master["studied_with"], list), (
+                f"master {master['id']} studied_with not an array"
+            )
+
+    def test_influenced_present_on_all_masters(self, masters_data):
+        for master in masters_data:
+            assert "influenced" in master, (
+                f"master {master.get('id', '<unknown>')!r} missing influenced field "
+                f"— must be present as at least an empty array"
+            )
+            assert isinstance(master["influenced"], list), (
+                f"master {master['id']} influenced not an array"
+            )
+
+    def test_lineage_edges_resolve_to_real_masters(self, masters_data):
+        """Every edge's master_id must reference an existing master entry."""
+        master_ids = {m["id"] for m in masters_data}
+        dangling = []
+        for m in masters_data:
+            for field in ("studied_with", "influenced"):
+                for edge in m.get(field, []):
+                    target = edge.get("master_id") if isinstance(edge, dict) else None
+                    if target is None:
+                        dangling.append(
+                            f"{m['id']}.{field} edge missing master_id: {edge}"
+                        )
+                    elif target not in master_ids:
+                        dangling.append(
+                            f"{m['id']}.{field} → {target!r} (no such master in corpus)"
+                        )
+        assert not dangling, "Dangling lineage edges: " + "; ".join(dangling)
+
+    def test_no_self_edges(self, masters_data):
+        """A master shouldn't list itself as teacher/influencer (no self-loops)."""
+        violations = []
+        for m in masters_data:
+            for field in ("studied_with", "influenced"):
+                for edge in m.get(field, []):
+                    target = edge.get("master_id") if isinstance(edge, dict) else None
+                    if target == m["id"]:
+                        violations.append(f"{m['id']}.{field} → self")
+        assert not violations, "Self-edges in lineage DAG: " + "; ".join(violations)
+
+    def test_no_duplicate_edges_within_a_field(self, masters_data):
+        """A master shouldn't list the same target twice in the same field."""
+        violations = []
+        for m in masters_data:
+            for field in ("studied_with", "influenced"):
+                targets = []
+                for edge in m.get(field, []):
+                    t = edge.get("master_id") if isinstance(edge, dict) else None
+                    if t is not None:
+                        targets.append(t)
+                seen = set()
+                for t in targets:
+                    if t in seen:
+                        violations.append(f"{m['id']}.{field} lists {t!r} twice")
+                    seen.add(t)
+        assert not violations, "Duplicate edges: " + "; ".join(violations)


### PR DESCRIPTION
## Summary

Documents the \`studied_with\` / \`influenced\` lineage edge fields that were already partially populated on \`masters.json\` (3 edges from prior work: martin-taylor→joe-pass, peter-bernstein→wes-montgomery, peter-bernstein→jim-hall). Adds the schema declarations the data shape was implicitly assuming, and gates graph-integrity invariants with CI.

This is the **structural half** of #563 — schema + tests + verified-correct field-presence backfill. The **content half** (extracting more edges from biography prose) is deferred to follow-up so each new edge can carry its \`source_phrase\` from the biography that justifies it. The schema + test gate now makes that follow-up cheap to do correctly.

## What ships

**\`schema/masters.schema.json\`** — new \`$defs/lineage_edge\`:

\`\`\`json
{
  \"description\": \"A single lineage edge (#563)…\",
  \"type\": \"object\",
  \"required\": [\"master_id\"],
  \"properties\": {
    \"master_id\": { \"type\": \"string\", \"pattern\": \"^[a-z0-9_-]+$\" },
    \"source_phrase\": { \"type\": \"string\" }
  },
  \"additionalProperties\": true
}
\`\`\`

Plus \`master.studied_with\` + \`master.influenced\` array properties referencing it.

**\`plugin/data/masters.json\`** — no data change. Verified all 34 masters already carry both fields (mostly empty arrays; 3 edges present from earlier work).

**\`tests/test_masters_schema.py\`** — new \`TestLineageDagIntegrity\` class, +5 tests:
1. \`studied_with\` present (at least empty array) on all 34 masters
2. \`influenced\` present (at least empty array) on all 34 masters
3. Every edge's \`master_id\` resolves to a real entry in \`masters[]\` (dangling-reference catch — typos / stale renames fail loud)
4. No self-edges (master can't list itself as teacher / influencer)
5. No duplicate edges within a single field

## Test plan

- [x] 29/29 in \`tests/test_masters_schema.py\` pass (24 existing + 5 new)
- [x] 370/370 across the CI subset
- [x] \`python scripts/validate.py --target masters\` reports \`Valid. 34 master(s) passed schema validation.\` with zero warnings

## Acceptance criteria status

| #563 criterion | Status |
|---|---|
| Schema for new fields documented in masters.schema.json | ✅ |
| All 34 masters have \`studied_with\` (possibly empty) | ✅ (was already true; test now enforces it) |
| All 34 masters have \`influenced\` (possibly empty) | ✅ (was already true; test now enforces it) |
| Graph-validation test catches typos | ✅ (dangling-reference + self-edge + duplicate-edge tests) |

## Deferred to follow-up

New-edge authoring is the substantive content half of #563 and the operator-judgement-heavy piece. Each new edge needs:
- A target master_id that's actually in the corpus
- A verbatim \`source_phrase\` from the source master's biography
- Operator decision on whether the relationship is \`studied_with\` (formal teacher) or \`influenced\` (stylistic without direct study)

That can be a separate ticket or operator-driven session work. The schema + test gate make the follow-up cheap to do correctly.

## Refs

ellington-web#96 — the v1.2 pedagogue-trust-model consumer this data eventually feeds. No urgency: per the ticket, v1.2 enabler, not blocker.