### PR TITLE
feat(#260): require summary on placeholder systems and works

### DIFF
--- a/schema/masters.schema.json
+++ b/schema/masters.schema.json
@@ -3,160 +3,336 @@
   "title": "Masters' Lessons Bookshelf (#220 / #276 Stage A / #293 Stage A.1 / #295 enum provenance fix)",
   "description": "Schema for plugin/data/masters.json. Stage A introduced a dual-shape window (legacy 'principles' / new 'systems'). Stage A.1 (#293) adds an optional 'works' layer for multi-method masters: Van Eps's 1939 Method vs Harmonic Mechanisms, Martin Taylor's multiple books, etc. Each master must declare at least one of principles[], systems[], works[]. The engine_payload.kind enum was rolled back in #295 from the originally-shipped invented names to the 12 names with design provenance in predecessor session 260521-aware-nebula's schema-systems-model.md. Per-master migration is tracked in #277-#285; Stage C will deprecate 'principles'.",
   "type": "object",
-  "required": ["version", "masters"],
+  "required": [
+    "version",
+    "masters"
+  ],
   "properties": {
-    "version": { "const": "v1" },
-    "schemaNote": { "type": "string" },
+    "version": {
+      "const": "v1"
+    },
+    "schemaNote": {
+      "type": "string"
+    },
     "masters": {
       "type": "array",
-      "items": { "$ref": "#/$defs/master" }
+      "items": {
+        "$ref": "#/$defs/master"
+      }
     }
   },
   "additionalProperties": false,
   "$defs": {
     "master": {
       "type": "object",
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "properties": {
-        "id": { "type": "string", "pattern": "^[a-z0-9_-]+$" },
-        "name": { "type": "string", "minLength": 1 },
-        "lived": { "type": "string" },
-        "traditions": { "type": "array", "items": { "type": "string" } },
-        "instrument": { "type": "string" },
-        "biography": { "type": "string" },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "lived": {
+          "type": "string"
+        },
+        "traditions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "instrument": {
+          "type": "string"
+        },
+        "biography": {
+          "type": "string"
+        },
         "principles": {
           "type": "array",
-          "items": { "$ref": "#/$defs/principle" }
+          "items": {
+            "$ref": "#/$defs/principle"
+          }
         },
         "systems": {
           "type": "array",
-          "items": { "$ref": "#/$defs/system" }
+          "items": {
+            "$ref": "#/$defs/system"
+          }
         },
         "works": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/work" }
+          "items": {
+            "$ref": "#/$defs/work"
+          }
         },
         "usage_notes": {
           "type": "array",
           "description": "Per-master × per-chord-quality pedagogical notes. Each entry says how this master uses or teaches voicings of the named chord quality — function role, idiom, common substitution, voice-leading context. Consumed by reviewer-facing surfaces (the #395 review form, the docs glossary) so reviewers can confirm 'is this how the master would use this chord in a lesson' rather than just 'is this a master-X voicing'. Optional; populated incrementally per #415 and follow-up tickets.",
-          "items": { "$ref": "#/$defs/usage_note" }
+          "items": {
+            "$ref": "#/$defs/usage_note"
+          }
         },
         "studied_with": {
           "type": "array",
           "description": "Lineage DAG edges (#563): masters who served as formal teacher or sustained study source for this master. Each edge cites the biography source phrase that justifies the edge. Conservative — only edges where both endpoints are in the corpus get encoded. Consumed by Ellington v1.2 pedagogue trust model (ellington-web#96) for per-Master expertise weighting. Empty array means no studied-with edges have been extracted yet (default state); missing entries get treated identically to empty.",
-          "items": { "$ref": "#/$defs/lineage_edge" }
+          "items": {
+            "$ref": "#/$defs/lineage_edge"
+          }
         },
         "influenced": {
           "type": "array",
           "description": "Lineage DAG edges (#563): masters who exerted stylistic / lineage influence on this master without direct study. Same edge shape and consumer contract as studied_with; semantic distinction is teacher-vs-influencer.",
-          "items": { "$ref": "#/$defs/lineage_edge" }
+          "items": {
+            "$ref": "#/$defs/lineage_edge"
+          }
         },
         "exegesis_of": {
           "type": "array",
           "description": "#333: cross-master references for masters whose work documents/exegetes another master's playing or tradition (Faria→Jobim/bossa, Bertoncini→jazz-standards-arrangement, mDecks→Bird, etc.). Each entry names the subject and summarizes what's being exegeted. master_id MAY be a `_pending:<slug>` for subjects not yet promoted to masters[] (e.g. Jobim is a composer not a guitar master and probably stays pending forever — that's the right shape). Optional; absence means the master is primary-source about their own playing.",
-          "items": { "$ref": "#/$defs/exegesis_of_entry" }
+          "items": {
+            "$ref": "#/$defs/exegesis_of_entry"
+          }
         }
       },
       "anyOf": [
-        { "required": ["principles"] },
-        { "required": ["systems"] },
-        { "required": ["works"] }
+        {
+          "required": [
+            "principles"
+          ]
+        },
+        {
+          "required": [
+            "systems"
+          ]
+        },
+        {
+          "required": [
+            "works"
+          ]
+        }
       ],
       "additionalProperties": true
     },
     "work": {
       "description": "A discrete body of method content authored by the master — typically one book or one method era. Multi-method masters (e.g. Van Eps's 1939 Method vs Harmonic Mechanisms) place their systems inside the matching work so per-method divergence is legible. Single-method masters do not need works[] at all; their systems live directly on the master.",
       "type": "object",
-      "required": ["id", "title"],
+      "required": [
+        "id",
+        "title"
+      ],
       "properties": {
         "id": {
           "type": "string",
           "pattern": "^(_placeholder:)?[a-z0-9_-]+$",
           "description": "Master-local kebab id (e.g. '1939-method', 'harmonic-mechanisms'). '_placeholder:' prefix marks a work whose interior is pending research; its systems[] may be empty or absent."
         },
-        "title": { "type": "string", "minLength": 1 },
-        "year": { "anyOf": [{ "type": "string" }, { "type": "number" }, { "type": "null" }] },
-        "instrument_scope": { "type": "string" },
-        "summary": { "type": "string" },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "year": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "instrument_scope": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
         "systems": {
           "type": "array",
-          "items": { "$ref": "#/$defs/system" }
+          "items": {
+            "$ref": "#/$defs/system"
+          }
         },
-        "references": { "$ref": "#/$defs/references" }
+        "references": {
+          "$ref": "#/$defs/references"
+        }
       },
       "additionalProperties": true
     },
     "principle": {
       "type": "object",
-      "required": ["id", "name", "summary"],
+      "required": [
+        "id",
+        "name",
+        "summary"
+      ],
       "properties": {
-        "id": { "type": "string", "pattern": "^[a-z0-9_-]+$" },
-        "name": { "type": "string" },
-        "summary": { "type": "string" },
-        "voicingStyleTags": { "type": "array", "items": { "type": "string" } },
-        "playStyleTags": { "type": "array", "items": { "type": "string" } },
-        "applies_to_modes": { "type": "array", "items": { "type": "string" } },
-        "applies_to_tunings": { "type": "array", "items": { "type": "string" } },
-        "tolerance_hints": { "type": "object" },
-        "references": { "$ref": "#/$defs/references" },
-        "example_voicing_signatures": { "type": "array" }
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+$"
+        },
+        "name": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "voicingStyleTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "playStyleTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "applies_to_modes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "applies_to_tunings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tolerance_hints": {
+          "type": "object"
+        },
+        "references": {
+          "$ref": "#/$defs/references"
+        },
+        "example_voicing_signatures": {
+          "type": "array"
+        }
       },
       "additionalProperties": true
     },
     "system": {
       "type": "object",
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "properties": {
         "id": {
           "type": "string",
           "pattern": "^(_placeholder:)?[a-z0-9_-]+:[a-z0-9_-]+(?::[a-z0-9_-]+)?$",
           "description": "Two- or three-segment id. Two-segment '<master>:<slug>' for systems living directly on master.systems (single-method masters). Three-segment '<master>:<work>:<slug>' for systems inside master.works[*].systems (multi-method masters). Optional '_placeholder:' prefix marks a system whose interior is intentionally empty pending design — placeholder shape relaxes the non-empty-members rule."
         },
-        "name": { "type": "string", "minLength": 1 },
-        "summary": { "type": "string" },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string"
+        },
         "members": {
           "type": "array",
-          "items": { "$ref": "#/$defs/taxonomy" }
+          "items": {
+            "$ref": "#/$defs/taxonomy"
+          }
         },
         "traversal_rules": {
           "type": "array",
-          "items": { "$ref": "#/$defs/rule" }
+          "items": {
+            "$ref": "#/$defs/rule"
+          }
         },
         "modification_rules": {
           "type": "array",
-          "items": { "$ref": "#/$defs/rule" }
+          "items": {
+            "$ref": "#/$defs/rule"
+          }
         },
         "preferences": {
           "type": "array",
-          "items": { "$ref": "#/$defs/preference" }
+          "items": {
+            "$ref": "#/$defs/preference"
+          }
         },
-        "examples": { "type": "array" },
-        "references": { "$ref": "#/$defs/references" },
+        "examples": {
+          "type": "array"
+        },
+        "references": {
+          "$ref": "#/$defs/references"
+        },
         "style_attested": {
           "type": "array",
           "description": "#338: which styles this system is attested in. Captured by Stage 4 when source quotes attest to a style application — substrate for future master × style engine composition. attestation values: `explicit` (master cites the style by name and applies the system), `implicit` (repertoire/examples are clearly in the style without naming it), `rejected` (master explicitly says this doesn't apply to the style). Optional; absent means no style attestation has been extracted yet.",
-          "items": { "$ref": "#/$defs/style_attestation" }
+          "items": {
+            "$ref": "#/$defs/style_attestation"
+          }
         }
       },
       "anyOf": [
         {
           "description": "Placeholder shape: id begins with '_placeholder:'; members/rules may be omitted or empty.",
           "properties": {
-            "id": { "pattern": "^_placeholder:[a-z0-9_-]+:[a-z0-9_-]+(?::[a-z0-9_-]+)?$" }
+            "id": {
+              "pattern": "^_placeholder:[a-z0-9_-]+:[a-z0-9_-]+(?::[a-z0-9_-]+)?$"
+            },
+            "summary": {
+              "type": "string",
+              "minLength": 1
+            }
           },
-          "required": ["id"]
+          "required": [
+            "id",
+            "summary"
+          ]
         },
         {
           "description": "Real shape: non-empty members[] AND at least one of traversal_rules or modification_rules non-empty.",
           "properties": {
-            "id": { "pattern": "^[a-z0-9_-]+:[a-z0-9_-]+(?::[a-z0-9_-]+)?$" },
-            "members": { "type": "array", "minItems": 1 }
+            "id": {
+              "pattern": "^[a-z0-9_-]+:[a-z0-9_-]+(?::[a-z0-9_-]+)?$"
+            },
+            "members": {
+              "type": "array",
+              "minItems": 1
+            }
           },
-          "required": ["members"],
+          "required": [
+            "members"
+          ],
           "anyOf": [
-            { "properties": { "traversal_rules":   { "type": "array", "minItems": 1 } }, "required": ["traversal_rules"] },
-            { "properties": { "modification_rules":{ "type": "array", "minItems": 1 } }, "required": ["modification_rules"] }
+            {
+              "properties": {
+                "traversal_rules": {
+                  "type": "array",
+                  "minItems": 1
+                }
+              },
+              "required": [
+                "traversal_rules"
+              ]
+            },
+            {
+              "properties": {
+                "modification_rules": {
+                  "type": "array",
+                  "minItems": 1
+                }
+              },
+              "required": [
+                "modification_rules"
+              ]
+            }
           ]
         }
       ],
@@ -164,29 +340,61 @@
     },
     "taxonomy": {
       "type": "object",
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "name": { "type": "string", "minLength": 1 },
-        "summary": { "type": "string" },
-        "tags": { "type": "array", "items": { "type": "string" } }
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "additionalProperties": true
     },
     "rule": {
       "type": "object",
-      "required": ["id", "name", "engine_payload"],
+      "required": [
+        "id",
+        "name",
+        "engine_payload"
+      ],
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "name": { "type": "string", "minLength": 1 },
-        "summary": { "type": "string" },
-        "engine_payload": { "$ref": "#/$defs/engine_payload" }
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string"
+        },
+        "engine_payload": {
+          "$ref": "#/$defs/engine_payload"
+        }
       },
       "additionalProperties": true
     },
     "engine_payload": {
       "type": "object",
-      "required": ["kind"],
+      "required": [
+        "kind"
+      ],
       "description": "Each rule carries one engine_payload. `kind` must be one of the 12 named kinds defined in docs/payload-kinds.md (#298), OR a `_pending:<kebab>` placeholder for rules that don't fit any named kind. See docs/payload-kinds.md for per-kind semantics, required/optional fields, worked examples, and boundary notes. Stretches — coercing a rule into a wrong name — are the failure mode the glossary exists to prevent; when in doubt, use `_pending:`.",
       "properties": {
         "kind": {
@@ -207,7 +415,10 @@
                 "TextureCycle"
               ]
             },
-            { "type": "string", "pattern": "^_pending:[a-z0-9-]+$" }
+            {
+              "type": "string",
+              "pattern": "^_pending:[a-z0-9-]+$"
+            }
           ]
         }
       },
@@ -215,19 +426,35 @@
     },
     "preference": {
       "type": "object",
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "name": { "type": "string", "minLength": 1 },
-        "summary": { "type": "string" },
-        "engine_payload": { "$ref": "#/$defs/engine_payload" }
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string"
+        },
+        "engine_payload": {
+          "$ref": "#/$defs/engine_payload"
+        }
       },
       "additionalProperties": true
     },
     "usage_note": {
       "description": "Per-master × per-chord-quality pedagogical note. Says how the master uses or teaches voicings of the given chord quality — function role, idiom, common substitution, voice-leading context. The narrative should give a reviewer enough to decide 'is this how the master would use this chord in a lesson' rather than just 'is this a master-X voicing'. Multiple notes per (master, quality) are allowed (e.g. Greene treats m7b5 differently in V-System vs sequential-articulation).",
       "type": "object",
-      "required": ["chord_quality", "narrative"],
+      "required": [
+        "chord_quality",
+        "narrative"
+      ],
       "properties": {
         "chord_quality": {
           "type": "string",
@@ -245,7 +472,9 @@
         },
         "source_principle_ids": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Optional refs to this master's principles[].id values that justify the note. Grounds the narrative claim in the principle structure."
         },
         "source_work_id": {
@@ -254,20 +483,32 @@
         },
         "provenance": {
           "type": "string",
-          "enum": ["extracted", "inferred-from-principles", "hand-authored", "placeholder"],
+          "enum": [
+            "extracted",
+            "inferred-from-principles",
+            "hand-authored",
+            "placeholder"
+          ],
           "description": "How this usage_note was produced. 'extracted' = distilled from source text via chapter-loop (authoritative); 'inferred-from-principles' = derived by reasoning over this master's principles[] (speculative, pending re-distillation); 'hand-authored' = written by a curator from direct source reading; 'placeholder' = structural-only, content TBD. Downstream consumers (form, glossary, Ellington) may render different provenance levels differently."
         },
         "polarity": {
           "type": "string",
-          "enum": ["prescriptive", "proscriptive"],
+          "enum": [
+            "prescriptive",
+            "proscriptive"
+          ],
           "description": "Whether the lesson tells the player what to DO (prescriptive — default) or what NOT to do (proscriptive — negative prescriptions, e.g. 'never substitute m6 before a dominant a 4th higher'). Optional; absent value is treated as 'prescriptive' by consumers. Added per #471 because corpus extractions repeatedly surface real negative-prescription content that the sub-5 coach (ellington-web#57) renders with different prose templates."
         },
         "cross_ref": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Optional refs to related usage_notes (matched by chord_quality + function_role within this master). Used to link a proscriptive parent to its prescriptive exception child (e.g. Greene's 'altered dominants may not replace I7 at song opening' proscriptive note cross-refs the dom7#9 'tonic-placement-exception' prescriptive note). Empty or absent means standalone."
         },
-        "references": { "$ref": "#/$defs/references" }
+        "references": {
+          "$ref": "#/$defs/references"
+        }
       },
       "additionalProperties": true
     },
@@ -275,11 +516,19 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["source"],
+        "required": [
+          "source"
+        ],
         "properties": {
-          "source": { "type": "string" },
-          "citation": { "type": "string" },
-          "url": { "type": "string" }
+          "source": {
+            "type": "string"
+          },
+          "citation": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
         "additionalProperties": true
       }
@@ -287,7 +536,9 @@
     "lineage_edge": {
       "description": "A single lineage edge (#563) — directed from the master that owns the studied_with/influenced array, to the master named by master_id. master_id MUST reference an existing master entry's id (graph-validation enforced by tests/test_masters_schema.py). source_phrase carries the biography quote that justifies the edge so the extraction is auditable.",
       "type": "object",
-      "required": ["master_id"],
+      "required": [
+        "master_id"
+      ],
       "properties": {
         "master_id": {
           "type": "string",
@@ -304,7 +555,10 @@
     "exegesis_of_entry": {
       "description": "#333: a single cross-master exegesis reference. master_id names the subject (real master id OR _pending:<slug> for un-promoted subjects); summary describes what about the subject's playing/tradition this work documents.",
       "type": "object",
-      "required": ["master_id", "summary"],
+      "required": [
+        "master_id",
+        "summary"
+      ],
       "properties": {
         "master_id": {
           "type": "string",
@@ -330,7 +584,10 @@
     "style_attestation": {
       "description": "#338: a single style-attestation entry — declares which style this system is attested in and how strongly. Substrate for future master × style engine composition.",
       "type": "object",
-      "required": ["style_id", "attestation"],
+      "required": [
+        "style_id",
+        "attestation"
+      ],
       "properties": {
         "style_id": {
           "type": "string",
@@ -339,7 +596,11 @@
         },
         "attestation": {
           "type": "string",
-          "enum": ["explicit", "implicit", "rejected"],
+          "enum": [
+            "explicit",
+            "implicit",
+            "rejected"
+          ],
           "description": "Strength of the attestation. `explicit` = master cites the style by name and applies the system. `implicit` = repertoire/examples are clearly in the style without naming it. `rejected` = master explicitly says the system doesn't apply to the style."
         },
         "evidence": {

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -318,6 +318,11 @@ def _check_masters_consistency(data: dict) -> list[str]:
                 warnings.append(f"{mid}: duplicate system id '{sid}'")
             all_system_ids.add(sid)
             _check_system_id(mid, None, sid, warnings, expect_segments=2)
+            if sid.startswith("_placeholder:") and not s.get("summary"):
+                warnings.append(
+                    f"{mid}: placeholder system '{sid}' must have a "
+                    f"non-empty summary describing what it will contain"
+                )
 
         seen_work_ids: set[str] = set()
         for w in m.get("works", []) or []:
@@ -325,6 +330,11 @@ def _check_masters_consistency(data: dict) -> list[str]:
             if wid in seen_work_ids:
                 warnings.append(f"{mid}: duplicate work id '{wid}'")
             seen_work_ids.add(wid)
+            if wid.startswith("_placeholder:") and not w.get("summary"):
+                warnings.append(
+                    f"{mid}: placeholder work '{wid}' must have a "
+                    f"non-empty summary describing what it will contain"
+                )
 
             for s in w.get("systems", []) or []:
                 sid = s.get("id", "<no-id>")
@@ -332,6 +342,11 @@ def _check_masters_consistency(data: dict) -> list[str]:
                     warnings.append(f"{mid}: duplicate system id '{sid}'")
                 all_system_ids.add(sid)
                 _check_system_id(mid, wid, sid, warnings, expect_segments=3)
+                if sid.startswith("_placeholder:") and not s.get("summary"):
+                    warnings.append(
+                        f"{mid}: placeholder system '{sid}' must have a "
+                        f"non-empty summary describing what it will contain"
+                    )
 
     return warnings
 

--- a/tests/test_masters_schema.py
+++ b/tests/test_masters_schema.py
@@ -92,6 +92,7 @@ def test_placeholder_system_allows_empty_interior(validator):
             {
                 "id": "_placeholder:van-eps:future-system",
                 "name": "Future system",
+                "summary": "Placeholder for future Van Eps system",
             }
         ],
     }
@@ -399,6 +400,7 @@ def test_three_segment_placeholder_system_inside_work_is_valid(validator):
                     {
                         "id": "_placeholder:van-eps:harmonic-mechanisms:lap-piano",
                         "name": "Lap piano counterpoint (research pending)",
+                        "summary": "Lap piano counterpoint techniques (source pending)",
                     }
                 ],
             }


### PR DESCRIPTION
Placeholder systems and works marked with the `_placeholder:` prefix must include a non-empty summary field describing what the system will contain once source material is acquired.

**Changes:**
- Schema: added `summary` to the placeholder anyOf shape required fields
- Validator: added consistency checks for placeholder systems/works missing summary at both master-level and work-level
- Tests: updated 2 test fixtures to include the now-required summary field

All 42 tests pass. All 4 existing placeholder entries in masters.json already have summary fields.

Closes #260