### PR TITLE
feat(#593): voicings.json top-level manifest contract (parallel to engine-rules)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         # firing-spec §10 fixture (this PR): test_conformance_fixture.py guards
         # the cross-project parity oracle's structural invariants against §10
         # drift — fixture itself fails CI if it falls out of sync with the spec.
-        run: python -m pytest tests/test_js_modules.py tests/test_core.py tests/test_masters_schema.py tests/test_engine_rules_schema.py tests/test_no_bare_console_log_in_model.py tests/test_conformance_fixture.py -v --tb=short
+        run: python -m pytest tests/test_js_modules.py tests/test_core.py tests/test_masters_schema.py tests/test_engine_rules_schema.py tests/test_no_bare_console_log_in_model.py tests/test_conformance_fixture.py tests/test_voicings_manifest.py -v --tb=short
 
       - name: Run schema validation
         if: always()

--- a/plugin/data/voicings.json
+++ b/plugin/data/voicings.json
@@ -1,8 +1,16 @@
 {
+  "manifest": {
+    "bundle_version": "2.3.0",
+    "schema_version": "voicings-v1",
+    "plugin_commit_sha": null,
+    "built_at": null,
+    "total_voicings": 820,
+    "min_consumer_version": "0.1.0"
+  },
   "voicings": [
     {
       "id": "c13b9-cm6-altered-6str-26",
-      "name": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)",
+      "name": "C13b9 — Fret 5 — Altered (6th on top)",
       "chord_quality": "13b9",
       "root": "C",
       "category": "altered",
@@ -65,7 +73,7 @@
     },
     {
       "id": "c13b9-cm7-altered-7str-28",
-      "name": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)",
+      "name": "C13b9 — Fret 2 — Altered (3rd on top)",
       "chord_quality": "13b9",
       "root": "C",
       "category": "altered",
@@ -126,7 +134,7 @@
     },
     {
       "id": "c13b9-cv6-altered-6str-25",
-      "name": "C13b9 \u2014 Fret 5 \u2014 Altered (6th on top)",
+      "name": "C13b9 — Fret 5 — Altered (6th on top)",
       "chord_quality": "13b9",
       "root": "C",
       "category": "altered",
@@ -189,7 +197,7 @@
     },
     {
       "id": "c13b9-cv7-altered-7str-27",
-      "name": "C13b9 \u2014 Fret 2 \u2014 Altered (3rd on top)",
+      "name": "C13b9 — Fret 2 — Altered (3rd on top)",
       "chord_quality": "13b9",
       "root": "C",
       "category": "altered",
@@ -250,7 +258,7 @@
     },
     {
       "id": "c13s9-cm6-altered-6str-30",
-      "name": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "name": "C13#9 — Fret 7 — Altered (3rd on top)",
       "chord_quality": "13sharp9",
       "root": "C",
       "category": "altered",
@@ -311,7 +319,7 @@
     },
     {
       "id": "c13s9-cm7-altered-7str-32",
-      "name": "C13#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "C13#9 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "13sharp9",
       "root": "C",
       "category": "altered",
@@ -375,7 +383,7 @@
     },
     {
       "id": "c13s9-cv6-altered-6str-29",
-      "name": "C13#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "name": "C13#9 — Fret 7 — Altered (3rd on top)",
       "chord_quality": "13sharp9",
       "root": "C",
       "category": "altered",
@@ -436,7 +444,7 @@
     },
     {
       "id": "c13s9-cv7-altered-7str-31",
-      "name": "C13#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "C13#9 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "13sharp9",
       "root": "C",
       "category": "altered",
@@ -500,7 +508,7 @@
     },
     {
       "id": "c13sus4-cm6-extended-6str-18",
-      "name": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)",
+      "name": "C13sus4 — Fret 8 — Extended (root on top)",
       "chord_quality": "13sus4",
       "root": "C",
       "category": "extended",
@@ -563,7 +571,7 @@
     },
     {
       "id": "c13sus4-cm7-extended-7str-20",
-      "name": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)",
+      "name": "C13sus4 — Fret 1 — Extended (4th on top)",
       "chord_quality": "13sus4",
       "root": "C",
       "category": "extended",
@@ -632,7 +640,7 @@
     },
     {
       "id": "c13sus4-cv6-extended-6str-17",
-      "name": "C13sus4 \u2014 Fret 8 \u2014 Extended (root on top)",
+      "name": "C13sus4 — Fret 8 — Extended (root on top)",
       "chord_quality": "13sus4",
       "root": "C",
       "category": "extended",
@@ -695,7 +703,7 @@
     },
     {
       "id": "c13sus4-cv7-extended-7str-19",
-      "name": "C13sus4 \u2014 Fret 1 \u2014 Extended (4th on top)",
+      "name": "C13sus4 — Fret 1 — Extended (4th on top)",
       "chord_quality": "13sus4",
       "root": "C",
       "category": "extended",
@@ -764,7 +772,7 @@
     },
     {
       "id": "c7b5b9-cm6-altered-6str-34",
-      "name": "C7b5b9 \u2014 Fret 6 \u2014 Altered (3rd on top)",
+      "name": "C7b5b9 — Fret 6 — Altered (3rd on top)",
       "chord_quality": "7b5b9",
       "root": "C",
       "category": "altered",
@@ -825,7 +833,7 @@
     },
     {
       "id": "c7b5b9-cm7-altered-7str-36",
-      "name": "C7b5b9 \u2014 Fret 2 \u2014 Altered (3rd on top)",
+      "name": "C7b5b9 — Fret 2 — Altered (3rd on top)",
       "chord_quality": "7b5b9",
       "root": "C",
       "category": "altered",
@@ -892,7 +900,7 @@
     },
     {
       "id": "c7b5b9-cv6-altered-6str-33",
-      "name": "C7b5b9 \u2014 Fret 6 \u2014 Altered (3rd on top)",
+      "name": "C7b5b9 — Fret 6 — Altered (3rd on top)",
       "chord_quality": "7b5b9",
       "root": "C",
       "category": "altered",
@@ -953,7 +961,7 @@
     },
     {
       "id": "c7b5b9-cv7-altered-7str-35",
-      "name": "C7b5b9 \u2014 Fret 2 \u2014 Altered (3rd on top)",
+      "name": "C7b5b9 — Fret 2 — Altered (3rd on top)",
       "chord_quality": "7b5b9",
       "root": "C",
       "category": "altered",
@@ -1020,7 +1028,7 @@
     },
     {
       "id": "c7b5s9-cm6-altered-6str-38",
-      "name": "C7b5#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "name": "C7b5#9 — Fret 7 — Altered (3rd on top)",
       "chord_quality": "7b5sharp9",
       "root": "C",
       "category": "altered",
@@ -1081,7 +1089,7 @@
     },
     {
       "id": "c7b5s9-cm7-altered-7str-40",
-      "name": "C7b5#9 \u2014 Fret 3 \u2014 Altered (3rd on top)",
+      "name": "C7b5#9 — Fret 3 — Altered (3rd on top)",
       "chord_quality": "7b5sharp9",
       "root": "C",
       "category": "altered",
@@ -1145,7 +1153,7 @@
     },
     {
       "id": "c7b5s9-cv6-altered-6str-37",
-      "name": "C7b5#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "name": "C7b5#9 — Fret 7 — Altered (3rd on top)",
       "chord_quality": "7b5sharp9",
       "root": "C",
       "category": "altered",
@@ -1206,7 +1214,7 @@
     },
     {
       "id": "c7b5s9-cv7-altered-7str-39",
-      "name": "C7b5#9 \u2014 Fret 3 \u2014 Altered (3rd on top)",
+      "name": "C7b5#9 — Fret 3 — Altered (3rd on top)",
       "chord_quality": "7b5sharp9",
       "root": "C",
       "category": "altered",
@@ -1270,7 +1278,7 @@
     },
     {
       "id": "c7b9sus4-cm6-altered-6str-22",
-      "name": "C7b9sus4 \u2014 Fret 6 \u2014 Altered (b7 on top)",
+      "name": "C7b9sus4 — Fret 6 — Altered (b7 on top)",
       "chord_quality": "7b9sus4",
       "root": "C",
       "category": "altered",
@@ -1333,7 +1341,7 @@
     },
     {
       "id": "c7b9sus4-cm7-altered-7str-24",
-      "name": "C7b9sus4 \u2014 Fret 1 \u2014 Altered (4th on top)",
+      "name": "C7b9sus4 — Fret 1 — Altered (4th on top)",
       "chord_quality": "7b9sus4",
       "root": "C",
       "category": "altered",
@@ -1402,7 +1410,7 @@
     },
     {
       "id": "c7b9sus4-cv6-altered-6str-21",
-      "name": "C7b9sus4 \u2014 Fret 6 \u2014 Altered (b7 on top)",
+      "name": "C7b9sus4 — Fret 6 — Altered (b7 on top)",
       "chord_quality": "7b9sus4",
       "root": "C",
       "category": "altered",
@@ -1465,7 +1473,7 @@
     },
     {
       "id": "c7b9sus4-cv7-altered-7str-23",
-      "name": "C7b9sus4 \u2014 Fret 1 \u2014 Altered (4th on top)",
+      "name": "C7b9sus4 — Fret 1 — Altered (4th on top)",
       "chord_quality": "7b9sus4",
       "root": "C",
       "category": "altered",
@@ -1534,7 +1542,7 @@
     },
     {
       "id": "c7s5b9-cm6-altered-6str-42",
-      "name": "C7#5b9 \u2014 Fret 7 \u2014 Altered (b9 on top)",
+      "name": "C7#5b9 — Fret 7 — Altered (b9 on top)",
       "chord_quality": "7sharp5b9",
       "root": "C",
       "category": "altered",
@@ -1597,7 +1605,7 @@
     },
     {
       "id": "c7s5b9-cm7-altered-7str-44",
-      "name": "C7#5b9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "C7#5b9 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "7sharp5b9",
       "root": "C",
       "category": "altered",
@@ -1661,7 +1669,7 @@
     },
     {
       "id": "c7s5b9-cv6-altered-6str-41",
-      "name": "C7#5b9 \u2014 Fret 7 \u2014 Altered (b9 on top)",
+      "name": "C7#5b9 — Fret 7 — Altered (b9 on top)",
       "chord_quality": "7sharp5b9",
       "root": "C",
       "category": "altered",
@@ -1724,7 +1732,7 @@
     },
     {
       "id": "c7s5b9-cv7-altered-7str-43",
-      "name": "C7#5b9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "C7#5b9 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "7sharp5b9",
       "root": "C",
       "category": "altered",
@@ -1788,7 +1796,7 @@
     },
     {
       "id": "c7s5s9-cm6-altered-6str-46",
-      "name": "C7#5#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "name": "C7#5#9 — Fret 7 — Altered (3rd on top)",
       "chord_quality": "7sharp5sharp9",
       "root": "C",
       "category": "altered",
@@ -1849,7 +1857,7 @@
     },
     {
       "id": "c7s5s9-cm7-altered-7str-48",
-      "name": "C7#5#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "C7#5#9 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "7sharp5sharp9",
       "root": "C",
       "category": "altered",
@@ -1913,7 +1921,7 @@
     },
     {
       "id": "c7s5s9-cv6-altered-6str-45",
-      "name": "C7#5#9 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "name": "C7#5#9 — Fret 7 — Altered (3rd on top)",
       "chord_quality": "7sharp5sharp9",
       "root": "C",
       "category": "altered",
@@ -1974,7 +1982,7 @@
     },
     {
       "id": "c7s5s9-cv7-altered-7str-47",
-      "name": "C7#5#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "C7#5#9 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "7sharp5sharp9",
       "root": "C",
       "category": "altered",
@@ -2038,7 +2046,7 @@
     },
     {
       "id": "c9sus4-cm6-extended-6str-14",
-      "name": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)",
+      "name": "C9sus4 — Fret 6 — Extended (b7 on top)",
       "chord_quality": "9sus4",
       "root": "C",
       "category": "extended",
@@ -2099,7 +2107,7 @@
     },
     {
       "id": "c9sus4-cm7-extended-7str-16",
-      "name": "C9sus4 \u2014 Fret 1 \u2014 Extended (4th on top)",
+      "name": "C9sus4 — Fret 1 — Extended (4th on top)",
       "chord_quality": "9sus4",
       "root": "C",
       "category": "extended",
@@ -2166,7 +2174,7 @@
     },
     {
       "id": "c9sus4-cv6-extended-6str-13",
-      "name": "C9sus4 \u2014 Fret 6 \u2014 Extended (b7 on top)",
+      "name": "C9sus4 — Fret 6 — Extended (b7 on top)",
       "chord_quality": "9sus4",
       "root": "C",
       "category": "extended",
@@ -2227,7 +2235,7 @@
     },
     {
       "id": "c9sus4-cv7-extended-7str-15",
-      "name": "C9sus4 \u2014 Fret 1 \u2014 Extended (4th on top)",
+      "name": "C9sus4 — Fret 1 — Extended (4th on top)",
       "chord_quality": "9sus4",
       "root": "C",
       "category": "extended",
@@ -2294,7 +2302,7 @@
     },
     {
       "id": "caug7-cm6-drop2-b7top-6",
-      "name": "Caug7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "Caug7 — Fret 5 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -2348,7 +2356,7 @@
     },
     {
       "id": "caug7-cm6-drop2-1top-6",
-      "name": "Caug7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Caug7 — Fret 8 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -2402,7 +2410,7 @@
     },
     {
       "id": "caug7-cm6-drop2-3rdtop-6",
-      "name": "Caug7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Caug7 — Fret 10 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -2460,7 +2468,7 @@
     },
     {
       "id": "caug7-cm6-shell-a-6",
-      "name": "Caug7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Caug7 — A shape — Shell (b7 on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -2515,7 +2523,7 @@
     },
     {
       "id": "caug7-shell-a-shape-6-cm6",
-      "name": "Caug7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "Caug7 — A shape — Shell (3rd on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -2566,7 +2574,7 @@
     },
     {
       "id": "caug7-shell-e-shape-6-cm6",
-      "name": "Caug7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "Caug7 — E shape — Shell (3rd on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -2617,7 +2625,7 @@
     },
     {
       "id": "caug7-shell-d-shape-6-cm6",
-      "name": "Caug7 \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Caug7 — D shape — Shell (7th on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -2668,7 +2676,7 @@
     },
     {
       "id": "caug7-cm7-drop2-b7top-7",
-      "name": "Caug7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "Caug7 — Fret 5 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -2724,7 +2732,7 @@
     },
     {
       "id": "caug7-cm7-drop2-1top-7",
-      "name": "Caug7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Caug7 — Fret 8 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -2780,7 +2788,7 @@
     },
     {
       "id": "caug7-cm7-drop2-3rdtop-7",
-      "name": "Caug7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Caug7 — Fret 10 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -2840,7 +2848,7 @@
     },
     {
       "id": "caug7-cm7-shell-a-7",
-      "name": "Caug7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Caug7 — A shape — Shell (b7 on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -2896,7 +2904,7 @@
     },
     {
       "id": "caug7-shell-a-shape-7-cm7",
-      "name": "Caug7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "Caug7 — A shape — Shell (3rd on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -2949,7 +2957,7 @@
     },
     {
       "id": "caug7-shell-e-shape-7-cm7",
-      "name": "Caug7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "Caug7 — E shape — Shell (3rd on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3002,7 +3010,7 @@
     },
     {
       "id": "caug7-shell-d-shape-7-cm7",
-      "name": "Caug7 \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Caug7 — D shape — Shell (7th on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3055,7 +3063,7 @@
     },
     {
       "id": "caug-chordsdb-f1-6",
-      "name": "Caug7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Caug7 — Fret 1 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -3127,7 +3135,7 @@
     },
     {
       "id": "caug-chordsdb-f3-6",
-      "name": "Caug7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Caug7 — Fret 3 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -3199,7 +3207,7 @@
     },
     {
       "id": "caug7-cv6-drop2-b7top-6",
-      "name": "Caug7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "Caug7 — Fret 5 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -3253,7 +3261,7 @@
     },
     {
       "id": "caug7-cv6-drop2-1top-6",
-      "name": "Caug7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Caug7 — Fret 8 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -3307,7 +3315,7 @@
     },
     {
       "id": "caug7-cv6-drop2-3rdtop-6",
-      "name": "Caug7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Caug7 — Fret 10 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -3365,7 +3373,7 @@
     },
     {
       "id": "caug7-cv6-shell-a-6",
-      "name": "Caug7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Caug7 — A shape — Shell (b7 on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3420,7 +3428,7 @@
     },
     {
       "id": "caug7-shell-a-shape-6",
-      "name": "Caug7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "Caug7 — A shape — Shell (3rd on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3471,7 +3479,7 @@
     },
     {
       "id": "caug7-shell-e-shape-6",
-      "name": "Caug7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "Caug7 — E shape — Shell (3rd on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3522,7 +3530,7 @@
     },
     {
       "id": "caug7-shell-d-shape-6",
-      "name": "Caug7 \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Caug7 — D shape — Shell (7th on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3573,7 +3581,7 @@
     },
     {
       "id": "caug7-cv7-drop2-b7top-7",
-      "name": "Caug7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "Caug7 — Fret 5 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -3629,7 +3637,7 @@
     },
     {
       "id": "caug7-cv7-drop2-1top-7",
-      "name": "Caug7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Caug7 — Fret 8 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -3685,7 +3693,7 @@
     },
     {
       "id": "caug7-cv7-drop2-3rdtop-7",
-      "name": "Caug7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Caug7 — Fret 10 — Drop 2",
       "chord_quality": "aug7",
       "root": "C",
       "category": "drop2",
@@ -3745,7 +3753,7 @@
     },
     {
       "id": "caug7-cv7-shell-a-7",
-      "name": "Caug7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Caug7 — A shape — Shell (b7 on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3802,7 +3810,7 @@
     },
     {
       "id": "caug7-shell-a-shape-7",
-      "name": "Caug7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "Caug7 — A shape — Shell (3rd on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3855,7 +3863,7 @@
     },
     {
       "id": "caug7-shell-e-shape-7",
-      "name": "Caug7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "Caug7 — E shape — Shell (3rd on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3908,7 +3916,7 @@
     },
     {
       "id": "caug7-shell-d-shape-7",
-      "name": "Caug7 \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Caug7 — D shape — Shell (7th on top)",
       "chord_quality": "aug7",
       "root": "C",
       "category": "shell",
@@ -3961,7 +3969,7 @@
     },
     {
       "id": "caugmaj7-drop2-a-shape-6-cm6",
-      "name": "CaugMaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "CaugMaj7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4015,7 +4023,7 @@
     },
     {
       "id": "caugmaj7-drop2-e-shape-6-cm6",
-      "name": "CaugMaj7 \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "name": "CaugMaj7 — E shape — Drop 2 (#5 on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4069,7 +4077,7 @@
     },
     {
       "id": "caugmaj7-cm6-drop2-3rdtop-6",
-      "name": "CaugMaj7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "CaugMaj7 — Fret 10 — Drop 2",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4123,7 +4131,7 @@
     },
     {
       "id": "caugmaj7-shell-a-shape-6-cm6",
-      "name": "CaugMaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "CaugMaj7 — A shape — Shell (7th on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "shell",
@@ -4174,7 +4182,7 @@
     },
     {
       "id": "caugmaj7-drop2-a-shape-7-cm7",
-      "name": "CaugMaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "CaugMaj7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4230,7 +4238,7 @@
     },
     {
       "id": "caugmaj7-drop2-e-shape-7-cm7",
-      "name": "CaugMaj7 \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "name": "CaugMaj7 — E shape — Drop 2 (#5 on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4286,7 +4294,7 @@
     },
     {
       "id": "caugmaj7-cm7-drop2-3rdtop-7",
-      "name": "CaugMaj7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "CaugMaj7 — Fret 10 — Drop 2",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4342,7 +4350,7 @@
     },
     {
       "id": "caugmaj7-cm7-shell-a-7",
-      "name": "CaugMaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "CaugMaj7 — A shape — Shell (7th on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "shell",
@@ -4394,7 +4402,7 @@
     },
     {
       "id": "caugmaj7-drop2-a-shape-6",
-      "name": "CaugMaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "CaugMaj7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4448,7 +4456,7 @@
     },
     {
       "id": "caugmaj7-drop2-e-shape-6",
-      "name": "CaugMaj7 \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "name": "CaugMaj7 — E shape — Drop 2 (#5 on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4502,7 +4510,7 @@
     },
     {
       "id": "caugmaj7-drop2-d-shape-6",
-      "name": "CaugMaj7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "CaugMaj7 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4556,7 +4564,7 @@
     },
     {
       "id": "caugmaj7-shell-a-shape-6",
-      "name": "CaugMaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "CaugMaj7 — A shape — Shell (7th on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "shell",
@@ -4607,7 +4615,7 @@
     },
     {
       "id": "caugmaj7-drop2-a-shape-7",
-      "name": "CaugMaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "CaugMaj7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4663,7 +4671,7 @@
     },
     {
       "id": "caugmaj7-drop2-e-shape-7",
-      "name": "CaugMaj7 \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "name": "CaugMaj7 — E shape — Drop 2 (#5 on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4719,7 +4727,7 @@
     },
     {
       "id": "caugmaj7-drop2-d-shape-7",
-      "name": "CaugMaj7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "CaugMaj7 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "drop2",
@@ -4775,7 +4783,7 @@
     },
     {
       "id": "caugmaj7-shell-a-shape-7",
-      "name": "CaugMaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "CaugMaj7 — A shape — Shell (7th on top)",
       "chord_quality": "augMaj7",
       "root": "C",
       "category": "shell",
@@ -4828,7 +4836,7 @@
     },
     {
       "id": "cdim7-cm6-drop2-b5top-6",
-      "name": "Cdim7 \u2014 Fret 2 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 2 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -4882,7 +4890,7 @@
     },
     {
       "id": "cdim7-drop2-a-shape-6-cm6",
-      "name": "Cdim7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cdim7 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -4937,7 +4945,7 @@
     },
     {
       "id": "cdim7-cm6-drop2-bb7top-6",
-      "name": "Cdim7 \u2014 Fret 4 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 4 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -4991,7 +4999,7 @@
     },
     {
       "id": "cdim7-cm6-drop2-1top-6",
-      "name": "Cdim7 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 7 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5045,7 +5053,7 @@
     },
     {
       "id": "cdim7-drop2-e-shape-6-cm6",
-      "name": "Cdim7 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "Cdim7 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5100,7 +5108,7 @@
     },
     {
       "id": "cdim7-cm6-drop2-b3top-6",
-      "name": "Cdim7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 10 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5154,7 +5162,7 @@
     },
     {
       "id": "cdim7-drop3-a-shape-6-cm6",
-      "name": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "name": "Cdim7 — A shape — Drop 3 (b5 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop3",
@@ -5208,7 +5216,7 @@
     },
     {
       "id": "cdim7-shell-a-shape-6-cm6",
-      "name": "Cdim7 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cdim7 — A shape — Shell (6th on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -5258,7 +5266,7 @@
     },
     {
       "id": "cdim7-shell-e-shape-6-cm6",
-      "name": "Cdim7 \u2014 E shape \u2014 Shell (bb7 on top)",
+      "name": "Cdim7 — E shape — Shell (bb7 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -5309,7 +5317,7 @@
     },
     {
       "id": "cdim7-cm7-drop2-b5top-7",
-      "name": "Cdim7 \u2014 Fret 2 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 2 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5365,7 +5373,7 @@
     },
     {
       "id": "cdim7-drop2-a-shape-7-cm7",
-      "name": "Cdim7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cdim7 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5422,7 +5430,7 @@
     },
     {
       "id": "cdim7-cm7-drop2-bb7top-7",
-      "name": "Cdim7 \u2014 Fret 4 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 4 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5478,7 +5486,7 @@
     },
     {
       "id": "cdim7-cm7-drop2-1top-7",
-      "name": "Cdim7 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 7 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5534,7 +5542,7 @@
     },
     {
       "id": "cdim7-drop2-e-shape-7-cm7",
-      "name": "Cdim7 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "Cdim7 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5591,7 +5599,7 @@
     },
     {
       "id": "cdim7-cm7-drop2-b3top-7",
-      "name": "Cdim7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 10 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5647,7 +5655,7 @@
     },
     {
       "id": "cdim7-drop3-a-shape-7-cm7",
-      "name": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "name": "Cdim7 — A shape — Drop 3 (b5 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop3",
@@ -5703,7 +5711,7 @@
     },
     {
       "id": "cdim7-cm7-shell-7str-7",
-      "name": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)",
+      "name": "Cdim7 — 7-str root — Shell (bb7 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -5756,7 +5764,7 @@
     },
     {
       "id": "cdim7-cm7-shell-a-7",
-      "name": "Cdim7 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cdim7 — A shape — Shell (6th on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -5807,7 +5815,7 @@
     },
     {
       "id": "cdim7-shell-e-shape-7",
-      "name": "Cdim7 \u2014 E shape \u2014 Shell (bb7 on top)",
+      "name": "Cdim7 — E shape — Shell (bb7 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -5859,7 +5867,7 @@
     },
     {
       "id": "cdim-chordsdb-f1-6",
-      "name": "Cdim7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 1 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5931,7 +5939,7 @@
     },
     {
       "id": "cdim7-cv6-drop2-b5top-6",
-      "name": "Cdim7 \u2014 Fret 2 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 2 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -5985,7 +5993,7 @@
     },
     {
       "id": "cdim7-drop2-a-shape-6",
-      "name": "Cdim7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cdim7 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6040,7 +6048,7 @@
     },
     {
       "id": "cdim-chordsdb-f3-6",
-      "name": "Cdim7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 3 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6112,7 +6120,7 @@
     },
     {
       "id": "cdim7-cv6-drop2-bb7top-6",
-      "name": "Cdim7 \u2014 Fret 4 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 4 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6166,7 +6174,7 @@
     },
     {
       "id": "cdim7-cv6-drop2-1top-6",
-      "name": "Cdim7 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 7 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6220,7 +6228,7 @@
     },
     {
       "id": "cdim7-drop2-e-shape-6",
-      "name": "Cdim7 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "Cdim7 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6275,7 +6283,7 @@
     },
     {
       "id": "cdim7-drop2-d-shape-6",
-      "name": "Cdim7 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cdim7 — D shape — Drop 2 (b3 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6330,7 +6338,7 @@
     },
     {
       "id": "cdim7-drop3-a-shape-6",
-      "name": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "name": "Cdim7 — A shape — Drop 3 (b5 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop3",
@@ -6384,7 +6392,7 @@
     },
     {
       "id": "cdim7-chordsdb-f1-6",
-      "name": "Cdim7 \u2014 Fret 1 \u2014 Extended",
+      "name": "Cdim7 — Fret 1 — Extended",
       "chord_quality": "dim7",
       "root": "C",
       "category": "extended",
@@ -6456,7 +6464,7 @@
     },
     {
       "id": "cdim7-chordsdb-f2-6",
-      "name": "Cdim7 \u2014 Fret 2 \u2014 Extended",
+      "name": "Cdim7 — Fret 2 — Extended",
       "chord_quality": "dim7",
       "root": "C",
       "category": "extended",
@@ -6537,7 +6545,7 @@
     },
     {
       "id": "cdim7-shell-a-shape-6",
-      "name": "Cdim7 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cdim7 — A shape — Shell (6th on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -6587,7 +6595,7 @@
     },
     {
       "id": "cdim7-shell-e-shape-6",
-      "name": "Cdim7 \u2014 E shape \u2014 Shell (bb7 on top)",
+      "name": "Cdim7 — E shape — Shell (bb7 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -6638,7 +6646,7 @@
     },
     {
       "id": "cdim7-cv7-drop2-b5top-7",
-      "name": "Cdim7 \u2014 Fret 2 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 2 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6694,7 +6702,7 @@
     },
     {
       "id": "cdim7-drop2-a-shape-7",
-      "name": "Cdim7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cdim7 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6751,7 +6759,7 @@
     },
     {
       "id": "cdim7-cv7-drop2-bb7top-7",
-      "name": "Cdim7 \u2014 Fret 4 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 4 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6807,7 +6815,7 @@
     },
     {
       "id": "cdim7-cv7-drop2-1top-7",
-      "name": "Cdim7 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cdim7 — Fret 7 — Drop 2",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6863,7 +6871,7 @@
     },
     {
       "id": "cdim7-drop2-e-shape-7",
-      "name": "Cdim7 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "Cdim7 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6920,7 +6928,7 @@
     },
     {
       "id": "cdim7-drop2-d-shape-7",
-      "name": "Cdim7 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cdim7 — D shape — Drop 2 (b3 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop2",
@@ -6977,7 +6985,7 @@
     },
     {
       "id": "cdim7-drop3-a-shape-7",
-      "name": "Cdim7 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "name": "Cdim7 — A shape — Drop 3 (b5 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "drop3",
@@ -7033,7 +7041,7 @@
     },
     {
       "id": "cdim7-cv7-shell-7str-7",
-      "name": "Cdim7 \u2014 7-str root \u2014 Shell (bb7 on top)",
+      "name": "Cdim7 — 7-str root — Shell (bb7 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -7086,7 +7094,7 @@
     },
     {
       "id": "cdim7-shell-a-shape-7",
-      "name": "Cdim7 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cdim7 — A shape — Shell (6th on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -7138,7 +7146,7 @@
     },
     {
       "id": "cdim7-shell-e-shape-7-cv7",
-      "name": "Cdim7 \u2014 E shape \u2014 Shell (bb7 on top)",
+      "name": "Cdim7 — E shape — Shell (bb7 on top)",
       "chord_quality": "dim7",
       "root": "C",
       "category": "shell",
@@ -7191,7 +7199,7 @@
     },
     {
       "id": "c13-drop2-e-shape-6-cm6",
-      "name": "C13 \u2014 E shape \u2014 Drop 2 (b7 on top)",
+      "name": "C13 — E shape — Drop 2 (b7 on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "drop2",
@@ -7245,7 +7253,7 @@
     },
     {
       "id": "c13-shell-a-shape-6-cm6",
-      "name": "C13 \u2014 A shape \u2014 Shell (13th on top)",
+      "name": "C13 — A shape — Shell (13th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -7299,7 +7307,7 @@
     },
     {
       "id": "cdom13-shell-a-shape-6-cm6",
-      "name": "C13 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "C13 — A shape — Shell (6th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -7350,7 +7358,7 @@
     },
     {
       "id": "c13-shell-e-shape-6-cm6",
-      "name": "C13 \u2014 E shape \u2014 Shell (13th on top)",
+      "name": "C13 — E shape — Shell (13th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -7404,7 +7412,7 @@
     },
     {
       "id": "c13-drop2-e-shape-7-cm7",
-      "name": "C13 \u2014 E shape \u2014 Drop 2 (b7 on top)",
+      "name": "C13 — E shape — Drop 2 (b7 on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "drop2",
@@ -7460,7 +7468,7 @@
     },
     {
       "id": "c13-shell-a-shape-7-cm7",
-      "name": "C13 \u2014 A shape \u2014 Shell (13th on top)",
+      "name": "C13 — A shape — Shell (13th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -7516,7 +7524,7 @@
     },
     {
       "id": "cdom13-cm7-shell-a-7",
-      "name": "C13 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "C13 — A shape — Shell (6th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -7568,7 +7576,7 @@
     },
     {
       "id": "c13-shell-e-shape-7-cm7",
-      "name": "C13 \u2014 E shape \u2014 Shell (13th on top)",
+      "name": "C13 — E shape — Shell (13th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -7624,7 +7632,7 @@
     },
     {
       "id": "c13-drop2-e-shape-6",
-      "name": "C13 \u2014 E shape \u2014 Drop 2 (b7 on top)",
+      "name": "C13 — E shape — Drop 2 (b7 on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "drop2",
@@ -7678,7 +7686,7 @@
     },
     {
       "id": "c13-chordsdb-f2-6",
-      "name": "C13 \u2014 Fret 2 \u2014 Extended",
+      "name": "C13 — Fret 2 — Extended",
       "chord_quality": "dom13",
       "root": "C",
       "category": "extended",
@@ -7759,7 +7767,7 @@
     },
     {
       "id": "c13-chordsdb-f3-6",
-      "name": "C13 \u2014 Fret 3 \u2014 Extended",
+      "name": "C13 — Fret 3 — Extended",
       "chord_quality": "dom13",
       "root": "C",
       "category": "extended",
@@ -7848,7 +7856,7 @@
     },
     {
       "id": "c13-shell-a-shape-6",
-      "name": "C13 \u2014 A shape \u2014 Shell (13th on top)",
+      "name": "C13 — A shape — Shell (13th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -7902,7 +7910,7 @@
     },
     {
       "id": "cdom13-shell-a-shape-6",
-      "name": "C13 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "C13 — A shape — Shell (6th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -7953,7 +7961,7 @@
     },
     {
       "id": "c13-shell-e-shape-6",
-      "name": "C13 \u2014 E shape \u2014 Shell (13th on top)",
+      "name": "C13 — E shape — Shell (13th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -8007,7 +8015,7 @@
     },
     {
       "id": "c13-drop2-e-shape-7",
-      "name": "C13 \u2014 E shape \u2014 Drop 2 (b7 on top)",
+      "name": "C13 — E shape — Drop 2 (b7 on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "drop2",
@@ -8063,7 +8071,7 @@
     },
     {
       "id": "c13-shell-a-shape-7",
-      "name": "C13 \u2014 A shape \u2014 Shell (13th on top)",
+      "name": "C13 — A shape — Shell (13th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -8119,7 +8127,7 @@
     },
     {
       "id": "cdom13-shell-a-shape-7",
-      "name": "C13 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "C13 — A shape — Shell (6th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -8172,7 +8180,7 @@
     },
     {
       "id": "c13-shell-e-shape-7",
-      "name": "C13 \u2014 E shape \u2014 Shell (13th on top)",
+      "name": "C13 — E shape — Shell (13th on top)",
       "chord_quality": "dom13",
       "root": "C",
       "category": "shell",
@@ -8228,7 +8236,7 @@
     },
     {
       "id": "c7-cm6-drop2-5top-6",
-      "name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "C7 — Fret 1 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8282,7 +8290,7 @@
     },
     {
       "id": "c7-drop2-a-shape-6-cm6",
-      "name": "C7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8336,7 +8344,7 @@
     },
     {
       "id": "c7-cm6-drop2-b7top-6",
-      "name": "C7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C7 — Fret 5 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8390,7 +8398,7 @@
     },
     {
       "id": "c7-cm6-drop2-1top-6",
-      "name": "C7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "C7 — Fret 8 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8444,7 +8452,7 @@
     },
     {
       "id": "c7-drop2-e-shape-6-cm6",
-      "name": "C7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "C7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8498,7 +8506,7 @@
     },
     {
       "id": "c7-cm6-drop2-3top-6",
-      "name": "C7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C7 — Fret 10 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8552,7 +8560,7 @@
     },
     {
       "id": "c7-drop3-a-shape-6-cm6",
-      "name": "C7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "C7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop3",
@@ -8606,7 +8614,7 @@
     },
     {
       "id": "cdom7-shell-a-shape-6-cm6",
-      "name": "C7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -8661,7 +8669,7 @@
     },
     {
       "id": "c7-shell-a-shape-6-cm6",
-      "name": "C7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "C7 — A shape — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -8711,7 +8719,7 @@
     },
     {
       "id": "c7-shell-e-shape-6-cm6",
-      "name": "C7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "C7 — E shape — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -8761,7 +8769,7 @@
     },
     {
       "id": "c7-shell-d-shape-6-cm6",
-      "name": "C7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "C7 — D shape — Shell (b7 on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -8811,7 +8819,7 @@
     },
     {
       "id": "c7-cm7-drop2-5top-7",
-      "name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "C7 — Fret 1 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8867,7 +8875,7 @@
     },
     {
       "id": "c7-drop2-a-shape-7-cm7",
-      "name": "C7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8923,7 +8931,7 @@
     },
     {
       "id": "c7-cm7-drop2-b7top-7",
-      "name": "C7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C7 — Fret 5 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -8979,7 +8987,7 @@
     },
     {
       "id": "c7-cm7-drop2-1top-7",
-      "name": "C7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "C7 — Fret 8 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9035,7 +9043,7 @@
     },
     {
       "id": "c7-drop2-e-shape-7-cm7",
-      "name": "C7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "C7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9091,7 +9099,7 @@
     },
     {
       "id": "c7-cm7-drop2-3top-7",
-      "name": "C7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C7 — Fret 10 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9147,7 +9155,7 @@
     },
     {
       "id": "c7-cm7-drop3-7str-7",
-      "name": "C7 \u2014 7-str bass \u2014 Drop 3",
+      "name": "C7 — 7-str bass — Drop 3",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop3",
@@ -9199,7 +9207,7 @@
     },
     {
       "id": "c7-drop3-a-shape-7-cm7",
-      "name": "C7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "C7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop3",
@@ -9255,7 +9263,7 @@
     },
     {
       "id": "c7-cm7-shell-7str-7",
-      "name": "C7 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "name": "C7 — 7-str root — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -9306,7 +9314,7 @@
     },
     {
       "id": "cdom7-cm7-shell-a-7",
-      "name": "C7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -9362,7 +9370,7 @@
     },
     {
       "id": "c7-shell-a-shape-7",
-      "name": "C7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "C7 — A shape — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -9413,7 +9421,7 @@
     },
     {
       "id": "c7-shell-e-shape-7",
-      "name": "C7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "C7 — E shape — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -9464,7 +9472,7 @@
     },
     {
       "id": "c7-shell-d-shape-7-cm7",
-      "name": "C7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "C7 — D shape — Shell (b7 on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -9516,7 +9524,7 @@
     },
     {
       "id": "c7-chordsdb-f1-6",
-      "name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "C7 — Fret 1 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9591,7 +9599,7 @@
     },
     {
       "id": "c7-cv6-drop2-5top-6",
-      "name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "C7 — Fret 1 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9645,7 +9653,7 @@
     },
     {
       "id": "c7-chordsdb-f3-6",
-      "name": "C7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "C7 — Fret 3 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9726,7 +9734,7 @@
     },
     {
       "id": "c7-drop2-a-shape-6",
-      "name": "C7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9780,7 +9788,7 @@
     },
     {
       "id": "c7-cv6-drop2-b7top-6",
-      "name": "C7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C7 — Fret 5 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9834,7 +9842,7 @@
     },
     {
       "id": "c7-cv6-drop2-1top-6",
-      "name": "C7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "C7 — Fret 8 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9888,7 +9896,7 @@
     },
     {
       "id": "c7-drop2-e-shape-6",
-      "name": "C7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "C7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9942,7 +9950,7 @@
     },
     {
       "id": "c7-drop2-d-shape-6",
-      "name": "C7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -9997,7 +10005,7 @@
     },
     {
       "id": "c7-drop3-a-shape-6",
-      "name": "C7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "C7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop3",
@@ -10051,7 +10059,7 @@
     },
     {
       "id": "cdom7-shell-a-shape-6",
-      "name": "C7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10106,7 +10114,7 @@
     },
     {
       "id": "c7-shell-a-shape-6",
-      "name": "C7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "C7 — A shape — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10156,7 +10164,7 @@
     },
     {
       "id": "c7-shell-e-shape-6",
-      "name": "C7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "C7 — E shape — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10206,7 +10214,7 @@
     },
     {
       "id": "c7-shell-d-shape-6",
-      "name": "C7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "C7 — D shape — Shell (b7 on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10256,7 +10264,7 @@
     },
     {
       "id": "c7-cv7-drop2-5top-7",
-      "name": "C7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "C7 — Fret 1 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -10312,7 +10320,7 @@
     },
     {
       "id": "c7-drop2-a-shape-7",
-      "name": "C7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -10368,7 +10376,7 @@
     },
     {
       "id": "c7-cv7-drop2-b7top-7",
-      "name": "C7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C7 — Fret 5 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -10424,7 +10432,7 @@
     },
     {
       "id": "c7-cv7-drop2-1top-7",
-      "name": "C7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "C7 — Fret 8 — Drop 2",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -10480,7 +10488,7 @@
     },
     {
       "id": "c7-drop2-e-shape-7",
-      "name": "C7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "C7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -10536,7 +10544,7 @@
     },
     {
       "id": "c7-drop2-d-shape-7",
-      "name": "C7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop2",
@@ -10593,7 +10601,7 @@
     },
     {
       "id": "c7-cv7-drop3-7str-7",
-      "name": "C7 \u2014 7-str bass \u2014 Drop 3",
+      "name": "C7 — 7-str bass — Drop 3",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop3",
@@ -10645,7 +10653,7 @@
     },
     {
       "id": "c7-drop3-a-shape-7",
-      "name": "C7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "C7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "drop3",
@@ -10701,7 +10709,7 @@
     },
     {
       "id": "c7-cv7-shell-7str-7",
-      "name": "C7 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "name": "C7 — 7-str root — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10752,7 +10760,7 @@
     },
     {
       "id": "cdom7-shell-a-shape-7",
-      "name": "C7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10809,7 +10817,7 @@
     },
     {
       "id": "c7-shell-a-shape-7-cv7",
-      "name": "C7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "C7 — A shape — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10861,7 +10869,7 @@
     },
     {
       "id": "c7-shell-e-shape-7-cv7",
-      "name": "C7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "C7 — E shape — Shell (3rd on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10913,7 +10921,7 @@
     },
     {
       "id": "c7-shell-d-shape-7",
-      "name": "C7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "C7 — D shape — Shell (b7 on top)",
       "chord_quality": "dom7",
       "root": "C",
       "category": "shell",
@@ -10965,7 +10973,7 @@
     },
     {
       "id": "c7alt-drop2-a-shape-6-cm6",
-      "name": "C7alt \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7alt — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11022,7 +11030,7 @@
     },
     {
       "id": "c7alt-drop2-e-shape-6-cm6",
-      "name": "C7alt \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "name": "C7alt — E shape — Drop 2 (#5 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11080,7 +11088,7 @@
     },
     {
       "id": "cdom7alt-cm6-drop2-3rdtop-6",
-      "name": "C7alt \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C7alt — Fret 10 — Drop 2",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11138,7 +11146,7 @@
     },
     {
       "id": "cdom7alt-shell-a-shape-6-cm6",
-      "name": "C7alt \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7alt — A shape — Shell (b7 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "shell",
@@ -11193,7 +11201,7 @@
     },
     {
       "id": "c7alt-drop2-a-shape-7-cm7",
-      "name": "C7alt \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7alt — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11252,7 +11260,7 @@
     },
     {
       "id": "c7alt-drop2-e-shape-7-cm7",
-      "name": "C7alt \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "name": "C7alt — E shape — Drop 2 (#5 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11312,7 +11320,7 @@
     },
     {
       "id": "cdom7alt-cm7-drop2-3rdtop-7",
-      "name": "C7alt \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C7alt — Fret 10 — Drop 2",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11372,7 +11380,7 @@
     },
     {
       "id": "c7alt-cm7-shell-7str-7",
-      "name": "C7alt \u2014 7-str root \u2014 Shell (b5 on top)",
+      "name": "C7alt — 7-str root — Shell (b5 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "shell",
@@ -11425,7 +11433,7 @@
     },
     {
       "id": "cdom7alt-cm7-shell-a-7",
-      "name": "C7alt \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7alt — A shape — Shell (b7 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "shell",
@@ -11481,7 +11489,7 @@
     },
     {
       "id": "c7alt-drop2-a-shape-6",
-      "name": "C7alt \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7alt — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11538,7 +11546,7 @@
     },
     {
       "id": "c7alt-drop2-e-shape-6",
-      "name": "C7alt \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "name": "C7alt — E shape — Drop 2 (#5 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11596,7 +11604,7 @@
     },
     {
       "id": "c7alt-drop2-d-shape-6",
-      "name": "C7alt \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7alt — D shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11655,7 +11663,7 @@
     },
     {
       "id": "cdom7alt-shell-a-shape-6",
-      "name": "C7alt \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7alt — A shape — Shell (b7 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "shell",
@@ -11710,7 +11718,7 @@
     },
     {
       "id": "c7alt-drop2-a-shape-7",
-      "name": "C7alt \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7alt — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11769,7 +11777,7 @@
     },
     {
       "id": "c7alt-drop2-e-shape-7",
-      "name": "C7alt \u2014 E shape \u2014 Drop 2 (#5 on top)",
+      "name": "C7alt — E shape — Drop 2 (#5 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11829,7 +11837,7 @@
     },
     {
       "id": "c7alt-drop2-d-shape-7",
-      "name": "C7alt \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7alt — D shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "drop2",
@@ -11890,7 +11898,7 @@
     },
     {
       "id": "c7alt-cv7-shell-7str-7",
-      "name": "C7alt \u2014 7-str root \u2014 Shell (b5 on top)",
+      "name": "C7alt — 7-str root — Shell (b5 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "shell",
@@ -11943,7 +11951,7 @@
     },
     {
       "id": "cdom7alt-shell-a-shape-7",
-      "name": "C7alt \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7alt — A shape — Shell (b7 on top)",
       "chord_quality": "dom7alt",
       "root": "C",
       "category": "shell",
@@ -12000,7 +12008,7 @@
     },
     {
       "id": "cdom7b13-cm6-drop2-3rdtop-6",
-      "name": "Cdom7b13 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdom7b13 — Fret 10 — Drop 2",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "drop2",
@@ -12058,7 +12066,7 @@
     },
     {
       "id": "c7b13-ext-a-shape-6-cm6",
-      "name": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)",
+      "name": "Cdom7b13 — A shape — Extended (b13 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "extended",
@@ -12112,7 +12120,7 @@
     },
     {
       "id": "c7b13-ext-e-shape-6-cm6",
-      "name": "Cdom7b13 \u2014 E shape \u2014 Extended (b13 on top)",
+      "name": "Cdom7b13 — E shape — Extended (b13 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "extended",
@@ -12169,7 +12177,7 @@
     },
     {
       "id": "cdom7b13-shell-a-shape-6-cm6",
-      "name": "Cdom7b13 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cdom7b13 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "shell",
@@ -12224,7 +12232,7 @@
     },
     {
       "id": "cdom7b13-cm7-drop2-3rdtop-7",
-      "name": "Cdom7b13 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdom7b13 — Fret 10 — Drop 2",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "drop2",
@@ -12284,7 +12292,7 @@
     },
     {
       "id": "c7b13-ext-a-shape-7-cm7",
-      "name": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)",
+      "name": "Cdom7b13 — A shape — Extended (b13 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "extended",
@@ -12340,7 +12348,7 @@
     },
     {
       "id": "c7b13-ext-e-shape-7-cm7",
-      "name": "Cdom7b13 \u2014 E shape \u2014 Extended (b13 on top)",
+      "name": "Cdom7b13 — E shape — Extended (b13 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "extended",
@@ -12399,7 +12407,7 @@
     },
     {
       "id": "cdom7b13-cm7-shell-a-7",
-      "name": "Cdom7b13 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cdom7b13 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "shell",
@@ -12455,7 +12463,7 @@
     },
     {
       "id": "cdom7b13-cv6-drop2-3rdtop-6",
-      "name": "Cdom7b13 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdom7b13 — Fret 10 — Drop 2",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "drop2",
@@ -12513,7 +12521,7 @@
     },
     {
       "id": "c7b13-ext-a-shape-6",
-      "name": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)",
+      "name": "Cdom7b13 — A shape — Extended (b13 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "extended",
@@ -12567,7 +12575,7 @@
     },
     {
       "id": "c7b13-ext-e-shape-6",
-      "name": "Cdom7b13 \u2014 E shape \u2014 Extended (b13 on top)",
+      "name": "Cdom7b13 — E shape — Extended (b13 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "extended",
@@ -12624,7 +12632,7 @@
     },
     {
       "id": "cdom7b13-shell-a-shape-6",
-      "name": "Cdom7b13 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cdom7b13 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "shell",
@@ -12679,7 +12687,7 @@
     },
     {
       "id": "cdom7b13-cv7-drop2-3rdtop-7",
-      "name": "Cdom7b13 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdom7b13 — Fret 10 — Drop 2",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "drop2",
@@ -12739,7 +12747,7 @@
     },
     {
       "id": "c7b13-ext-a-shape-7",
-      "name": "Cdom7b13 \u2014 A shape \u2014 Extended (b13 on top)",
+      "name": "Cdom7b13 — A shape — Extended (b13 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "extended",
@@ -12795,7 +12803,7 @@
     },
     {
       "id": "c7b13-ext-e-shape-7",
-      "name": "Cdom7b13 \u2014 E shape \u2014 Extended (b13 on top)",
+      "name": "Cdom7b13 — E shape — Extended (b13 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "extended",
@@ -12854,7 +12862,7 @@
     },
     {
       "id": "cdom7b13-shell-a-shape-7",
-      "name": "Cdom7b13 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cdom7b13 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7b13",
       "root": "C",
       "category": "shell",
@@ -12911,7 +12919,7 @@
     },
     {
       "id": "c7b9-altered-a-shape-6-cm6",
-      "name": "C7b9 \u2014 A shape \u2014 Altered (b9 on top)",
+      "name": "C7b9 — A shape — Altered (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "altered",
@@ -12965,7 +12973,7 @@
     },
     {
       "id": "c7b9-altered-e-shape-6-cm6",
-      "name": "C7b9 \u2014 E shape \u2014 Altered (b9 on top)",
+      "name": "C7b9 — E shape — Altered (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "altered",
@@ -13025,7 +13033,7 @@
     },
     {
       "id": "cdom7b9-drop2-a-shape-6-cm6",
-      "name": "C7b9 \u2014 A shape \u2014 Drop 2 (b9 on top)",
+      "name": "C7b9 — A shape — Drop 2 (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13078,7 +13086,7 @@
     },
     {
       "id": "c7b9-cm6-drop2-1top-6",
-      "name": "C7b9 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C7b9 — Fret 5 — Drop 2",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13132,7 +13140,7 @@
     },
     {
       "id": "c7b9-cm6-drop2-b9top-6",
-      "name": "C7b9 \u2014 Fret 9 \u2014 Drop 2",
+      "name": "C7b9 — Fret 9 — Drop 2",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13186,7 +13194,7 @@
     },
     {
       "id": "cdom7b9-shell-a-shape-6-cm6",
-      "name": "C7b9 \u2014 A shape \u2014 Shell (b9 on top)",
+      "name": "C7b9 — A shape — Shell (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "shell",
@@ -13234,7 +13242,7 @@
     },
     {
       "id": "c7b9-altered-a-shape-7-cm7",
-      "name": "C7b9 \u2014 A shape \u2014 Altered (b9 on top)",
+      "name": "C7b9 — A shape — Altered (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "altered",
@@ -13290,7 +13298,7 @@
     },
     {
       "id": "c7b9-altered-e-shape-7-cm7",
-      "name": "C7b9 \u2014 E shape \u2014 Altered (b9 on top)",
+      "name": "C7b9 — E shape — Altered (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "altered",
@@ -13352,7 +13360,7 @@
     },
     {
       "id": "cdom7b9-drop2-a-shape-7-cm7",
-      "name": "C7b9 \u2014 A shape \u2014 Drop 2 (b9 on top)",
+      "name": "C7b9 — A shape — Drop 2 (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13407,7 +13415,7 @@
     },
     {
       "id": "c7b9-cm7-drop2-1top-7",
-      "name": "C7b9 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C7b9 — Fret 5 — Drop 2",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13463,7 +13471,7 @@
     },
     {
       "id": "c7b9-cm7-drop2-b9top-7",
-      "name": "C7b9 \u2014 Fret 9 \u2014 Drop 2",
+      "name": "C7b9 — Fret 9 — Drop 2",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13519,7 +13527,7 @@
     },
     {
       "id": "c7b9-cm7-shell-7str-7",
-      "name": "C7b9 \u2014 7-str root \u2014 Shell (b9 on top)",
+      "name": "C7b9 — 7-str root — Shell (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "shell",
@@ -13570,7 +13578,7 @@
     },
     {
       "id": "cdom7b9-cm7-shell-a-7",
-      "name": "C7b9 \u2014 A shape \u2014 Shell (b9 on top)",
+      "name": "C7b9 — A shape — Shell (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "shell",
@@ -13619,7 +13627,7 @@
     },
     {
       "id": "c7b9-altered-a-shape-6",
-      "name": "C7b9 \u2014 A shape \u2014 Altered (b9 on top)",
+      "name": "C7b9 — A shape — Altered (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "altered",
@@ -13673,7 +13681,7 @@
     },
     {
       "id": "c7b9-altered-e-shape-6",
-      "name": "C7b9 \u2014 E shape \u2014 Altered (b9 on top)",
+      "name": "C7b9 — E shape — Altered (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "altered",
@@ -13733,7 +13741,7 @@
     },
     {
       "id": "cdom7b9-drop2-a-shape-6",
-      "name": "C7b9 \u2014 A shape \u2014 Drop 2 (b9 on top)",
+      "name": "C7b9 — A shape — Drop 2 (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13786,7 +13794,7 @@
     },
     {
       "id": "c7b9-cv6-drop2-1top-6",
-      "name": "C7b9 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C7b9 — Fret 5 — Drop 2",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13840,7 +13848,7 @@
     },
     {
       "id": "cdom7b9-drop2-d-shape-6",
-      "name": "C7b9 \u2014 D shape \u2014 Drop 2 (b9 on top)",
+      "name": "C7b9 — D shape — Drop 2 (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -13893,7 +13901,7 @@
     },
     {
       "id": "c7b9-chordsdb-f2-6",
-      "name": "C7b9 \u2014 Fret 2 \u2014 Extended",
+      "name": "C7b9 — Fret 2 — Extended",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "extended",
@@ -13974,7 +13982,7 @@
     },
     {
       "id": "c7b9-chordsdb-f6-6",
-      "name": "C7b9 \u2014 Fret 6 \u2014 Extended",
+      "name": "C7b9 — Fret 6 — Extended",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "extended",
@@ -14046,7 +14054,7 @@
     },
     {
       "id": "cdom7b9-shell-a-shape-6",
-      "name": "C7b9 \u2014 A shape \u2014 Shell (b9 on top)",
+      "name": "C7b9 — A shape — Shell (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "shell",
@@ -14094,7 +14102,7 @@
     },
     {
       "id": "c7b9-altered-a-shape-7",
-      "name": "C7b9 \u2014 A shape \u2014 Altered (b9 on top)",
+      "name": "C7b9 — A shape — Altered (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "altered",
@@ -14150,7 +14158,7 @@
     },
     {
       "id": "c7b9-altered-e-shape-7",
-      "name": "C7b9 \u2014 E shape \u2014 Altered (b9 on top)",
+      "name": "C7b9 — E shape — Altered (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "altered",
@@ -14212,7 +14220,7 @@
     },
     {
       "id": "cdom7b9-drop2-a-shape-7",
-      "name": "C7b9 \u2014 A shape \u2014 Drop 2 (b9 on top)",
+      "name": "C7b9 — A shape — Drop 2 (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -14267,7 +14275,7 @@
     },
     {
       "id": "c7b9-cv7-drop2-1top-7",
-      "name": "C7b9 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C7b9 — Fret 5 — Drop 2",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -14323,7 +14331,7 @@
     },
     {
       "id": "cdom7b9-drop2-d-shape-7",
-      "name": "C7b9 \u2014 D shape \u2014 Drop 2 (b9 on top)",
+      "name": "C7b9 — D shape — Drop 2 (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "drop2",
@@ -14378,7 +14386,7 @@
     },
     {
       "id": "c7b9-cv7-shell-7str-7",
-      "name": "C7b9 \u2014 7-str root \u2014 Shell (b9 on top)",
+      "name": "C7b9 — 7-str root — Shell (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "shell",
@@ -14429,7 +14437,7 @@
     },
     {
       "id": "cdom7b9-shell-a-shape-7",
-      "name": "C7b9 \u2014 A shape \u2014 Shell (b9 on top)",
+      "name": "C7b9 — A shape — Shell (b9 on top)",
       "chord_quality": "dom7b9",
       "root": "C",
       "category": "shell",
@@ -14479,7 +14487,7 @@
     },
     {
       "id": "c7b5-drop2-a-shape-6-cm6",
-      "name": "C7b5 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7b5 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -14535,7 +14543,7 @@
     },
     {
       "id": "c7b5-drop2-e-shape-6-cm6",
-      "name": "C7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "C7b5 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -14589,7 +14597,7 @@
     },
     {
       "id": "cdom7b5-cm6-drop2-3rdtop-6",
-      "name": "C7b5 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C7b5 — Fret 10 — Drop 2",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -14645,7 +14653,7 @@
     },
     {
       "id": "cdom7b5-shell-a-shape-6-cm6",
-      "name": "C7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7b5 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "shell",
@@ -14700,7 +14708,7 @@
     },
     {
       "id": "c7b5-drop2-a-shape-7-cm7",
-      "name": "C7b5 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7b5 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -14758,7 +14766,7 @@
     },
     {
       "id": "c7b5-drop2-e-shape-7-cm7",
-      "name": "C7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "C7b5 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -14814,7 +14822,7 @@
     },
     {
       "id": "cdom7b5-cm7-drop2-3rdtop-7",
-      "name": "C7b5 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C7b5 — Fret 10 — Drop 2",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -14872,7 +14880,7 @@
     },
     {
       "id": "cdom7b5-cm7-shell-a-7",
-      "name": "C7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7b5 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "shell",
@@ -14928,7 +14936,7 @@
     },
     {
       "id": "c7b5-chordsdb-f1-6",
-      "name": "C7b5 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "C7b5 — Fret 1 — Drop 2",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -15000,7 +15008,7 @@
     },
     {
       "id": "c7b5-drop2-a-shape-6",
-      "name": "C7b5 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7b5 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -15056,7 +15064,7 @@
     },
     {
       "id": "c7b5-drop2-e-shape-6",
-      "name": "C7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "C7b5 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -15110,7 +15118,7 @@
     },
     {
       "id": "c7b5-drop2-d-shape-6",
-      "name": "C7b5 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7b5 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -15166,7 +15174,7 @@
     },
     {
       "id": "cdom7b5-shell-a-shape-6",
-      "name": "C7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7b5 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "shell",
@@ -15221,7 +15229,7 @@
     },
     {
       "id": "c7b5-drop2-a-shape-7",
-      "name": "C7b5 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7b5 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -15279,7 +15287,7 @@
     },
     {
       "id": "c7b5-drop2-e-shape-7",
-      "name": "C7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "C7b5 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -15335,7 +15343,7 @@
     },
     {
       "id": "c7b5-drop2-d-shape-7",
-      "name": "C7b5 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7b5 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "drop2",
@@ -15393,7 +15401,7 @@
     },
     {
       "id": "cdom7b5-shell-a-shape-7",
-      "name": "C7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7b5 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7flat5",
       "root": "C",
       "category": "shell",
@@ -15450,7 +15458,7 @@
     },
     {
       "id": "cdom7s11-cm6-drop2-3rdtop-6",
-      "name": "Cdom7sharp11 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdom7sharp11 — Fret 10 — Drop 2",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "drop2",
@@ -15506,7 +15514,7 @@
     },
     {
       "id": "c7s11-ext-a-shape-6-cm6",
-      "name": "Cdom7sharp11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "name": "Cdom7sharp11 — A shape — Extended (3rd on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "extended",
@@ -15562,7 +15570,7 @@
     },
     {
       "id": "c7s11-ext-e-shape-6-cm6",
-      "name": "Cdom7sharp11 \u2014 E shape \u2014 Extended (3rd on top)",
+      "name": "Cdom7sharp11 — E shape — Extended (3rd on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "extended",
@@ -15616,7 +15624,7 @@
     },
     {
       "id": "cdom7s11-shell-a-shape-6-cm6",
-      "name": "Cdom7sharp11 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cdom7sharp11 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "shell",
@@ -15671,7 +15679,7 @@
     },
     {
       "id": "cdom7s11-cm7-drop2-3rdtop-7",
-      "name": "Cdom7sharp11 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdom7sharp11 — Fret 10 — Drop 2",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "drop2",
@@ -15729,7 +15737,7 @@
     },
     {
       "id": "c7s11-ext-a-shape-7-cm7",
-      "name": "Cdom7sharp11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "name": "Cdom7sharp11 — A shape — Extended (3rd on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "extended",
@@ -15787,7 +15795,7 @@
     },
     {
       "id": "c7s11-ext-e-shape-7-cm7",
-      "name": "Cdom7sharp11 \u2014 E shape \u2014 Extended (3rd on top)",
+      "name": "Cdom7sharp11 — E shape — Extended (3rd on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "extended",
@@ -15843,7 +15851,7 @@
     },
     {
       "id": "cdom7s11-cm7-shell-a-7",
-      "name": "Cdom7sharp11 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cdom7sharp11 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "shell",
@@ -15899,7 +15907,7 @@
     },
     {
       "id": "cdom7s11-cv6-drop2-3rdtop-6",
-      "name": "Cdom7sharp11 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdom7sharp11 — Fret 10 — Drop 2",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "drop2",
@@ -15955,7 +15963,7 @@
     },
     {
       "id": "c7s11-ext-a-shape-6",
-      "name": "Cdom7sharp11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "name": "Cdom7sharp11 — A shape — Extended (3rd on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "extended",
@@ -16011,7 +16019,7 @@
     },
     {
       "id": "c7s11-ext-e-shape-6",
-      "name": "Cdom7sharp11 \u2014 E shape \u2014 Extended (3rd on top)",
+      "name": "Cdom7sharp11 — E shape — Extended (3rd on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "extended",
@@ -16065,7 +16073,7 @@
     },
     {
       "id": "cdom7s11-shell-a-shape-6",
-      "name": "Cdom7sharp11 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cdom7sharp11 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "shell",
@@ -16120,7 +16128,7 @@
     },
     {
       "id": "cdom7s11-cv7-drop2-3rdtop-7",
-      "name": "Cdom7sharp11 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cdom7sharp11 — Fret 10 — Drop 2",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "drop2",
@@ -16178,7 +16186,7 @@
     },
     {
       "id": "c7s11-ext-a-shape-7",
-      "name": "Cdom7sharp11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "name": "Cdom7sharp11 — A shape — Extended (3rd on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "extended",
@@ -16236,7 +16244,7 @@
     },
     {
       "id": "c7s11-ext-e-shape-7",
-      "name": "Cdom7sharp11 \u2014 E shape \u2014 Extended (3rd on top)",
+      "name": "Cdom7sharp11 — E shape — Extended (3rd on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "extended",
@@ -16292,7 +16300,7 @@
     },
     {
       "id": "cdom7s11-shell-a-shape-7",
-      "name": "Cdom7sharp11 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cdom7sharp11 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7sharp11",
       "root": "C",
       "category": "shell",
@@ -16349,7 +16357,7 @@
     },
     {
       "id": "c7s5-altered-a-shape-6-cm6",
-      "name": "C7#5 \u2014 A shape \u2014 Altered (3rd on top)",
+      "name": "C7#5 — A shape — Altered (3rd on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "altered",
@@ -16405,7 +16413,7 @@
     },
     {
       "id": "c7s5-altered-e-shape-6-cm6",
-      "name": "C7#5 \u2014 E shape \u2014 Altered (#5 on top)",
+      "name": "C7#5 — E shape — Altered (#5 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "altered",
@@ -16462,7 +16470,7 @@
     },
     {
       "id": "cdom7s5-cm6-drop2-3rdtop-6",
-      "name": "C7#5 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C7#5 — Fret 10 — Drop 2",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "drop2",
@@ -16520,7 +16528,7 @@
     },
     {
       "id": "cdom7s5-shell-a-shape-6-cm6",
-      "name": "C7#5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7#5 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "shell",
@@ -16575,7 +16583,7 @@
     },
     {
       "id": "c7s5-altered-a-shape-7-cm7",
-      "name": "C7#5 \u2014 A shape \u2014 Altered (3rd on top)",
+      "name": "C7#5 — A shape — Altered (3rd on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "altered",
@@ -16633,7 +16641,7 @@
     },
     {
       "id": "c7s5-altered-e-shape-7-cm7",
-      "name": "C7#5 \u2014 E shape \u2014 Altered (#5 on top)",
+      "name": "C7#5 — E shape — Altered (#5 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "altered",
@@ -16692,7 +16700,7 @@
     },
     {
       "id": "cdom7s5-cm7-drop2-3rdtop-7",
-      "name": "C7#5 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C7#5 — Fret 10 — Drop 2",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "drop2",
@@ -16752,7 +16760,7 @@
     },
     {
       "id": "c7s5-cm7-shell-7str-7",
-      "name": "C7#5 \u2014 7-str root \u2014 Shell (#5 on top)",
+      "name": "C7#5 — 7-str root — Shell (#5 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "shell",
@@ -16808,7 +16816,7 @@
     },
     {
       "id": "cdom7s5-cm7-shell-a-7",
-      "name": "C7#5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7#5 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "shell",
@@ -16864,7 +16872,7 @@
     },
     {
       "id": "c7s5-altered-a-shape-6",
-      "name": "C7#5 \u2014 A shape \u2014 Altered (3rd on top)",
+      "name": "C7#5 — A shape — Altered (3rd on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "altered",
@@ -16920,7 +16928,7 @@
     },
     {
       "id": "c7s5-altered-e-shape-6",
-      "name": "C7#5 \u2014 E shape \u2014 Altered (#5 on top)",
+      "name": "C7#5 — E shape — Altered (#5 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "altered",
@@ -16977,7 +16985,7 @@
     },
     {
       "id": "c7s5-drop2-d-shape-6",
-      "name": "C7#5 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7#5 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "drop2",
@@ -17036,7 +17044,7 @@
     },
     {
       "id": "cdom7s5-shell-a-shape-6",
-      "name": "C7#5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7#5 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "shell",
@@ -17091,7 +17099,7 @@
     },
     {
       "id": "c7s5-altered-a-shape-7",
-      "name": "C7#5 \u2014 A shape \u2014 Altered (3rd on top)",
+      "name": "C7#5 — A shape — Altered (3rd on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "altered",
@@ -17149,7 +17157,7 @@
     },
     {
       "id": "c7s5-altered-e-shape-7",
-      "name": "C7#5 \u2014 E shape \u2014 Altered (#5 on top)",
+      "name": "C7#5 — E shape — Altered (#5 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "altered",
@@ -17208,7 +17216,7 @@
     },
     {
       "id": "c7s5-drop2-d-shape-7",
-      "name": "C7#5 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C7#5 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "drop2",
@@ -17269,7 +17277,7 @@
     },
     {
       "id": "c7s5-cv7-shell-7str-7",
-      "name": "C7#5 \u2014 7-str root \u2014 Shell (#5 on top)",
+      "name": "C7#5 — 7-str root — Shell (#5 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "shell",
@@ -17325,7 +17333,7 @@
     },
     {
       "id": "cdom7s5-shell-a-shape-7",
-      "name": "C7#5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "C7#5 — A shape — Shell (b7 on top)",
       "chord_quality": "dom7sharp5",
       "root": "C",
       "category": "shell",
@@ -17382,7 +17390,7 @@
     },
     {
       "id": "c7s9-cm6-altered-6str-6",
-      "name": "C7#9 \u2014 Fret 5 \u2014 Altered (3rd on top)",
+      "name": "C7#9 — Fret 5 — Altered (3rd on top)",
       "chord_quality": "dom7sharp9",
       "root": "C",
       "category": "altered",
@@ -17443,7 +17451,7 @@
     },
     {
       "id": "c7s9-cm7-altered-7str-8",
-      "name": "C7#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "C7#9 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "dom7sharp9",
       "root": "C",
       "category": "altered",
@@ -17507,7 +17515,7 @@
     },
     {
       "id": "c7s9-cv6-altered-6str-5",
-      "name": "C7#9 \u2014 Fret 5 \u2014 Altered (3rd on top)",
+      "name": "C7#9 — Fret 5 — Altered (3rd on top)",
       "chord_quality": "dom7sharp9",
       "root": "C",
       "category": "altered",
@@ -17568,7 +17576,7 @@
     },
     {
       "id": "c7s9-chordsdb-f2-6",
-      "name": "C7#9 \u2014 Fret 2 \u2014 Drop 2",
+      "name": "C7#9 — Fret 2 — Drop 2",
       "chord_quality": "dom7sharp9",
       "root": "C",
       "category": "drop2",
@@ -17640,7 +17648,7 @@
     },
     {
       "id": "c7s9-chordsdb-f3-6",
-      "name": "C7#9 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "C7#9 — Fret 3 — Drop 2",
       "chord_quality": "dom7sharp9",
       "root": "C",
       "category": "drop2",
@@ -17715,7 +17723,7 @@
     },
     {
       "id": "c7s9-cv7-altered-7str-7",
-      "name": "C7#9 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "C7#9 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "dom7sharp9",
       "root": "C",
       "category": "altered",
@@ -17779,7 +17787,7 @@
     },
     {
       "id": "cdom9-drop2-d-shape-6-cm6",
-      "name": "C9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "C9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "drop2",
@@ -17832,7 +17840,7 @@
     },
     {
       "id": "c9-extended-e-shape-6-cm6",
-      "name": "C9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "C9 — E shape — Extended (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "extended",
@@ -17891,7 +17899,7 @@
     },
     {
       "id": "c9-shell-a-shape-6-cm6",
-      "name": "C9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "C9 — A shape — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -17945,7 +17953,7 @@
     },
     {
       "id": "c9-shell-e-shape-6-cm6",
-      "name": "C9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "C9 — E shape — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -17999,7 +18007,7 @@
     },
     {
       "id": "cdom9-drop2-d-shape-7-cm7",
-      "name": "C9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "C9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "drop2",
@@ -18054,7 +18062,7 @@
     },
     {
       "id": "c9-extended-e-shape-7-cm7",
-      "name": "C9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "C9 — E shape — Extended (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "extended",
@@ -18115,7 +18123,7 @@
     },
     {
       "id": "c9-cm7-shell-7str-7",
-      "name": "C9 \u2014 7-str root \u2014 Shell (9th on top)",
+      "name": "C9 — 7-str root — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -18171,7 +18179,7 @@
     },
     {
       "id": "c9-shell-a-shape-7-cm7",
-      "name": "C9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "C9 — A shape — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -18227,7 +18235,7 @@
     },
     {
       "id": "c9-shell-e-shape-7-cm7",
-      "name": "C9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "C9 — E shape — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -18283,7 +18291,7 @@
     },
     {
       "id": "cdom9-drop2-d-shape-6",
-      "name": "C9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "C9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "drop2",
@@ -18336,7 +18344,7 @@
     },
     {
       "id": "c9-chordsdb-f2-1",
-      "name": "C9 \u2014 Fret 2 \u2014 Extended",
+      "name": "C9 — Fret 2 — Extended",
       "chord_quality": "dom9",
       "root": "C",
       "category": "extended",
@@ -18425,7 +18433,7 @@
     },
     {
       "id": "c9-chordsdb-f2-6",
-      "name": "C9 \u2014 Fret 2 \u2014 Extended",
+      "name": "C9 — Fret 2 — Extended",
       "chord_quality": "dom9",
       "root": "C",
       "category": "extended",
@@ -18494,7 +18502,7 @@
     },
     {
       "id": "c9-extended-e-shape-6",
-      "name": "C9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "C9 — E shape — Extended (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "extended",
@@ -18553,7 +18561,7 @@
     },
     {
       "id": "c9-shell-a-shape-6",
-      "name": "C9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "C9 — A shape — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -18607,7 +18615,7 @@
     },
     {
       "id": "c9-shell-e-shape-6",
-      "name": "C9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "C9 — E shape — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -18661,7 +18669,7 @@
     },
     {
       "id": "cdom9-drop2-d-shape-7",
-      "name": "C9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "C9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "drop2",
@@ -18716,7 +18724,7 @@
     },
     {
       "id": "c9-extended-e-shape-7",
-      "name": "C9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "C9 — E shape — Extended (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "extended",
@@ -18777,7 +18785,7 @@
     },
     {
       "id": "c9-cv7-shell-7str-7",
-      "name": "C9 \u2014 7-str root \u2014 Shell (9th on top)",
+      "name": "C9 — 7-str root — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -18833,7 +18841,7 @@
     },
     {
       "id": "c9-shell-a-shape-7",
-      "name": "C9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "C9 — A shape — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -18889,7 +18897,7 @@
     },
     {
       "id": "c9-shell-e-shape-7",
-      "name": "C9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "C9 — E shape — Shell (9th on top)",
       "chord_quality": "dom9",
       "root": "C",
       "category": "shell",
@@ -18945,7 +18953,7 @@
     },
     {
       "id": "cmaj13-ext-e-shape-6-cm6",
-      "name": "Cmaj13 \u2014 E shape \u2014 Extended (13th on top)",
+      "name": "Cmaj13 — E shape — Extended (13th on top)",
       "chord_quality": "maj13",
       "root": "C",
       "category": "extended",
@@ -18999,7 +19007,7 @@
     },
     {
       "id": "cmaj13-shell-a-shape-6-cm6",
-      "name": "Cmaj13 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cmaj13 — A shape — Shell (6th on top)",
       "chord_quality": "maj13",
       "root": "C",
       "category": "shell",
@@ -19050,7 +19058,7 @@
     },
     {
       "id": "cmaj13-ext-e-shape-7-cm7",
-      "name": "Cmaj13 \u2014 E shape \u2014 Extended (13th on top)",
+      "name": "Cmaj13 — E shape — Extended (13th on top)",
       "chord_quality": "maj13",
       "root": "C",
       "category": "extended",
@@ -19106,7 +19114,7 @@
     },
     {
       "id": "cmaj13-cm7-shell-a-7",
-      "name": "Cmaj13 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cmaj13 — A shape — Shell (6th on top)",
       "chord_quality": "maj13",
       "root": "C",
       "category": "shell",
@@ -19158,7 +19166,7 @@
     },
     {
       "id": "cmaj13-ext-e-shape-6",
-      "name": "Cmaj13 \u2014 E shape \u2014 Extended (13th on top)",
+      "name": "Cmaj13 — E shape — Extended (13th on top)",
       "chord_quality": "maj13",
       "root": "C",
       "category": "extended",
@@ -19212,7 +19220,7 @@
     },
     {
       "id": "cmaj13-shell-a-shape-6",
-      "name": "Cmaj13 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cmaj13 — A shape — Shell (6th on top)",
       "chord_quality": "maj13",
       "root": "C",
       "category": "shell",
@@ -19263,7 +19271,7 @@
     },
     {
       "id": "cmaj13-ext-e-shape-7",
-      "name": "Cmaj13 \u2014 E shape \u2014 Extended (13th on top)",
+      "name": "Cmaj13 — E shape — Extended (13th on top)",
       "chord_quality": "maj13",
       "root": "C",
       "category": "extended",
@@ -19319,7 +19327,7 @@
     },
     {
       "id": "cmaj13-shell-a-shape-7",
-      "name": "Cmaj13 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cmaj13 — A shape — Shell (6th on top)",
       "chord_quality": "maj13",
       "root": "C",
       "category": "shell",
@@ -19372,7 +19380,7 @@
     },
     {
       "id": "c6-drop2-a-shape-6-cm6",
-      "name": "C6 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C6 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -19426,7 +19434,7 @@
     },
     {
       "id": "c6-cm6-drop2-5top-6",
-      "name": "C6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "C6 — Fret 3 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -19480,7 +19488,7 @@
     },
     {
       "id": "c6-cm6-drop2-6top-6",
-      "name": "C6 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C6 — Fret 5 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -19536,7 +19544,7 @@
     },
     {
       "id": "c6-cm6-drop2-1top-6",
-      "name": "C6 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "C6 — Fret 7 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -19592,7 +19600,7 @@
     },
     {
       "id": "c6-drop2-e-shape-6-cm6",
-      "name": "C6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "C6 — E shape — Drop 2 (5th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -19646,7 +19654,7 @@
     },
     {
       "id": "cmaj6-cm6-drop2-3rdtop-6",
-      "name": "C6 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C6 — Fret 10 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -19702,7 +19710,7 @@
     },
     {
       "id": "c6-shell-a-shape-6-cm6",
-      "name": "C6 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "C6 — A shape — Shell (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -19751,7 +19759,7 @@
     },
     {
       "id": "cmaj6-shell-a-shape-6-cm6",
-      "name": "C6 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "C6 — A shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -19802,7 +19810,7 @@
     },
     {
       "id": "c6-shell-e-shape-6-cm6",
-      "name": "C6 \u2014 E shape \u2014 Shell (6th on top)",
+      "name": "C6 — E shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -19851,7 +19859,7 @@
     },
     {
       "id": "c6-shell-d-shape-6-cm6",
-      "name": "C6 \u2014 D shape \u2014 Shell (6th on top)",
+      "name": "C6 — D shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -19900,7 +19908,7 @@
     },
     {
       "id": "c6-drop2-a-shape-7-cm7",
-      "name": "C6 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C6 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -19956,7 +19964,7 @@
     },
     {
       "id": "c6-cm7-drop2-5top-7",
-      "name": "C6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "C6 — Fret 3 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20012,7 +20020,7 @@
     },
     {
       "id": "c6-cm7-drop2-7top-7",
-      "name": "C6 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C6 — Fret 5 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20070,7 +20078,7 @@
     },
     {
       "id": "c6-cm7-drop2-1top-7",
-      "name": "C6 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "C6 — Fret 7 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20128,7 +20136,7 @@
     },
     {
       "id": "c6-drop2-e-shape-7-cm7",
-      "name": "C6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "C6 — E shape — Drop 2 (5th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20184,7 +20192,7 @@
     },
     {
       "id": "cmaj6-cm7-drop2-3rdtop-7",
-      "name": "C6 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "C6 — Fret 10 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20242,7 +20250,7 @@
     },
     {
       "id": "c6-cm7-shell-7str-7",
-      "name": "C6 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "name": "C6 — 7-str root — Shell (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -20289,7 +20297,7 @@
     },
     {
       "id": "c6-shell-a-shape-7-cm7",
-      "name": "C6 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "C6 — A shape — Shell (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -20340,7 +20348,7 @@
     },
     {
       "id": "cmaj6-cm7-shell-a-7",
-      "name": "C6 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "C6 — A shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -20392,7 +20400,7 @@
     },
     {
       "id": "c6-shell-e-shape-7-cm7",
-      "name": "C6 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "C6 — E shape — Shell (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -20443,7 +20451,7 @@
     },
     {
       "id": "c6-shell-e-shape-7",
-      "name": "C6 \u2014 E shape \u2014 Shell (6th on top)",
+      "name": "C6 — E shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -20493,7 +20501,7 @@
     },
     {
       "id": "c6-shell-d-shape-7-cm7",
-      "name": "C6 \u2014 D shape \u2014 Shell (6th on top)",
+      "name": "C6 — D shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -20544,7 +20552,7 @@
     },
     {
       "id": "c6-drop2-a-shape-6",
-      "name": "C6 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C6 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20598,7 +20606,7 @@
     },
     {
       "id": "c6-cv6-drop2-5top-6",
-      "name": "C6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "C6 — Fret 3 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20652,7 +20660,7 @@
     },
     {
       "id": "c6-cv6-drop2-6top-6",
-      "name": "C6 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C6 — Fret 5 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20708,7 +20716,7 @@
     },
     {
       "id": "c6-cv6-drop2-1top-6",
-      "name": "C6 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "C6 — Fret 7 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20764,7 +20772,7 @@
     },
     {
       "id": "c6-drop2-e-shape-6",
-      "name": "C6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "C6 — E shape — Drop 2 (5th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20818,7 +20826,7 @@
     },
     {
       "id": "c6-drop2-d-shape-6",
-      "name": "C6 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C6 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -20874,7 +20882,7 @@
     },
     {
       "id": "c6-chordsdb-f1-6",
-      "name": "C6 \u2014 Fret 1 \u2014 Extended",
+      "name": "C6 — Fret 1 — Extended",
       "chord_quality": "maj6",
       "root": "C",
       "category": "extended",
@@ -20949,7 +20957,7 @@
     },
     {
       "id": "c6-chordsdb-f3-6",
-      "name": "C6 \u2014 Fret 3 \u2014 Extended",
+      "name": "C6 — Fret 3 — Extended",
       "chord_quality": "maj6",
       "root": "C",
       "category": "extended",
@@ -21030,7 +21038,7 @@
     },
     {
       "id": "c6-shell-a-shape-6",
-      "name": "C6 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "C6 — A shape — Shell (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21079,7 +21087,7 @@
     },
     {
       "id": "cmaj6-shell-a-shape-6",
-      "name": "C6 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "C6 — A shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21130,7 +21138,7 @@
     },
     {
       "id": "c6-shell-e-shape-6",
-      "name": "C6 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "C6 — E shape — Shell (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21179,7 +21187,7 @@
     },
     {
       "id": "c6-shell-e-shape-6-cv6",
-      "name": "C6 \u2014 E shape \u2014 Shell (6th on top)",
+      "name": "C6 — E shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21228,7 +21236,7 @@
     },
     {
       "id": "c6-shell-d-shape-6",
-      "name": "C6 \u2014 D shape \u2014 Shell (6th on top)",
+      "name": "C6 — D shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21277,7 +21285,7 @@
     },
     {
       "id": "c6-drop2-a-shape-7",
-      "name": "C6 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "C6 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -21333,7 +21341,7 @@
     },
     {
       "id": "c6-cv7-drop2-5top-7",
-      "name": "C6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "C6 — Fret 3 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -21389,7 +21397,7 @@
     },
     {
       "id": "c6-cv7-drop2-6top-7",
-      "name": "C6 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "C6 — Fret 5 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -21447,7 +21455,7 @@
     },
     {
       "id": "c6-cv7-drop2-1top-7",
-      "name": "C6 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "C6 — Fret 7 — Drop 2",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -21505,7 +21513,7 @@
     },
     {
       "id": "c6-drop2-e-shape-7",
-      "name": "C6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "C6 — E shape — Drop 2 (5th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -21561,7 +21569,7 @@
     },
     {
       "id": "c6-drop2-d-shape-7",
-      "name": "C6 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "C6 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "drop2",
@@ -21619,7 +21627,7 @@
     },
     {
       "id": "c6-cv7-shell-7str-7",
-      "name": "C6 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "name": "C6 — 7-str root — Shell (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21666,7 +21674,7 @@
     },
     {
       "id": "c6-shell-a-shape-7",
-      "name": "C6 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "C6 — A shape — Shell (3rd on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21717,7 +21725,7 @@
     },
     {
       "id": "cmaj6-shell-a-shape-7",
-      "name": "C6 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "C6 — A shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21770,7 +21778,7 @@
     },
     {
       "id": "c6-shell-e-shape-7-cv7",
-      "name": "C6 \u2014 E shape \u2014 Shell (6th on top)",
+      "name": "C6 — E shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21821,7 +21829,7 @@
     },
     {
       "id": "c6-shell-d-shape-7",
-      "name": "C6 \u2014 D shape \u2014 Shell (6th on top)",
+      "name": "C6 — D shape — Shell (6th on top)",
       "chord_quality": "maj6",
       "root": "C",
       "category": "shell",
@@ -21872,7 +21880,7 @@
     },
     {
       "id": "cmaj69-drop2-d-shape-6-cm6",
-      "name": "Cmaj69 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj69 — D shape — Drop 2 (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "drop2",
@@ -21925,7 +21933,7 @@
     },
     {
       "id": "c69-ext-a-shape-6-cm6",
-      "name": "Cmaj69 \u2014 A shape \u2014 Extended (9th on top)",
+      "name": "Cmaj69 — A shape — Extended (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -21979,7 +21987,7 @@
     },
     {
       "id": "c69-ext-e-shape-6-cm6",
-      "name": "Cmaj69 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cmaj69 — E shape — Extended (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -22033,7 +22041,7 @@
     },
     {
       "id": "cmaj69-drop2-a-shape-7",
-      "name": "Cmaj69 \u2014 A shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj69 — A shape — Drop 2 (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "drop2",
@@ -22088,7 +22096,7 @@
     },
     {
       "id": "cmaj69-drop2-d-shape-7-cm7",
-      "name": "Cmaj69 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj69 — D shape — Drop 2 (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "drop2",
@@ -22143,7 +22151,7 @@
     },
     {
       "id": "c69-ext-e-shape-7-cm7",
-      "name": "Cmaj69 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cmaj69 — E shape — Extended (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -22199,7 +22207,7 @@
     },
     {
       "id": "cmaj69-drop2-d-shape-6",
-      "name": "Cmaj69 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj69 — D shape — Drop 2 (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "drop2",
@@ -22252,7 +22260,7 @@
     },
     {
       "id": "c69-chordsdb-f2-6",
-      "name": "Cmaj69 \u2014 Fret 2 \u2014 Extended",
+      "name": "Cmaj69 — Fret 2 — Extended",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -22333,7 +22341,7 @@
     },
     {
       "id": "c69-ext-a-shape-6",
-      "name": "Cmaj69 \u2014 A shape \u2014 Extended (9th on top)",
+      "name": "Cmaj69 — A shape — Extended (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -22387,7 +22395,7 @@
     },
     {
       "id": "c69-chordsdb-f3-6",
-      "name": "Cmaj69 \u2014 Fret 3 \u2014 Extended",
+      "name": "Cmaj69 — Fret 3 — Extended",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -22455,7 +22463,7 @@
     },
     {
       "id": "c69-ext-e-shape-6",
-      "name": "Cmaj69 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cmaj69 — E shape — Extended (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -22509,7 +22517,7 @@
     },
     {
       "id": "cmaj69-drop2-d-shape-7",
-      "name": "Cmaj69 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj69 — D shape — Drop 2 (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "drop2",
@@ -22564,7 +22572,7 @@
     },
     {
       "id": "c69-ext-a-shape-7",
-      "name": "Cmaj69 \u2014 A shape \u2014 Extended (9th on top)",
+      "name": "Cmaj69 — A shape — Extended (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -22620,7 +22628,7 @@
     },
     {
       "id": "c69-ext-e-shape-7",
-      "name": "Cmaj69 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cmaj69 — E shape — Extended (9th on top)",
       "chord_quality": "maj69",
       "root": "C",
       "category": "extended",
@@ -22676,7 +22684,7 @@
     },
     {
       "id": "cmaj7-cm6-drop2-5top-6",
-      "name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 1 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -22730,7 +22738,7 @@
     },
     {
       "id": "cmaj7-drop2-a-shape-6-cm6",
-      "name": "Cmaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "Cmaj7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -22784,7 +22792,7 @@
     },
     {
       "id": "cmaj7-cm6-drop2-7top-6",
-      "name": "Cmaj7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 5 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -22838,7 +22846,7 @@
     },
     {
       "id": "cmaj7-cm6-drop2-1top-6",
-      "name": "Cmaj7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 8 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -22892,7 +22900,7 @@
     },
     {
       "id": "cmaj7-drop2-e-shape-6-cm6",
-      "name": "Cmaj7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cmaj7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -22946,7 +22954,7 @@
     },
     {
       "id": "cmaj7-cm6-drop2-3top-6",
-      "name": "Cmaj7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 10 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -23000,7 +23008,7 @@
     },
     {
       "id": "cmaj7-drop3-a-shape-6-cm6",
-      "name": "Cmaj7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "Cmaj7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop3",
@@ -23054,7 +23062,7 @@
     },
     {
       "id": "cmaj7-cm6-shell-a-6",
-      "name": "Cmaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7 — A shape — Shell (7th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23105,7 +23113,7 @@
     },
     {
       "id": "cmaj7-shell-a-shape-6-cm6",
-      "name": "Cmaj7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — A shape — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23157,7 +23165,7 @@
     },
     {
       "id": "cmaj7-shell-e-shape-6-cm6",
-      "name": "Cmaj7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — E shape — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23209,7 +23217,7 @@
     },
     {
       "id": "cmaj7-shell-d-shape-6-cm6",
-      "name": "Cmaj7 \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7 — D shape — Shell (7th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23261,7 +23269,7 @@
     },
     {
       "id": "cmaj7-cm7-drop2-5top-7",
-      "name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 1 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -23317,7 +23325,7 @@
     },
     {
       "id": "cmaj7-drop2-a-shape-7-cm7",
-      "name": "Cmaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "Cmaj7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -23373,7 +23381,7 @@
     },
     {
       "id": "cmaj7-cm7-drop2-7top-7",
-      "name": "Cmaj7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 5 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -23429,7 +23437,7 @@
     },
     {
       "id": "cmaj7-cm7-drop2-1top-7",
-      "name": "Cmaj7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 8 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -23485,7 +23493,7 @@
     },
     {
       "id": "cmaj7-drop2-e-shape-7-cm7",
-      "name": "Cmaj7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cmaj7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -23541,7 +23549,7 @@
     },
     {
       "id": "cmaj7-cm7-drop2-3top-7",
-      "name": "Cmaj7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 10 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -23597,7 +23605,7 @@
     },
     {
       "id": "cmaj7-cm7-drop3-7str-7",
-      "name": "Cmaj7 \u2014 7-str bass \u2014 Drop 3",
+      "name": "Cmaj7 — 7-str bass — Drop 3",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop3",
@@ -23649,7 +23657,7 @@
     },
     {
       "id": "cmaj7-drop3-a-shape-7-cm7",
-      "name": "Cmaj7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "Cmaj7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop3",
@@ -23705,7 +23713,7 @@
     },
     {
       "id": "cmaj7-cm7-shell-7str-7",
-      "name": "Cmaj7 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — 7-str root — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23756,7 +23764,7 @@
     },
     {
       "id": "cmaj7-cm7-shell-a-7",
-      "name": "Cmaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7 — A shape — Shell (7th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23808,7 +23816,7 @@
     },
     {
       "id": "cmaj7-shell-a-shape-7",
-      "name": "Cmaj7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — A shape — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23861,7 +23869,7 @@
     },
     {
       "id": "cmaj7-shell-e-shape-7",
-      "name": "Cmaj7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — E shape — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23914,7 +23922,7 @@
     },
     {
       "id": "cmaj7-shell-d-shape-7-cm7",
-      "name": "Cmaj7 \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7 — D shape — Shell (7th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -23968,7 +23976,7 @@
     },
     {
       "id": "cmaj7-cv6-drop2-5top-6",
-      "name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 1 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24022,7 +24030,7 @@
     },
     {
       "id": "cmajor-chordsdb-f1-6",
-      "name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 1 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24090,7 +24098,7 @@
     },
     {
       "id": "cmaj7-chordsdb-f2-6",
-      "name": "Cmaj7 \u2014 Fret 2 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 2 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24159,7 +24167,7 @@
     },
     {
       "id": "cmaj7-chordsdb-f3-6",
-      "name": "Cmaj7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 3 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24248,7 +24256,7 @@
     },
     {
       "id": "cmaj7-drop2-a-shape-6",
-      "name": "Cmaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "Cmaj7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24302,7 +24310,7 @@
     },
     {
       "id": "cmajor-chordsdb-f3-6",
-      "name": "Cmaj7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 3 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24383,7 +24391,7 @@
     },
     {
       "id": "cmaj7-cv6-drop2-7top-6",
-      "name": "Cmaj7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 5 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24437,7 +24445,7 @@
     },
     {
       "id": "cmaj7-cv6-drop2-1top-6",
-      "name": "Cmaj7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 8 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24491,7 +24499,7 @@
     },
     {
       "id": "cmaj7-drop2-e-shape-6",
-      "name": "Cmaj7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cmaj7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24545,7 +24553,7 @@
     },
     {
       "id": "cmaj7-drop2-d-shape-6",
-      "name": "Cmaj7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "Cmaj7 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24600,7 +24608,7 @@
     },
     {
       "id": "cmaj7-drop3-a-shape-6",
-      "name": "Cmaj7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "Cmaj7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop3",
@@ -24654,7 +24662,7 @@
     },
     {
       "id": "cmaj7-cv6-shell-a-6",
-      "name": "Cmaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7 — A shape — Shell (7th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -24705,7 +24713,7 @@
     },
     {
       "id": "cmaj7-shell-a-shape-6",
-      "name": "Cmaj7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — A shape — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -24757,7 +24765,7 @@
     },
     {
       "id": "cmaj7-shell-e-shape-6",
-      "name": "Cmaj7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — E shape — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -24809,7 +24817,7 @@
     },
     {
       "id": "cmaj7-shell-d-shape-6",
-      "name": "Cmaj7 \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7 — D shape — Shell (7th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -24861,7 +24869,7 @@
     },
     {
       "id": "cmaj7-cv7-drop2-5top-7",
-      "name": "Cmaj7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 1 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24917,7 +24925,7 @@
     },
     {
       "id": "cmaj7-drop2-a-shape-7",
-      "name": "Cmaj7 \u2014 A shape \u2014 Drop 2 (3rd on top)",
+      "name": "Cmaj7 — A shape — Drop 2 (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -24973,7 +24981,7 @@
     },
     {
       "id": "cmaj7-cv7-drop2-7top-7",
-      "name": "Cmaj7 \u2014 Fret 5 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 5 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -25029,7 +25037,7 @@
     },
     {
       "id": "cmaj7-cv7-drop2-1top-7",
-      "name": "Cmaj7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Cmaj7 — Fret 8 — Drop 2",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -25085,7 +25093,7 @@
     },
     {
       "id": "cmaj7-drop2-e-shape-7",
-      "name": "Cmaj7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cmaj7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -25141,7 +25149,7 @@
     },
     {
       "id": "cmaj7-drop2-d-shape-7",
-      "name": "Cmaj7 \u2014 D shape \u2014 Drop 2 (3rd on top)",
+      "name": "Cmaj7 — D shape — Drop 2 (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop2",
@@ -25198,7 +25206,7 @@
     },
     {
       "id": "cmaj7-cv7-drop3-7str-7",
-      "name": "Cmaj7 \u2014 7-str bass \u2014 Drop 3",
+      "name": "Cmaj7 — 7-str bass — Drop 3",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop3",
@@ -25250,7 +25258,7 @@
     },
     {
       "id": "cmaj7-drop3-a-shape-7",
-      "name": "Cmaj7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "Cmaj7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "drop3",
@@ -25306,7 +25314,7 @@
     },
     {
       "id": "cmaj7-cv7-shell-7str-7",
-      "name": "Cmaj7 \u2014 7-str root \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — 7-str root — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -25357,7 +25365,7 @@
     },
     {
       "id": "cmaj7-cv7-shell-a-7",
-      "name": "Cmaj7 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7 — A shape — Shell (7th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -25410,7 +25418,7 @@
     },
     {
       "id": "cmaj7-shell-a-shape-7-cv7",
-      "name": "Cmaj7 \u2014 A shape \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — A shape — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -25464,7 +25472,7 @@
     },
     {
       "id": "cmaj7-shell-e-shape-7-cv7",
-      "name": "Cmaj7 \u2014 E shape \u2014 Shell (3rd on top)",
+      "name": "Cmaj7 — E shape — Shell (3rd on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -25518,7 +25526,7 @@
     },
     {
       "id": "cmaj7-shell-d-shape-7",
-      "name": "Cmaj7 \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7 — D shape — Shell (7th on top)",
       "chord_quality": "maj7",
       "root": "C",
       "category": "shell",
@@ -25572,7 +25580,7 @@
     },
     {
       "id": "cmaj7s11-cm6-drop2-3rdtop-6",
-      "name": "Cmaj7#11 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cmaj7#11 — Fret 10 — Drop 2",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "drop2",
@@ -25628,7 +25636,7 @@
     },
     {
       "id": "cmaj7s11-ext-a-shape-6-cm6",
-      "name": "Cmaj7#11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "name": "Cmaj7#11 — A shape — Extended (3rd on top)",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "extended",
@@ -25684,7 +25692,7 @@
     },
     {
       "id": "cmaj7s11-shell-a-shape-6-cm6",
-      "name": "Cmaj7#11 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7#11 — A shape — Shell (7th on top)",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "shell",
@@ -25735,7 +25743,7 @@
     },
     {
       "id": "cmaj7s11-cm7-drop2-3rdtop-7",
-      "name": "Cmaj7#11 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cmaj7#11 — Fret 10 — Drop 2",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "drop2",
@@ -25793,7 +25801,7 @@
     },
     {
       "id": "cmaj7s11-ext-a-shape-7-cm7",
-      "name": "Cmaj7#11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "name": "Cmaj7#11 — A shape — Extended (3rd on top)",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "extended",
@@ -25851,7 +25859,7 @@
     },
     {
       "id": "cmaj7s11-cm7-shell-a-7",
-      "name": "Cmaj7#11 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7#11 — A shape — Shell (7th on top)",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "shell",
@@ -25903,7 +25911,7 @@
     },
     {
       "id": "cmaj7s11-cv6-drop2-3rdtop-6",
-      "name": "Cmaj7#11 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cmaj7#11 — Fret 10 — Drop 2",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "drop2",
@@ -25959,7 +25967,7 @@
     },
     {
       "id": "cmaj7s11-ext-a-shape-6",
-      "name": "Cmaj7#11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "name": "Cmaj7#11 — A shape — Extended (3rd on top)",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "extended",
@@ -26015,7 +26023,7 @@
     },
     {
       "id": "cmaj7s11-shell-a-shape-6",
-      "name": "Cmaj7#11 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7#11 — A shape — Shell (7th on top)",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "shell",
@@ -26066,7 +26074,7 @@
     },
     {
       "id": "cmaj7s11-cv7-drop2-3rdtop-7",
-      "name": "Cmaj7#11 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cmaj7#11 — Fret 10 — Drop 2",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "drop2",
@@ -26124,7 +26132,7 @@
     },
     {
       "id": "cmaj7s11-ext-a-shape-7",
-      "name": "Cmaj7#11 \u2014 A shape \u2014 Extended (3rd on top)",
+      "name": "Cmaj7#11 — A shape — Extended (3rd on top)",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "extended",
@@ -26182,7 +26190,7 @@
     },
     {
       "id": "cmaj7s11-shell-a-shape-7",
-      "name": "Cmaj7#11 \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cmaj7#11 — A shape — Shell (7th on top)",
       "chord_quality": "maj7sharp11",
       "root": "C",
       "category": "shell",
@@ -26235,7 +26243,7 @@
     },
     {
       "id": "cmaj7s5-cm6-altered-6str-2",
-      "name": "Cmaj7#5 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "name": "Cmaj7#5 — Fret 7 — Altered (3rd on top)",
       "chord_quality": "maj7sharp5",
       "root": "C",
       "category": "altered",
@@ -26296,7 +26304,7 @@
     },
     {
       "id": "cmaj7s5-cm7-altered-7str-4",
-      "name": "Cmaj7#5 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "Cmaj7#5 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "maj7sharp5",
       "root": "C",
       "category": "altered",
@@ -26357,7 +26365,7 @@
     },
     {
       "id": "cmaj7s5-cv6-altered-6str-1",
-      "name": "Cmaj7#5 \u2014 Fret 7 \u2014 Altered (3rd on top)",
+      "name": "Cmaj7#5 — Fret 7 — Altered (3rd on top)",
       "chord_quality": "maj7sharp5",
       "root": "C",
       "category": "altered",
@@ -26418,7 +26426,7 @@
     },
     {
       "id": "cmaj7s5-cv7-altered-7str-3",
-      "name": "Cmaj7#5 \u2014 Fret 1 \u2014 Altered (3rd on top)",
+      "name": "Cmaj7#5 — Fret 1 — Altered (3rd on top)",
       "chord_quality": "maj7sharp5",
       "root": "C",
       "category": "altered",
@@ -26479,7 +26487,7 @@
     },
     {
       "id": "cmaj9-drop2-d-shape-6-cm6",
-      "name": "Cmaj9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "drop2",
@@ -26532,7 +26540,7 @@
     },
     {
       "id": "cmaj9-extended-e-shape-6-cm6",
-      "name": "Cmaj9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cmaj9 — E shape — Extended (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "extended",
@@ -26591,7 +26599,7 @@
     },
     {
       "id": "cmaj9-shell-a-shape-6-cm6",
-      "name": "Cmaj9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — A shape — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -26645,7 +26653,7 @@
     },
     {
       "id": "cmaj9-shell-e-shape-6-cm6",
-      "name": "Cmaj9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — E shape — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -26699,7 +26707,7 @@
     },
     {
       "id": "cmaj9-drop2-d-shape-7-cm7",
-      "name": "Cmaj9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "drop2",
@@ -26754,7 +26762,7 @@
     },
     {
       "id": "cmaj9-extended-e-shape-7-cm7",
-      "name": "Cmaj9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cmaj9 — E shape — Extended (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "extended",
@@ -26815,7 +26823,7 @@
     },
     {
       "id": "cmaj9-cm7-shell-7str-7",
-      "name": "Cmaj9 \u2014 7-str root \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — 7-str root — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -26871,7 +26879,7 @@
     },
     {
       "id": "cmaj9-shell-a-shape-7-cm7",
-      "name": "Cmaj9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — A shape — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -26927,7 +26935,7 @@
     },
     {
       "id": "cmaj9-shell-e-shape-7-cm7",
-      "name": "Cmaj9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — E shape — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -26983,7 +26991,7 @@
     },
     {
       "id": "cmaj9-drop2-d-shape-6",
-      "name": "Cmaj9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "drop2",
@@ -27036,7 +27044,7 @@
     },
     {
       "id": "cmaj9-chordsdb-f2-6",
-      "name": "Cmaj9 \u2014 Fret 2 \u2014 Extended",
+      "name": "Cmaj9 — Fret 2 — Extended",
       "chord_quality": "maj9",
       "root": "C",
       "category": "extended",
@@ -27117,7 +27125,7 @@
     },
     {
       "id": "cmaj9-chordsdb-f3-6",
-      "name": "Cmaj9 \u2014 Fret 3 \u2014 Extended",
+      "name": "Cmaj9 — Fret 3 — Extended",
       "chord_quality": "maj9",
       "root": "C",
       "category": "extended",
@@ -27171,7 +27179,7 @@
     },
     {
       "id": "cmaj9-extended-e-shape-6",
-      "name": "Cmaj9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cmaj9 — E shape — Extended (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "extended",
@@ -27230,7 +27238,7 @@
     },
     {
       "id": "cmaj9-shell-a-shape-6",
-      "name": "Cmaj9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — A shape — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -27284,7 +27292,7 @@
     },
     {
       "id": "cmaj9-shell-e-shape-6",
-      "name": "Cmaj9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — E shape — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -27338,7 +27346,7 @@
     },
     {
       "id": "cmaj9-drop2-d-shape-7",
-      "name": "Cmaj9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cmaj9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "drop2",
@@ -27393,7 +27401,7 @@
     },
     {
       "id": "cmaj9-extended-e-shape-7",
-      "name": "Cmaj9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cmaj9 — E shape — Extended (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "extended",
@@ -27454,7 +27462,7 @@
     },
     {
       "id": "cmaj9-cv7-shell-7str-7",
-      "name": "Cmaj9 \u2014 7-str root \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — 7-str root — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -27510,7 +27518,7 @@
     },
     {
       "id": "cmaj9-shell-a-shape-7",
-      "name": "Cmaj9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — A shape — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -27566,7 +27574,7 @@
     },
     {
       "id": "cmaj9-shell-e-shape-7",
-      "name": "Cmaj9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "Cmaj9 — E shape — Shell (9th on top)",
       "chord_quality": "maj9",
       "root": "C",
       "category": "shell",
@@ -27622,7 +27630,7 @@
     },
     {
       "id": "cmmaj7-drop2-a-shape-6-cm6",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm(maj7) — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -27676,7 +27684,7 @@
     },
     {
       "id": "cmmaj7-drop2-e-shape-6-cm6",
-      "name": "Cm(maj7) \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm(maj7) — E shape — Drop 2 (5th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -27730,7 +27738,7 @@
     },
     {
       "id": "cmin-maj7-cm6-drop2-b3top-6",
-      "name": "Cm(maj7) \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cm(maj7) — Fret 10 — Drop 2",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -27784,7 +27792,7 @@
     },
     {
       "id": "cmin-maj7-shell-a-shape-6-cm6",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cm(maj7) — A shape — Shell (7th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -27832,7 +27840,7 @@
     },
     {
       "id": "cmmaj7-shell-a-shape-6-cm6",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — A shape — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -27881,7 +27889,7 @@
     },
     {
       "id": "cmmaj7-shell-d-shape-6-cm6",
-      "name": "Cm(maj7) \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Cm(maj7) — D shape — Shell (7th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -27930,7 +27938,7 @@
     },
     {
       "id": "cmmaj7-shell-e-shape-6-cm6",
-      "name": "Cm(maj7) \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — E shape — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -27979,7 +27987,7 @@
     },
     {
       "id": "cmmaj7-drop2-a-shape-7-cm7",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm(maj7) — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28035,7 +28043,7 @@
     },
     {
       "id": "cmmaj7-drop2-e-shape-7-cm7",
-      "name": "Cm(maj7) \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm(maj7) — E shape — Drop 2 (5th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28091,7 +28099,7 @@
     },
     {
       "id": "cmin-maj7-cm7-drop2-b3top-7",
-      "name": "Cm(maj7) \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cm(maj7) — Fret 10 — Drop 2",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28147,7 +28155,7 @@
     },
     {
       "id": "cmin-maj7-cm7-shell-a-7",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cm(maj7) — A shape — Shell (7th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28196,7 +28204,7 @@
     },
     {
       "id": "cmmaj7-cm7-shell-7str-7",
-      "name": "Cm(maj7) \u2014 7-str root \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — 7-str root — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28247,7 +28255,7 @@
     },
     {
       "id": "cmmaj7-shell-a-shape-7-cm7",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — A shape — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28298,7 +28306,7 @@
     },
     {
       "id": "cmmaj7-shell-d-shape-7-cm7",
-      "name": "Cm(maj7) \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Cm(maj7) — D shape — Shell (7th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28349,7 +28357,7 @@
     },
     {
       "id": "cmmaj7-shell-e-shape-7-cm7",
-      "name": "Cm(maj7) \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — E shape — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28400,7 +28408,7 @@
     },
     {
       "id": "cmmaj7-drop2-a-shape-6",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm(maj7) — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28454,7 +28462,7 @@
     },
     {
       "id": "cmmaj7-drop2-e-shape-6",
-      "name": "Cm(maj7) \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm(maj7) — E shape — Drop 2 (5th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28508,7 +28516,7 @@
     },
     {
       "id": "cmmaj7-drop2-d-shape-6",
-      "name": "Cm(maj7) \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm(maj7) — D shape — Drop 2 (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28562,7 +28570,7 @@
     },
     {
       "id": "cmin-maj7-shell-a-shape-6",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cm(maj7) — A shape — Shell (7th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28610,7 +28618,7 @@
     },
     {
       "id": "cmmaj7-shell-a-shape-6",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — A shape — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28659,7 +28667,7 @@
     },
     {
       "id": "cmmaj7-shell-d-shape-6",
-      "name": "Cm(maj7) \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Cm(maj7) — D shape — Shell (7th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28708,7 +28716,7 @@
     },
     {
       "id": "cmmaj7-shell-e-shape-6",
-      "name": "Cm(maj7) \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — E shape — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28757,7 +28765,7 @@
     },
     {
       "id": "cmmaj7-drop2-a-shape-7",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm(maj7) — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28813,7 +28821,7 @@
     },
     {
       "id": "cmmaj7-drop2-e-shape-7",
-      "name": "Cm(maj7) \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm(maj7) — E shape — Drop 2 (5th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28869,7 +28877,7 @@
     },
     {
       "id": "cmmaj7-drop2-d-shape-7",
-      "name": "Cm(maj7) \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm(maj7) — D shape — Drop 2 (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "drop2",
@@ -28925,7 +28933,7 @@
     },
     {
       "id": "cmin-maj7-shell-a-shape-7",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Shell (7th on top)",
+      "name": "Cm(maj7) — A shape — Shell (7th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -28975,7 +28983,7 @@
     },
     {
       "id": "cmmaj7-cv7-shell-7str-7",
-      "name": "Cm(maj7) \u2014 7-str root \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — 7-str root — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -29026,7 +29034,7 @@
     },
     {
       "id": "cmmaj7-shell-a-shape-7",
-      "name": "Cm(maj7) \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — A shape — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -29077,7 +29085,7 @@
     },
     {
       "id": "cmmaj7-shell-d-shape-7",
-      "name": "Cm(maj7) \u2014 D shape \u2014 Shell (7th on top)",
+      "name": "Cm(maj7) — D shape — Shell (7th on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -29128,7 +29136,7 @@
     },
     {
       "id": "cmmaj7-shell-e-shape-7",
-      "name": "Cm(maj7) \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm(maj7) — E shape — Shell (b3 on top)",
       "chord_quality": "min-maj7",
       "root": "C",
       "category": "shell",
@@ -29179,7 +29187,7 @@
     },
     {
       "id": "cmmaj9-cm6-extended-6str-10",
-      "name": "Cm(maj9) \u2014 Fret 6 \u2014 Extended (7th on top)",
+      "name": "Cm(maj9) — Fret 6 — Extended (7th on top)",
       "chord_quality": "min-maj9",
       "root": "C",
       "category": "extended",
@@ -29237,7 +29245,7 @@
     },
     {
       "id": "cmmaj9-cm7-extended-7str-12",
-      "name": "Cm(maj9) \u2014 Fret 3 \u2014 Extended (7th on top)",
+      "name": "Cm(maj9) — Fret 3 — Extended (7th on top)",
       "chord_quality": "min-maj9",
       "root": "C",
       "category": "extended",
@@ -29301,7 +29309,7 @@
     },
     {
       "id": "cmmaj9-cv6-extended-6str-9",
-      "name": "Cm(maj9) \u2014 Fret 6 \u2014 Extended (7th on top)",
+      "name": "Cm(maj9) — Fret 6 — Extended (7th on top)",
       "chord_quality": "min-maj9",
       "root": "C",
       "category": "extended",
@@ -29359,7 +29367,7 @@
     },
     {
       "id": "cmmaj9-cv7-extended-7str-11",
-      "name": "Cm(maj9) \u2014 Fret 3 \u2014 Extended (7th on top)",
+      "name": "Cm(maj9) — Fret 3 — Extended (7th on top)",
       "chord_quality": "min-maj9",
       "root": "C",
       "category": "extended",
@@ -29423,7 +29431,7 @@
     },
     {
       "id": "cm11-ext-a-shape-6-cm6",
-      "name": "Cmin11 \u2014 A shape \u2014 Extended (11th on top)",
+      "name": "Cmin11 — A shape — Extended (11th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -29477,7 +29485,7 @@
     },
     {
       "id": "cm11-ext-e-shape-6-cm6",
-      "name": "Cmin11 \u2014 E shape \u2014 Extended (11th on top)",
+      "name": "Cmin11 — E shape — Extended (11th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -29531,7 +29539,7 @@
     },
     {
       "id": "cm11-ext-a-shape-7-cm7",
-      "name": "Cmin11 \u2014 A shape \u2014 Extended (11th on top)",
+      "name": "Cmin11 — A shape — Extended (11th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -29587,7 +29595,7 @@
     },
     {
       "id": "cm11-ext-e-shape-7-cm7",
-      "name": "Cmin11 \u2014 E shape \u2014 Extended (11th on top)",
+      "name": "Cmin11 — E shape — Extended (11th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -29643,7 +29651,7 @@
     },
     {
       "id": "cmin11-cm7-shell-7str-7",
-      "name": "Cmin11 \u2014 7-str root \u2014 Shell (4th on top)",
+      "name": "Cmin11 — 7-str root — Shell (4th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "shell",
@@ -29693,7 +29701,7 @@
     },
     {
       "id": "c11-chordsdb-f1-6",
-      "name": "Cmin11 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cmin11 — Fret 1 — Drop 2",
       "chord_quality": "min11",
       "root": "C",
       "category": "drop2",
@@ -29774,7 +29782,7 @@
     },
     {
       "id": "c11-chordsdb-f3-6",
-      "name": "Cmin11 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cmin11 — Fret 3 — Drop 2",
       "chord_quality": "min11",
       "root": "C",
       "category": "drop2",
@@ -29855,7 +29863,7 @@
     },
     {
       "id": "cm11-chordsdb-f3-6",
-      "name": "Cmin11 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cmin11 — Fret 3 — Drop 2",
       "chord_quality": "min11",
       "root": "C",
       "category": "drop2",
@@ -29936,7 +29944,7 @@
     },
     {
       "id": "cm11-chordsdb-f1-6",
-      "name": "Cmin11 \u2014 Fret 1 \u2014 Extended",
+      "name": "Cmin11 — Fret 1 — Extended",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -30017,7 +30025,7 @@
     },
     {
       "id": "cm11-ext-a-shape-6",
-      "name": "Cmin11 \u2014 A shape \u2014 Extended (11th on top)",
+      "name": "Cmin11 — A shape — Extended (11th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -30071,7 +30079,7 @@
     },
     {
       "id": "cm11-ext-e-shape-6",
-      "name": "Cmin11 \u2014 E shape \u2014 Extended (11th on top)",
+      "name": "Cmin11 — E shape — Extended (11th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -30125,7 +30133,7 @@
     },
     {
       "id": "cm11-ext-a-shape-7",
-      "name": "Cmin11 \u2014 A shape \u2014 Extended (11th on top)",
+      "name": "Cmin11 — A shape — Extended (11th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -30181,7 +30189,7 @@
     },
     {
       "id": "cm11-ext-e-shape-7",
-      "name": "Cmin11 \u2014 E shape \u2014 Extended (11th on top)",
+      "name": "Cmin11 — E shape — Extended (11th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "extended",
@@ -30237,7 +30245,7 @@
     },
     {
       "id": "cmin11-cv7-shell-7str-7",
-      "name": "Cmin11 \u2014 7-str root \u2014 Shell (4th on top)",
+      "name": "Cmin11 — 7-str root — Shell (4th on top)",
       "chord_quality": "min11",
       "root": "C",
       "category": "shell",
@@ -30286,7 +30294,7 @@
     },
     {
       "id": "cm6-drop2-a-shape-6-cm6",
-      "name": "Cm6 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm6 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30340,7 +30348,7 @@
     },
     {
       "id": "cm6-cm6-drop2-5top-6",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm6 — Fret 3 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30394,7 +30402,7 @@
     },
     {
       "id": "cm6-cm6-drop2-6top-6",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm6 — Fret 3 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30448,7 +30456,7 @@
     },
     {
       "id": "cm6-cm6-drop2-1top-6",
-      "name": "Cm6 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cm6 — Fret 7 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30504,7 +30512,7 @@
     },
     {
       "id": "cm6-drop2-e-shape-6-cm6",
-      "name": "Cm6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm6 — E shape — Drop 2 (5th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30558,7 +30566,7 @@
     },
     {
       "id": "cmin6-cm6-drop2-b3top-6",
-      "name": "Cm6 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cm6 — Fret 10 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30612,7 +30620,7 @@
     },
     {
       "id": "cmin6-shell-a-shape-6-cm6",
-      "name": "Cm6 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — A shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -30662,7 +30670,7 @@
     },
     {
       "id": "cm6-shell-a-shape-6-cm6",
-      "name": "Cm6 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm6 — A shape — Shell (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -30711,7 +30719,7 @@
     },
     {
       "id": "cm6-shell-d-shape-6-cm6",
-      "name": "Cm6 \u2014 D shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — D shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -30760,7 +30768,7 @@
     },
     {
       "id": "cm6-shell-e-shape-6-cm6",
-      "name": "Cm6 \u2014 E shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — E shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -30811,7 +30819,7 @@
     },
     {
       "id": "cm6-drop2-a-shape-7-cm7",
-      "name": "Cm6 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm6 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30867,7 +30875,7 @@
     },
     {
       "id": "cm6-cm7-drop2-5top-7",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm6 — Fret 3 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30923,7 +30931,7 @@
     },
     {
       "id": "cm6-cm7-drop2-7top-7",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm6 — Fret 3 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -30979,7 +30987,7 @@
     },
     {
       "id": "cm6-cm7-drop2-1top-7",
-      "name": "Cm6 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cm6 — Fret 7 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31037,7 +31045,7 @@
     },
     {
       "id": "cm6-drop2-e-shape-7-cm7",
-      "name": "Cm6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm6 — E shape — Drop 2 (5th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31093,7 +31101,7 @@
     },
     {
       "id": "cmin6-cm7-drop2-b3top-7",
-      "name": "Cm6 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cm6 — Fret 10 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31149,7 +31157,7 @@
     },
     {
       "id": "cm6-cm7-shell-7str-7",
-      "name": "Cm6 \u2014 7-str root \u2014 Shell (6th on top)",
+      "name": "Cm6 — 7-str root — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -31202,7 +31210,7 @@
     },
     {
       "id": "cmin6-cm7-shell-a-7",
-      "name": "Cm6 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — A shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -31253,7 +31261,7 @@
     },
     {
       "id": "cm6-shell-a-shape-7-cm7",
-      "name": "Cm6 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm6 — A shape — Shell (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -31304,7 +31312,7 @@
     },
     {
       "id": "cm6-shell-e-shape-7-cm7",
-      "name": "Cm6 \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm6 — E shape — Shell (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -31355,7 +31363,7 @@
     },
     {
       "id": "cm6-shell-d-shape-7-cm7",
-      "name": "Cm6 \u2014 D shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — D shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -31406,7 +31414,7 @@
     },
     {
       "id": "cm6-shell-e-shape-7",
-      "name": "Cm6 \u2014 E shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — E shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -31458,7 +31466,7 @@
     },
     {
       "id": "cm6-drop2-a-shape-6",
-      "name": "Cm6 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm6 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31512,7 +31520,7 @@
     },
     {
       "id": "cm6-cv6-drop2-5top-6",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm6 — Fret 3 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31566,7 +31574,7 @@
     },
     {
       "id": "cm6-cv6-drop2-6top-6",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm6 — Fret 3 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31620,7 +31628,7 @@
     },
     {
       "id": "cm6-cv6-drop2-1top-6",
-      "name": "Cm6 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cm6 — Fret 7 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31676,7 +31684,7 @@
     },
     {
       "id": "cm6-drop2-e-shape-6",
-      "name": "Cm6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm6 — E shape — Drop 2 (5th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31730,7 +31738,7 @@
     },
     {
       "id": "cm6-drop2-d-shape-6",
-      "name": "Cm6 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm6 — D shape — Drop 2 (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -31784,7 +31792,7 @@
     },
     {
       "id": "cm6-chordsdb-f1-6",
-      "name": "Cm6 \u2014 Fret 1 \u2014 Extended",
+      "name": "Cm6 — Fret 1 — Extended",
       "chord_quality": "min6",
       "root": "C",
       "category": "extended",
@@ -31865,7 +31873,7 @@
     },
     {
       "id": "cm6-chordsdb-f3-6",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Extended",
+      "name": "Cm6 — Fret 3 — Extended",
       "chord_quality": "min6",
       "root": "C",
       "category": "extended",
@@ -31937,7 +31945,7 @@
     },
     {
       "id": "cmin6-shell-a-shape-6",
-      "name": "Cm6 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — A shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -31987,7 +31995,7 @@
     },
     {
       "id": "cm6-shell-a-shape-6",
-      "name": "Cm6 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm6 — A shape — Shell (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32036,7 +32044,7 @@
     },
     {
       "id": "cm6-shell-e-shape-6",
-      "name": "Cm6 \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm6 — E shape — Shell (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32085,7 +32093,7 @@
     },
     {
       "id": "cm6-shell-d-shape-6",
-      "name": "Cm6 \u2014 D shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — D shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32134,7 +32142,7 @@
     },
     {
       "id": "cm6-shell-e-shape-6-cv6",
-      "name": "Cm6 \u2014 E shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — E shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32185,7 +32193,7 @@
     },
     {
       "id": "cm6-drop2-a-shape-7",
-      "name": "Cm6 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm6 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -32241,7 +32249,7 @@
     },
     {
       "id": "cm6-cv7-drop2-5top-7",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm6 — Fret 3 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -32297,7 +32305,7 @@
     },
     {
       "id": "cm6-cv7-drop2-6top-7",
-      "name": "Cm6 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm6 — Fret 3 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -32353,7 +32361,7 @@
     },
     {
       "id": "cm6-cv7-drop2-1top-7",
-      "name": "Cm6 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cm6 — Fret 7 — Drop 2",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -32411,7 +32419,7 @@
     },
     {
       "id": "cm6-drop2-e-shape-7",
-      "name": "Cm6 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm6 — E shape — Drop 2 (5th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -32467,7 +32475,7 @@
     },
     {
       "id": "cm6-drop2-d-shape-7",
-      "name": "Cm6 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm6 — D shape — Drop 2 (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "drop2",
@@ -32523,7 +32531,7 @@
     },
     {
       "id": "cm6-cv7-shell-7str-7",
-      "name": "Cm6 \u2014 7-str root \u2014 Shell (6th on top)",
+      "name": "Cm6 — 7-str root — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32576,7 +32584,7 @@
     },
     {
       "id": "cmin6-shell-a-shape-7",
-      "name": "Cm6 \u2014 A shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — A shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32628,7 +32636,7 @@
     },
     {
       "id": "cm6-shell-a-shape-7",
-      "name": "Cm6 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm6 — A shape — Shell (b3 on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32679,7 +32687,7 @@
     },
     {
       "id": "cm6-shell-d-shape-7",
-      "name": "Cm6 \u2014 D shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — D shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32730,7 +32738,7 @@
     },
     {
       "id": "cm6-shell-e-shape-7-cv7",
-      "name": "Cm6 \u2014 E shape \u2014 Shell (6th on top)",
+      "name": "Cm6 — E shape — Shell (6th on top)",
       "chord_quality": "min6",
       "root": "C",
       "category": "shell",
@@ -32783,7 +32791,7 @@
     },
     {
       "id": "cm7-cm6-drop2-5top-6",
-      "name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cm7 — Fret 1 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -32839,7 +32847,7 @@
     },
     {
       "id": "cm7-cm6-drop2-b7top-6",
-      "name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm7 — Fret 3 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -32893,7 +32901,7 @@
     },
     {
       "id": "cm7-drop2-a-shape-6-cm6",
-      "name": "Cm7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -32947,7 +32955,7 @@
     },
     {
       "id": "cm7-cm6-drop2-1top-6",
-      "name": "Cm7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Cm7 — Fret 8 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33003,7 +33011,7 @@
     },
     {
       "id": "cm7-drop2-e-shape-6-cm6",
-      "name": "Cm7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33057,7 +33065,7 @@
     },
     {
       "id": "cm7-cm6-drop2-b3top-6",
-      "name": "Cm7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cm7 — Fret 10 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33113,7 +33121,7 @@
     },
     {
       "id": "cm7-drop3-a-shape-6-cm6",
-      "name": "Cm7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "Cm7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop3",
@@ -33167,7 +33175,7 @@
     },
     {
       "id": "cmin7-shell-a-shape-6-cm6",
-      "name": "Cm7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cm7 — A shape — Shell (b7 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -33217,7 +33225,7 @@
     },
     {
       "id": "cm7-shell-a-shape-6-cm6",
-      "name": "Cm7 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm7 — A shape — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -33269,7 +33277,7 @@
     },
     {
       "id": "cm7-shell-d-shape-6-cm6",
-      "name": "Cm7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Cm7 — D shape — Shell (b7 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -33321,7 +33329,7 @@
     },
     {
       "id": "cm7-shell-e-shape-6-cm6",
-      "name": "Cm7 \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm7 — E shape — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -33373,7 +33381,7 @@
     },
     {
       "id": "cm7-cm7-drop2-5top-7",
-      "name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cm7 — Fret 1 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33431,7 +33439,7 @@
     },
     {
       "id": "cm7-cm7-drop2-b7top-7",
-      "name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm7 — Fret 3 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33487,7 +33495,7 @@
     },
     {
       "id": "cm7-drop2-a-shape-7-cm7",
-      "name": "Cm7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33543,7 +33551,7 @@
     },
     {
       "id": "cm7-cm7-drop2-1top-7",
-      "name": "Cm7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Cm7 — Fret 8 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33601,7 +33609,7 @@
     },
     {
       "id": "cm7-drop2-e-shape-7-cm7",
-      "name": "Cm7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33657,7 +33665,7 @@
     },
     {
       "id": "cm7-cm7-drop2-b3top-7",
-      "name": "Cm7 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cm7 — Fret 10 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -33715,7 +33723,7 @@
     },
     {
       "id": "cm7-cm7-drop3-7str-7",
-      "name": "Cm7 \u2014 7-str bass \u2014 Drop 3",
+      "name": "Cm7 — 7-str bass — Drop 3",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop3",
@@ -33767,7 +33775,7 @@
     },
     {
       "id": "cm7-drop3-a-shape-7-cm7",
-      "name": "Cm7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "Cm7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop3",
@@ -33823,7 +33831,7 @@
     },
     {
       "id": "cm7-cm7-shell-7str-7",
-      "name": "Cm7 \u2014 7-str root \u2014 Shell (b3 on top)",
+      "name": "Cm7 — 7-str root — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -33874,7 +33882,7 @@
     },
     {
       "id": "cmin7-cm7-shell-a-7",
-      "name": "Cm7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cm7 — A shape — Shell (b7 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -33925,7 +33933,7 @@
     },
     {
       "id": "cm7-shell-a-shape-7",
-      "name": "Cm7 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm7 — A shape — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -33978,7 +33986,7 @@
     },
     {
       "id": "cm7-shell-d-shape-7-cm7",
-      "name": "Cm7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Cm7 — D shape — Shell (b7 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -34032,7 +34040,7 @@
     },
     {
       "id": "cm7-shell-e-shape-7",
-      "name": "Cm7 \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm7 — E shape — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -34085,7 +34093,7 @@
     },
     {
       "id": "cm7-chordsdb-f1-6",
-      "name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cm7 — Fret 1 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34157,7 +34165,7 @@
     },
     {
       "id": "cm7-cv6-drop2-5top-6",
-      "name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cm7 — Fret 1 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34213,7 +34221,7 @@
     },
     {
       "id": "cminor-chordsdb-f1-6",
-      "name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cm7 — Fret 1 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34288,7 +34296,7 @@
     },
     {
       "id": "cm7-cv6-drop2-b7top-6",
-      "name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm7 — Fret 3 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34342,7 +34350,7 @@
     },
     {
       "id": "cm7-drop2-a-shape-6",
-      "name": "Cm7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34396,7 +34404,7 @@
     },
     {
       "id": "cminor-chordsdb-f3-6",
-      "name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm7 — Fret 3 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34485,7 +34493,7 @@
     },
     {
       "id": "cm7-cv6-drop2-1top-6",
-      "name": "Cm7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Cm7 — Fret 8 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34541,7 +34549,7 @@
     },
     {
       "id": "cm7-drop2-e-shape-6",
-      "name": "Cm7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34595,7 +34603,7 @@
     },
     {
       "id": "cm7-drop2-d-shape-6",
-      "name": "Cm7 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7 — D shape — Drop 2 (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34652,7 +34660,7 @@
     },
     {
       "id": "cm7-drop3-a-shape-6",
-      "name": "Cm7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "Cm7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop3",
@@ -34706,7 +34714,7 @@
     },
     {
       "id": "cmin7-shell-a-shape-6",
-      "name": "Cm7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cm7 — A shape — Shell (b7 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -34756,7 +34764,7 @@
     },
     {
       "id": "cm7-shell-a-shape-6",
-      "name": "Cm7 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm7 — A shape — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -34808,7 +34816,7 @@
     },
     {
       "id": "cm7-shell-d-shape-6",
-      "name": "Cm7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Cm7 — D shape — Shell (b7 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -34860,7 +34868,7 @@
     },
     {
       "id": "cm7-shell-e-shape-6",
-      "name": "Cm7 \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm7 — E shape — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -34912,7 +34920,7 @@
     },
     {
       "id": "cm7-cv7-drop2-5top-7",
-      "name": "Cm7 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Cm7 — Fret 1 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -34970,7 +34978,7 @@
     },
     {
       "id": "cm7-cv7-drop2-b7top-7",
-      "name": "Cm7 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Cm7 — Fret 3 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -35026,7 +35034,7 @@
     },
     {
       "id": "cm7-drop2-a-shape-7",
-      "name": "Cm7 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -35082,7 +35090,7 @@
     },
     {
       "id": "cm7-cv7-drop2-1top-7",
-      "name": "Cm7 \u2014 Fret 8 \u2014 Drop 2",
+      "name": "Cm7 — Fret 8 — Drop 2",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -35140,7 +35148,7 @@
     },
     {
       "id": "cm7-drop2-e-shape-7",
-      "name": "Cm7 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Cm7 — E shape — Drop 2 (5th on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -35196,7 +35204,7 @@
     },
     {
       "id": "cm7-drop2-d-shape-7",
-      "name": "Cm7 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7 — D shape — Drop 2 (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop2",
@@ -35255,7 +35263,7 @@
     },
     {
       "id": "cm7-cv7-drop3-7str-7",
-      "name": "Cm7 \u2014 7-str bass \u2014 Drop 3",
+      "name": "Cm7 — 7-str bass — Drop 3",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop3",
@@ -35307,7 +35315,7 @@
     },
     {
       "id": "cm7-drop3-a-shape-7",
-      "name": "Cm7 \u2014 A shape \u2014 Drop 3 (5th on top)",
+      "name": "Cm7 — A shape — Drop 3 (5th on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "drop3",
@@ -35363,7 +35371,7 @@
     },
     {
       "id": "cm7-cv7-shell-7str-7",
-      "name": "Cm7 \u2014 7-str root \u2014 Shell (b3 on top)",
+      "name": "Cm7 — 7-str root — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -35414,7 +35422,7 @@
     },
     {
       "id": "cmin7-shell-a-shape-7",
-      "name": "Cm7 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cm7 — A shape — Shell (b7 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -35466,7 +35474,7 @@
     },
     {
       "id": "cm7-shell-a-shape-7-cv7",
-      "name": "Cm7 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm7 — A shape — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -35520,7 +35528,7 @@
     },
     {
       "id": "cm7-shell-d-shape-7",
-      "name": "Cm7 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Cm7 — D shape — Shell (b7 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -35574,7 +35582,7 @@
     },
     {
       "id": "cm7-shell-e-shape-7-cv7",
-      "name": "Cm7 \u2014 E shape \u2014 Shell (b3 on top)",
+      "name": "Cm7 — E shape — Shell (b3 on top)",
       "chord_quality": "min7",
       "root": "C",
       "category": "shell",
@@ -35628,7 +35636,7 @@
     },
     {
       "id": "cm7b5-drop2-a-shape-6-cm6",
-      "name": "Cm7b5 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -35683,7 +35691,7 @@
     },
     {
       "id": "cm7b5-cm6-drop2-b7top-6",
-      "name": "Cm7b5 \u2014 Fret 4 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 4 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -35737,7 +35745,7 @@
     },
     {
       "id": "cm7b5-cm6-drop2-1top-6",
-      "name": "Cm7b5 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 7 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -35791,7 +35799,7 @@
     },
     {
       "id": "cm7b5-drop2-e-shape-6-26",
-      "name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "Cm7b5 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -35846,7 +35854,7 @@
     },
     {
       "id": "cm7b5-drop2-e-shape-6-cm6",
-      "name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — E shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -35897,7 +35905,7 @@
     },
     {
       "id": "cmin7b5-cm6-drop2-b3top-6",
-      "name": "Cm7b5 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 10 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -35953,7 +35961,7 @@
     },
     {
       "id": "cm7b5-drop3-a-shape-6-cm6",
-      "name": "Cm7b5 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "name": "Cm7b5 — A shape — Drop 3 (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop3",
@@ -36007,7 +36015,7 @@
     },
     {
       "id": "cmin7b5-shell-a-shape-6-cm6",
-      "name": "Cm7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — A shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36057,7 +36065,7 @@
     },
     {
       "id": "cm7b5-shell-a-shape-6-cm6",
-      "name": "Cm7b5 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm7b5 — A shape — Shell (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36109,7 +36117,7 @@
     },
     {
       "id": "cm7b5-shell-d-shape-6-cm6",
-      "name": "Cm7b5 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — D shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36161,7 +36169,7 @@
     },
     {
       "id": "cm7b5-shell-e-shape-6-cm6",
-      "name": "Cm7b5 \u2014 E shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — E shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36210,7 +36218,7 @@
     },
     {
       "id": "cm7b5-drop2-a-shape-7-cm7",
-      "name": "Cm7b5 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -36267,7 +36275,7 @@
     },
     {
       "id": "cm7b5-cm7-drop2-b7top-7",
-      "name": "Cm7b5 \u2014 Fret 4 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 4 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -36323,7 +36331,7 @@
     },
     {
       "id": "cm7b5-cm7-drop2-1top-7",
-      "name": "Cm7b5 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 7 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -36379,7 +36387,7 @@
     },
     {
       "id": "cm7b5-drop2-e-shape-6-27",
-      "name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "Cm7b5 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -36436,7 +36444,7 @@
     },
     {
       "id": "cm7b5-drop2-e-shape-7-cm7",
-      "name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — E shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -36489,7 +36497,7 @@
     },
     {
       "id": "cmin7b5-cm7-drop2-b3top-7",
-      "name": "Cm7b5 \u2014 Fret 10 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 10 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -36547,7 +36555,7 @@
     },
     {
       "id": "cm7b5-drop3-a-shape-7-cm7",
-      "name": "Cm7b5 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "name": "Cm7b5 — A shape — Drop 3 (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop3",
@@ -36603,7 +36611,7 @@
     },
     {
       "id": "cm7b5-cm7-shell-7str-7",
-      "name": "Cm7b5 \u2014 7-str root \u2014 Shell (b5 on top)",
+      "name": "Cm7b5 — 7-str root — Shell (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36656,7 +36664,7 @@
     },
     {
       "id": "cmin7b5-cm7-shell-a-7",
-      "name": "Cm7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — A shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36707,7 +36715,7 @@
     },
     {
       "id": "cm7b5-shell-a-shape-7-cm7",
-      "name": "Cm7b5 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm7b5 — A shape — Shell (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36761,7 +36769,7 @@
     },
     {
       "id": "cm7b5-shell-d-shape-7-cm7",
-      "name": "Cm7b5 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — D shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36815,7 +36823,7 @@
     },
     {
       "id": "cm7b5-shell-e-shape-7",
-      "name": "Cm7b5 \u2014 E shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — E shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -36865,7 +36873,7 @@
     },
     {
       "id": "cm7b5-drop2-a-shape-6",
-      "name": "Cm7b5 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -36920,7 +36928,7 @@
     },
     {
       "id": "cm7b5-cv6-drop2-b7top-6",
-      "name": "Cm7b5 \u2014 Fret 4 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 4 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -36974,7 +36982,7 @@
     },
     {
       "id": "cm7b5-cv6-drop2-1top-6",
-      "name": "Cm7b5 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 7 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37028,7 +37036,7 @@
     },
     {
       "id": "cm7b5-drop2-e-shape-6-2",
-      "name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "Cm7b5 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37083,7 +37091,7 @@
     },
     {
       "id": "cm7b5-drop2-e-shape-6",
-      "name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — E shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37134,7 +37142,7 @@
     },
     {
       "id": "cm7b5-drop2-d-shape-6",
-      "name": "Cm7b5 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — D shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37191,7 +37199,7 @@
     },
     {
       "id": "cm7b5-drop3-a-shape-6",
-      "name": "Cm7b5 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "name": "Cm7b5 — A shape — Drop 3 (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop3",
@@ -37245,7 +37253,7 @@
     },
     {
       "id": "cmin7b5-shell-a-shape-6",
-      "name": "Cm7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — A shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -37295,7 +37303,7 @@
     },
     {
       "id": "cm7b5-shell-a-shape-6",
-      "name": "Cm7b5 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm7b5 — A shape — Shell (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -37347,7 +37355,7 @@
     },
     {
       "id": "cm7b5-shell-d-shape-6",
-      "name": "Cm7b5 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — D shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -37399,7 +37407,7 @@
     },
     {
       "id": "cm7b5-shell-e-shape-6",
-      "name": "Cm7b5 \u2014 E shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — E shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -37448,7 +37456,7 @@
     },
     {
       "id": "cm7b5-drop2-a-shape-7",
-      "name": "Cm7b5 \u2014 A shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — A shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37505,7 +37513,7 @@
     },
     {
       "id": "cm7b5-cv7-drop2-b7top-7",
-      "name": "Cm7b5 \u2014 Fret 4 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 4 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37561,7 +37569,7 @@
     },
     {
       "id": "cm7b5-cv7-drop2-1top-7",
-      "name": "Cm7b5 \u2014 Fret 7 \u2014 Drop 2",
+      "name": "Cm7b5 — Fret 7 — Drop 2",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37617,7 +37625,7 @@
     },
     {
       "id": "cm7b5-drop2-e-shape-7-2",
-      "name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b5 on top)",
+      "name": "Cm7b5 — E shape — Drop 2 (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37674,7 +37682,7 @@
     },
     {
       "id": "cm7b5-drop2-e-shape-7",
-      "name": "Cm7b5 \u2014 E shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — E shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37727,7 +37735,7 @@
     },
     {
       "id": "cm7b5-drop2-d-shape-7",
-      "name": "Cm7b5 \u2014 D shape \u2014 Drop 2 (b3 on top)",
+      "name": "Cm7b5 — D shape — Drop 2 (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop2",
@@ -37786,7 +37794,7 @@
     },
     {
       "id": "cm7b5-drop3-a-shape-7",
-      "name": "Cm7b5 \u2014 A shape \u2014 Drop 3 (b5 on top)",
+      "name": "Cm7b5 — A shape — Drop 3 (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "drop3",
@@ -37842,7 +37850,7 @@
     },
     {
       "id": "cm7b5-cv7-shell-7str-7",
-      "name": "Cm7b5 \u2014 7-str root \u2014 Shell (b5 on top)",
+      "name": "Cm7b5 — 7-str root — Shell (b5 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -37895,7 +37903,7 @@
     },
     {
       "id": "cmin7b5-shell-a-shape-7",
-      "name": "Cm7b5 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — A shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -37947,7 +37955,7 @@
     },
     {
       "id": "cm7b5-shell-a-shape-7",
-      "name": "Cm7b5 \u2014 A shape \u2014 Shell (b3 on top)",
+      "name": "Cm7b5 — A shape — Shell (b3 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -38001,7 +38009,7 @@
     },
     {
       "id": "cm7b5-shell-d-shape-7",
-      "name": "Cm7b5 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — D shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -38055,7 +38063,7 @@
     },
     {
       "id": "cm7b5-shell-e-shape-7-cv7",
-      "name": "Cm7b5 \u2014 E shape \u2014 Shell (b7 on top)",
+      "name": "Cm7b5 — E shape — Shell (b7 on top)",
       "chord_quality": "min7b5",
       "root": "C",
       "category": "shell",
@@ -38106,7 +38114,7 @@
     },
     {
       "id": "cmin9-drop2-d-shape-6-cm6",
-      "name": "Cm9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cm9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "drop2",
@@ -38159,7 +38167,7 @@
     },
     {
       "id": "cm9-extended-e-shape-6-cm6",
-      "name": "Cm9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cm9 — E shape — Extended (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "extended",
@@ -38218,7 +38226,7 @@
     },
     {
       "id": "cm9-shell-a-shape-6-cm6",
-      "name": "Cm9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "Cm9 — A shape — Shell (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "shell",
@@ -38272,7 +38280,7 @@
     },
     {
       "id": "cm9-shell-e-shape-6-cm6",
-      "name": "Cm9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "Cm9 — E shape — Shell (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "shell",
@@ -38326,7 +38334,7 @@
     },
     {
       "id": "cmin9-drop2-d-shape-7-cm7",
-      "name": "Cm9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cm9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "drop2",
@@ -38381,7 +38389,7 @@
     },
     {
       "id": "cm9-extended-e-shape-7-cm7",
-      "name": "Cm9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cm9 — E shape — Extended (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "extended",
@@ -38442,7 +38450,7 @@
     },
     {
       "id": "cm9-shell-a-shape-7-cm7",
-      "name": "Cm9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "Cm9 — A shape — Shell (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "shell",
@@ -38498,7 +38506,7 @@
     },
     {
       "id": "cm9-shell-e-shape-7-cm7",
-      "name": "Cm9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "Cm9 — E shape — Shell (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "shell",
@@ -38554,7 +38562,7 @@
     },
     {
       "id": "cmin9-drop2-d-shape-6",
-      "name": "Cm9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cm9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "drop2",
@@ -38607,7 +38615,7 @@
     },
     {
       "id": "cm9-chordsdb-f1-6",
-      "name": "Cm9 \u2014 Fret 1 \u2014 Extended",
+      "name": "Cm9 — Fret 1 — Extended",
       "chord_quality": "min9",
       "root": "C",
       "category": "extended",
@@ -38688,7 +38696,7 @@
     },
     {
       "id": "cm9-chordsdb-f3-6",
-      "name": "Cm9 \u2014 Fret 3 \u2014 Extended",
+      "name": "Cm9 — Fret 3 — Extended",
       "chord_quality": "min9",
       "root": "C",
       "category": "extended",
@@ -38763,7 +38771,7 @@
     },
     {
       "id": "cm9-extended-e-shape-6",
-      "name": "Cm9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cm9 — E shape — Extended (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "extended",
@@ -38822,7 +38830,7 @@
     },
     {
       "id": "cm9-shell-a-shape-6",
-      "name": "Cm9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "Cm9 — A shape — Shell (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "shell",
@@ -38876,7 +38884,7 @@
     },
     {
       "id": "cm9-shell-e-shape-6",
-      "name": "Cm9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "Cm9 — E shape — Shell (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "shell",
@@ -38930,7 +38938,7 @@
     },
     {
       "id": "cmin9-drop2-d-shape-7",
-      "name": "Cm9 \u2014 D shape \u2014 Drop 2 (9th on top)",
+      "name": "Cm9 — D shape — Drop 2 (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "drop2",
@@ -38985,7 +38993,7 @@
     },
     {
       "id": "cm9-extended-e-shape-7",
-      "name": "Cm9 \u2014 E shape \u2014 Extended (9th on top)",
+      "name": "Cm9 — E shape — Extended (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "extended",
@@ -39046,7 +39054,7 @@
     },
     {
       "id": "cm9-shell-a-shape-7",
-      "name": "Cm9 \u2014 A shape \u2014 Shell (9th on top)",
+      "name": "Cm9 — A shape — Shell (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "shell",
@@ -39102,7 +39110,7 @@
     },
     {
       "id": "cm9-shell-e-shape-7",
-      "name": "Cm9 \u2014 E shape \u2014 Shell (9th on top)",
+      "name": "Cm9 — E shape — Shell (9th on top)",
       "chord_quality": "min9",
       "root": "C",
       "category": "shell",
@@ -39158,7 +39166,7 @@
     },
     {
       "id": "cquartal-a-lower-6-cm6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (root on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39199,7 +39207,7 @@
     },
     {
       "id": "cquartal-bb-lower-6-cm6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (9th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39254,7 +39262,7 @@
     },
     {
       "id": "cquartal-d-upper-6-cm6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39300,7 +39308,7 @@
     },
     {
       "id": "cquartal-eb-upper-6-cm6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39357,7 +39365,7 @@
     },
     {
       "id": "cquartal-f-upper-6-cm6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39412,7 +39420,7 @@
     },
     {
       "id": "cquartal-quartal-a-shape-6-cm6",
-      "name": "Cquartal \u2014 A shape \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — A shape — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39468,7 +39476,7 @@
     },
     {
       "id": "cquartal-d-lower-6-cm6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39523,7 +39531,7 @@
     },
     {
       "id": "cquartal-g-upper-6-cm6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39578,7 +39586,7 @@
     },
     {
       "id": "cquartal-eb-lower-6-cm6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39635,7 +39643,7 @@
     },
     {
       "id": "cquartal-a-upper-6-cm6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (root on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39690,7 +39698,7 @@
     },
     {
       "id": "cquartal-bb-upper-6-cm6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (9th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39745,7 +39753,7 @@
     },
     {
       "id": "cquartal-f-lower-6-cm6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39800,7 +39808,7 @@
     },
     {
       "id": "cquartal-g-lower-6-cm6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39855,7 +39863,7 @@
     },
     {
       "id": "cquartal-quartal-d-shape-6-cm6",
-      "name": "Cquartal \u2014 D shape \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — D shape — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39911,7 +39919,7 @@
     },
     {
       "id": "cquartal-a-lower-7-cm7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (root on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -39954,7 +39962,7 @@
     },
     {
       "id": "cquartal-bb-lower-7-cm7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (9th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40011,7 +40019,7 @@
     },
     {
       "id": "cquartal-c-7str-low-7-cm7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40068,7 +40076,7 @@
     },
     {
       "id": "cquartal-d-upper-7-cm7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40116,7 +40124,7 @@
     },
     {
       "id": "cquartal-eb-upper-7-cm7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40175,7 +40183,7 @@
     },
     {
       "id": "cquartal-d-7str-low-7-cm7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40232,7 +40240,7 @@
     },
     {
       "id": "cquartal-f-upper-7-cm7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40289,7 +40297,7 @@
     },
     {
       "id": "cquartal-quartal-a-shape-7-cm7",
-      "name": "Cquartal \u2014 A shape \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — A shape — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40347,7 +40355,7 @@
     },
     {
       "id": "cquartal-d-lower-7-cm7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40404,7 +40412,7 @@
     },
     {
       "id": "cquartal-eb-7str-low-7-cm7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40461,7 +40469,7 @@
     },
     {
       "id": "cquartal-g-upper-7-cm7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40518,7 +40526,7 @@
     },
     {
       "id": "cquartal-eb-lower-7-cm7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40577,7 +40585,7 @@
     },
     {
       "id": "cquartal-f-7str-low-7-cm7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40634,7 +40642,7 @@
     },
     {
       "id": "cquartal-a-upper-7-cm7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (root on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40691,7 +40699,7 @@
     },
     {
       "id": "cquartal-bb-upper-7-cm7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (9th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40748,7 +40756,7 @@
     },
     {
       "id": "cquartal-f-lower-7-cm7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40805,7 +40813,7 @@
     },
     {
       "id": "cquartal-g-7str-low-7-cm7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40862,7 +40870,7 @@
     },
     {
       "id": "cquartal-g-lower-7-cm7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40919,7 +40927,7 @@
     },
     {
       "id": "cquartal-quartal-d-shape-7-cm7",
-      "name": "Cquartal \u2014 D shape \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — D shape — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -40977,7 +40985,7 @@
     },
     {
       "id": "cquartal-a-lower-6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (root on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41018,7 +41026,7 @@
     },
     {
       "id": "cquartal-bb-lower-6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (9th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41073,7 +41081,7 @@
     },
     {
       "id": "cquartal-d-upper-6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41119,7 +41127,7 @@
     },
     {
       "id": "cquartal-eb-upper-6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41176,7 +41184,7 @@
     },
     {
       "id": "cquartal-f-upper-6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41231,7 +41239,7 @@
     },
     {
       "id": "cquartal-quartal-a-shape-6",
-      "name": "Cquartal \u2014 A shape \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — A shape — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41287,7 +41295,7 @@
     },
     {
       "id": "cquartal-d-lower-6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41342,7 +41350,7 @@
     },
     {
       "id": "cquartal-g-upper-6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41397,7 +41405,7 @@
     },
     {
       "id": "cquartal-eb-lower-6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41454,7 +41462,7 @@
     },
     {
       "id": "cquartal-a-upper-6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (root on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41509,7 +41517,7 @@
     },
     {
       "id": "cquartal-bb-upper-6",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (9th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41564,7 +41572,7 @@
     },
     {
       "id": "cquartal-f-lower-6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41619,7 +41627,7 @@
     },
     {
       "id": "cquartal-g-lower-6",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41674,7 +41682,7 @@
     },
     {
       "id": "cquartal-quartal-d-shape-6",
-      "name": "Cquartal \u2014 D shape \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — D shape — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41730,7 +41738,7 @@
     },
     {
       "id": "cquartal-a-lower-7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (root on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (root on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41773,7 +41781,7 @@
     },
     {
       "id": "cquartal-bb-lower-7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (9th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (9th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41830,7 +41838,7 @@
     },
     {
       "id": "cquartal-c-7str-low-7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41887,7 +41895,7 @@
     },
     {
       "id": "cquartal-d-upper-7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41935,7 +41943,7 @@
     },
     {
       "id": "cquartal-eb-upper-7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -41994,7 +42002,7 @@
     },
     {
       "id": "cquartal-d-7str-low-7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42051,7 +42059,7 @@
     },
     {
       "id": "cquartal-f-upper-7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42108,7 +42116,7 @@
     },
     {
       "id": "cquartal-quartal-a-shape-7",
-      "name": "Cquartal \u2014 A shape \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — A shape — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42166,7 +42174,7 @@
     },
     {
       "id": "cquartal-d-lower-7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (4th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (4th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42223,7 +42231,7 @@
     },
     {
       "id": "cquartal-eb-7str-low-7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42280,7 +42288,7 @@
     },
     {
       "id": "cquartal-g-upper-7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42337,7 +42345,7 @@
     },
     {
       "id": "cquartal-eb-lower-7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (5th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (5th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42396,7 +42404,7 @@
     },
     {
       "id": "cquartal-f-7str-low-7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42453,7 +42461,7 @@
     },
     {
       "id": "cquartal-a-upper-7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (root on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (root on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42510,7 +42518,7 @@
     },
     {
       "id": "cquartal-bb-upper-7",
-      "name": "Cquartal \u2014 Str 1-2-3-4 \u2014 Quartal (9th on top)",
+      "name": "Cquartal — Str 1-2-3-4 — Quartal (9th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42567,7 +42575,7 @@
     },
     {
       "id": "cquartal-f-lower-7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (13th on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (13th on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42624,7 +42632,7 @@
     },
     {
       "id": "cquartal-g-7str-low-7",
-      "name": "Cquartal \u2014 Str 4-5-6-7 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 4-5-6-7 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42681,7 +42689,7 @@
     },
     {
       "id": "cquartal-g-lower-7",
-      "name": "Cquartal \u2014 Str 2-3-4-5 \u2014 Quartal (b7 on top)",
+      "name": "Cquartal — Str 2-3-4-5 — Quartal (b7 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42738,7 +42746,7 @@
     },
     {
       "id": "cquartal-quartal-d-shape-7",
-      "name": "Cquartal \u2014 D shape \u2014 Quartal (b3 on top)",
+      "name": "Cquartal — D shape — Quartal (b3 on top)",
       "chord_quality": "quartal",
       "root": "C",
       "category": "quartal",
@@ -42796,7 +42804,7 @@
     },
     {
       "id": "csus2-drop2-a-shape-6-cm6",
-      "name": "Csus2 \u2014 A shape \u2014 Drop 2 (2nd on top)",
+      "name": "Csus2 — A shape — Drop 2 (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -42850,7 +42858,7 @@
     },
     {
       "id": "csus2-drop2-e-shape-6-cm6",
-      "name": "Csus2 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Csus2 — E shape — Drop 2 (5th on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -42904,7 +42912,7 @@
     },
     {
       "id": "csus2-drop2-d-shape-6-cm6",
-      "name": "Csus2 \u2014 D shape \u2014 Drop 2 (2nd on top)",
+      "name": "Csus2 — D shape — Drop 2 (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -42958,7 +42966,7 @@
     },
     {
       "id": "csus2-shell-a-shape-6-cm6",
-      "name": "Csus2 \u2014 A shape \u2014 Shell (2nd on top)",
+      "name": "Csus2 — A shape — Shell (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43007,7 +43015,7 @@
     },
     {
       "id": "csus2-shell-d-shape-6-cm6",
-      "name": "Csus2 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Csus2 — D shape — Shell (b7 on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43056,7 +43064,7 @@
     },
     {
       "id": "csus2-shell-e-shape-6-cm6",
-      "name": "Csus2 \u2014 E shape \u2014 Shell (2nd on top)",
+      "name": "Csus2 — E shape — Shell (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43105,7 +43113,7 @@
     },
     {
       "id": "csus2-drop2-a-shape-7-cm7",
-      "name": "Csus2 \u2014 A shape \u2014 Drop 2 (2nd on top)",
+      "name": "Csus2 — A shape — Drop 2 (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -43161,7 +43169,7 @@
     },
     {
       "id": "csus2-drop2-e-shape-7-cm7",
-      "name": "Csus2 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Csus2 — E shape — Drop 2 (5th on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -43217,7 +43225,7 @@
     },
     {
       "id": "csus2-drop2-d-shape-7-cm7",
-      "name": "Csus2 \u2014 D shape \u2014 Drop 2 (2nd on top)",
+      "name": "Csus2 — D shape — Drop 2 (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -43273,7 +43281,7 @@
     },
     {
       "id": "csus2-shell-a-shape-7-cm7",
-      "name": "Csus2 \u2014 A shape \u2014 Shell (2nd on top)",
+      "name": "Csus2 — A shape — Shell (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43324,7 +43332,7 @@
     },
     {
       "id": "csus2-shell-d-shape-7-cm7",
-      "name": "Csus2 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Csus2 — D shape — Shell (b7 on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43375,7 +43383,7 @@
     },
     {
       "id": "csus2-shell-e-shape-7-cm7",
-      "name": "Csus2 \u2014 E shape \u2014 Shell (2nd on top)",
+      "name": "Csus2 — E shape — Shell (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43426,7 +43434,7 @@
     },
     {
       "id": "csus2-drop2-a-shape-6",
-      "name": "Csus2 \u2014 A shape \u2014 Drop 2 (2nd on top)",
+      "name": "Csus2 — A shape — Drop 2 (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -43480,7 +43488,7 @@
     },
     {
       "id": "csus2-drop2-e-shape-6",
-      "name": "Csus2 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Csus2 — E shape — Drop 2 (5th on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -43534,7 +43542,7 @@
     },
     {
       "id": "csus2-drop2-d-shape-6",
-      "name": "Csus2 \u2014 D shape \u2014 Drop 2 (2nd on top)",
+      "name": "Csus2 — D shape — Drop 2 (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -43588,7 +43596,7 @@
     },
     {
       "id": "csus2-chordsdb-f1-6",
-      "name": "Csus2 \u2014 Fret 1 \u2014 Extended",
+      "name": "Csus2 — Fret 1 — Extended",
       "chord_quality": "sus2",
       "root": "C",
       "category": "extended",
@@ -43656,7 +43664,7 @@
     },
     {
       "id": "csus2-chordsdb-f3-6",
-      "name": "Csus2 \u2014 Fret 3 \u2014 Extended",
+      "name": "Csus2 — Fret 3 — Extended",
       "chord_quality": "sus2",
       "root": "C",
       "category": "extended",
@@ -43724,7 +43732,7 @@
     },
     {
       "id": "csus2-shell-a-shape-6",
-      "name": "Csus2 \u2014 A shape \u2014 Shell (2nd on top)",
+      "name": "Csus2 — A shape — Shell (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43773,7 +43781,7 @@
     },
     {
       "id": "csus2-shell-d-shape-6",
-      "name": "Csus2 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Csus2 — D shape — Shell (b7 on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43822,7 +43830,7 @@
     },
     {
       "id": "csus2-shell-e-shape-6",
-      "name": "Csus2 \u2014 E shape \u2014 Shell (2nd on top)",
+      "name": "Csus2 — E shape — Shell (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -43871,7 +43879,7 @@
     },
     {
       "id": "csus2-drop2-a-shape-7",
-      "name": "Csus2 \u2014 A shape \u2014 Drop 2 (2nd on top)",
+      "name": "Csus2 — A shape — Drop 2 (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -43927,7 +43935,7 @@
     },
     {
       "id": "csus2-drop2-e-shape-7",
-      "name": "Csus2 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Csus2 — E shape — Drop 2 (5th on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -43983,7 +43991,7 @@
     },
     {
       "id": "csus2-drop2-d-shape-7",
-      "name": "Csus2 \u2014 D shape \u2014 Drop 2 (2nd on top)",
+      "name": "Csus2 — D shape — Drop 2 (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "drop2",
@@ -44039,7 +44047,7 @@
     },
     {
       "id": "csus2-shell-a-shape-7",
-      "name": "Csus2 \u2014 A shape \u2014 Shell (2nd on top)",
+      "name": "Csus2 — A shape — Shell (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -44090,7 +44098,7 @@
     },
     {
       "id": "csus2-shell-d-shape-7",
-      "name": "Csus2 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Csus2 — D shape — Shell (b7 on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -44141,7 +44149,7 @@
     },
     {
       "id": "csus2-shell-e-shape-7",
-      "name": "Csus2 \u2014 E shape \u2014 Shell (2nd on top)",
+      "name": "Csus2 — E shape — Shell (2nd on top)",
       "chord_quality": "sus2",
       "root": "C",
       "category": "shell",
@@ -44192,7 +44200,7 @@
     },
     {
       "id": "csus4-drop2-a-shape-6-cm6",
-      "name": "Csus4 \u2014 A shape \u2014 Drop 2 (4th on top)",
+      "name": "Csus4 — A shape — Drop 2 (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -44246,7 +44254,7 @@
     },
     {
       "id": "csus4-drop2-e-shape-6-cm6",
-      "name": "Csus4 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Csus4 — E shape — Drop 2 (5th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -44300,7 +44308,7 @@
     },
     {
       "id": "csus4-drop2-d-shape-6-cm6",
-      "name": "Csus4 \u2014 D shape \u2014 Drop 2 (4th on top)",
+      "name": "Csus4 — D shape — Drop 2 (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -44354,7 +44362,7 @@
     },
     {
       "id": "csus4-cm6-shell-a-6",
-      "name": "Csus4 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Csus4 — A shape — Shell (b7 on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44402,7 +44410,7 @@
     },
     {
       "id": "csus4-shell-a-shape-6-cm6",
-      "name": "Csus4 \u2014 A shape \u2014 Shell (4th on top)",
+      "name": "Csus4 — A shape — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44451,7 +44459,7 @@
     },
     {
       "id": "csus4-shell-e-shape-6-cm6",
-      "name": "Csus4 \u2014 E shape \u2014 Shell (4th on top)",
+      "name": "Csus4 — E shape — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44500,7 +44508,7 @@
     },
     {
       "id": "csus4-shell-d-shape-6-cm6",
-      "name": "Csus4 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Csus4 — D shape — Shell (b7 on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44549,7 +44557,7 @@
     },
     {
       "id": "csus4-drop2-a-shape-7-cm7",
-      "name": "Csus4 \u2014 A shape \u2014 Drop 2 (4th on top)",
+      "name": "Csus4 — A shape — Drop 2 (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -44605,7 +44613,7 @@
     },
     {
       "id": "csus4-drop2-e-shape-7-cm7",
-      "name": "Csus4 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Csus4 — E shape — Drop 2 (5th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -44661,7 +44669,7 @@
     },
     {
       "id": "csus4-drop2-d-shape-7-cm7",
-      "name": "Csus4 \u2014 D shape \u2014 Drop 2 (4th on top)",
+      "name": "Csus4 — D shape — Drop 2 (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -44717,7 +44725,7 @@
     },
     {
       "id": "csus4-cm7-shell-7str-7",
-      "name": "Csus4 \u2014 7-str root \u2014 Shell (4th on top)",
+      "name": "Csus4 — 7-str root — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44768,7 +44776,7 @@
     },
     {
       "id": "csus4-cm7-shell-a-7",
-      "name": "Csus4 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Csus4 — A shape — Shell (b7 on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44817,7 +44825,7 @@
     },
     {
       "id": "csus4-shell-a-shape-7-cm7",
-      "name": "Csus4 \u2014 A shape \u2014 Shell (4th on top)",
+      "name": "Csus4 — A shape — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44868,7 +44876,7 @@
     },
     {
       "id": "csus4-shell-e-shape-7-cm7",
-      "name": "Csus4 \u2014 E shape \u2014 Shell (4th on top)",
+      "name": "Csus4 — E shape — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44919,7 +44927,7 @@
     },
     {
       "id": "csus4-shell-d-shape-7-cm7",
-      "name": "Csus4 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Csus4 — D shape — Shell (b7 on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -44970,7 +44978,7 @@
     },
     {
       "id": "csus4-chordsdb-f1-6",
-      "name": "Csus4 \u2014 Fret 1 \u2014 Drop 2",
+      "name": "Csus4 — Fret 1 — Drop 2",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -45045,7 +45053,7 @@
     },
     {
       "id": "csus4-chordsdb-f3-6",
-      "name": "Csus4 \u2014 Fret 3 \u2014 Drop 2",
+      "name": "Csus4 — Fret 3 — Drop 2",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -45134,7 +45142,7 @@
     },
     {
       "id": "csus4-drop2-a-shape-6",
-      "name": "Csus4 \u2014 A shape \u2014 Drop 2 (4th on top)",
+      "name": "Csus4 — A shape — Drop 2 (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -45188,7 +45196,7 @@
     },
     {
       "id": "csus4-drop2-e-shape-6",
-      "name": "Csus4 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Csus4 — E shape — Drop 2 (5th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -45242,7 +45250,7 @@
     },
     {
       "id": "csus4-drop2-d-shape-6",
-      "name": "Csus4 \u2014 D shape \u2014 Drop 2 (4th on top)",
+      "name": "Csus4 — D shape — Drop 2 (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -45296,7 +45304,7 @@
     },
     {
       "id": "csus4-cv6-shell-a-6",
-      "name": "Csus4 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Csus4 — A shape — Shell (b7 on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -45344,7 +45352,7 @@
     },
     {
       "id": "csus4-shell-a-shape-6",
-      "name": "Csus4 \u2014 A shape \u2014 Shell (4th on top)",
+      "name": "Csus4 — A shape — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -45393,7 +45401,7 @@
     },
     {
       "id": "csus4-shell-e-shape-6",
-      "name": "Csus4 \u2014 E shape \u2014 Shell (4th on top)",
+      "name": "Csus4 — E shape — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -45442,7 +45450,7 @@
     },
     {
       "id": "csus4-shell-d-shape-6",
-      "name": "Csus4 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Csus4 — D shape — Shell (b7 on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -45491,7 +45499,7 @@
     },
     {
       "id": "csus4-drop2-a-shape-7",
-      "name": "Csus4 \u2014 A shape \u2014 Drop 2 (4th on top)",
+      "name": "Csus4 — A shape — Drop 2 (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -45547,7 +45555,7 @@
     },
     {
       "id": "csus4-drop2-e-shape-7",
-      "name": "Csus4 \u2014 E shape \u2014 Drop 2 (5th on top)",
+      "name": "Csus4 — E shape — Drop 2 (5th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -45603,7 +45611,7 @@
     },
     {
       "id": "csus4-drop2-d-shape-7",
-      "name": "Csus4 \u2014 D shape \u2014 Drop 2 (4th on top)",
+      "name": "Csus4 — D shape — Drop 2 (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "drop2",
@@ -45659,7 +45667,7 @@
     },
     {
       "id": "csus4-cv7-shell-7str-7",
-      "name": "Csus4 \u2014 7-str root \u2014 Shell (4th on top)",
+      "name": "Csus4 — 7-str root — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -45710,7 +45718,7 @@
     },
     {
       "id": "csus4-cv7-shell-a-7",
-      "name": "Csus4 \u2014 A shape \u2014 Shell (b7 on top)",
+      "name": "Csus4 — A shape — Shell (b7 on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -45760,7 +45768,7 @@
     },
     {
       "id": "csus4-shell-a-shape-7",
-      "name": "Csus4 \u2014 A shape \u2014 Shell (4th on top)",
+      "name": "Csus4 — A shape — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -45811,7 +45819,7 @@
     },
     {
       "id": "csus4-shell-e-shape-7",
-      "name": "Csus4 \u2014 E shape \u2014 Shell (4th on top)",
+      "name": "Csus4 — E shape — Shell (4th on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",
@@ -45862,7 +45870,7 @@
     },
     {
       "id": "csus4-shell-d-shape-7",
-      "name": "Csus4 \u2014 D shape \u2014 Shell (b7 on top)",
+      "name": "Csus4 — D shape — Shell (b7 on top)",
       "chord_quality": "sus4",
       "root": "C",
       "category": "shell",

--- a/schema/voicings.schema.json
+++ b/schema/voicings.schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "required": ["voicings"],
   "properties": {
+    "manifest": {
+      "$ref": "#/$defs/manifest",
+      "description": "#593: top-level provenance manifest, parallel to engine-rules-bundle's manifest.json. Optional during rollout — once Ellington's sync_voicings is updated to require the manifest, this becomes required."
+    },
     "voicings": {
       "type": "array",
       "items": {
@@ -13,6 +17,39 @@
     }
   },
   "$defs": {
+    "manifest": {
+      "description": "Provenance manifest for the voicings corpus. Mirrors the engine-rules-bundle manifest shape so downstream consumers can verify (plugin_commit_sha, bundle_version) for reproducible idempotent syncs.",
+      "type": "object",
+      "required": ["bundle_version", "schema_version", "total_voicings"],
+      "properties": {
+        "bundle_version": {
+          "type": "string",
+          "description": "Semver of this voicings-corpus state, e.g. \"2.3.0\". Mirrors the plugin release the corpus shipped in. Bump when voicings are added/removed/edited; consumers key idempotence on (plugin_commit_sha, bundle_version)."
+        },
+        "schema_version": {
+          "type": "string",
+          "description": "Schema generation. Currently \"voicings-v1\"; bump on breaking schema changes."
+        },
+        "plugin_commit_sha": {
+          "anyOf": [{ "type": "string" }, { "type": "null" }],
+          "description": "Source-of-truth git commit SHA the corpus was published at. Filled at release time by the build workflow; null in committed source (chicken-and-egg — a file can't contain its own commit SHA). Consumers SHOULD fall back to deriving from the git ref they pulled when null."
+        },
+        "built_at": {
+          "anyOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }],
+          "description": "ISO-8601 timestamp the corpus was last bundled. Null in committed source; filled at release time."
+        },
+        "total_voicings": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Count of entries in voicings[]. Validated by CI to match actual array length."
+        },
+        "min_consumer_version": {
+          "type": "string",
+          "description": "Minimum sync_voicings consumer version that understands this corpus shape. Forward-compat guard (Hyrum's-law) — older consumers refuse to ingest."
+        }
+      },
+      "additionalProperties": true
+    },
     "voicing": {
       "type": "object",
       "required": [

--- a/tests/test_voicings_manifest.py
+++ b/tests/test_voicings_manifest.py
@@ -1,0 +1,91 @@
+"""#593 — voicings.json top-level manifest contract.
+
+Asserts the manifest block is present, schema-shaped, and that
+`total_voicings` stays in sync with the actual `voicings[]` length.
+The latter catches the most common drift mode: a voicing gets added/
+removed without bumping the count.
+
+See plugin/docs/engine-rules-firing-spec.md for the consumer-contract
+pattern this mirrors (engine-rules-bundle manifest.json).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "schema" / "voicings.schema.json"
+DATA_PATH = REPO_ROOT / "plugin" / "data" / "voicings.json"
+
+
+@pytest.fixture(scope="module")
+def data():
+    return json.loads(DATA_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def schema():
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_present(data):
+    assert "manifest" in data, "voicings.json missing top-level manifest block (#593)"
+    assert isinstance(data["manifest"], dict)
+
+
+def test_manifest_has_required_fields(data):
+    required = {"bundle_version", "schema_version", "total_voicings"}
+    actual = set(data["manifest"].keys())
+    missing = required - actual
+    assert not missing, f"manifest missing required fields: {missing}"
+
+
+def test_total_voicings_matches_array_length(data):
+    """The most common drift mode: voicings added/removed but the
+    manifest count never gets bumped."""
+    declared = data["manifest"]["total_voicings"]
+    actual = len(data["voicings"])
+    assert declared == actual, (
+        f"manifest.total_voicings={declared} but voicings[] has {actual} entries — "
+        "bump the manifest after any add/remove"
+    )
+
+
+def test_schema_version_is_known(data):
+    """Sanity check on schema_version. Currently only voicings-v1; bump on breaking change."""
+    assert data["manifest"]["schema_version"] == "voicings-v1", (
+        "Unknown schema_version; spec change requires consumer-side migration"
+    )
+
+
+def test_committed_source_has_null_commit_sha_and_built_at(data):
+    """Per the manifest contract: plugin_commit_sha and built_at are null in
+    committed source (chicken-and-egg) and filled at release time. If they're
+    non-null in the committed file, something's gone wrong — possibly a stale
+    release artifact got committed."""
+    sha = data["manifest"].get("plugin_commit_sha")
+    built = data["manifest"].get("built_at")
+    assert sha is None, (
+        f"manifest.plugin_commit_sha should be null in committed source, got {sha!r} — "
+        "release-time fill artifact got committed?"
+    )
+    assert built is None, (
+        f"manifest.built_at should be null in committed source, got {built!r}"
+    )
+
+
+def test_full_voicings_schema_validates(data, schema):
+    """The whole file (manifest + voicings) validates against the schema."""
+    jsonschema.validate(instance=data, schema=schema)
+
+
+def test_manifest_min_consumer_version_present(data):
+    """min_consumer_version is the forward-compat guard (Hyrum's-law). Optional
+    in the schema but should be present in practice so consumers can refuse
+    incompatible corpus versions."""
+    assert "min_consumer_version" in data["manifest"], (
+        "min_consumer_version missing — set the forward-compat floor"
+    )


### PR DESCRIPTION
## Summary

Adds a top-level \`manifest\` block to \`voicings.json\` parallel to engine-rules-bundle's \`manifest.json\` shape so Ellington's \`sync_voicings\` (and any future consumer) can verify provenance reproducibly and key idempotence on \`(plugin_commit_sha, bundle_version)\` instead of synthesizing from file mtime.

Backward-compatible rollout per #593's plan:
1. Plugin ships \`voicings.json\` with both \`manifest\` AND \`voicings\` at the top.
2. Existing consumers that read \`payload[\"voicings\"]\` keep working.
3. Ellington's \`sync_voicings\` uses the manifest when present, falls back to synthesis when missing.
4. After one release cycle, ellington's CI requires the manifest; synthesis fallback becomes a hard error.

## Manifest shape

```json
{
  \"manifest\": {
    \"bundle_version\": \"2.3.0\",
    \"schema_version\": \"voicings-v1\",
    \"plugin_commit_sha\": null,
    \"built_at\": null,
    \"total_voicings\": 820,
    \"min_consumer_version\": \"0.1.0\"
  },
  \"voicings\": [ ... ]
}
```

Field decisions:

| Field | Value | Why |
|---|---|---|
| \`bundle_version\` | \`\"2.3.0\"\` | Mirrors current plugin release |
| \`schema_version\` | \`\"voicings-v1\"\` | First schema generation; bump on breaking change |
| \`plugin_commit_sha\` | \`null\` in committed source | Chicken-and-egg — a file can't contain its own commit SHA. Release workflow fills at build time; consumers fall back to git ref. |
| \`built_at\` | \`null\` in committed source | Same chicken-and-egg; release workflow fills |
| \`total_voicings\` | \`820\` | Matches array length; drift-detected in CI |
| \`min_consumer_version\` | \`\"0.1.0\"\` | Forward-compat guard (Hyrum's-law) |

## What ships

| File | Change |
|---|---|
| \`schema/voicings.schema.json\` | New \`$defs/manifest\` + top-level optional \`manifest\` property (kept optional during rollout; required once ellington's sync_voicings is updated per #593's plan) |
| \`plugin/data/voicings.json\` | Prepended manifest block. Note: large reformatting diff — \`json.dump\` produces canonical layout differing from the prior file's formatting; **the voicings array content is unchanged** (820 entries before and after, verified) |
| \`tests/test_voicings_manifest.py\` | New, 7 tests |
| \`.github/workflows/test.yml\` | Added the new test to CI |

## Test coverage (7 new tests)

1. \`manifest\` present + a dict
2. Required fields (\`bundle_version\`, \`schema_version\`, \`total_voicings\`) all there
3. **\`total_voicings\` stays in sync with \`voicings[]\` length** — catches the most common drift mode (voicings added/removed without bump)
4. \`schema_version\` is \`voicings-v1\` (sanity check on known generation)
5. Committed source carries \`null\` \`plugin_commit_sha\` + \`built_at\` (guards against accidentally committing a stale release artifact — if these fields are non-null in main, something's gone wrong)
6. Full file validates against the updated schema
7. \`min_consumer_version\` present (forward-compat floor set)

## Test plan

- [x] 372/372 across CI subset (was 365 + 7 new)
- [x] \`python scripts/validate.py --target voicings\` passes (pre-existing notes/dots warnings unrelated to manifest)
- [x] Voicing count verified: 820 before, 820 after — no data loss in the reformat

## Refs

ellington-web#208 — the cross-project ask that surfaced this gap. After this PR merges, ellington side can switch \`sync_voicings\` to consume the manifest directly.