### PR TITLE
feat(#270): add breau-7-high-a tuning config

### DIFF
--- a/plugin/tunings/breau-7-high-a.json
+++ b/plugin/tunings/breau-7-high-a.json
@@ -1,0 +1,22 @@
+{
+  "name": "Breau 7-String (High A)",
+  "description": "Lenny Breau 7-string tuning. Standard 6-string with high A (A4) on the 1st string.",
+  "strings": {
+    "1": 69,
+    "2": 64,
+    "3": 59,
+    "4": 55,
+    "5": 50,
+    "6": 45,
+    "7": 40
+  },
+  "notes": {
+    "1": "A4",
+    "2": "E4",
+    "3": "B3",
+    "4": "G3",
+    "5": "D3",
+    "6": "A2",
+    "7": "E2"
+  }
+}


### PR DESCRIPTION
Adds Lenny Breau 7-string high-A tuning config (A4-E4-B3-G3-D3-A2-E2). Standard 6-string with high A (MIDI 69) above the standard high E, distinct from Van Eps low-A 7-string.

Refs: #270