### PR TITLE
fix(#310): strip duplicate frontmatter from STATEMENT.md

### DIFF
--- a/pipelines/master-distillation/stages/s4_systems.py
+++ b/pipelines/master-distillation/stages/s4_systems.py
@@ -1,3 +1,4 @@
+import re
 """Stage 4 — Statement of outputs.
 
 Reads the chapter files (Stage 2) + chapter and book summaries (Stage 3)
@@ -413,7 +414,8 @@ def _write_statement(
         source_pages=None,
         model=model,
     )
-    text_out = prov.yaml_block() + "\n\n" + statement.strip() + "\n"
+    clean = re.sub(r"\A---\n.*?\n---\n*", "", statement.strip(), count=1, flags=re.DOTALL)
+    text_out = prov.yaml_block() + "\n\n" + clean.strip() + "\n"
     book.statement.write_text(text_out)
 
 

--- a/plugin/data/masters-corpus/greg-orourke/complete-chord-melody/derived/STATEMENT.md
+++ b/plugin/data/masters-corpus/greg-orourke/complete-chord-melody/derived/STATEMENT.md
@@ -7,15 +7,6 @@ extracted_at: 2026-05-23T23:38:58+00:00
 schema_version: 0.1
 ---
 
----
-run_id: 2026-05-23T23-23-45-orourke-complete-chord-melody
-stage: s4
-source_pdf: complete_chord_melody.pdf
-model: claude-sonnet
-extracted_at: 2026-05-23T23:32:30+00:00
-schema_version: 0.1
----
-
 # Complete Chord Melody (Greg O'Rourke) — Statement of Outputs
 
 ## Overview

--- a/plugin/data/masters-corpus/jimmy-bruno/the-art-of-picking/derived/STATEMENT.md
+++ b/plugin/data/masters-corpus/jimmy-bruno/the-art-of-picking/derived/STATEMENT.md
@@ -7,15 +7,6 @@ extracted_at: 2026-05-23T22:30:48+00:00
 schema_version: 0.1
 ---
 
----
-run_id: 2026-05-23T22-12-11-bruno-art-of-picking
-stage: s4
-source_pdf: Jimmy-Bruno-The-Art-Of-Picking.pdf
-model: claude-sonnet
-extracted_at: 2026-05-23T22:30:00+00:00
-schema_version: 0.1
----
-
 # The Art of Picking — Statement of Outputs
 
 ## Overview

--- a/plugin/data/masters-corpus/mickey-baker/complete-course-in-jazz-guitar/derived/STATEMENT.md
+++ b/plugin/data/masters-corpus/mickey-baker/complete-course-in-jazz-guitar/derived/STATEMENT.md
@@ -7,15 +7,6 @@ extracted_at: 2026-05-26T18:17:20+00:00
 schema_version: 0.1
 ---
 
----
-run_id: 2026-05-23T23-56-18-baker-jazz-guitar
-stage: s4
-source_pdf: Mickey-Baker-s-Jazz-Guitar.pdf
-model: claude-sonnet
-extracted_at: 2026-05-26T18:08:54+00:00
-schema_version: 0.1
----
-
 # Mickey Baker's Complete Course in Jazz Guitar Vol. 1 — Statement of Outputs
 
 ## Overview

--- a/plugin/data/masters-corpus/van-eps/harmonic-mechanisms-vol-1/derived/STATEMENT.md
+++ b/plugin/data/masters-corpus/van-eps/harmonic-mechanisms-vol-1/derived/STATEMENT.md
@@ -7,15 +7,6 @@ extracted_at: 2026-05-26T19:48:38+00:00
 schema_version: 0.1
 ---
 
----
-run_id: 2026-05-26T05-04-34-van-eps-harmonic-mechanisms-vol-1
-stage: s4
-source_pdf: Van-Eps-Harmonic-Mechanisms-Vol-1.pdf
-model: claude-opus
-extracted_at: 2026-05-26T05-04-34+00:00
-schema_version: 0.1
----
-
 # George Van Eps, *Harmonic Mechanisms for Guitar*, Vol. 1 — Statement of Outputs
 
 ## Overview


### PR DESCRIPTION
Strips any existing leading frontmatter from the LLM response in s4_systems.py before prepending the provenance block. Cleans up 4 existing STATEMENT.md files. Refs: #310