### PR TITLE
feat(#522): codify worktree isolation for parallel Stage B drivers

### DIFF
--- a/pipelines/master-distillation/QUEUE.md
+++ b/pipelines/master-distillation/QUEUE.md
@@ -98,7 +98,18 @@ to run via `source.host = "cyberpower"` against the canonical PDF corpus at
 ## Operational notes
 
 - **Run one book at a time.** Cyberpower vision-rescue serializes on Ollama anyway.
-- **Per-book branch.** `feature/<book-slug>` off `develop`; Stage B merges into develop.
+- **Per-book branch with worktree isolation.** When running Stage B for multiple books in parallel, each driver MUST use its own git worktree to avoid shared-HEAD contention. The shared `.git` dir is concurrency-safe (Git locks index/refs internally); the working tree is not.
+
+  ```bash
+  WORKTREE=~/git/siege-analytics/worktrees/<run-slug>
+  git worktree add "$WORKTREE" -b feat/<ticket>-stage-b-<run-slug> origin/develop
+  cd "$WORKTREE"
+  # ... run Stage B injection, commit, push, open PR ...
+  cd ~/git/siege-analytics/musescore4-chord-library-plugin
+  git worktree remove "$WORKTREE"
+  ```
+
+  Serial Stage B runs (one at a time) may use the main working tree directly, but worktrees are always safe and preferred.
 - **For books over ~150 pages** (most of Tier 3 + Tier 4 Felts): apply tight-cap Stage 4 prompt from PR #322 to avoid systems-draft subagent timeout.
 - **Recovery**: if local orchestrator dies mid-run, `python3 pipelines/master-distillation/ocr/reingest.py <run-id>` pulls the cyberpower outbox + rebuilds Stage 1 outputs.
 

--- a/pipelines/master-distillation/queue/MASTER-DISTILLATION-WORKER.md
+++ b/pipelines/master-distillation/queue/MASTER-DISTILLATION-WORKER.md
@@ -153,7 +153,7 @@ Return a structured report to the main agent:
 
 ## What you don't do
 
-- Stage B (editing `plugin/data/masters.json` to add the work/systems): main agent does this with curatorial judgment.
+- Stage B (editing `plugin/data/masters.json` to add the work/systems): main agent does this with curatorial judgment. When running parallel Stage B drivers, each uses a git worktree for isolation (see QUEUE.md operational notes).
 - Composite STATEMENT.md at master level (e.g. `plugin/data/masters-corpus/<master>/STATEMENT.md`): main agent does this if needed.
 - Opening PRs or committing: main agent handles git operations.
 - Curatorial decisions about which quotes are "really" load-bearing: trust the LLM's selection unless it's clearly hallucinating.


### PR DESCRIPTION
Codifies the worktree isolation pattern proven in PRs #517, #518, #520 into the canonical pipeline documentation.

Changes:
- QUEUE.md: per-book branch bullet replaced with worktree isolation convention including bash recipe
- MASTER-DISTILLATION-WORKER.md: cross-reference added to Stage B bullet in What you dont do section

Closes #522