### PR TITLE
fix(#289): enable Windows long-path support in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+      - name: Enable long paths (Windows)
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

Windows CI runners hit WinError 206 (MAX_PATH 260-char limit) when temp paths + repo paths + test fixture paths exceed the default limit.

## Fix

Add `git config --system core.longpaths true` as a conditional step (Windows only) before checkout. This enables the Win32 long-path API, removing the 260-char ceiling. Standard approach for Windows CI runners.

Closes #289