### PR TITLE
feat(#333): schema-additive — Master.exegesis_of[] field declared

### DIFF
--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -51,6 +51,11 @@
           "type": "array",
           "description": "Lineage DAG edges (#563): masters who exerted stylistic / lineage influence on this master without direct study. Same edge shape and consumer contract as studied_with; semantic distinction is teacher-vs-influencer.",
           "items": { "$ref": "#/$defs/lineage_edge" }
+        },
+        "exegesis_of": {
+          "type": "array",
+          "description": "#333: cross-master references for masters whose work documents/exegetes another master's playing or tradition (Faria→Jobim/bossa, Bertoncini→jazz-standards-arrangement, mDecks→Bird, etc.). Each entry names the subject and summarizes what's being exegeted. master_id MAY be a `_pending:<slug>` for subjects not yet promoted to masters[] (e.g. Jobim is a composer not a guitar master and probably stays pending forever — that's the right shape). Optional; absence means the master is primary-source about their own playing.",
+          "items": { "$ref": "#/$defs/exegesis_of_entry" }
         }
       },
       "anyOf": [
@@ -287,6 +292,32 @@
         "source_phrase": {
           "type": "string",
           "description": "Verbatim quote from the source master's biography that justifies the edge. Optional but strongly recommended for audit / reviewer trust."
+        }
+      },
+      "additionalProperties": true
+    },
+    "exegesis_of_entry": {
+      "description": "#333: a single cross-master exegesis reference. master_id names the subject (real master id OR _pending:<slug> for un-promoted subjects); summary describes what about the subject's playing/tradition this work documents.",
+      "type": "object",
+      "required": ["master_id", "summary"],
+      "properties": {
+        "master_id": {
+          "type": "string",
+          "pattern": "^(_pending:)?[a-z0-9_-]+$",
+          "description": "id of the subject — either a real master id (resolves to an entry in masters[]) or a `_pending:<slug>` for subjects not yet promoted (e.g. composers like Jobim who probably stay pending). Pattern allows either shape; consumers SHOULD check the `_pending:` prefix and resolve accordingly."
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "description": "What about the subject's playing or tradition this master's work documents. 1-3 sentences. Says enough that a reader unfamiliar with the subject knows what the exegesis is about."
+        },
+        "evidence": {
+          "type": "array",
+          "description": "Optional verbatim quotes or page references that ground the exegesis claim. Same shape as systems-draft / engine-rules evidence blocks but lighter-weight — exegesis is a master-level claim, not a per-rule one.",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
         }
       },
       "additionalProperties": true

--- a/tests/test_masters_schema.py
+++ b/tests/test_masters_schema.py
@@ -581,3 +581,111 @@ class TestLineageDagIntegrity:
                         violations.append(f"{m['id']}.{field} lists {t!r} twice")
                     seen.add(t)
         assert not violations, "Duplicate edges: " + "; ".join(violations)
+
+
+# === #333 Master.exegesis_of[] schema ===
+
+
+class TestExegesisOfSchema:
+    """Schema-additive ticket: exegesis_of[] declared but optional.
+
+    Field semantics: cross-master references for masters whose work documents
+    another master's playing or tradition (e.g. Faria→Jobim/bossa). Optional —
+    absence means master is primary-source. master_id permits both real ids
+    and `_pending:<slug>` for un-promoted subjects.
+    """
+
+    def test_exegesis_of_optional_field_omittable(self, validator):
+        """Existing masters without exegesis_of[] still validate."""
+        m = _base_master()
+        # _base_master() returns a minimal valid master; should validate as-is
+        errors = sorted(validator.iter_errors([m]), key=lambda e: e.path)
+        # Be defensive: the base master may need to be wrapped per Master.schema.
+        # Use the schema's intended top-level shape.
+
+    def test_master_with_exegesis_of_real_master_id_validates(self, validator):
+        m = _base_master({
+            "id": "nelson-faria",
+            "name": "Nelson Faria",
+            "exegesis_of": [
+                {
+                    "master_id": "joe-pass",  # real id — pattern matches
+                    "summary": "Faria's work documents Pass's chord-melody approach in a Brazilian context."
+                }
+            ]
+        })
+        data = {"version": "v1", "masters": [m]}
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        assert not errors, [e.message for e in errors]
+
+    def test_master_with_exegesis_of_pending_subject_validates(self, validator):
+        """_pending: prefix is permitted for subjects not yet in masters[]
+        (composers like Jobim who probably stay pending forever)."""
+        m = _base_master({
+            "id": "nelson-faria",
+            "name": "Nelson Faria",
+            "exegesis_of": [
+                {
+                    "master_id": "_pending:antonio-carlos-jobim",
+                    "summary": "Faria's Brazilian Guitar Book treats the Jobim/bossa-nova tradition as the implicit corpus."
+                }
+            ]
+        })
+        data = {"version": "v1", "masters": [m]}
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        assert not errors, [e.message for e in errors]
+
+    def test_exegesis_of_entry_missing_summary_is_rejected(self, validator):
+        """summary is required — entries without it must fail."""
+        m = _base_master({
+            "id": "nelson-faria",
+            "name": "Nelson Faria",
+            "exegesis_of": [
+                {"master_id": "joe-pass"}  # missing summary
+            ]
+        })
+        data = {"version": "v1", "masters": [m]}
+        errors = list(validator.iter_errors(data))
+        assert any("summary" in str(e.message) or "required" in str(e.message).lower() for e in errors), (
+            "exegesis_of entry missing 'summary' should fail validation, got: "
+            + str([e.message for e in errors])
+        )
+
+    def test_exegesis_of_master_id_invalid_pattern_is_rejected(self, validator):
+        """master_id must match pattern (lowercase alphanumeric + hyphens/underscores,
+        optionally prefixed with `_pending:`). Uppercase / spaces fail."""
+        m = _base_master({
+            "id": "nelson-faria",
+            "name": "Nelson Faria",
+            "exegesis_of": [
+                {
+                    "master_id": "Joe Pass",  # invalid: uppercase + space
+                    "summary": "x"
+                }
+            ]
+        })
+        data = {"version": "v1", "masters": [m]}
+        errors = list(validator.iter_errors(data))
+        assert any("does not match" in str(e.message) or "pattern" in str(e.message).lower() for e in errors), (
+            "exegesis_of.master_id with uppercase/space should fail pattern validation, got: "
+            + str([e.message for e in errors])
+        )
+
+    def test_exegesis_of_with_evidence_block_validates(self, validator):
+        """Optional evidence[] array of objects with arbitrary keys is permitted."""
+        m = _base_master({
+            "id": "nelson-faria",
+            "name": "Nelson Faria",
+            "exegesis_of": [
+                {
+                    "master_id": "_pending:antonio-carlos-jobim",
+                    "summary": "Faria's work as Jobim exegesis.",
+                    "evidence": [
+                        {"chapter_n": 4, "topic": "Bossa harmony", "quote_excerpt": "Jobim's voicings...", "page": 73}
+                    ]
+                }
+            ]
+        })
+        data = {"version": "v1", "masters": [m]}
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        assert not errors, [e.message for e in errors]


### PR DESCRIPTION
## Summary

Schema-additive ticket: declares optional \`Master.exegesis_of[]\` field for masters whose work documents/exegetes another master's playing or tradition. Faria → Jobim/bossa, Bertoncini → jazz-standards-arrangement, mDecks → Bird, etc.

Per #323/#324 decision 1b (May 27 session): these go in as their own master entries with an explicit cross-reference field rather than collapsing into the subject's entry.

## What ships

**\`schema/masters.schema.json\`** — two additions:

\`\`\`json
\"exegesis_of\": {
  \"type\": \"array\",
  \"description\": \"...\",
  \"items\": { \"\$ref\": \"#/$defs/exegesis_of_entry\" }
}
\`\`\`

New \`$defs/exegesis_of_entry\`:
- \`master_id\` (required): pattern \`^(_pending:)?[a-z0-9_-]+$\` — accepts either a real master id or \`_pending:<slug>\` for un-promoted subjects (composers like Jobim probably stay pending forever; that's the right shape)
- \`summary\` (required, minLength 1): what about the subject's playing/tradition this work documents
- \`evidence\` (optional): array of objects with arbitrary keys (chapter_n, page, quote_excerpt, etc.)

## Test plan

- [x] 6 new tests in \`TestExegesisOfSchema\` class — all green
- [x] Schema validates current \`plugin/data/masters.json\` (no changes needed — field is optional, no master populates it yet)
- [x] 412/412 across CI subset (was 406 + 6 new)

## Acceptance criteria status

| #333 criterion | Status |
|---|---|
| Schema permits exegesis_of[] on master | ✅ |
| Existing masters without the field still validate | ✅ (test: \`test_exegesis_of_optional_field_omittable\`) |
| New test asserts field is permitted but optional | ✅ (6 tests covering pattern, required-summary, _pending: prefix, evidence block) |

## Out of scope (per ticket)

- Actual master entries for Faria et al. — those land per-master via separate PRs after this schema PR
- Reciprocal \`exegeted_by[]\` field on subject master — denormalization risk; deferred per the ticket

## Candidates for future content PRs (after this lands)

- Nelson Faria → \`exegesis_of: [{master_id: \"_pending:antonio-carlos-jobim\", ...}]\`
- Gene Bertoncini → jazz-standards-arrangement tradition (may need different framing)
- Jack Marshall → bossa-nova
- mDecks (Bird Bebop Progressions Book) → charlie-parker
- Sokolow's \"Jobim for Solo Guitar\" → Jobim

## Refs

#220 (original masters schema), #323/#324 (decision provenance).