### PR TITLE
feat(#338): schema-additive — System.style_attested[] field declared

### DIFF
--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -132,7 +132,12 @@
           "items": { "$ref": "#/$defs/preference" }
         },
         "examples": { "type": "array" },
-        "references": { "$ref": "#/$defs/references" }
+        "references": { "$ref": "#/$defs/references" },
+        "style_attested": {
+          "type": "array",
+          "description": "#338: which styles this system is attested in. Captured by Stage 4 when source quotes attest to a style application — substrate for future master × style engine composition. attestation values: `explicit` (master cites the style by name and applies the system), `implicit` (repertoire/examples are clearly in the style without naming it), `rejected` (master explicitly says this doesn't apply to the style). Optional; absent means no style attestation has been extracted yet.",
+          "items": { "$ref": "#/$defs/style_attestation" }
+        }
       },
       "anyOf": [
         {
@@ -318,6 +323,36 @@
             "type": "object",
             "additionalProperties": true
           }
+        }
+      },
+      "additionalProperties": true
+    },
+    "style_attestation": {
+      "description": "#338: a single style-attestation entry — declares which style this system is attested in and how strongly. Substrate for future master × style engine composition.",
+      "type": "object",
+      "required": ["style_id", "attestation"],
+      "properties": {
+        "style_id": {
+          "type": "string",
+          "pattern": "^(_pending:)?[a-z0-9_-]+$",
+          "description": "id of the style being attested. May be a real id resolving to plugin/data/styles.json, OR a `_pending:<slug>` for styles not yet cataloged."
+        },
+        "attestation": {
+          "type": "string",
+          "enum": ["explicit", "implicit", "rejected"],
+          "description": "Strength of the attestation. `explicit` = master cites the style by name and applies the system. `implicit` = repertoire/examples are clearly in the style without naming it. `rejected` = master explicitly says the system doesn't apply to the style."
+        },
+        "evidence": {
+          "type": "array",
+          "description": "Optional source quotes / page references that ground the attestation. Each entry is a free-shape object (chapter_n, topic, quote_excerpt, page).",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "caveats": {
+          "type": "string",
+          "description": "Optional prose noting where this attestation is partial or conditional (e.g. 'works with sus-2 substitution; avoid extended chromatic alterations')."
         }
       },
       "additionalProperties": true

--- a/tests/test_masters_schema.py
+++ b/tests/test_masters_schema.py
@@ -689,3 +689,101 @@ class TestExegesisOfSchema:
         data = {"version": "v1", "masters": [m]}
         errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
         assert not errors, [e.message for e in errors]
+
+
+# === #338 System.style_attested[] schema ===
+
+
+class TestStyleAttestationSchema:
+    """Schema-additive ticket: style_attested[] declared on $defs/system."""
+
+    def _master_with_attested_system(self, attestations):
+        return _base_master({
+            "id": "van-eps",
+            "name": "George Van Eps",
+            "principles": [
+                {"id": "p", "name": "P", "summary": "test"}
+            ],
+            "systems": [{
+                "id": "van-eps:harmonic-mechanisms",
+                "name": "Harmonic Mechanisms",
+                "members": [{"id": "x", "name": "X"}],
+                "traversal_rules": [
+                    {"id": "t", "name": "T",
+                     "engine_payload": {"kind": "VoiceMotion"}}
+                ],
+                "style_attested": attestations
+            }]
+        })
+
+    def test_system_without_style_attested_validates(self, validator):
+        m = _base_master({
+            "principles": [
+                {"id": "p", "name": "P", "summary": "test"}
+            ],
+            "systems": [{
+                "id": "van-eps:foo",
+                "name": "Foo",
+                "members": [{"id": "x", "name": "X"}],
+                "traversal_rules": [
+                    {"id": "t", "name": "T", "engine_payload": {"kind": "VoiceMotion"}}
+                ]
+            }]
+        })
+        data = {"version": "v1", "masters": [m]}
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        assert not errors, [e.message for e in errors]
+
+    def test_system_with_explicit_attestation_validates(self, validator):
+        m = self._master_with_attested_system([
+            {
+                "style_id": "ballad",
+                "attestation": "explicit",
+                "evidence": [{"chapter_n": 3, "topic": "ballad voicings", "page": 42}],
+                "caveats": "works with sus-2 substitution"
+            }
+        ])
+        data = {"version": "v1", "masters": [m]}
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        assert not errors, [e.message for e in errors]
+
+    def test_system_with_implicit_and_rejected_attestations_validates(self, validator):
+        m = self._master_with_attested_system([
+            {"style_id": "swing", "attestation": "implicit"},
+            {"style_id": "free-jazz", "attestation": "rejected"}
+        ])
+        data = {"version": "v1", "masters": [m]}
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        assert not errors, [e.message for e in errors]
+
+    def test_pending_style_id_validates(self, validator):
+        m = self._master_with_attested_system([
+            {"style_id": "_pending:gypsy-jazz", "attestation": "explicit"}
+        ])
+        data = {"version": "v1", "masters": [m]}
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        assert not errors, [e.message for e in errors]
+
+    def test_invalid_attestation_enum_rejected(self, validator):
+        m = self._master_with_attested_system([
+            {"style_id": "ballad", "attestation": "maybe"}
+        ])
+        data = {"version": "v1", "masters": [m]}
+        errors = list(validator.iter_errors(data))
+        assert any("'maybe'" in str(e.message) or "enum" in str(e.message).lower() for e in errors), [e.message for e in errors]
+
+    def test_missing_style_id_rejected(self, validator):
+        m = self._master_with_attested_system([
+            {"attestation": "explicit"}
+        ])
+        data = {"version": "v1", "masters": [m]}
+        errors = list(validator.iter_errors(data))
+        assert any("style_id" in str(e.message) or "required" in str(e.message).lower() for e in errors), [e.message for e in errors]
+
+    def test_invalid_style_id_pattern_rejected(self, validator):
+        m = self._master_with_attested_system([
+            {"style_id": "Ballad Mode", "attestation": "explicit"}
+        ])
+        data = {"version": "v1", "masters": [m]}
+        errors = list(validator.iter_errors(data))
+        assert any("does not match" in str(e.message) or "pattern" in str(e.message).lower() for e in errors), [e.message for e in errors]


### PR DESCRIPTION
## Summary

Schema-additive: declares optional \`System.style_attested[]\` field for capturing style-attestation evidence at the system level. Substrate for future master × style engine composition.

## What ships

**\`schema/masters.schema.json\`**:
- New optional \`System.style_attested[]\` array (works on systems living at \`master.systems[]\` AND \`master.works[*].systems[]\`)
- New \`\$defs/style_attestation\` shape:

\`\`\`json
{
  \"style_id\": \"ballad\",                    // or \"_pending:<slug>\"
  \"attestation\": \"explicit\",              // or \"implicit\" / \"rejected\"
  \"evidence\": [                             // optional
    { \"chapter_n\": 3, \"topic\": \"ballad voicings\", \"page\": 42 }
  ],
  \"caveats\": \"works with sus-2 substitution\"  // optional
}
\`\`\`

attestation enum (per ticket §):
- \`explicit\` — master cites the style by name and applies the system
- \`implicit\` — repertoire/examples are clearly in the style without naming it
- \`rejected\` — master explicitly says system doesn't apply to the style

## Test plan

- [x] 7 new tests in \`TestStyleAttestationSchema\` class — all green
- [x] Schema validates current \`plugin/data/masters.json\` (no master populates style_attested yet — field is optional)
- [x] 413/413 across CI subset

## Acceptance criteria status

| #338 criterion | Status |
|---|---|
| Schema permits style_attested[] on system | ✅ |
| attestation enum: explicit / implicit / rejected | ✅ |
| evidence array of source-quote objects | ✅ |
| Field optional — existing systems still validate | ✅ |

## Out of scope (per ticket)

- Style schema (\`style.harmonic_grammar\`) — separate corpus/PR
- Compatibility function (engine layer composition)
- Backfill of \`style_attested[]\` on already-promoted masters — Van Eps Vol 1 + Bruno would benefit but not required by this schema PR; follow-up work

## Refs

#220 #323 #327 #328.