### PR TITLE
feat(#302): pre-flight check prevents clobbering existing chapter outputs

### DIFF
--- a/pipelines/master-distillation/run.py
+++ b/pipelines/master-distillation/run.py
@@ -76,6 +76,22 @@ def cmd_new_run(args: argparse.Namespace) -> int:
     run_id = state.make_run_id(slug)
 
     book = _book_paths(cfg, run_id)
+
+    existing = list(book.committed_chapters_dir.glob("ch*.md"))
+    if existing and not args.overwrite:
+        print(
+            f"work_id '{cfg['work']['id']}' already has {len(existing)} "
+            f"committed chapter outputs at {book.committed_chapters_dir}. "
+            f"Use --overwrite to replace, or use a different work_id.",
+            file=sys.stderr,
+        )
+        return 1
+    if existing and args.overwrite:
+        print(
+            f"WARNING: --overwrite set; {len(existing)} existing chapter "
+            f"outputs at {book.committed_chapters_dir} will be replaced.",
+        )
+
     book.ensure_dirs()
 
     run = state.RunState.new(run_id, str(config_path))
@@ -223,6 +239,10 @@ def main() -> int:
 
     p_new = sub.add_parser("new-run", help="start a fresh run")
     p_new.add_argument("config", help="path to per-book YAML config")
+    p_new.add_argument(
+        "--overwrite", action="store_true",
+        help="allow clobbering existing chapter outputs for this work_id",
+    )
     p_new.set_defaults(func=cmd_new_run)
 
     p_resume = sub.add_parser("resume", help="continue an existing run")

--- a/pipelines/master-distillation/stages/s4_systems.py
+++ b/pipelines/master-distillation/stages/s4_systems.py
@@ -1,4 +1,3 @@
-import re
 """Stage 4 — Statement of outputs.
 
 Reads the chapter files (Stage 2) + chapter and book summaries (Stage 3)
@@ -22,6 +21,7 @@ available (or cloud-Sonnet via the file-dance fallback).
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from lib import provenance

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -520,15 +520,15 @@ def test_ocr_defaults_cover_required_keys():
     required = {
         "host", "user", "vision_model",
         "confidence_threshold", "min_chars_per_page", "render_dpi",
-        "max_wait_minutes",  # #339 F8 fix
+        "stall_minutes",  # #504 renamed from max_wait_minutes
     }
     assert required <= set(s1_extract.OCR_DEFAULTS.keys())
 
 
-def test_ocr_defaults_max_wait_minutes_is_positive():
-    """The poll-loop cap (#339 F8) must be a positive number; 0 would
-    immediately timeout, negative would loop forever (elapsed > -N false)."""
-    assert s1_extract.OCR_DEFAULTS["max_wait_minutes"] > 0
+def test_ocr_defaults_stall_minutes_is_positive():
+    """The stall-detection cap (#504) must be a positive number; 0 would
+    immediately timeout, negative would loop forever."""
+    assert s1_extract.OCR_DEFAULTS["stall_minutes"] > 0
 
 
 def test_ocr_orchestrator_does_not_pass_unexpanded_HOME_to_ssh(monkeypatch, tmp_path):
@@ -653,3 +653,77 @@ def test_remote_quoted_path_handles_spaces_and_apostrophes():
     assert quoted.endswith('.pdf"')
     # apostrophe survives inside double quotes
     assert "Baker's" in quoted
+
+
+# ---------------------------------------------------------------------------
+# cmd_new_run pre-flight check (#302)
+# ---------------------------------------------------------------------------
+
+
+def test_new_run_refuses_existing_chapters(tmp_path, monkeypatch):
+    """new-run must error if committed_chapters_dir already has ch*.md files."""
+    monkeypatch.setattr("lib.paths.CORPUS_ROOT", tmp_path / "corpus")
+    monkeypatch.setattr("lib.paths.RUNS_ROOT", tmp_path / "runs")
+
+    chapters_dir = tmp_path / "corpus" / "test" / "vol-1" / "chapters"
+    chapters_dir.mkdir(parents=True)
+    (chapters_dir / "ch01.md").write_text("existing chapter")
+    (chapters_dir / "ch02.md").write_text("existing chapter 2")
+
+    config_path = tmp_path / "test.toml"
+    config_path.write_text("""
+[master]
+id = "test"
+
+[work]
+id = "vol-1"
+
+[source]
+pdf = "/tmp/fake.pdf"
+""")
+
+    import importlib
+    run_mod = importlib.import_module("run")
+
+    args = type("Args", (), {
+        "config": str(config_path),
+        "overwrite": False,
+    })()
+
+    result = run_mod.cmd_new_run(args)
+    assert result == 1
+
+
+def test_new_run_allows_overwrite(tmp_path, monkeypatch):
+    """new-run with --overwrite must proceed past the chapter check."""
+    monkeypatch.setattr("lib.paths.CORPUS_ROOT", tmp_path / "corpus")
+    monkeypatch.setattr("lib.paths.RUNS_ROOT", tmp_path / "runs")
+
+    chapters_dir = tmp_path / "corpus" / "test" / "vol-1" / "chapters"
+    chapters_dir.mkdir(parents=True)
+    (chapters_dir / "ch01.md").write_text("existing chapter")
+
+    config_path = tmp_path / "test.toml"
+    config_path.write_text("""
+[master]
+id = "test"
+
+[work]
+id = "vol-1"
+
+[source]
+pdf = "/tmp/fake.pdf"
+""")
+
+    import importlib
+    run_mod = importlib.import_module("run")
+
+    args = type("Args", (), {
+        "config": str(config_path),
+        "overwrite": True,
+    })()
+
+    # Will proceed past the guard. May fail downstream (no PDF, etc.)
+    # but the pre-flight check should not fire.
+    result = run_mod.cmd_new_run(args)
+    assert result != 1


### PR DESCRIPTION
new-run now checks committed_chapters_dir for existing ch*.md files before proceeding. Errors with an actionable message by default; --overwrite flag provides explicit bypass.

Also fixes two pre-existing issues:
- s4_systems.py: import re placed before module docstring causing SyntaxError (from #603)
- test_pipeline.py: OCR_DEFAULTS key names updated for stall_minutes rename (from #504)

60/60 tests pass.

Closes #302